### PR TITLE
Unmarshall process additional fields to raw json

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/MetaData.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/MetaData.scala
@@ -4,7 +4,13 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.Duration
 
+// TODO: remove this trait and duplicated ProcessAdditionalFields and Group in restmodel module.
 trait UserDefinedProcessAdditionalFields
+
+case class ProcessAdditionalFields(description: Option[String],
+                                   groups: Set[Group],
+                                   properties: Map[String, String]) extends UserDefinedProcessAdditionalFields
+case class Group(id: String, nodes: Set[String])
 
 // todo: MetaData should hold ProcessName as id
 case class MetaData(id: String,

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
@@ -4,10 +4,10 @@ import org.apache.commons.lang3.ClassUtils
 import pl.touk.nussknacker.engine.api.typed.ClazzRef
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
 import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
-import sink.SinkRef
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition.SubprocessParameter
 import pl.touk.nussknacker.engine.graph.service.ServiceRef
+import pl.touk.nussknacker.engine.graph.sink.SinkRef
 import pl.touk.nussknacker.engine.graph.source.{JoinRef, SourceRef}
 import pl.touk.nussknacker.engine.graph.subprocess.SubprocessRef
 import pl.touk.nussknacker.engine.graph.variable.Field
@@ -51,7 +51,10 @@ object node {
 
   case class BranchEnd(data: BranchEndData) extends SubsequentNode
 
+  // TODO: remove this trait and duplicated NodeAdditionalFields in restmodel module.
   trait UserDefinedAdditionalNodeFields
+
+  case class NodeAdditionalFields(description: Option[String]) extends UserDefinedAdditionalNodeFields
 
   sealed trait NodeData {
     def id: String


### PR DESCRIPTION
This PR adds possibility to access additional fields from process meta data inside services. For now the fields are not deserialized and are None in the result. The downside is the fields are exposed as raw json that needs to be manually parsed but it is actually an instance of `ProcessAdditionalFields` from `restmodel` module.