### PR TITLE
Validate subprocess input parameters.

### DIFF
--- a/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/encode/BestEffortAvroEncoder.scala
+++ b/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/encode/BestEffortAvroEncoder.scala
@@ -21,10 +21,6 @@ object BestEffortAvroEncoder {
 
   type WithError[T] = ValidatedNel[String, T]
 
-  private val syntax = ValidatedSyntax[String]
-
-  import syntax.A
-
   // It is quite similar logic to GenericDatumReader.readWithConversion but instead of reading from decoder, it read directly from value
   def encode(value: Any, schema: Schema): WithError[Any] = {
     (schema.getType, value) match {

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompiledProcess.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompiledProcess.scala
@@ -25,7 +25,7 @@ object CompiledProcess {
 
     val expressionCompiler = ExpressionCompiler.withOptimization(userCodeClassLoader, definitions.expressionConfig)
     //for testing environment it's important to take classloader from user jar
-    val subCompiler = new PartSubGraphCompiler(expressionCompiler, definitions.expressionConfig, servicesDefs)
+    val subCompiler = new PartSubGraphCompiler(userCodeClassLoader, expressionCompiler, definitions.expressionConfig, servicesDefs)
     val processCompiler = new ProcessCompiler(userCodeClassLoader, subCompiler, definitions)
 
     processCompiler.compile(process).result.map { compiledProcess =>

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilationError.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilationError.scala
@@ -1,5 +1,7 @@
 package pl.touk.nussknacker.engine.compile
 
+import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition.SubprocessClazzRef
+
 sealed trait ProcessCompilationError {
   def nodeIds: Set[String]
 }
@@ -55,6 +57,9 @@ object ProcessCompilationError {
     def apply(message: String, fieldName: Option[String], originalExpr: String)(implicit nodeId: NodeId): PartSubGraphCompilationError =
       ExpressionParseError(message, nodeId.id, fieldName, originalExpr)
   }
+
+  case class SubprocessParamClassLoadError(fieldName: String, typ: SubprocessClazzRef, nodeId: String)
+    extends PartSubGraphCompilationError with InASingleNode
 
   case class MissingService(serviceId: String, nodeId: String)
     extends PartSubGraphCompilationError with InASingleNode

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
@@ -331,7 +331,7 @@ object ProcessValidator {
     val expressionCompiler = ExpressionCompiler.withoutOptimization(loader, definitions.expressionConfig)
 
     val sub = new PartSubGraphCompiler(
-      expressionCompiler, definitions.expressionConfig, definitions.services)
+      loader, expressionCompiler, definitions.expressionConfig, definitions.services)
 
     new ProcessCompiler(loader, sub, definitions)
   }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
@@ -131,8 +131,12 @@ object node {
     override val componentId = ref.typ
   }
 
-  case class SubprocessInput(id: String, ref: SubprocessRef,
-                             additionalFields: Option[UserDefinedAdditionalNodeFields] = None, isDisabled: Option[Boolean] = None) extends OneOutputSubsequentNodeData with EndingNodeData with WithComponent  with Disableable{
+  // TODO: A better way of passing information regarding subprocess parameter definition
+  case class SubprocessInput(id: String,
+                             ref: SubprocessRef,
+                             additionalFields: Option[UserDefinedAdditionalNodeFields] = None,
+                             isDisabled: Option[Boolean] = None,
+                             subprocessParams: Option[List[SubprocessParameter]] = None) extends OneOutputSubsequentNodeData with EndingNodeData with WithComponent  with Disableable{
     override val componentId = ref.id
   }
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/SubprocessResolverSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/SubprocessResolverSpec.scala
@@ -30,9 +30,11 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
       .subprocessOneOut("sub2", "subProcess1", "output", "ala" -> "'makota'")
       .emptySink("sink", "sink1"))
 
+    val suprocessParameters = List(SubprocessParameter("ala", SubprocessClazzRef[String]))
+
     val subprocess =  CanonicalProcess(MetaData("subProcess1", StreamMetaData()), null,
       List(
-        canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
+        canonicalnode.FlatNode(SubprocessInputDefinition("start", suprocessParameters)),
         canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "output"))) , None
     )
 
@@ -44,6 +46,8 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
     resolved.nodes.filter(_.isInstanceOf[Subprocess]) shouldBe 'empty
     resolved.nodes.find(_.id == "f1") shouldBe 'empty
     resolved.nodes.find(_.id == "sub-f1") shouldBe 'defined
+    resolved.nodes.find(_.id == "sub").get.data should matchPattern { case SubprocessInput(_, _, _, _, Some(subprocessParameters)) => }
+    resolved.nodes.find(_.id == "sub").get.data
     resolved.nodes.find(_.id == "sub2-f1") shouldBe 'defined
 
 
@@ -222,7 +226,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
           case e => fail(e.toString)
         }
         flatNodes(1) match {
-          case FlatNode(SubprocessInput(id, _, _, _)) =>
+          case FlatNode(SubprocessInput(id, _, _, _, _)) =>
             id shouldBe "sub"
           case e => fail(e.toString)
         }

--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/validated/ValidatedSyntax.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/validated/ValidatedSyntax.scala
@@ -10,9 +10,6 @@ class ValidatedSyntax[Err] {
   implicit val nelSemigroup: Semigroup[NonEmptyList[Err]] =
     SemigroupK[NonEmptyList].algebra[Err]
 
-  // Using Cartesian syntax causes IntelliJ idea errors
-  val A = Applicative[({type V[B] = ValidatedNel[Err, B]})#V]
-
   // Using travers syntax causes IntelliJ idea errors
   implicit class ValidationTraverseOps[T[_]: Traverse, B](traverse: T[ValidatedNel[Err, B]]) {
     def sequence: ValidatedNel[Err, T[B]] =

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
@@ -216,7 +216,7 @@ abstract class DBFetchingProcessRepository[F[_]](val dbConfig: DbConfig) extends
     : Map[String, LocalDateTime] = {
 
     val allSubprocesses = process.nodes.collect {
-      case SubprocessInput(_, SubprocessRef(subprocessId, _), _,_) => subprocessId
+      case SubprocessInput(_, SubprocessRef(subprocessId, _), _,_, _) => subprocessId
     }.toSet
     val floatingVersionSubprocesses = allSubprocesses -- process.metaData.subprocessVersions.keySet
     floatingVersionSubprocesses.flatMap(id => subprocessesVersions.get(ProcessName(id)).map((id, _))).toMap

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/util/PdfExporter.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/util/PdfExporter.scala
@@ -189,7 +189,7 @@ object PdfExporter extends LazyLogging {
       case Processor(_, ServiceRef(typ, params), _, _) => ("Type", typ) :: params.map(p => (p.name, p.expression.expression))
       case Sink(_, SinkRef(typ, params), output, _, _) => ("Type", typ) :: output.map(expr => ("Output", expr.expression)).toList ++ params.map(p => (p.name, p.expression.expression))
       case CustomNode(_, output, typ, params, _) => ("Type", typ) :: ("Output", output) :: params.map(p => (p.name, p.expression.expression))
-      case SubprocessInput(_, SubprocessRef(typ, params), _, _) => ("Type", typ) :: params.map(p => (p.name, p.expression.expression))
+      case SubprocessInput(_, SubprocessRef(typ, params), _, _, _) => ("Type", typ) :: params.map(p => (p.name, p.expression.expression))
       //TODO: variable, variable builder,
       case _ => List()
     }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/PrettyValidationErrors.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/PrettyValidationErrors.scala
@@ -17,6 +17,8 @@ object PrettyValidationErrors {
     error match {
       case ExpressionParseError(message, _, fieldName, _) => node(s"Failed to parse expression: $message",
         s"There is problem with expression in field $fieldName - it could not be parsed.", fieldName = fieldName)
+      case SubprocessParamClassLoadError(fieldName, typ, nodeId) =>
+        node("Ivalid parameter type.", s"Failed to load ${typ.refClazzName}", fieldName = Some(fieldName))
       case DuplicatedNodeIds(ids) => node(s"Duplicate node ids: ${ids.mkString(", ")}", "Two nodes cannot have same id", errorType = NodeValidationErrorType.RenderNotAllowed)
       case EmptyProcess => node("Empty process", "Process is empty, please add some nodes")
       case InvalidRootNode(_) => node("Invalid root node", "Process can start only from source node")

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.ConfigFactory
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.{DeploymentId, ProcessDeploymentData, ProcessState, RunningState}
 import pl.touk.nussknacker.engine.api.process.ProcessName
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.management.{FlinkProcessManager, FlinkProcessManagerProvider}
 import pl.touk.nussknacker.ui.api.RouteWithUser
 import pl.touk.nussknacker.ui.api.helpers.TestPermissions.CategorizedPermission
@@ -27,7 +28,7 @@ object TestFactory extends TestPermissions{
   val testCategory:CategorizedPermission= Map(testCategoryName -> Set.empty)
   val testEnvironment = "test"
 
-  val sampleSubprocessRepository = SampleSubprocessRepository
+  val sampleSubprocessRepository = new SampleSubprocessRepository(Set(ProcessTestData.sampleSubprocess))
   val sampleResolver = new SubprocessResolver(sampleSubprocessRepository)
 
   val processValidation = new ProcessValidation(
@@ -118,11 +119,8 @@ object TestFactory extends TestPermissions{
     override protected def runProgram(processName: ProcessName, mainClass: String, args: List[String], savepointPath: Option[String]): Future[Unit] = ???
   }
 
-  object SampleSubprocessRepository extends SubprocessRepository {
-    val subprocesses = Set(ProcessTestData.sampleSubprocess)
-
-    override def loadSubprocesses(versions: Map[String, Long]): Set[SubprocessDetails] = {
+  class SampleSubprocessRepository(subprocesses: Set[CanonicalProcess]) extends SubprocessRepository {
+    override def loadSubprocesses(versions: Map[String, Long]): Set[SubprocessDetails] =
       subprocesses.map(c => SubprocessDetails(c, testCategoryName))
-    }
   }
 }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/TestMigrations.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/TestMigrations.scala
@@ -104,7 +104,7 @@ class TestMigrations(migrationsToAdd:Int*) extends ProcessMigrations {
       case sub@SubprocessInputDefinition(_, subParams, _) if !subParams.exists(_.name == "param42") && subParams.exists(_.name == "param1") =>
         sub.copy(parameters = sub.parameters.map(p => if (p.name == "param1") p.copy(name = "param42") else p))
 
-      case sub@SubprocessInput(_, ref, _,_) if !ref.parameters.exists(_.name == "param42") && ref.parameters.exists(_.name == "param1") =>
+      case sub@SubprocessInput(_, ref, _,_, _) if !ref.parameters.exists(_.name == "param42") && ref.parameters.exists(_.name == "param1") =>
         sub.copy(ref = sub.ref.copy(parameters = sub.ref.parameters.map(p => if (p.name == "param1") p.copy(name = "param42") else p)))
     }
   }


### PR DESCRIPTION
Currently we are not validating input parameters of a subprocess. We are mapping them to `typed.Unknown`
In this change `SubprocessResolver` enriches `SubprocessInput` with suprocess typing input definition, so it can be validated in `PartSubGraphCompiler`.