### PR TITLE
Configuring queryable state from Flink configuration only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -584,7 +584,7 @@ lazy val queryableState = (project in engine("queryableState")).
         "com.typesafe" % "config" % configV
       )
     }
-  ).dependsOn(api)
+  ).dependsOn(api, interpreter)
 
 
 

--- a/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/QueryableStateTest.scala
+++ b/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/QueryableStateTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.api.{JobData, ProcessVersion}
 import pl.touk.nussknacker.engine.build.EspProcessBuilder
-import pl.touk.nussknacker.engine.flink.queryablestate.EspQueryableClient
+import pl.touk.nussknacker.engine.flink.queryablestate.FlinkQueryableClient
 import pl.touk.nussknacker.engine.flink.test.{FlinkTestConfiguration, StoppableExecutionEnvironment}
 import pl.touk.nussknacker.engine.kafka.{KafkaSpec, KafkaZookeeperServer}
 import pl.touk.nussknacker.engine.management.sample.TestProcessConfigCreator
@@ -62,7 +62,7 @@ class QueryableStateTest extends FlatSpec with BeforeAndAfterAll with Matchers w
     val jobId = env.execute().getJobID.toString
     //this port should not exist...
     val strangePort = 12345
-    val client = EspQueryableClient(s"localhost:$strangePort, localhost:$QueryStateProxyPortLow")
+    val client = FlinkQueryableClient(s"localhost:$strangePort, localhost:$QueryStateProxyPortLow")
 
 
     def queryState(jobId: String): Future[Boolean] =

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/ProcessManagerProvider.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/ProcessManagerProvider.scala
@@ -5,26 +5,27 @@ import java.net.URL
 import com.typesafe.config.Config
 import pl.touk.nussknacker.engine.api.TypeSpecificData
 import pl.touk.nussknacker.engine.api.deployment.ProcessManager
+import pl.touk.nussknacker.engine.queryablestate.QueryableClient
 
 
 trait ProcessManagerProvider {
-
   def createProcessManager(modelData: ModelData, config: Config): ProcessManager
+
+  def createQueryableClient(config: Config): Option[QueryableClient]
 
   def name: String
 
   def emptyProcessMetadata(isSubprocess: Boolean): TypeSpecificData
 
   def supportsSignals: Boolean
-
-  def supportsQueryableState: Boolean
-
 }
 
 
 case class ProcessingTypeData(processManager: ProcessManager,
                               modelData: ModelData,
-                              emptyProcessCreate: Boolean => TypeSpecificData)
+                              emptyProcessCreate: Boolean => TypeSpecificData,
+                              queryableClient: Option[QueryableClient],
+                              supportsSignals: Boolean)
 
 case class ProcessingTypeConfig(engineType: String,
                                 classPath: List[URL],
@@ -43,8 +44,12 @@ object ProcessingTypeData {
     val ProcessingTypeConfig(_, classPathConfig, managerConfig, processConfig) = processTypeConfig
     val modelData = ModelData(processConfig, classPathConfig)
     val manager = processManagerProvider.createProcessManager(modelData, managerConfig)
-    ProcessingTypeData(manager, modelData, processManagerProvider.emptyProcessMetadata)
+    val queryableClient = processManagerProvider.createQueryableClient(managerConfig)
+    ProcessingTypeData(
+      manager,
+      modelData,
+      processManagerProvider.emptyProcessMetadata,
+      queryableClient,
+      processManagerProvider.supportsSignals)
   }
-
-
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/queryablestate/QueryableClient.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/queryablestate/QueryableClient.scala
@@ -1,0 +1,8 @@
+package pl.touk.nussknacker.engine.queryablestate
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait QueryableClient {
+  def fetchJsonState(taskId: String, queryName: String, key: String)(implicit ec: ExecutionContext): Future[String]
+  def fetchJsonState(taskId: String, queryName: String)(implicit ec: ExecutionContext): Future[String]
+}

--- a/engine/queryableState/src/main/scala/pl/touk/nussknacker/engine/flink/queryablestate/FlinkQueryableClient.scala
+++ b/engine/queryableState/src/main/scala/pl/touk/nussknacker/engine/flink/queryablestate/FlinkQueryableClient.scala
@@ -7,14 +7,14 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.queryablestate.client.QueryableStateClient
 import org.apache.flink.streaming.api.scala._
 import pl.touk.nussknacker.engine.api.QueryableState
+import pl.touk.nussknacker.engine.queryablestate.QueryableClient
 
 import scala.compat.java8.FutureConverters
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-object EspQueryableClient {
-
-  def apply(queryableStateProxyUrl: String): EspQueryableClient = {
+object FlinkQueryableClient {
+  def apply(queryableStateProxyUrl: String): FlinkQueryableClient = {
 
     //TODO: this is workaround for https://issues.apache.org/jira/browse/FLINK-10225, we want to be able to configure all task managers
     val queryableStateProxyUrls = queryableStateProxyUrl.split(",").toList
@@ -22,7 +22,7 @@ object EspQueryableClient {
       val (queryableStateProxyHost, queryableStateProxyPort) = parseHostAndPort(url.trim)
       new QueryableStateClient(queryableStateProxyHost, queryableStateProxyPort)
     }
-    new EspQueryableClient(clients)
+    new FlinkQueryableClient(clients)
   }
 
   private def parseHostAndPort(url: String): (String, Int) = {
@@ -31,10 +31,9 @@ object EspQueryableClient {
       throw new IllegalArgumentException("Should by in host:port format")
     (parts(0), parts(1).toInt)
   }
-
 }
 
-class EspQueryableClient(clients: List[QueryableStateClient]) extends LazyLogging {
+class FlinkQueryableClient(clients: List[QueryableStateClient]) extends QueryableClient with LazyLogging {
 
   def fetchState[V: TypeInformation](jobId: String, queryName: String, key: String)
                                     (implicit ec: ExecutionContext): Future[V] = {

--- a/engine/queryableState/src/main/scala/pl/touk/nussknacker/engine/flink/queryablestate/QueryableClientProvider.scala
+++ b/engine/queryableState/src/main/scala/pl/touk/nussknacker/engine/flink/queryablestate/QueryableClientProvider.scala
@@ -1,5 +1,0 @@
-package pl.touk.nussknacker.engine.flink.queryablestate
-
-trait QueryableClientProvider {
-  def queryableClient: EspQueryableClient
-}

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -22,6 +22,7 @@ import pl.touk.nussknacker.engine.definition._
 import pl.touk.nussknacker.engine.graph.EspProcess
 import pl.touk.nussknacker.engine.graph.node.Source
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
+import pl.touk.nussknacker.engine.queryablestate.QueryableClient
 import pl.touk.nussknacker.engine.standalone.StandaloneProcessInterpreter
 import pl.touk.nussknacker.engine.standalone.api.DeploymentData
 import pl.touk.nussknacker.engine.standalone.api.types._
@@ -200,13 +201,13 @@ class StandaloneProcessManagerProvider extends ProcessManagerProvider {
   override def createProcessManager(modelData: ModelData, config: Config): ProcessManager
     = StandaloneProcessManager(modelData, config)
 
+  override def createQueryableClient(config: Config): Option[QueryableClient] = None
+
   override def name: String = "requestResponseStandalone"
 
   override def emptyProcessMetadata(isSubprocess: Boolean): TypeSpecificData = StandaloneMetaData(None)
 
   override def supportsSignals: Boolean = false
-
-  override def supportsQueryableState: Boolean = false
 }
 
 object StandaloneProcessManagerProvider {

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/config/FeatureTogglesConfig.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/config/FeatureTogglesConfig.scala
@@ -15,9 +15,7 @@ case class FeatureTogglesConfig(development: Boolean,
                                 environmentAlert:Option[EnvironmentAlert],
                                 commentSettings: Option[CommentSettings],
                                 deploySettings: Option[DeploySettings],
-                                attachments: Option[String],
-                                queryableStateProxyUrl: Option[String]
-)
+                                attachments: Option[String])
 
 object FeatureTogglesConfig extends LazyLogging{
   import argonaut.ArgonautShapeless._
@@ -39,8 +37,6 @@ object FeatureTogglesConfig extends LazyLogging{
     val commentSettings = parseOptionalConfig[CommentSettings](config, "commentSettings")
     val deploySettings = parseOptionalConfig[DeploySettings](config, "deploySettings")
     val attachments = parseOptionalConfig[String](config, "attachmentsPath")
-    //TODO: unnecessary duplication?
-    val queryableStateProxyUrl = parseOptionalConfig[String](config, "flinkConfig.queryableStateProxyUrl")
 
     FeatureTogglesConfig(
       development = isDevelopmentMode,
@@ -52,8 +48,7 @@ object FeatureTogglesConfig extends LazyLogging{
       commentSettings = commentSettings,
       deploySettings = deploySettings,
       environmentAlert = environmentAlert,
-      attachments = attachments,
-      queryableStateProxyUrl = queryableStateProxyUrl
+      attachments = attachments
     )
   }
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
@@ -143,7 +143,7 @@ class ManagementActor(environment: String, managers: Map[ProcessingType, Process
 
   private def deployProcess(processId: ProcessId, savepointPath: Option[String], comment: Option[String])(implicit user: LoggedUser): Future[Unit] = {
     for {
-      processingType <- getProcessingType(processId)
+      processingType <- processRepository.fetchProcessingType(processId)
       latestProcessEntity <- processRepository.fetchLatestProcessVersion(processId)
       result <- latestProcessEntity match {
         case Some(latestVersion) => deployAndSaveProcess(processingType, latestVersion, savepointPath, comment)
@@ -182,13 +182,7 @@ class ManagementActor(environment: String, managers: Map[ProcessingType, Process
   }
 
   private def processManager(processId: ProcessId)(implicit ec: ExecutionContext, user: LoggedUser) = {
-    getProcessingType(processId).map(managers)
-  }
-
-  private def getProcessingType(id: ProcessId)(implicit ec: ExecutionContext, user: LoggedUser) = {
-    processRepository.fetchLatestProcessDetailsForProcessId(id)
-      .map(_.map(_.processingType))
-      .map(_.getOrElse(throw new RuntimeException(ProcessNotFoundError(id.value.toString).getMessage)))
+    processRepository.fetchProcessingType(processId).map(managers)
   }
 
   //during deployment using Client.run Flink holds some data in statics and there is an exception when

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.ui.process.repository
 
+import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.restmodel.process.ProcessId
 import pl.touk.nussknacker.restmodel.processdetails.{DeploymentHistoryEntry, ProcessDetails}
@@ -46,4 +47,6 @@ trait FetchingProcessRepository {
   def fetchProcessName(processId: ProcessId)(implicit ec: ExecutionContext): Future[Option[ProcessName]]
 
   def fetchDeploymentHistory(processId: ProcessId)(implicit ec: ExecutionContext): Future[List[DeploymentHistoryEntry]]
+
+  def fetchProcessingType(processId: ProcessId)(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[ProcessingType]
 }


### PR DESCRIPTION
There is a misleading configuration option `flinkConfig.queryableStateProxyUrl` that is now being used for determining cluster location for querying jobs' state. It is also invalid to use it as different processing types might refer to different cluster locations. This change removes this legacy configuration and uses already defined, but not used `processTypes.[...].queryableStateProxyUrl`