### PR TITLE
Log unhandled API errors

### DIFF
--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/EspErrorToHttp.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/EspErrorToHttp.scala
@@ -12,6 +12,7 @@ import pl.touk.http.argonaut.Argonaut62Support
 import pl.touk.nussknacker.ui.validation.FatalValidationError
 
 import scala.language.implicitConversions
+import scala.util.control.NonFatal
 
 object EspErrorToHttp extends LazyLogging with Argonaut62Support {
 
@@ -42,7 +43,7 @@ object EspErrorToHttp extends LazyLogging with Argonaut62Support {
   def espErrorHandler: ExceptionHandler = {
     import akka.http.scaladsl.server.Directives._
     ExceptionHandler {
-      case e: EspError => complete(errorToHttp(e))
+      case NonFatal(e) => complete(errorToHttp(e))
     }
   }
 


### PR DESCRIPTION
Unhandled errors are silently swallowed what makes debugging harder. In this PR behaviour is changed to log all unexpected errors with a stacktrace.