### PR TITLE
Properties variable

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/MetaData.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/MetaData.scala
@@ -2,21 +2,37 @@ package pl.touk.nussknacker.engine.api
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration.Duration
+import argonaut.Argonaut.{jdecode3L, jencode3L}
+import argonaut.{DecodeJson, EncodeJson}
 
-// TODO: remove this trait and duplicated ProcessAdditionalFields and Group in restmodel module.
-trait UserDefinedProcessAdditionalFields
+import scala.concurrent.duration.Duration
 
 case class ProcessAdditionalFields(description: Option[String],
                                    groups: Set[Group],
-                                   properties: Map[String, String]) extends UserDefinedProcessAdditionalFields
+                                   properties: Map[String, String])
+
+object ProcessAdditionalFields {
+  import argonaut.ArgonautShapeless._
+
+  implicit val decoder: DecodeJson[ProcessAdditionalFields] = {
+    // this is needed for parsing json that does not have groups or properties fields
+    jdecode3L((description: Option[String], groups: Option[Set[Group]], properties: Option[Map[String, String]]) =>
+      ProcessAdditionalFields(description, groups.getOrElse(Set.empty), properties.getOrElse(Map.empty))
+    )("description", "groups", "properties").map(identity[ProcessAdditionalFields])
+  }
+
+  implicit val encoder: EncodeJson[ProcessAdditionalFields] = {
+    EncodeJson.derive[ProcessAdditionalFields]
+  }
+}
+
 case class Group(id: String, nodes: Set[String])
 
 // todo: MetaData should hold ProcessName as id
 case class MetaData(id: String,
                     typeSpecificData: TypeSpecificData,
                     isSubprocess: Boolean = false,
-                    additionalFields: Option[UserDefinedProcessAdditionalFields] = None,
+                    additionalFields: Option[ProcessAdditionalFields] = None,
                     subprocessVersions: Map[String, Long] = Map.empty)
 
 sealed trait TypeSpecificData {

--- a/engine/httpUtils/src/main/scala/pl/touk/nussknacker/engine/dispatch/LoggingHandler.scala
+++ b/engine/httpUtils/src/main/scala/pl/touk/nussknacker/engine/dispatch/LoggingHandler.scala
@@ -22,19 +22,19 @@ private class LoggingHandler[T] (handler: AsyncHandler[T], logger: Logger, id: S
   override def onStatusReceived(responseStatus: HttpResponseStatus): AsyncHandler.State = {
     val message = s"[$id]" +
       s" status code: ${responseStatus.getStatusCode}" +
-      s" status rext: ${responseStatus.getStatusText}"
+      s" status text: ${responseStatus.getStatusText}"
     logger.debug(message)
     handler.onStatusReceived(responseStatus)
   }
 
   override def onCompleted(): T = {
     val result = handler.onCompleted()
-    logger.debug(s"[$id] recived object: $result")
+    logger.debug(s"[$id] received object: $result")
     result
   }
 
   override def onThrowable(t: Throwable): Unit = {
-    logger.error(s"[$id] request casued error", t)
+    logger.error(s"[$id] request caused error", t)
     handler.onThrowable(t)
   }
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/MetaVariables.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/MetaVariables.scala
@@ -1,3 +1,0 @@
-package pl.touk.nussknacker.engine
-
-final case class MetaVariables(processName: String)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/build/EspProcessBuilder.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/build/EspProcessBuilder.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.build
 
 import cats.data.NonEmptyList
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.{MetaData, StandaloneMetaData, StreamMetaData, UserDefinedProcessAdditionalFields}
+import pl.touk.nussknacker.engine.api.{Group, MetaData, ProcessAdditionalFields, StandaloneMetaData, StreamMetaData}
 import pl.touk.nussknacker.engine.build.GraphBuilder.Creator
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
 import pl.touk.nussknacker.engine.graph.expression.Expression
@@ -21,8 +21,12 @@ class ProcessMetaDataBuilder private[build](metaData: MetaData) {
   def subprocessVersions(subprocessVersions: Map[String, Long]) =
     new ProcessMetaDataBuilder(metaData.copy(subprocessVersions = subprocessVersions))
 
-  def additionalFields(userDefinedProcessAdditionalFields: UserDefinedProcessAdditionalFields) =
-    new ProcessMetaDataBuilder(metaData.copy(additionalFields = Some(userDefinedProcessAdditionalFields)))
+  def additionalFields(description: Option[String] = None,
+                       groups: Set[Group] = Set.empty,
+                       properties: Map[String, String] = Map.empty) =
+    new ProcessMetaDataBuilder(metaData.copy(
+      additionalFields = Some(ProcessAdditionalFields(description, groups, properties)))
+    )
 
   def exceptionHandler(params: (String, Expression)*) =
     new ProcessExceptionHandlerBuilder(ExceptionHandlerRef(params.map(evaluatedparam.Parameter.tupled).toList))

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
@@ -1,8 +1,6 @@
 package pl.touk.nussknacker.engine.expression
 
-import cats.Now
 import cats.effect.IO
-import pl.touk.nussknacker.engine.{Interpreter, MetaVariables}
 import pl.touk.nussknacker.engine.api.lazyy.{LazyContext, LazyValuesProvider}
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors.NodeContext
 import pl.touk.nussknacker.engine.api.{Context, MetaData, ProcessListener, ValueWithContext}
@@ -10,6 +8,7 @@ import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
 import pl.touk.nussknacker.engine.compiledgraph.expression.Expression
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectWithMethodDef
 import pl.touk.nussknacker.engine.definition.ServiceInvoker
+import pl.touk.nussknacker.engine.variables.MetaVariables
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -81,8 +80,10 @@ class ExpressionEvaluator(globalVariables: Map[String, Any],
   def evaluate[R](expr: Expression, expressionId: String, nodeId: String, ctx: Context)
                          (implicit ec: ExecutionContext, metaData: MetaData): Future[ValueWithContext[R]] = {
     val lazyValuesProvider = lazyValuesProviderCreator(ec, metaData, nodeId)
-    val ctxWithGlobals = ctx.withVariables(globalVariables).withVariable(Interpreter.MetaParamName, MetaVariables(metaData.id))
-    expr.evaluate[R](ctxWithGlobals, lazyValuesProvider).map { valueWithLazyContext =>
+    val ctxWithGlobals = ctx.withVariables(globalVariables)
+    val ctxWithMeta = MetaVariables.withVariable(ctxWithGlobals)
+
+    expr.evaluate[R](ctxWithMeta, lazyValuesProvider).map { valueWithLazyContext =>
       listeners.foreach(_.expressionEvaluated(nodeId, expressionId, expr.original, ctx, metaData, valueWithLazyContext.value))
       ValueWithContext(valueWithLazyContext.value, ctx.withLazyContext(valueWithLazyContext.lazyContext))
     }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/marshall/ProcessMarshaller.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/marshall/ProcessMarshaller.scala
@@ -17,7 +17,7 @@ import scala.reflect.ClassTag
 
 class ProcessMarshaller(implicit
                         additionalNodeDataFieldsCodec: CodecJson[Option[node.UserDefinedAdditionalNodeFields]] = ProcessMarshaller.additionalNodeDataFieldsCodec,
-                        additionalProcessFieldsCodec: CodecJson[Option[UserDefinedProcessAdditionalFields]] = ProcessMarshaller.additionalProcessFieldsCodec ) {
+                        additionalProcessFieldsCodec: CodecJson[Option[ProcessAdditionalFields]] = ProcessMarshaller.additionalProcessFieldsCodec ) {
 
   //TODO: UI needs it - unfortunately there were some argonaut/compile issues...
   val typeSpecificEncoder =  CodecJson.derived[TypeSpecificData]
@@ -127,15 +127,8 @@ object ProcessMarshaller {
   val additionalNodeDataFieldsCodec: CodecJson[Option[UserDefinedAdditionalNodeFields]] =
     derivedTypeOrNoneCodec[UserDefinedAdditionalNodeFields, NodeAdditionalFields]
 
-  val additionalProcessFieldsCodec: CodecJson[Option[UserDefinedProcessAdditionalFields]] = {
-    val derivedCodec = derivedTypeOrNoneCodec[UserDefinedProcessAdditionalFields, ProcessAdditionalFields]
-    val processAdditionalFieldsDecode = jdecode3L((description: Option[String], groups: Option[Set[Group]], properties: Option[Map[String, String]]) =>
-      ProcessAdditionalFields(description, groups.getOrElse(Set.empty), properties.getOrElse(Map.empty)))("description", "groups", "properties")
-      .map(identity[UserDefinedProcessAdditionalFields])
-    CodecJson.derived(
-      derivedCodec.Encoder,
-      OptionDecodeJson(processAdditionalFieldsDecode)
-    )
+  val additionalProcessFieldsCodec: CodecJson[Option[ProcessAdditionalFields]] = {
+    CodecJson.derived[Option[ProcessAdditionalFields]]
   }
 
   private def derivedTypeOrNoneCodec[Base, Derived <: Base : ClassTag](implicit

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/TypesInformationExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/TypesInformationExtractor.scala
@@ -1,12 +1,12 @@
 package pl.touk.nussknacker.engine.types
 
 import org.apache.commons.lang3.ClassUtils
-import pl.touk.nussknacker.engine.MetaVariables
 import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
 import pl.touk.nussknacker.engine.api.typed.ClazzRef
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypedObjectTypingResult, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.definition.TypeInfos.{ClazzDefinition, MethodInfo}
 import pl.touk.nussknacker.engine.types.EspTypeUtils.clazzDefinition
+import pl.touk.nussknacker.engine.variables.MetaVariables
 
 object TypesInformationExtractor {
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/variables/MetaVariables.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/variables/MetaVariables.scala
@@ -1,0 +1,32 @@
+package pl.touk.nussknacker.engine.variables
+
+import pl.touk.nussknacker.engine.Interpreter
+import pl.touk.nussknacker.engine.api.typed.{ClazzRef, TypedMap, TypedObjectDefinition}
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult, TypingResult}
+import pl.touk.nussknacker.engine.api.{Context, MetaData}
+
+final case class MetaVariables(processName: String, properties: TypedMap)
+
+object MetaVariables {
+  def withVariable(ctx: Context)(implicit metaData: MetaData): Context = {
+    ctx.withVariable(Interpreter.MetaParamName, MetaVariables(metaData.id, properties(metaData)))
+  }
+
+  def typingResult(metaData: MetaData): TypingResult = TypedObjectTypingResult(Map(
+    "processName" -> Typed[String],
+    "properties" -> propertiesType(metaData)
+  ))
+
+  def withType(types: Map[String, TypingResult])(implicit metaData: MetaData): Map[String, TypingResult] = {
+    types + (Interpreter.MetaParamName -> typingResult(metaData))
+  }
+
+  private def properties(meta: MetaData): TypedMap = {
+    TypedMap(meta.additionalFields.map(_.properties).getOrElse(Map.empty))
+  }
+
+  private def propertiesType(metaData: MetaData) = {
+    val definedProperties = metaData.additionalFields.map(_.properties).getOrElse(Map.empty)
+    TypedObjectTypingResult(TypedObjectDefinition(definedProperties.mapValues(_ => ClazzRef[String])))
+  }
+}

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -30,6 +30,7 @@ import pl.touk.nussknacker.engine.types.TypesInformationExtractor
 import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder._
 import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder.ObjectProcessDefinition
 import pl.touk.nussknacker.engine.util.typing.TypingUtils
+import pl.touk.nussknacker.engine.variables.MetaVariables
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -95,14 +96,14 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
     }
 
     compilationResult.variablesInNodes shouldBe Map(
-      "id1" -> Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
-      "filter1" -> Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
-      "filter2" -> Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
-      "filter3" -> Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
-      "sampleProcessor1" -> Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
-      "sampleProcessor2" -> Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
-      "bv1" -> Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)), "out" -> Typed[SimpleRecord]),
-      "id2" -> Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)), "out" -> Typed[SimpleRecord],
+      "id1" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
+      "filter1" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
+      "filter2" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
+      "filter3" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
+      "sampleProcessor1" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
+      "sampleProcessor2" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
+      "bv1" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)), "out" -> Typed[SimpleRecord]),
+      "id2" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)), "out" -> Typed[SimpleRecord],
         "vars" -> TypedObjectTypingResult(Map(
           "v1" -> Typed[Integer],
           "mapVariable" -> TypedObjectTypingResult(Map("Field1" -> Typed[String], "Field2" -> Typed[String], "Field3" -> Typed[BigDecimal])),
@@ -181,7 +182,7 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
     }
     compilationResult.variablesInNodes("sink") shouldBe Map(
       "input" -> Typed[SimpleRecord],
-      "meta" -> Typed[MetaVariables],
+      "meta" -> MetaVariables.typingResult(processWithRefToMissingService.metaData),
       "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)),
       "event" -> Typed[SimpleRecord]
     )
@@ -228,7 +229,7 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
     }
     compilationResult.variablesInNodes("id2") shouldBe Map(
       "input" -> Unknown,
-      "meta" -> Typed[MetaVariables],
+      "meta" -> MetaVariables.typingResult(processWithRefToMissingService.metaData),
       "simpleVar" -> Typed[String]
     )
 
@@ -329,8 +330,8 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
     compilationResult.result should matchPattern {
       case Invalid(NonEmptyList(ExpressionParseError("There is no property 'value3' in type 'pl.touk.nussknacker.engine.compile.ProcessValidatorSpec$AnotherSimpleRecord'", "sampleFilter2", None, _), _)) =>
     }
-    compilationResult.variablesInNodes("id2") shouldBe Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)))
-    compilationResult.variablesInNodes("id3") shouldBe Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)))
+    compilationResult.variablesInNodes("id2") shouldBe Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(process.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)))
+    compilationResult.variablesInNodes("id3") shouldBe Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(process.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)))
   }
 
   test("validate custom node return type") {
@@ -456,7 +457,7 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
     compilationResult.result should matchPattern {
       case Invalid(NonEmptyList(OverwrittenVariable("var1", "var1overwrite"), _)) =>
     }
-    compilationResult.variablesInNodes("id2") shouldBe Map("input" -> Typed[SimpleRecord], "meta" -> Typed[MetaVariables], "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)), "var1" -> Typed[String])
+    compilationResult.variablesInNodes("id2") shouldBe Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(process.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)), "var1" -> Typed[String])
   }
 
   test("not allow to overwrite variable by switch node") {
@@ -543,13 +544,13 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
     }
     compilationResult.variablesInNodes("id2") shouldBe Map(
       "input" -> Typed[SimpleRecord],
-      "meta" -> Typed[MetaVariables],
+      "meta" -> MetaVariables.typingResult(process.metaData),
       "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)),
       "var2" -> Typed[String],
       "var3" -> Typed[String])
     compilationResult.variablesInNodes("id3") shouldBe Map(
       "input" -> Typed[SimpleRecord],
-      "meta" -> Typed[MetaVariables],
+      "meta" -> MetaVariables.typingResult(process.metaData),
       "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass)),
       "var2" -> Typed[String],
       "var3" -> Typed(ClazzRef[Int])
@@ -726,6 +727,21 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
         .exceptionHandler()
         .source("id1", "source")
         .emptySink("sinkWithLazyParam","sinkWithLazyParam", "lazyString" -> "#input.toString()")
+
+    validate(process, baseDefinition).result should matchPattern {
+      case Valid(_) =>
+    }
+  }
+
+  test("allow using process properties via meta.properties") {
+    val process =
+      EspProcessBuilder
+        .id("process1")
+        .additionalFields(properties = Map("property1" -> "value1"))
+        .exceptionHandler()
+        .source("id1", "source")
+        .buildSimpleVariable("var1", "var1", "#meta.properties.property1")
+        .emptySink("sink", "sink")
 
     validate(process, baseDefinition).result should matchPattern {
       case Valid(_) =>

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/marshall/ProcessMarshallerSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/marshall/ProcessMarshallerSpec.scala
@@ -71,7 +71,7 @@ class ProcessMarshallerSpec extends FlatSpec with Matchers with OptionValues wit
     forAll(processAdditionalFields) { additionalFields =>
       val process = EspProcessBuilder
         .id("process1")
-        .additionalFields(additionalFields)
+        .additionalFields(additionalFields.description, additionalFields.groups, additionalFields.properties)
         .exceptionHandler()
         .source("a", "")
         .processorEnd("d", "dService", "p1" -> "expr3")
@@ -131,26 +131,6 @@ class ProcessMarshallerSpec extends FlatSpec with Matchers with OptionValues wit
     }
   }
 
-  it should "not marshall custom process additional fields" in {
-    val process = EspProcessBuilder
-      .id("process1")
-      .additionalFields(TestProcessAdditionalFields(field1 = "abc", field2 = 3))
-      .exceptionHandler()
-      .source("a", "")
-      .processorEnd("d", "dService", "p1" -> "expr3")
-
-    val result = ProcessMarshaller.toJson(process, PrettyParams.spaces2)
-
-    result should include (
-      """
-        |  "metaData" : {
-        |    "id" : "process1",
-        |    "typeSpecificData" : {
-        |      "type" : "StreamMetaData"
-        |    }
-        |  },""".stripMargin)
-  }
-
   // TODO: There is no way to create a node with additional fields.
 
   it should "unmarshall and omit custom additional fields" in {
@@ -205,6 +185,4 @@ class ProcessMarshallerSpec extends FlatSpec with Matchers with OptionValues wit
       |    ]
       |}
     """.stripMargin
-
-  case class TestProcessAdditionalFields(field1: String, field2: Int) extends UserDefinedProcessAdditionalFields
 }

--- a/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/RestModelCodecs.scala
+++ b/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/RestModelCodecs.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.restmodel
 
 import argonaut.{EncodeJson, _}
 import argonaut.derive.{DerivedInstances, JsonSumCodec, JsonSumCodecFor, SingletonInstances}
-import pl.touk.nussknacker.engine.api.{TypeSpecificData, UserDefinedProcessAdditionalFields}
+import pl.touk.nussknacker.engine.api.{ProcessAdditionalFields, TypeSpecificData}
 import pl.touk.nussknacker.engine.api.typed.typing
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.definition.TestingCapabilities
@@ -12,7 +12,7 @@ import pl.touk.nussknacker.engine.graph.node.NodeData
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
 import pl.touk.nussknacker.engine.util.json.Codecs
 import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ProcessProperties, ValidatedDisplayableProcess}
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, EdgeType, NodeAdditionalFields, ProcessAdditionalFields}
+import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, EdgeType, NodeAdditionalFields}
 import pl.touk.nussknacker.restmodel.processdetails.{DeploymentAction, DeploymentHistoryEntry, ProcessDetails, ProcessHistoryEntry}
 import pl.touk.nussknacker.restmodel.validation.ValidationResults
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeValidationErrorType, ValidationResult}
@@ -38,9 +38,8 @@ trait RestModelCodecs extends Codecs with Argonauts with SingletonInstances with
       .asInstanceOf[CodecJson[Option[node.UserDefinedAdditionalNodeFields]]]
   }
 
-  implicit def processAdditionalFieldsOptCodec: CodecJson[Option[UserDefinedProcessAdditionalFields]] = {
-    CodecJson.derived[Option[ProcessAdditionalFields]]
-      .asInstanceOf[CodecJson[Option[UserDefinedProcessAdditionalFields]]]
+  implicit val processAdditionalFieldsOptCodec = {
+    ProcessMarshaller.additionalProcessFieldsCodec
   }
 
   implicit def testingCapabilitiesCodec: CodecJson[TestingCapabilities] = CodecJson.derive[TestingCapabilities]

--- a/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/displayedgraph/DisplayableProcess.scala
+++ b/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/displayedgraph/DisplayableProcess.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.restmodel.displayedgraph
 
-import pl.touk.nussknacker.engine.api.{MetaData, TypeSpecificData, UserDefinedProcessAdditionalFields}
+import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields, TypeSpecificData}
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
 import pl.touk.nussknacker.engine.graph.node.NodeData
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
@@ -57,6 +57,6 @@ case class ValidatedDisplayableProcess(id: String,
 case class ProcessProperties(typeSpecificProperties: TypeSpecificData,
                              exceptionHandler: ExceptionHandlerRef,
                              isSubprocess: Boolean = false,
-                             additionalFields: Option[UserDefinedProcessAdditionalFields] = None,
+                             additionalFields: Option[ProcessAdditionalFields] = None,
                              subprocessVersions: Map[String, Long]
                             )

--- a/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/displayedgraph/displayablenode.scala
+++ b/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/displayedgraph/displayablenode.scala
@@ -1,6 +1,5 @@
 package pl.touk.nussknacker.restmodel.displayedgraph
 
-import pl.touk.nussknacker.engine.api.UserDefinedProcessAdditionalFields
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.graph.node
 
@@ -19,10 +18,4 @@ object displayablenode {
 
   case class Edge(from: String, to: String, edgeType: Option[EdgeType])
   case class NodeAdditionalFields(description: Option[String]) extends node.UserDefinedAdditionalNodeFields
-  case class ProcessAdditionalFields(description: Option[String],
-                                     groups: Set[Group] = Set(),
-                                     properties: Map[String, String] = Map.empty) extends UserDefinedProcessAdditionalFields
-
-  case class Group(id: String, nodes: Set[String])
-
 }

--- a/ui/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/RestModelCodecsSpec.scala
+++ b/ui/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/RestModelCodecsSpec.scala
@@ -4,13 +4,13 @@ import java.time.LocalDateTime
 
 import org.scalatest.{FunSuite, Matchers}
 import argonaut.Argonaut._
-import pl.touk.nussknacker.engine.api.StreamMetaData
+import pl.touk.nussknacker.engine.api.{ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition.{SubprocessClazzRef, SubprocessParameter}
 import pl.touk.nussknacker.engine.graph.node.{CustomNode, SubprocessInputDefinition}
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, NodeAdditionalFields, ProcessAdditionalFields}
+import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, NodeAdditionalFields}
 import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ProcessProperties}
 import pl.touk.nussknacker.restmodel.processdetails.{DeploymentEntry, ProcessHistoryEntry}
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/NewProcessPreparer.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/NewProcessPreparer.scala
@@ -2,14 +2,13 @@ package pl.touk.nussknacker.ui.process
 
 import pl.touk.nussknacker.engine.ProcessingTypeData
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
-import pl.touk.nussknacker.engine.api.{MetaData, TypeSpecificData, UserDefinedProcessAdditionalFields}
+import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields, TypeSpecificData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectDefinition
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.ProcessDefinition
 import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
 import pl.touk.nussknacker.engine.graph.expression.Expression
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.ProcessAdditionalFields
 import pl.touk.nussknacker.ui.definition.AdditionalProcessProperty
 
 object NewProcessPreparer {
@@ -40,10 +39,10 @@ class NewProcessPreparer(definitions: Map[ProcessingType, ProcessDefinition[Obje
     emptyCanonical
   }
 
-  private def defaultAdditionalFields(processingType: ProcessingType): Option[UserDefinedProcessAdditionalFields] = {
+  private def defaultAdditionalFields(processingType: ProcessingType): Option[ProcessAdditionalFields] = {
     Option(defaultProperties(processingType))
       .filter(_.nonEmpty)
-      .map(properties => ProcessAdditionalFields(None, properties = properties))
+      .map(properties => ProcessAdditionalFields(None, Set.empty, properties = properties))
   }
 
   private def defaultProperties(processingType: ProcessingType): Map[String, String] = additionalFields(processingType)

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/processreport/ProcessCounter.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/processreport/ProcessCounter.scala
@@ -1,9 +1,9 @@
 package pl.touk.nussknacker.ui.processreport
 
+import pl.touk.nussknacker.engine.api.ProcessAdditionalFields
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode._
 import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.ProcessAdditionalFields
 import pl.touk.nussknacker.ui.process.subprocess.SubprocessRepository
 import shapeless.syntax.typeable._
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/AdditionalPropertiesValidator.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/AdditionalPropertiesValidator.scala
@@ -1,8 +1,8 @@
 package pl.touk.nussknacker.ui.validation
 
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
+import pl.touk.nussknacker.engine.api.ProcessAdditionalFields
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.ProcessAdditionalFields
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeValidationError, ValidationResult}
 import pl.touk.nussknacker.ui.definition.{AdditionalProcessProperty, PropertyType}
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/ProcessValidation.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/ProcessValidation.scala
@@ -5,10 +5,10 @@ import cats.data.Validated.{Invalid, Valid}
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
+import pl.touk.nussknacker.engine.api.ProcessAdditionalFields
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.compile.ProcessValidator
 import pl.touk.nussknacker.engine.graph.node.{Disableable, NodeData, Source, SubprocessInputDefinition}
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.ProcessAdditionalFields
 import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ValidatedDisplayableProcess}
 import pl.touk.nussknacker.restmodel.validation.CustomProcessValidator
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationResult

--- a/ui/server/src/test/scala/db/migration/V1_016__TypeSpecificMetaDataChangeSpec.scala
+++ b/ui/server/src/test/scala/db/migration/V1_016__TypeSpecificMetaDataChangeSpec.scala
@@ -2,8 +2,7 @@ package db.migration
 
 import argonaut.Parse
 import org.scalatest.{FlatSpec, Matchers}
-import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.ProcessAdditionalFields
+import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.ui.process.marshall.UiProcessMarshaller
 
 class V1_016__TypeSpecificMetaDataChangeSpec extends FlatSpec with Matchers {
@@ -20,6 +19,6 @@ class V1_016__TypeSpecificMetaDataChangeSpec extends FlatSpec with Matchers {
     val metaData = converted.map(_.metaData)
     
 
-    metaData shouldBe Some(MetaData("DEFGH", StreamMetaData(parallelism = Some(3)), false, Some(ProcessAdditionalFields(None, Set()))))
+    metaData shouldBe Some(MetaData("DEFGH", StreamMetaData(parallelism = Some(3)), false, Some(ProcessAdditionalFields(None, Set(), Map.empty))))
   }
 }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesExportImportResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesExportImportResourcesSpec.scala
@@ -6,12 +6,11 @@ import argonaut.PrettyParams
 import org.scalatest._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Millis, Seconds, Span}
-import pl.touk.nussknacker.engine.api.StreamMetaData
+import pl.touk.nussknacker.engine.api.{ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.ui.api.helpers.{EspItTest, ProcessTestData}
 import pl.touk.nussknacker.ui.api.helpers.TestFactory._
 import pl.touk.nussknacker.ui.codec.UiCodecs._
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.ProcessAdditionalFields
 import pl.touk.nussknacker.ui.process.marshall.UiProcessMarshaller
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.ui.util.{FileUploadUtils, MultipartUtils}
@@ -56,7 +55,7 @@ class ProcessesExportImportResourcesSpec extends FlatSpec with ScalatestRouteTes
   it should "export process in new version" in {
     val description = "alamakota"
     val processToSave = ProcessTestData.sampleDisplayableProcess
-    val processWithDescription = processToSave.copy(properties = processToSave.properties.copy(additionalFields = Some(ProcessAdditionalFields(Some(description)))))
+    val processWithDescription = processToSave.copy(properties = processToSave.properties.copy(additionalFields = Some(ProcessAdditionalFields(Some(description), Set.empty, Map.empty))))
 
     saveProcess(processToSave) {
       status shouldEqual StatusCodes.OK

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -19,7 +19,7 @@ import pl.touk.nussknacker.ui.api.helpers._
 import pl.touk.nussknacker.ui.api.helpers.TestFactory._
 import pl.touk.nussknacker.ui.codec.UiCodecs
 import pl.touk.nussknacker.ui.process.ProcessToSave
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, ProcessAdditionalFields}
+import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.Edge
 import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ProcessProperties}
 import pl.touk.nussknacker.ui.process.marshall.{ProcessConverter, UiProcessMarshaller}
 import pl.touk.nussknacker.ui.process.repository.ProcessActivityRepository.ProcessActivity

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.ui.api.helpers
 import java.time.LocalDateTime
 
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
+import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.build.{EspProcessBuilder, GraphBuilder}
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.{FlatNode, SplitNode}
 import pl.touk.nussknacker.engine.canonicalgraph.{CanonicalProcess, canonicalnode}
@@ -20,7 +20,7 @@ import pl.touk.nussknacker.engine.spel
 import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder
 import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder._
 import pl.touk.nussknacker.restmodel.ProcessType
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, NodeAdditionalFields, ProcessAdditionalFields}
+import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, NodeAdditionalFields}
 import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ProcessProperties, ValidatedDisplayableProcess}
 import pl.touk.nussknacker.restmodel.processdetails.{BaseProcessDetails, ProcessDetails, ValidatedProcessDetails}
 import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
@@ -164,7 +164,7 @@ object ProcessTestData {
   val sampleDisplayableProcess = {
     DisplayableProcess(
       id = "fooProcess",
-      properties = ProcessProperties(StreamMetaData(Some(2)), ExceptionHandlerRef(List.empty), false, Some(ProcessAdditionalFields(Some("process description"))), subprocessVersions = Map.empty),
+      properties = ProcessProperties(StreamMetaData(Some(2)), ExceptionHandlerRef(List.empty), false, Some(ProcessAdditionalFields(Some("process description"), Set.empty, Map.empty)), subprocessVersions = Map.empty),
       nodes = List(
         node.Source(
           id = "sourceId",

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/codec/UiCodecsSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/codec/UiCodecsSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api
 import pl.touk.nussknacker.engine.api.deployment.TestProcess.TestResults
 import pl.touk.nussknacker.engine.api.typed.ClazzRef
-import pl.touk.nussknacker.engine.api.{Displayable, StreamMetaData}
+import pl.touk.nussknacker.engine.api.{Displayable, ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectDefinition
 import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
@@ -18,7 +18,7 @@ import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition.{Subproce
 import pl.touk.nussknacker.engine.graph.node.{CustomNode, Join, NodeData, Processor, SubprocessInputDefinition}
 import pl.touk.nussknacker.engine.graph.service.ServiceRef
 import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.EdgeType.SubprocessOutput
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, EdgeType, NodeAdditionalFields, ProcessAdditionalFields}
+import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, EdgeType, NodeAdditionalFields}
 import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ProcessProperties}
 import pl.touk.nussknacker.ui.definition._
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
@@ -2,9 +2,8 @@ package pl.touk.nussknacker.ui.process.marshall
 
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FunSuite, Matchers}
-import pl.touk.nussknacker.engine.MetaVariables
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
-import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
+import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.canonize.ProcessCanonizer
 import pl.touk.nussknacker.engine.compile.ProcessValidator
@@ -16,6 +15,7 @@ import pl.touk.nussknacker.engine.graph.node._
 import pl.touk.nussknacker.engine.graph.service.ServiceRef
 import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder
+import pl.touk.nussknacker.engine.variables.MetaVariables
 import pl.touk.nussknacker.ui.api.helpers.TestFactory.sampleResolver
 import pl.touk.nussknacker.ui.api.helpers.TestProcessingTypes
 import pl.touk.nussknacker.ui.validation.ProcessValidation
@@ -90,9 +90,10 @@ class ProcessConverterSpec extends FunSuite with Matchers with TableDrivenProper
 
 
   test("return variable type information for process that cannot be canonized") {
+    val meta = MetaData("process", StreamMetaData(Some(2), Some(false)), additionalFields = Some(ProcessAdditionalFields(None, Set.empty, Map.empty)))
     val process = ValidatedDisplayableProcess(
-      "process",
-      ProcessProperties(StreamMetaData(Some(2), Some(false)), ExceptionHandlerRef(List()), subprocessVersions = Map.empty),
+      meta.id,
+      ProcessProperties(meta.typeSpecificData, ExceptionHandlerRef(List()), subprocessVersions = Map.empty),
       List(Source("s", SourceRef("sourceRef", List())), Variable("v", "test", Expression("spel", "''")), Filter("e", Expression("spel", "''"))),
       List(Edge("s", "v", None), Edge("v", "e", None)),
       TestProcessingTypes.Streaming,
@@ -100,7 +101,10 @@ class ProcessConverterSpec extends FunSuite with Matchers with TableDrivenProper
         Map("e" -> List(NodeValidationError("InvalidTailOfBranch", "Invalid end of process", "Process branch can only end with sink or processor", None, errorType = NodeValidationErrorType.SaveAllowed))),
         List.empty,
         List.empty,
-        Map("s" -> Map("input" -> Typed[Null], "meta" -> Typed[MetaVariables]), "v" -> Map("input" -> Typed[Null], "meta" -> Typed[MetaVariables]), "e" -> Map("input" -> Typed[Null], "meta" -> Typed[MetaVariables], "test" -> Typed[String]))
+        Map(
+          "s" -> Map("input" -> Typed[Null], "meta" -> MetaVariables.typingResult(meta)),
+          "v" -> Map("input" -> Typed[Null], "meta" -> MetaVariables.typingResult(meta)),
+          "e" -> Map("input" -> Typed[Null], "meta" -> MetaVariables.typingResult(meta), "test" -> Typed[String]))
       )
     )
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/UiProcessMarshallerSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/UiProcessMarshallerSpec.scala
@@ -3,16 +3,32 @@ package pl.touk.nussknacker.ui.process.marshall
 import argonaut.{Parse, PrettyParams}
 import org.scalatest.{FlatSpec, Matchers}
 import pl.touk.nussknacker.ui.api.helpers.TestProcessingTypes
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{NodeAdditionalFields, ProcessAdditionalFields}
+import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.NodeAdditionalFields
 
 class UiProcessMarshallerSpec extends FlatSpec with Matchers {
 
   val someProcessDescription = "process description"
   val someNodeDescription = "single node description"
-  val processWithAdditionalFields =
+  val processWithPartialAdditionalFields =
     s"""
        |{
-       |    "metaData" : { "id": "custom", "typeSpecificData": {"type": "StreamMetaData", "parallelism" : 2}, "additionalFields": { "description": "$someProcessDescription"} },
+       |    "metaData" : { "id": "custom", "typeSpecificData": {"type": "StreamMetaData", "parallelism" : 2}, "additionalFields": {"description": "$someProcessDescription"}},
+       |    "exceptionHandlerRef" : { "parameters" : [ { "name": "errorsTopic", "expression": { "language": "spel", "expression": "error.topic" }}]},
+       |    "nodes" : [
+       |        {
+       |            "type" : "Source",
+       |            "id" : "start",
+       |            "ref" : { "typ": "kafka-transaction", "parameters": [ { "name": "topic", "expression": { "language": "spel", "expression": "in.topic" }}]},
+       |            "additionalFields": { "description": "$someNodeDescription"}
+       |        }
+       |    ],"additionalBranches":[]
+       |}
+      """.stripMargin
+
+  val processWithFullAdditionalFields =
+    s"""
+       |{
+       |    "metaData" : { "id": "custom", "typeSpecificData": {"type": "StreamMetaData", "parallelism" : 2}, "additionalFields": { "description": "$someProcessDescription", "groups": [], "properties": {}} },
        |    "exceptionHandlerRef" : { "parameters" : [ { "name": "errorsTopic", "expression": { "language": "spel", "expression": "error.topic" }}]},
        |    "nodes" : [
        |        {
@@ -42,16 +58,16 @@ class UiProcessMarshallerSpec extends FlatSpec with Matchers {
 
 
   it should "unmarshall to displayable process properly" in {
-    val displayableProcess = ProcessConverter.toDisplayableOrDie(processWithAdditionalFields, TestProcessingTypes.Streaming)
+    val displayableProcess = ProcessConverter.toDisplayableOrDie(processWithPartialAdditionalFields, TestProcessingTypes.Streaming)
 
-    val processDescription = displayableProcess.properties.additionalFields.flatMap(_.asInstanceOf[ProcessAdditionalFields].description)
+    val processDescription = displayableProcess.properties.additionalFields.flatMap(_.description)
     val nodeDescription = displayableProcess.nodes.head.additionalFields.flatMap(_.asInstanceOf[NodeAdditionalFields].description)
     processDescription shouldBe Some(someProcessDescription)
     nodeDescription shouldBe Some(someNodeDescription)
   }
 
   it should "marshall and unmarshall process" in {
-    val baseProcess = processWithAdditionalFields
+    val baseProcess = processWithFullAdditionalFields
     val displayableProcess = ProcessConverter.toDisplayableOrDie(baseProcess, TestProcessingTypes.Streaming)
     val canonical = ProcessConverter.fromDisplayable(displayableProcess)
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/processreport/ProcessCounterTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/processreport/ProcessCounterTest.scala
@@ -1,14 +1,13 @@
 package pl.touk.nussknacker.ui.processreport
 
 import org.scalatest.{FlatSpec, Matchers}
-import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
+import pl.touk.nussknacker.engine.api.{Group, MetaData, ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.build.EspProcessBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
 import pl.touk.nussknacker.engine.canonize.ProcessCanonizer
 import pl.touk.nussknacker.engine.graph.node.{Filter, SubprocessInputDefinition, SubprocessOutputDefinition}
 import pl.touk.nussknacker.engine.spel
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Group, ProcessAdditionalFields}
 import pl.touk.nussknacker.ui.process.subprocess.{SubprocessDetails, SubprocessRepository}
 
 //numbers & processes in this test can be totaly uncorrect and unrealistic, as processCounter does not care
@@ -41,7 +40,7 @@ class ProcessCounterTest extends FlatSpec with Matchers {
       .source("source1", "")
       .filter("filter1", "")
       .emptySink("sink11", "")).copy(metaData = MetaData("test", StreamMetaData(), false,
-        Some(ProcessAdditionalFields(Some(""), Set(Group("gr1", Set("filter1", "sink11")))))))
+        Some(ProcessAdditionalFields(Some(""), Set(Group("gr1", Set("filter1", "sink11"))), Map.empty))))
     val processCounter = new ProcessCounter(subprocessRepository(Set()))
 
     val computed = processCounter.computeCounts(process, Map("source1" -> RawCount(50, 0L),

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/validation/AdditionalPropertiesValidatorTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/validation/AdditionalPropertiesValidatorTest.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.ui.validation
 
 import org.scalatest.{FunSuite, Matchers}
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.ProcessAdditionalFields
+import pl.touk.nussknacker.engine.api.ProcessAdditionalFields
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationResult
 import pl.touk.nussknacker.ui.api.helpers.ProcessTestData
 import pl.touk.nussknacker.ui.definition.{AdditionalProcessProperty, PropertyType}
@@ -22,7 +22,7 @@ class AdditionalPropertiesValidatorTest extends FunSuite with Matchers {
 
   test("validate non empty config with required property") {
     val process = ProcessTestData.displayableWithAdditionalFields(Some(
-      ProcessAdditionalFields(None, properties = Map(
+      ProcessAdditionalFields(None, Set.empty, properties = Map(
         "propReq" -> "5"
       ))
     ))
@@ -34,7 +34,7 @@ class AdditionalPropertiesValidatorTest extends FunSuite with Matchers {
 
   test("validate non empty config without required property") {
     val process = ProcessTestData.displayableWithAdditionalFields(Some(
-      ProcessAdditionalFields(None, properties = Map(
+      ProcessAdditionalFields(None, Set.empty, properties = Map(
         "propOpt" -> "a"
       ))
     ))
@@ -45,7 +45,7 @@ class AdditionalPropertiesValidatorTest extends FunSuite with Matchers {
 
   test("validate non empty config with empty required property") {
     val process = ProcessTestData.displayableWithAdditionalFields(Some(
-      ProcessAdditionalFields(None, properties = Map(
+      ProcessAdditionalFields(None, Set.empty, properties = Map(
         "propReq" -> ""
       ))
     ))
@@ -56,7 +56,7 @@ class AdditionalPropertiesValidatorTest extends FunSuite with Matchers {
 
   test("validate non empty config with required property of invalid type") {
     val process = ProcessTestData.displayableWithAdditionalFields(Some(
-      ProcessAdditionalFields(None, properties = Map(
+      ProcessAdditionalFields(None, Set.empty, properties = Map(
         "propOpt" -> "a"
       ))
     ))

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/validation/ProcessValidationSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/validation/ProcessValidationSpec.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.ui.validation
 
 import org.scalatest.{FlatSpec, FunSuite, Matchers}
 import pl.touk.nussknacker.engine.{ProcessingTypeData, spel}
-import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
+import pl.touk.nussknacker.engine.api.{Group, MetaData, ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.{CanonicalProcess, canonicalnode}
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.{CanonicalNode, FlatNode}
 import pl.touk.nussknacker.engine.compile.ProcessValidator
@@ -20,7 +20,7 @@ import pl.touk.nussknacker.ui.api.helpers.TestFactory.{SampleSubprocessRepositor
 import pl.touk.nussknacker.ui.api.helpers.{ProcessTestData, TestFactory, TestProcessingTypes}
 import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.EdgeType.{NextSwitch, SwitchDefault}
 import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ProcessProperties}
-import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, EdgeType, Group, ProcessAdditionalFields}
+import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.{Edge, EdgeType}
 import pl.touk.nussknacker.restmodel.validation.ValidationResults
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeValidationError, ValidationErrors, ValidationResult, ValidationWarnings}
 import pl.touk.nussknacker.ui.process.subprocess.SubprocessResolver


### PR DESCRIPTION
This PR introduces properties variable - allows business users to access process properties in diagram.

Additionally, I've decided to remove UserDefinedProcessAdditionalFields trait as it is source of many argonaut-related problems.