### PR TITLE
[CONFIG] - remove unused zkAddress config

### DIFF
--- a/demo/docker/app/application.conf
+++ b/demo/docker/app/application.conf
@@ -61,7 +61,6 @@ processConfig {
   }
   restartInterval: "10s"
   kafka = {
-    zkAddress = "zookeeper:2181"
     kafkaAddress = "kafka:9092"
   }
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -56,7 +56,6 @@ processConfig {
   checkpointInterval: 10m
   restartInterval: "10s"
   kafka = {
-    zkAddress = "zookeeper:2181"
     kafkaAddress = "kafka:9092"
   }
   defaultValues {

--- a/engine/example/src/main/java/pl/touk/nussknacker/engine/javaexample/ExampleProcessConfigCreator.java
+++ b/engine/example/src/main/java/pl/touk/nussknacker/engine/javaexample/ExampleProcessConfigCreator.java
@@ -151,7 +151,6 @@ public class ExampleProcessConfigCreator implements ProcessConfigCreator {
 
     private KafkaConfig getKafkaConfig(Config config) {
         return new KafkaConfig(
-                config.getString("kafka.zkAddress"),
                 config.getString("kafka.kafkaAddress"),
                 Option.empty(),
                 Option.empty()

--- a/engine/example/src/test/scala/pl/touk/nussknacker/engine/example/BaseItTest.scala
+++ b/engine/example/src/test/scala/pl/touk/nussknacker/engine/example/BaseItTest.scala
@@ -45,8 +45,7 @@ object TestConfig {
   def apply(kafkaZookeeperServer: KafkaZookeeperServer) = {
     ConfigFactory.load()
       .withValue("kafka.kafkaAddress", fromAnyRef(kafkaZookeeperServer.kafkaAddress))
-      .withValue("kafka.zkAddress", fromAnyRef(kafkaZookeeperServer.zkAddress))
-      
+
   }
 }
 

--- a/engine/flink/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/KafkaAvroSourceFactorySpec.scala
+++ b/engine/flink/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/KafkaAvroSourceFactorySpec.scala
@@ -21,7 +21,7 @@ class KafkaAvroSourceFactorySpec extends FunSpec with BeforeAndAfterAll with Kaf
   import collection.JavaConverters._
 
   // schema.registry.url have to be defined even for MockSchemaRegistryClient
-  private lazy val kafkaConfig = KafkaConfig(kafkaZookeeperServer.zkAddress, kafkaZookeeperServer.kafkaAddress,
+  private lazy val kafkaConfig = KafkaConfig(kafkaZookeeperServer.kafkaAddress,
     Some(Map("schema.registry.url" -> "not_used")), None)
 
   private lazy val keySerializer = {

--- a/engine/flink/generic/src/test/scala/pl/touk/nussknacker/genericmodel/GenericItSpec.scala
+++ b/engine/flink/generic/src/test/scala/pl/touk/nussknacker/genericmodel/GenericItSpec.scala
@@ -183,7 +183,6 @@ class GenericItSpec extends FunSpec with BeforeAndAfterAll with Matchers with Ev
     super.beforeAll()
     val config = ConfigFactory.load()
       .withValue("kafka.kafkaAddress", fromAnyRef(kafkaZookeeperServer.kafkaAddress))
-      .withValue("kafka.zkAddress", fromAnyRef(kafkaZookeeperServer.zkAddress))
       .withValue("kafka.kafkaProperties.\"schema.registry.url\"", fromAnyRef("not_used"))
     env.getConfig.disableSysoutLogging()
     registrar = new StandardFlinkProcessCompiler(creator, config).createFlinkProcessRegistrar()

--- a/engine/flink/kafka-util/src/test/scala/pl/touk/nussknacker/engine/kafka/KafkaSourceFactorySpec.scala
+++ b/engine/flink/kafka-util/src/test/scala/pl/touk/nussknacker/engine/kafka/KafkaSourceFactorySpec.scala
@@ -12,7 +12,7 @@ class KafkaSourceFactorySpec extends FlatSpec with BeforeAndAfterAll with KafkaS
 
   implicit val stringTypeInfo = new GenericTypeInfo(classOf[String])
 
-  lazy val kafkaConfig = KafkaConfig(kafkaZookeeperServer.zkAddress, kafkaZookeeperServer.kafkaAddress, None, None)
+  lazy val kafkaConfig = KafkaConfig(kafkaZookeeperServer.kafkaAddress, None, None)
 
   it should "read last messages to generate data" in {
     val topic = "testTopic1"

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/CustomProcess.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/CustomProcess.scala
@@ -23,7 +23,6 @@ object CustomProcess {
     val config = ConfigFactory.parseString(args(1))
 
     val props = new Properties()
-    props.setProperty("zookeeper.connect", config.getString("kafka.zkAddress"))
     props.setProperty("bootstrap.servers", config.getString("kafka.kafkaAddress"))
 
     env.addSource(new FlinkKafkaConsumer011[String]("testTopic", new SimpleStringSchema, props))

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/TestProcessConfigCreator.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/TestProcessConfigCreator.scala
@@ -45,7 +45,7 @@ class TestProcessConfigCreator extends ProcessConfigCreator {
 
 
   override def sinkFactories(config: Config) = {
-    val kConfig = KafkaConfig(config.getString("kafka.zkAddress"), config.getString("kafka.kafkaAddress"), None, None)
+    val kConfig = KafkaConfig(config.getString("kafka.kafkaAddress"), None, None)
 
     val sendSmsSink = EmptySink
     val monitorSink = EmptySink
@@ -66,7 +66,7 @@ class TestProcessConfigCreator extends ProcessConfigCreator {
   override def listeners(config: Config) = List(LoggingListener)
 
   override def sourceFactories(config: Config) = {
-    val kConfig = KafkaConfig(config.getString("kafka.zkAddress"), config.getString("kafka.kafkaAddress"), None, None)
+    val kConfig = KafkaConfig(config.getString("kafka.kafkaAddress"), None, None)
 
     Map(
       "real-kafka" -> WithCategories(new KafkaSourceFactory[String](kConfig,
@@ -178,7 +178,7 @@ class TestProcessConfigCreator extends ProcessConfigCreator {
   }
 
   override def customStreamTransformers(config: Config) = {
-    val kConfig = KafkaConfig(config.getString("kafka.zkAddress"), config.getString("kafka.kafkaAddress"), None, None)
+    val kConfig = KafkaConfig(config.getString("kafka.kafkaAddress"), None, None)
     val signalsTopic = config.getString("signals.topic")
     Map(
       "noneReturnTypeTransformer" -> WithCategories(NoneReturnTypeTransformer, "TESTCAT"),
@@ -194,7 +194,7 @@ class TestProcessConfigCreator extends ProcessConfigCreator {
   }
 
   override def signals(config: Config) = {
-    val kConfig = KafkaConfig(config.getString("kafka.zkAddress"), config.getString("kafka.kafkaAddress"), None, None)
+    val kConfig = KafkaConfig(config.getString("kafka.kafkaAddress"), None, None)
     val signalsTopic = config.getString("signals.topic")
     Map(
       "removeLockSignal" -> WithCategories(new RemoveLockProcessSignalFactory(kConfig, signalsTopic), "Category1", "Category2")

--- a/engine/flink/management/src/it/resources/application.conf
+++ b/engine/flink/management/src/it/resources/application.conf
@@ -17,7 +17,6 @@ processConfig {
   }
   #this will be overwritten for docker tests
   kafka = {
-    zkAddress = "zookeeper:2181"
     kafkaAddress = "kafka:9092"
   }
 

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/FlinkProcessRegistrarKafkaSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/FlinkProcessRegistrarKafkaSpec.scala
@@ -56,7 +56,7 @@ class FlinkProcessRegistrarKafkaSpec
     Future {
       KeyValueTestHelper.processInvoker.invokeWithKafka(
         process,
-        KafkaConfig(kafkaZookeeperServer.zkAddress, kafkaZookeeperServer.kafkaAddress, None, None)
+        KafkaConfig(kafkaZookeeperServer.kafkaAddress, None, None)
       )
     }
 

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkProcessMainSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkProcessMainSpec.scala
@@ -157,7 +157,7 @@ class SimpleProcessConfigCreator extends ProcessConfigCreator {
   )
 
   override def signals(config: Config) = Map("sig1" ->
-          WithCategories(new TestProcessSignalFactory(KafkaConfig("", "", None, None), "")))
+          WithCategories(new TestProcessSignalFactory(KafkaConfig("", None, None), "")))
 
 
   override def exceptionHandlerFactory(config: Config) =

--- a/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaConfig.scala
+++ b/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaConfig.scala
@@ -1,4 +1,5 @@
 package pl.touk.nussknacker.engine.kafka
 
-case class KafkaConfig(zkAddress: String, kafkaAddress: String,
-                       kafkaProperties: Option[Map[String, String]], kafkaEspProperties: Option[Map[String, String]])
+case class KafkaConfig(kafkaAddress: String,
+                       kafkaProperties: Option[Map[String, String]],
+                       kafkaEspProperties: Option[Map[String, String]])

--- a/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaEspUtils.scala
+++ b/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaEspUtils.scala
@@ -46,7 +46,6 @@ object KafkaEspUtils extends LazyLogging {
 
   def toProperties(config: KafkaConfig, groupId: Option[String]) = {
     val props = new Properties()
-    props.setProperty("zookeeper.connect", config.zkAddress)
     props.setProperty("bootstrap.servers", config.kafkaAddress)
     props.setProperty("auto.offset.reset", "earliest")
     groupId.foreach(props.setProperty("group.id", _))

--- a/nussknacker-dist/src/universal/conf/application.conf
+++ b/nussknacker-dist/src/universal/conf/application.conf
@@ -31,7 +31,6 @@ countsSettings {
 #Add your model configuration here
 processConfig {
   kafka = {
-    zkAddress = "localhost:2181"
     kafkaAddress = "localhost:9092"
   }
 

--- a/nussknacker-dist/src/universal/conf/docker-application.conf
+++ b/nussknacker-dist/src/universal/conf/docker-application.conf
@@ -61,7 +61,6 @@ processConfig {
   }
   restartInterval: "10s"
   kafka = {
-    zkAddress = "zookeeper:2181"
     kafkaAddress = "kafka:9092"
   }
 

--- a/ui/server/develConf/demo/application.conf
+++ b/ui/server/develConf/demo/application.conf
@@ -73,7 +73,6 @@ processConfig {
   }
   restartInterval: "10s"
   kafka = {
-    zkAddress = "localhost:2181"
     kafkaAddress = "localhost:9092"
   }
 

--- a/ui/server/develConf/generic/application.conf
+++ b/ui/server/develConf/generic/application.conf
@@ -96,7 +96,6 @@ processConfig {
   checkpointInterval: 10s
 
   kafka = {
-    zkAddress = "poc-esp1:2181"
     kafkaAddress = "poc-esp2:9092"
     kafkaProperties {
       "schema.registry.url" = "http://poc-esp1:8081"

--- a/ui/server/develConf/sample/application.conf
+++ b/ui/server/develConf/sample/application.conf
@@ -117,7 +117,6 @@ processConfig {
   checkpointInterval: 10s
 
   kafka = {
-    zkAddress = "localhost:2181"
     kafkaAddress = "localhost:9092"
   }
   asyncExecutionConfig {

--- a/ui/server/src/test/resources/application.conf
+++ b/ui/server/src/test/resources/application.conf
@@ -52,7 +52,6 @@ processConfig {
     parallelismMultiplier: 2
   }
   kafka = {
-    zkAddress = "notexisting.com:2181"
     kafkaAddress = "notexisting.org:9092"
   }
 


### PR DESCRIPTION
In newer (like less than 3 years old...) zookeeper.connect is not used by clients 