### PR TITLE
[Fix] Migration test takes too long for large processes list

### DIFF
--- a/engine/standalone/engine/src/it/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManagerSpec.scala
+++ b/engine/standalone/engine/src/it/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManagerSpec.scala
@@ -1,13 +1,11 @@
 package pl.touk.nussknacker.engine.standalone.management
 
-import java.nio.file.{Files, Paths}
-
 import argonaut.PrettyParams
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
-import pl.touk.nussknacker.engine.api.{MetaData, ProcessVersion, StandaloneMetaData}
+import pl.touk.nussknacker.engine.api.{MetaData, StandaloneMetaData}
 import pl.touk.nussknacker.engine.api.deployment.TestProcess.TestData
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -17,7 +15,6 @@ import pl.touk.nussknacker.engine.graph.node.{Sink, Source}
 import pl.touk.nussknacker.engine.graph.sink.SinkRef
 import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
-import pl.touk.nussknacker.engine.standalone.api.DeploymentData
 
 class StandaloneProcessManagerSpec extends FunSuite with ScalaFutures with Matchers {
 

--- a/engine/standalone/engine/src/it/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManagerSpec.scala
+++ b/engine/standalone/engine/src/it/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManagerSpec.scala
@@ -1,11 +1,13 @@
 package pl.touk.nussknacker.engine.standalone.management
 
+import java.nio.file.{Files, Paths}
+
 import argonaut.PrettyParams
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
-import pl.touk.nussknacker.engine.api.{MetaData, StandaloneMetaData}
+import pl.touk.nussknacker.engine.api.{MetaData, ProcessVersion, StandaloneMetaData}
 import pl.touk.nussknacker.engine.api.deployment.TestProcess.TestData
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -15,6 +17,7 @@ import pl.touk.nussknacker.engine.graph.node.{Sink, Source}
 import pl.touk.nussknacker.engine.graph.sink.SinkRef
 import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
+import pl.touk.nussknacker.engine.standalone.api.DeploymentData
 
 class StandaloneProcessManagerSpec extends FunSuite with ScalaFutures with Matchers {
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/SettingsResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/SettingsResources.scala
@@ -22,7 +22,7 @@ class SettingsResources(config: FeatureTogglesConfig, typeToConfig: Map[Processi
             counts = config.counts.isDefined,
             search = config.search,
             metrics = config.metrics,
-            remoteEnvironment = config.remoteEnvironment.map(c => RemoteEnvironmentConfig(c.targetEnvironemntId)),
+            remoteEnvironment = config.remoteEnvironment.map(c => RemoteEnvironmentConfig(c.targetEnvironmentId)),
             environmentAlert = config.environmentAlert,
             commentSettings = config.commentSettings,
             deploySettings = config.deploySettings,

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/SettingsResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/SettingsResources.scala
@@ -22,7 +22,7 @@ class SettingsResources(config: FeatureTogglesConfig, typeToConfig: Map[Processi
             counts = config.counts.isDefined,
             search = config.search,
             metrics = config.metrics,
-            remoteEnvironment = config.remoteEnvironment.map(c => RemoteEnvironmentConfig(c.environmentId)),
+            remoteEnvironment = config.remoteEnvironment.map(c => RemoteEnvironmentConfig(c.targetEnvironemntId)),
             environmentAlert = config.environmentAlert,
             commentSettings = config.commentSettings,
             deploySettings = config.deploySettings,

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
 import argonaut.DecodeJson
 import cats.data.EitherT
 import cats.implicits._
@@ -19,13 +20,14 @@ import pl.touk.nussknacker.ui.codec.UiCodecs
 import pl.touk.nussknacker.ui.process.ProcessToSave
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.InvalidProcessTypeError
-import pl.touk.nussknacker.restmodel.processdetails.{ProcessDetails, ProcessHistoryEntry, ValidatedProcessDetails}
+import pl.touk.nussknacker.restmodel.processdetails.{BasicProcess, ProcessDetails, ProcessHistoryEntry, ValidatedProcessDetails}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.ui.util.ProcessComparator
 import pl.touk.nussknacker.ui.util.ProcessComparator.Difference
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.{ValidationErrors, ValidationResult}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 trait RemoteEnvironment {
 
@@ -51,40 +53,47 @@ case class MigrationValidationError(errors: ValidationErrors) extends EspError {
   }
 }
 
-case class HttpRemoteEnvironmentConfig(url: String, user: String, password: String, environmentId: String)
+case class HttpRemoteEnvironmentConfig(user: String, password: String, targetEnvironemntId: String, remoteConfig: StandardRemoteEnvironmentConfig)
 
-
-class HttpRemoteEnvironment(config: HttpRemoteEnvironmentConfig,
+class HttpRemoteEnvironment(httpConfig: HttpRemoteEnvironmentConfig,
                             val testModelMigrations: TestModelMigrations,
-                            val environmentId: String)(implicit as: ActorSystem, val materializer: Materializer) extends StandardRemoteEnvironment {
+                            val environmentId: String
+                           )(implicit as: ActorSystem, val materializer: Materializer) extends StandardRemoteEnvironment {
+  override val config: StandardRemoteEnvironmentConfig = httpConfig.remoteConfig
 
-  override def targetEnvironmentId : String = config.environmentId
-
-  val http = Http()
-
-  override def baseUrl: Uri = config.url
+  override def targetEnvironmentId: String = httpConfig.targetEnvironemntId
 
   override protected def request(uri: Uri, method: HttpMethod, request: MessageEntity): Future[HttpResponse] = {
-    http.singleRequest(HttpRequest(uri = uri, method = method, entity = request,
-      headers = List(Authorization(BasicHttpCredentials(config.user, config.password)))))
+    // fixme: this shouldn't be done this way but I cannot get Akka client to send that many requests in a row otherwise
+    Source.single(
+      HttpRequest(uri = uri.toRelative, method = method, entity = request,
+        headers = List(Authorization(BasicHttpCredentials(httpConfig.user, httpConfig.password))))
+    ).via(Http().outgoingConnection(uri.authority.host.address(), uri.authority.port))
+      .runWith(Sink.head)
   }
 }
+
+case class StandardRemoteEnvironmentConfig(uri: String,
+                                           migrationTimeout: Duration,
+                                           migrationBatchSize: Int)
 
 //TODO: extract interface to remote environment?
 trait StandardRemoteEnvironment extends Argonaut62Support with RemoteEnvironment with UiCodecs {
 
   def environmentId: String
 
+  def config: StandardRemoteEnvironmentConfig
+
   def testModelMigrations: TestModelMigrations
 
-  def baseUrl: Uri
+  def baseUri = Uri(config.uri)
 
   implicit def materializer: Materializer
 
   private def invoke[T](method: HttpMethod, pathParts: List[String], queryString: Option[String] = None, requestEntity: RequestEntity = HttpEntity.Empty)
                        (f: HttpResponse => Future[T])(implicit ec: ExecutionContext): Future[T] = {
-    val pathEncoded = pathParts.foldLeft[Path](baseUrl.path)(_ / _)
-    val uri = baseUrl.withPath(pathEncoded).withRawQueryString(queryString.getOrElse(""))
+    val pathEncoded = pathParts.foldLeft[Path](baseUri.path)(_ / _)
+    val uri = baseUri.withPath(pathEncoded).withRawQueryString(queryString.getOrElse(""))
 
     request(uri, method, requestEntity) flatMap f
   }
@@ -172,8 +181,22 @@ trait StandardRemoteEnvironment extends Argonaut62Support with RemoteEnvironment
 
   override def testMigration(implicit ec: ExecutionContext): Future[Either[EspError, List[TestMigrationResult]]] = {
     (for {
-      processes <- EitherT(invokeJson[List[ValidatedProcessDetails]](HttpMethods.GET,List("processesDetails")))
-      subprocesses <- EitherT(invokeJson[List[ValidatedProcessDetails]](HttpMethods.GET,List("subProcessesDetails")))
+      basicProcesses <- EitherT(invokeJson[List[BasicProcess]](HttpMethods.GET, List("processes")))
+      processes      <- fetchGroupByGroup(basicProcesses, basicProcess => EitherT(invokeJson[ValidatedProcessDetails](HttpMethods.GET, List("processes", basicProcess.name))))
+      subprocesses   <- EitherT(invokeJson[List[ValidatedProcessDetails]](HttpMethods.GET, List("subProcessesDetails")))
     } yield testModelMigrations.testMigrations(processes, subprocesses)).value
+  }
+
+  private def fetchGroupByGroup[T](basicProcesses: List[BasicProcess],
+                                   getOne: BasicProcess => EitherT[Future, EspError, ValidatedProcessDetails])
+                                  (implicit ec: ExecutionContext): EitherT[Future, EspError, List[ValidatedProcessDetails]] = {
+    EitherT(Future.successful(Await.result(
+      Future.sequence(
+        basicProcesses.grouped(config.migrationBatchSize)
+          .flatMap(_.map(getOne(_).value))
+          .toList
+      ).map(_.sequence),
+      config.migrationTimeout
+    )))
   }
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -53,7 +53,7 @@ case class MigrationValidationError(errors: ValidationErrors) extends EspError {
   }
 }
 
-case class HttpRemoteEnvironmentConfig(user: String, password: String, targetEnvironemntId: String, remoteConfig: StandardRemoteEnvironmentConfig)
+case class HttpRemoteEnvironmentConfig(user: String, password: String, targetEnvironmentId: String, remoteConfig: StandardRemoteEnvironmentConfig)
 
 class HttpRemoteEnvironment(httpConfig: HttpRemoteEnvironmentConfig,
                             val testModelMigrations: TestModelMigrations,
@@ -61,7 +61,7 @@ class HttpRemoteEnvironment(httpConfig: HttpRemoteEnvironmentConfig,
                            )(implicit as: ActorSystem, val materializer: Materializer) extends StandardRemoteEnvironment {
   override val config: StandardRemoteEnvironmentConfig = httpConfig.remoteConfig
 
-  override def targetEnvironmentId: String = httpConfig.targetEnvironemntId
+  override def targetEnvironmentId: String = httpConfig.targetEnvironmentId
 
   override protected def request(uri: Uri, method: HttpMethod, request: MessageEntity): Future[HttpResponse] = {
     // fixme: this shouldn't be done this way but I cannot get Akka client to send that many requests in a row otherwise

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
@@ -30,9 +30,9 @@ class StandardRemoteEnvironmentSpec extends FlatSpec with Matchers with ScalaFut
     override def environmentId = "testEnv"
 
     def config: StandardRemoteEnvironmentConfig = StandardRemoteEnvironmentConfig(
-      "http://localhost:8087/api",
-      10.seconds,
-      10
+      uri = "http://localhost:8087/api",
+      migrationTimeout = 10.seconds,
+      migrationBatchSize = 10
     )
 
     override def targetEnvironmentId = "targetTestEnv"


### PR DESCRIPTION
Currently testMigration tries to fetch all processes' jsons via single HTTP request. As size of the response might be enormous we should fetch processes one by one.

There is one drawback of this solution though - I haven't been able to empty internal Akka HTTP requests queue and ended up opening new connection for every request.