### PR TITLE
[Config] Other CountsReporters can be loaded via ServiceLoader mechanism

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -574,6 +574,7 @@ lazy val processReports = (project in engine("processReports")).
       Seq(
         "com.typesafe" % "config" % "1.3.0",
         "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,
+        "com.iheart" %% "ficus" % ficusV,
         "org.scalatest" %% "scalatest" % scalaTestV % "test"
       )
     }
@@ -670,7 +671,7 @@ lazy val ui = (project in file("ui/server"))
     Keys.test in SlowTests := (Keys.test in SlowTests).dependsOn(
       //TODO: maybe here there should be engine/demo??
       (assembly in Compile) in managementSample
-    ),
+    ).value,
     Keys.test in Test := (Keys.test in Test).dependsOn(
       //TODO: maybe here there should be engine/demo??
       (assembly in Compile) in managementSample

--- a/engine/processReports/src/main/scala/pl/touk/nussknacker/processCounts/CountsReporter.scala
+++ b/engine/processReports/src/main/scala/pl/touk/nussknacker/processCounts/CountsReporter.scala
@@ -2,9 +2,25 @@ package pl.touk.nussknacker.processCounts
 
 import java.time.LocalDateTime
 
+import com.typesafe.config.Config
+
 import scala.concurrent.{ExecutionContext, Future}
 
-//In the future we can extract it to enable metric backends other than influx
+object CountsReporterCreator {
+
+  val reporterCreatorConfigPath = "countsSettings"
+
+}
+
+//By default it's InfluxCountsReporterCreator, other implementation can be used via ServiceLoaderMechanism
+//@see NussknackerApp#prepareCountsReporter
+trait CountsReporterCreator {
+
+  def createReporter(env: String, config: Config): CountsReporter
+
+}
+
+
 trait CountsReporter {
 
   def prepareRawCounts(processId: String, countsRequest: CountsRequest)(implicit ec: ExecutionContext): Future[String => Option[Long]]

--- a/engine/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxCountsReporter.scala
+++ b/engine/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxCountsReporter.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.processCounts.influxdb
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+import com.typesafe.config.Config
 import pl.touk.nussknacker.processCounts._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -32,4 +33,14 @@ class InfluxCountsReporter(env: String, config: InfluxReporterConfig) extends Co
   private def queryInflux(processId: String, fromDate: Option[LocalDateTime], toDate: LocalDateTime)(implicit ec: ExecutionContext): Future[String => Option[Long]] = {
     influxBaseReporter.fetchBaseProcessCounts(processId, fromDate, toDate).map(pbc => nodeId => pbc.getCountForNodeId(nodeId))
   }
+}
+
+class InfluxCountsReporterCreator extends CountsReporterCreator {
+
+  import net.ceedubs.ficus.Ficus._
+  import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+
+  override def createReporter(env: String, config: Config): CountsReporter = new InfluxCountsReporter(env,
+    config.as[InfluxReporterConfig](CountsReporterCreator.reporterCreatorConfigPath))
+
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/config/FeatureTogglesConfig.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/config/FeatureTogglesConfig.scala
@@ -1,17 +1,17 @@
 package pl.touk.nussknacker.ui.config
 
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import net.ceedubs.ficus.readers.ValueReader
 import pl.touk.nussknacker.ui.api._
 import pl.touk.nussknacker.ui.process.migrate.HttpRemoteEnvironmentConfig
-import pl.touk.nussknacker.processCounts.influxdb.InfluxReporterConfig
 
 case class FeatureTogglesConfig(development: Boolean,
                                 standaloneMode: Boolean,
                                 search: Option[KibanaSettings],
                                 metrics: Option[MetricsSettings],
                                 remoteEnvironment: Option[HttpRemoteEnvironmentConfig],
-                                counts: Option[InfluxReporterConfig],
+                                counts: Option[Config],
                                 environmentAlert:Option[EnvironmentAlert],
                                 commentSettings: Option[CommentSettings],
                                 deploySettings: Option[DeploySettings],
@@ -29,8 +29,7 @@ object FeatureTogglesConfig extends LazyLogging{
     val standaloneModeEnabled = config.hasPath("standaloneModeEnabled") && config.getBoolean("standaloneModeEnabled")
     val metrics = parseOptionalConfig[MetricsSettings](config, "metricsSettings")
       .orElse(parseOptionalConfig[MetricsSettings](config, "grafanaSettings"))
-    val counts = parseOptionalConfig[InfluxReporterConfig](config, "countsSettings")
-      .orElse(parseOptionalConfig[InfluxReporterConfig](config, "grafanaSettings"))
+    val counts = parseOptionalConfig[Config](config, "countsSettings")
 
     val remoteEnvironment = parseOptionalConfig[HttpRemoteEnvironmentConfig](config, "secondaryEnvironment")
     val search = parseOptionalConfig[KibanaSettings](config, "kibanaSettings")


### PR DESCRIPTION
We may want to get counts differently (e.g. not from influx?)