### PR TITLE
Add healthcheck endpoint in standalone app

### DIFF
--- a/engine/standalone/app/src/main/scala/pl/touk/nussknacker/engine/standalone/http/ManagementRoute.scala
+++ b/engine/standalone/app/src/main/scala/pl/touk/nussknacker/engine/standalone/http/ManagementRoute.scala
@@ -49,6 +49,12 @@ class ManagementRoute(deploymentService: DeploymentService) extends Directives w
           }
         }
       }
+    } ~ path("healthCheck") {
+      get {
+        complete {
+          HttpResponse(status = StatusCodes.OK)
+        }
+      }
     }
 
 

--- a/engine/standalone/app/src/test/scala/pl/touk/nussknacker/engine/standalone/http/StandaloneHttpAppSpec.scala
+++ b/engine/standalone/app/src/test/scala/pl/touk/nussknacker/engine/standalone/http/StandaloneHttpAppSpec.scala
@@ -271,6 +271,12 @@ class StandaloneHttpAppSpec extends FlatSpec with Matchers with ScalatestRouteTe
     }
   }
 
+  it should "return health" in {
+    Get("/healthCheck") ~> managementRoute ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
   def cancelProcess(processName: ProcessName) = {
     val id = processName.value
 


### PR DESCRIPTION
Simple healthcheck endpoint to ensure standalone application is running.