### PR TITLE
Fetch processes details by process names batch

### DIFF
--- a/ui/server/develConf/generic/application.conf
+++ b/ui/server/develConf/generic/application.conf
@@ -66,8 +66,8 @@ secondaryEnvironment {
   targetEnvironmentId: "localtest"
   remoteConfig: {
     uri: "http://localhost:8081/api",
-    migrationTimeout: 60s
-    migrationBatchSize: 10
+    batchSize: 10
+    batchTimeout: 60s
   }
 }
 

--- a/ui/server/develConf/generic/application.conf
+++ b/ui/server/develConf/generic/application.conf
@@ -67,7 +67,6 @@ secondaryEnvironment {
   remoteConfig: {
     uri: "http://localhost:8081/api",
     batchSize: 10
-    batchTimeout: 60s
   }
 }
 

--- a/ui/server/develConf/sample/application.conf
+++ b/ui/server/develConf/sample/application.conf
@@ -67,8 +67,8 @@ secondaryEnvironment {
   targetEnvironmentId: "localtest"
   remoteConfig: {
     uri: "http://localhost:8081/api",
-    migrationTimeout: 60s
-    migrationBatchSize: 10
+    batchSize: 10
+    batchTimeout: 60s
   }
 }
 

--- a/ui/server/develConf/sample/application.conf
+++ b/ui/server/develConf/sample/application.conf
@@ -68,7 +68,6 @@ secondaryEnvironment {
   remoteConfig: {
     uri: "http://localhost:8081/api",
     batchSize: 10
-    batchTimeout: 60s
   }
 }
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -90,6 +90,13 @@ class ProcessesResources(val processRepository: FetchingProcessRepository,
             }
           }
         } ~ path("processesDetails") {
+          post {
+            entity(as[List[String]]) { namesToFetch =>
+              complete {
+                validateAll(processRepository.fetchProcessesDetails(namesToFetch.map(ProcessName(_))))
+              }
+            }
+          } ~
           get {
             complete {
               validateAll(processRepository.fetchProcessesDetails())

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
@@ -1,6 +1,5 @@
 package pl.touk.nussknacker.ui.process.repository
 
-import java.sql.{Date, Timestamp}
 import java.time.LocalDateTime
 
 import cats.data.OptionT
@@ -47,6 +46,11 @@ abstract class DBFetchingProcessRepository[F[_]](val dbConfig: DbConfig) extends
 
   def fetchProcessesDetails()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[ProcessDetails]] = {
     run(fetchProcessDetailsByQueryActionUnarchived(p => !p.isSubprocess))
+  }
+
+  def fetchProcessesDetails(processNames: List[ProcessName])(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[ProcessDetails]] = {
+    val processNamesSet = processNames.map(_.value).toSet
+    run(fetchProcessDetailsByQueryActionUnarchived(p => !p.isSubprocess && p.name.inSet(processNamesSet)))
   }
 
   def fetchSubProcessesDetails()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[ProcessDetails]] = {

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
@@ -36,6 +36,8 @@ trait FetchingProcessRepository {
 
   def fetchProcessesDetails()(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[ProcessDetails]]
 
+  def fetchProcessesDetails(processNames: List[ProcessName])(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[ProcessDetails]]
+
   def fetchSubProcessesDetails()(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[ProcessDetails]]
 
   def fetchAllProcessesDetails()(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[ProcessDetails]]

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
@@ -31,8 +31,8 @@ class StandardRemoteEnvironmentSpec extends FlatSpec with Matchers with ScalaFut
 
     def config: StandardRemoteEnvironmentConfig = StandardRemoteEnvironmentConfig(
       uri = "http://localhost:8087/api",
-      migrationTimeout = 10.seconds,
-      migrationBatchSize = 10
+      batchSize = 100,
+      batchTimeout = 60.seconds
     )
 
     override def targetEnvironmentId = "targetTestEnv"

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
@@ -31,8 +31,7 @@ class StandardRemoteEnvironmentSpec extends FlatSpec with Matchers with ScalaFut
 
     def config: StandardRemoteEnvironmentConfig = StandardRemoteEnvironmentConfig(
       uri = "http://localhost:8087/api",
-      batchSize = 100,
-      batchTimeout = 60.seconds
+      batchSize = 100
     )
 
     override def targetEnvironmentId = "targetTestEnv"


### PR DESCRIPTION
Ultimately, I'd like to get rid of processesDetails endpoints altogether. This change mitigates problem with exposing all processes' jsons in one request.

Additionally, it adds batching support for migration testing