### PR TITLE
Workaround copying to clipboard for content delivered via HTTP

### DIFF
--- a/ui/client/common/ClipboardUtils.js
+++ b/ui/client/common/ClipboardUtils.js
@@ -1,0 +1,18 @@
+const readText = event => (event.clipboardData || window.clipboardData).getData('text')
+
+const writeText = (text, elementId) => {
+  const el = document.createElement('textarea');
+  el.value = text;
+  el.setAttribute("id", elementId)
+  el.setAttribute('readonly', '');
+  el.style = {position: 'absolute', left: '-9999px'};
+  document.body.appendChild(el);
+  el.select();
+  document.execCommand('copy');
+  document.body.removeChild(el);
+}
+
+export default {
+  readText,
+  writeText,
+}

--- a/ui/client/common/ClipboardUtils.js
+++ b/ui/client/common/ClipboardUtils.js
@@ -1,5 +1,12 @@
 const readText = event => (event.clipboardData || window.clipboardData).getData('text')
 
+// We could have used navigator.clipboard.writeText but it is not defined for
+// content delivered via HTTP. The workaround is to create a hidden element
+// and then write text into it. After that copy command is used to replace
+// clipboard's contents with given text. What is more the hidden element is
+// assigned with given id to be able to differentiate between artificial
+// copy event and the real one triggered by user.
+// Based on https://techoverflow.net/2018/03/30/copying-strings-to-the-clipboard-using-pure-javascript/
 const writeText = (text, elementId) => {
   const el = document.createElement('textarea');
   el.value = text;

--- a/ui/client/components/graph/Graph.js
+++ b/ui/client/components/graph/Graph.js
@@ -19,6 +19,7 @@ import * as GraphUtils from "./GraphUtils";
 import * as JointJsGraphUtils from "./JointJsGraphUtils";
 import PropTypes from 'prop-types';
 import * as JsonUtils from "../../common/JsonUtils";
+import ClipboardUtils from "../../common/ClipboardUtils";
 
 class Graph extends React.Component {
 
@@ -89,9 +90,11 @@ class Graph extends React.Component {
 		return this.canCopyNode() && this.props.capabilities.write
 	}
 
-	copyNode() {
-		if (this.canCopyNode()) {
-			navigator.clipboard.writeText(JSON.stringify(this.props.nodeToDisplay))
+	copyNode(event) {
+		const copyNodeElementId = 'copy-node'
+		if (event.target && event.target.id !== copyNodeElementId && this.canCopyNode()) {
+			const nodeString = JSON.stringify(this.props.nodeToDisplay);
+			ClipboardUtils.writeText(nodeString, copyNodeElementId)
 		}
 	}
 
@@ -99,15 +102,15 @@ class Graph extends React.Component {
 		if (!this.props.allModalsClosed) {
 			return
 		}
-		const clipboardText = (event.clipboardData || window.clipboardData).getData('text');
+		const clipboardText = ClipboardUtils.readText(event);
 		const node = JsonUtils.tryParseOrNull(clipboardText)
 		const position = {x: 0, y: 0}
 		this.addNode(node, position)
 	}
 
-	cutNode() {
+	cutNode(event) {
 		if (this.canCutNode() ) {
-			this.copyNode()
+			this.copyNode(event)
 			this.props.actions.deleteNode(this.props.nodeToDisplay.id)
 		}
 	}


### PR DESCRIPTION
`navigator.clipboard` is not accessible via HTTP. As a workaround in order to copy node's JSON, a hidden element is created, then text content is written to it and finally, second copy is executed. Because of copying twice, two events get generated so we need to discard artificial one. 