### PR TITLE
Convert isDisabled parameter in split to option

### DIFF
--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
@@ -115,7 +115,7 @@ object node {
     override val componentId = nodeType
   }
 
-  case class Split(id: String, isDisabled: Boolean = false, additionalFields: Option[UserDefinedAdditionalNodeFields] = None) extends NodeData
+  case class Split(id: String, isDisabled: Option[Boolean] = Some(false), additionalFields: Option[UserDefinedAdditionalNodeFields] = None) extends NodeData
 
   case class Processor(id: String, service: ServiceRef, isDisabled: Option[Boolean] = None, additionalFields: Option[UserDefinedAdditionalNodeFields] = None) extends OneOutputSubsequentNodeData with EndingNodeData with Disableable with WithComponent {
     override val componentId = service.id

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
@@ -115,7 +115,7 @@ object node {
     override val componentId = nodeType
   }
 
-  case class Split(id: String, isDisabled: Option[Boolean] = Some(false), additionalFields: Option[UserDefinedAdditionalNodeFields] = None) extends NodeData
+  case class Split(id: String, additionalFields: Option[UserDefinedAdditionalNodeFields] = None) extends NodeData
 
   case class Processor(id: String, service: ServiceRef, isDisabled: Option[Boolean] = None, additionalFields: Option[UserDefinedAdditionalNodeFields] = None) extends OneOutputSubsequentNodeData with EndingNodeData with Disableable with WithComponent {
     override val componentId = service.id


### PR DESCRIPTION
Now it's consistent with other nodes like `Sink`, `Processor`, etc. What is more processes details could not be deserialized by circe because for some reason isDisabled field was omitted by argonaut - probably there is a different optional parameters behaviour in these libraries.