### PR TITLE
Test standalone process is correctly loaded from file

### DIFF
--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/deployment/ProcessRepository.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/deployment/ProcessRepository.scala
@@ -63,7 +63,8 @@ class FileProcessRepository(path: File) extends ProcessRepository {
   }
 
   override def loadAll: Map[ProcessName, DeploymentData] = path.listFiles().filter(_.isFile).map { file =>
-    ProcessName(file.getName) -> CirceUtil.decodeJson[DeploymentData](fileToString(file)).right.get
+    ProcessName(file.getName) -> CirceUtil.decodeJson[DeploymentData](fileToString(file))
+      .fold(error => throw new IllegalStateException(s"Could not decode deployment data for file: $file", error), identity)
   }.toMap
 
 }

--- a/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/deployment/FileProcessRepositoryTest.scala
+++ b/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/deployment/FileProcessRepositoryTest.scala
@@ -1,0 +1,46 @@
+package pl.touk.nussknacker.engine.standalone.deployment
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import org.scalatest.{FunSuite, Matchers}
+import pl.touk.nussknacker.engine.api.process.ProcessName
+
+class FileProcessRepositoryTest extends FunSuite with Matchers {
+
+  private val processesDirectory = Files.createTempDirectory("fileProcessRepositoryTest")
+
+  private val repository = new FileProcessRepository(processesDirectory.toFile)
+
+  private val processJson = """{\"additionalBranches\":[],\"nodes\":[{\"ref\":{\"parameters\":[],\"typ\":\"request1-post-source\"},\"id\":\"start\",\"type\":\"Source\"},{\"endResult\":{\"expression\":\"''\",\"language\":\"spel\"},\"ref\":{\"parameters\":[],\"typ\":\"response-sink\"},\"id\":\"endNodeIID\",\"type\":\"Sink\"}],\"exceptionHandlerRef\":{\"parameters\":[]},\"metaData\":{\"typeSpecificData\":{\"path\":\"alamakota\",\"type\":\"StandaloneMetaData\"},\"id\":\"process1\"}}"""
+  private val deploymentJson =
+    s"""
+      |{
+      |  "processVersion" : {
+      |    "versionId" : 1,
+      |    "processName" : "process1",
+      |    "user" : "testUser",
+      |    "modelVersion" : 3
+      |  },
+      |  "deploymentTime" : 5,
+      |  "processJson":"$processJson"
+      |}
+      |""".stripMargin
+
+  test("should load deployment data from file") {
+    val processName = ProcessName("process1")
+    Files.write(processesDirectory.resolve(processName.value), deploymentJson.getBytes(StandardCharsets.UTF_8))
+
+    val deployments = repository.loadAll
+
+    deployments should have size 1
+    deployments should contain key (processName)
+    val deployment = deployments(processName)
+    deployment.processVersion.processName shouldBe processName
+    deployment.processVersion.versionId shouldBe 1
+    deployment.processVersion.modelVersion shouldBe Some(3)
+    deployment.processVersion.user shouldBe "testUser"
+    deployment.deploymentTime shouldBe 5
+    deployment.processJson shouldBe processJson.replace("\\", "")
+  }
+}


### PR DESCRIPTION
After migration to circe, `ProcessName` is serialized as a value. On the other hand, using argonaut, it was serialized as an object. As a result existing processes could not be loaded. I added a test case to prevent such errors in future.