### PR TITLE
Fix bug with permissions part 2

### DIFF
--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/ModelData.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/ModelData.scala
@@ -62,6 +62,10 @@ trait ModelData extends ConfigCreatorSignalDispatcher {
 
   lazy val validator: ProcessValidator = ProcessValidator.default(processWithObjectsDefinition, modelClassLoader.classLoader)
 
+  lazy val processDefinitionCategories: List[String] = {
+    processDefinition.categories
+  }
+
   def withThisAsContextClassLoader[T](block: => T) : T = {
     ThreadUtils.withThisAsContextClassLoader(modelClassLoader.classLoader) {
       block

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/ModelData.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/ModelData.scala
@@ -62,10 +62,6 @@ trait ModelData extends ConfigCreatorSignalDispatcher {
 
   lazy val validator: ProcessValidator = ProcessValidator.default(processWithObjectsDefinition, modelClassLoader.classLoader)
 
-  lazy val processDefinitionCategories: List[String] = {
-    processDefinition.categories
-  }
-
   def withThisAsContextClassLoader[T](block: => T) : T = {
     ThreadUtils.withThisAsContextClassLoader(modelClassLoader.classLoader) {
       block

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractor.scala
@@ -122,19 +122,6 @@ object ProcessDefinitionExtractor {
         signalsWithTransformers.keys
       ids.toList
     }
-
-    @Override
-    def categories: List[String] = {
-      val categories = customStreamTransformers.values.flatMap{ case (metadata, _) => metadata.categories }.toList ++
-      expressionConfig.globalVariables.values.flatMap(_.categories).toList ++
-      services.values.flatMap(_.categories).toList
-      signalsWithTransformers.values.flatMap{ case (metadata, _) => metadata.categories }.toList ++
-      sinkFactories.values.flatMap{ case (metadata, _) => metadata.categories }.toList ++
-      sourceFactories.values.flatMap(_.categories).toList ++
-      exceptionHandlerFactory.categories
-
-      categories.distinct
-    }
   }
 
   def toObjectDefinition(definition: ProcessDefinition[ObjectWithMethodDef]) : ProcessDefinition[ObjectDefinition] = {

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractor.scala
@@ -123,6 +123,18 @@ object ProcessDefinitionExtractor {
       ids.toList
     }
 
+    @Override
+    def categories: List[String] = {
+      val categories = customStreamTransformers.values.flatMap{ case (metadata, _) => metadata.categories }.toList ++
+      expressionConfig.globalVariables.values.flatMap(_.categories).toList ++
+      services.values.flatMap(_.categories).toList
+      signalsWithTransformers.values.flatMap{ case (metadata, _) => metadata.categories }.toList ++
+      sinkFactories.values.flatMap{ case (metadata, _) => metadata.categories }.toList ++
+      sourceFactories.values.flatMap(_.categories).toList ++
+      exceptionHandlerFactory.categories
+
+      categories.distinct
+    }
   }
 
   def toObjectDefinition(definition: ProcessDefinition[ObjectWithMethodDef]) : ProcessDefinition[ObjectDefinition] = {

--- a/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
+++ b/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
@@ -1,15 +1,15 @@
 package pl.touk.nussknacker.ui.security.api
 
-import Permission.Permission
+import pl.touk.nussknacker.ui.security.api.Permission.Permission
 
-case class LoggedUser(id: String,
-                      categoryPermissions: Map[String, Set[Permission]]=Map.empty) {
+case class LoggedUser(
+  id: String,
+  categoryPermissions: Map[String, Set[Permission]] = Map.empty,
+  isAdmin: Boolean = false
+) {
   private val permissions = categoryPermissions.values.flatten.toSet
+
   def hasPermission(permission: Permission): Boolean = {
-    permissions.contains(permission) || isAdmin
+    isAdmin || permissions.contains(permission)
   }
-
-  //TODO: remove
-  def isAdmin: Boolean = permissions.contains(Permission.Admin)
-
 }

--- a/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/Permission.scala
+++ b/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/Permission.scala
@@ -5,7 +5,6 @@ object Permission extends Enumeration {
   val Read = Value("Read")
   val Write = Value("Write")
   val Deploy = Value("Deploy")
-  val Admin = Value("Admin")
 
-  final val ALL_PERMISSIONS = Set(Read, Write, Deploy, Admin)
+  final val ALL_PERMISSIONS = Set(Read, Write, Deploy)
 }

--- a/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntax.scala
+++ b/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntax.scala
@@ -5,17 +5,15 @@ object PermissionSyntax {
   implicit class UserPermissionsQuery(user: LoggedUser) {
     def can(permission: Permission.Permission): Set[String] =
       user.categoryPermissions.collect{
-        case (c, p) if p.exists(containsPermissionOrAdmin(permission)) =>
-          c
+        case (c, p) if user.isAdmin || p.exists(containsPermission(permission)) => c
       }.toSet
 
-    def can(category:String,permission: Permission.Permission): Boolean =
-      user.categoryPermissions
+    def can(category:String, permission: Permission.Permission): Boolean =
+      user.isAdmin || user.categoryPermissions
         .getOrElse(category, Set.empty)
-        .exists(containsPermissionOrAdmin(permission))
-  }
-  private[api] def containsPermissionOrAdmin(expected: Permission.Permission)(userCategoryPermission:Permission.Permission):Boolean = {
-    expected == userCategoryPermission || userCategoryPermission == Permission.Admin
+        .exists(containsPermission(permission))
   }
 
+  private[api] def containsPermission(expected: Permission.Permission)(userCategoryPermission: Permission.Permission): Boolean =
+    expected == userCategoryPermission
 }

--- a/engine/security-api/src/test/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntaxTest.scala
+++ b/engine/security-api/src/test/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntaxTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import Permission._
 import org.scalatest.prop.{TableFor3, TableFor4}
-import pl.touk.nussknacker.ui.security.api
 
 class PermissionSyntaxTest extends FunSuite with Matchers {
   import PermissionSyntax._
@@ -21,13 +20,25 @@ class PermissionSyntaxTest extends FunSuite with Matchers {
       u.can(p) shouldEqual c
     }
   }
+
   test("Admin permission grands other permissions") {
-    PermissionSyntax.containsPermissionOrAdmin(Permission.Read)(Permission.Admin) shouldBe true
+    def admin(cp: Map[String, Set[Permission]]) = LoggedUser("admin", cp, true)
+
+    val perms: TableFor3[LoggedUser, Permission, String] = Table(
+      ("user", "permission", "category"),
+      (admin(Map("c1"->Set(Read))), Read, "c1"),
+      (admin(Map.empty), Read, "c1"),
+      (admin(Map("c2"->Set(Write))), Write, "c2"),
+      (admin(Map.empty), Write, "c2")
+    )
+
+    forAll(perms) { (user: LoggedUser, p: Permission, c: String) =>
+      user.can(c, p) shouldEqual true
+    }
   }
 
   test("check user permission in category") {
     def u(m: Map[String, Set[Permission]]) = LoggedUser("", categoryPermissions = m)
-
 
     val perms: TableFor4[LoggedUser, Permission, String, Boolean] = Table(
       ("categoryPermissions", "permission", "category", "result"),

--- a/nussknacker-dist/src/universal/conf/docker-users.conf
+++ b/nussknacker-dist/src/universal/conf/docker-users.conf
@@ -3,12 +3,10 @@ users: [
     id: "admin"
     password: "admin"
     isAdmin: true
-    categoryPermissions: {}
   },
   {
     id: "noperm"
     password: "TOUK_321_ESP"
-    categoryPermissions: {}
   },
   {
     id: "reader"

--- a/nussknacker-dist/src/universal/conf/docker-users.conf
+++ b/nussknacker-dist/src/universal/conf/docker-users.conf
@@ -2,11 +2,8 @@ users: [
   {
     id: "admin"
     password: "admin"
-    categoryPermissions: {
-      "Default": ["Read", "Write", "Deploy", "Admin"]
-      "FraudDetection": ["Read", "Write", "Deploy", "Admin"],
-      "Recommendations": ["Read", "Write", "Deploy", "Admin"]
-    }
+    isAdmin: true
+    categoryPermissions: {}
   },
   {
     id: "noperm"

--- a/nussknacker-dist/src/universal/conf/users.conf
+++ b/nussknacker-dist/src/universal/conf/users.conf
@@ -3,7 +3,6 @@ users: [
     id: "admin"
     password: "admin"
     isAdmin: true
-    categoryPermissions: {}
   },
   {
     id: "reader"

--- a/nussknacker-dist/src/universal/conf/users.conf
+++ b/nussknacker-dist/src/universal/conf/users.conf
@@ -2,9 +2,8 @@ users: [
   {
     id: "admin"
     password: "admin"
-    categoryPermissions: {
-      "Default":["Read", "Write", "Deploy", "Admin"]
-    }
+    isAdmin: true
+    categoryPermissions: {}
   },
   {
     id: "reader"

--- a/ui/client/common/models/User.js
+++ b/ui/client/common/models/User.js
@@ -1,12 +1,16 @@
 import * as _ from "lodash"
 
 const User = function User(data) {
-  _.defaultsDeep(this, data)
+  this.permissions = _.uniq(_.flatMap(data.categoryPermissions))
+  this.categoryPermissions = data.categoryPermissions
+  this.categories = data.categories
+  this.isAdmin = data.isAdmin
+  this.id = data.id
 }
 
 User.prototype.hasPermission = function (permission, category) {
   let permissions = this.categoryPermissions[category] || []
-  return category && permissions.includes(permission)
+  return this.isAdmin || category && permissions.includes(permission)
 }
 
 User.prototype.canRead = function (category) {
@@ -21,20 +25,8 @@ User.prototype.canWrite = function (category) {
   return this.hasPermission("Write", category)
 }
 
-User.prototype.isReader = function () {
-  return this.permissions.includes("Read")
-}
-
-User.prototype.isDeployer = function () {
-  return this.permissions.includes("Deploy")
-}
-
 User.prototype.isWriter = function () {
-  return this.permissions.includes("Write")
-}
-
-User.prototype.isAdmin = function () {
-  return this.permissions.includes("Admin")
+  return this.isAdmin || this.permissions.includes("Write")
 }
 
 export default User

--- a/ui/client/containers/Processes.js
+++ b/ui/client/containers/Processes.js
@@ -117,9 +117,8 @@ class Processes extends BaseProcesses {
               theme={this.customSelectTheme}
             />
           </div>
-
           {
-            this.props.loggedUser.isWriter ? (
+            this.props.loggedUser.isWriter() ? (
               <div
                 id="process-add-button"
                 className="big-blue-button input-group "

--- a/ui/client/containers/SubProcesses.js
+++ b/ui/client/containers/SubProcesses.js
@@ -63,7 +63,7 @@ class SubProcesses extends BaseProcesses {
           </div>
           
           {
-            this.props.loggedUser.isWriter ? (
+            this.props.loggedUser.isWriter() ? (
               <div
                 id="process-add-button"
                 className="big-blue-button input-group"

--- a/ui/server/develConf/generic/users.conf
+++ b/ui/server/develConf/generic/users.conf
@@ -2,8 +2,7 @@ users: [
   {
     id: "admin"
     password: "admin"
-    categoryPermissions: {
-      "Default": ["Read", "Write", "Deploy", "Admin"]
-    }
+    isAdmin: true
+    categoryPermissions: {}
   }
 ]

--- a/ui/server/develConf/generic/users.conf
+++ b/ui/server/develConf/generic/users.conf
@@ -3,6 +3,5 @@ users: [
     id: "admin"
     password: "admin"
     isAdmin: true
-    categoryPermissions: {}
   }
 ]

--- a/ui/server/develConf/sample/application.conf
+++ b/ui/server/develConf/sample/application.conf
@@ -136,8 +136,6 @@ processConfig {
   signals {
     topic: "esp.dev.signals"
   }
-
-
 }
 
 akka {

--- a/ui/server/develConf/sample/users.conf
+++ b/ui/server/develConf/sample/users.conf
@@ -3,12 +3,10 @@ users: [
     id: "admin"
     password: "admin"
     isAdmin: true
-    categoryPermissions: {}
   },
   {
     id: "noperm"
     password: "noperm"
-    categoryPermissions: {}
   },
   {
     id: "reader"
@@ -22,7 +20,7 @@ users: [
     id: "writer"
     password: "writer"
     categoryPermissions: {
-      "Category1": ["Read", "Write"]
+      "Category1": ["Read"]
       "Category2": ["Read", "Write"]
     }
   }

--- a/ui/server/develConf/sample/users.conf
+++ b/ui/server/develConf/sample/users.conf
@@ -2,13 +2,8 @@ users: [
   {
     id: "admin"
     password: "admin"
-    categoryPermissions: {
-      "Category1": ["Read", "Write", "Deploy", "Admin"]
-      "Category2": ["Read", "Write", "Deploy", "Admin"]
-      "Technical": ["Read", "Write", "Deploy", "Admin"]
-      "Default": ["Read", "Write", "Deploy", "Admin"]
-      "StandaloneCategory1": ["Read", "Write", "Deploy", "Admin"]
-    }
+    isAdmin: true
+    categoryPermissions: {}
   },
   {
     id: "noperm"

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -91,6 +91,9 @@ object NussknackerApp extends App with Directives with LazyLogging {
     val typeToConfig = ProcessingTypeDeps(config, featureTogglesConfig.standaloneMode)
 
     val modelData = typeToConfig.mapValues(_.modelData)
+
+    val systemCategories = modelData.values.flatMap(_.processDefinitionCategories).toList.distinct
+
     val managers = typeToConfig.mapValues(_.processManager)
 
     val subprocessRepository = new DbSubprocessRepository(db, system.dispatcher)
@@ -135,7 +138,7 @@ object NussknackerApp extends App with Directives with LazyLogging {
         new ValidationResources(processValidation),
         new DefinitionResources(modelData, subprocessRepository),
         new SignalsResources(modelData, processRepository, processAuthorizer),
-        new UserResources(),
+        new UserResources(systemCategories),
         new NotificationResources(managementActor, processRepository),
         new SettingsResources(featureTogglesConfig, typeToConfig),
         new AppResources(config, modelData, processRepository, processValidation, jobStatusService),

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -92,7 +92,7 @@ object NussknackerApp extends App with Directives with LazyLogging {
 
     val modelData = typeToConfig.mapValues(_.modelData)
 
-    val systemCategories = modelData.values.flatMap(_.processDefinitionCategories).toList.distinct
+    val typesForCategories = new ProcessTypesForCategories(config)
 
     val managers = typeToConfig.mapValues(_.processManager)
 
@@ -127,7 +127,7 @@ object NussknackerApp extends App with Directives with LazyLogging {
           jobStatusService = jobStatusService,
           processActivityRepository = processActivityRepository,
           processValidation = processValidation,
-          typesForCategories = new ProcessTypesForCategories(config),
+          typesForCategories = typesForCategories,
           newProcessPreparer = NewProcessPreparer(typeToConfig, additionalFields),
           processAuthorizer = processAuthorizer
         ),
@@ -138,7 +138,7 @@ object NussknackerApp extends App with Directives with LazyLogging {
         new ValidationResources(processValidation),
         new DefinitionResources(modelData, subprocessRepository),
         new SignalsResources(modelData, processRepository, processAuthorizer),
-        new UserResources(systemCategories),
+        new UserResources(typesForCategories),
         new NotificationResources(managementActor, processRepository),
         new SettingsResources(featureTogglesConfig, typeToConfig),
         new AppResources(config, modelData, processRepository, processValidation, jobStatusService),

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/AppResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/AppResources.scala
@@ -82,7 +82,7 @@ class AppResources(config: Config,
         }
       } ~ path("config") {
         //config can contain sensitive information, so only Admin can see it
-        authorize(user.hasPermission(Permission.Admin)) {
+        authorize(user.isAdmin) {
           get {
             complete {
               io.circe.parser.parse(config.root().render(ConfigRenderOptions.concise())).left.map(_.message)

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/AuthorizeProcessDirectives.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/AuthorizeProcessDirectives.scala
@@ -10,13 +10,9 @@ import scala.language.implicitConversions
 trait AuthorizeProcessDirectives {
   val processAuthorizer: AuthorizeProcess
 
-  protected implicit def attachImplicitUserToProcessId(id: ProcessId)
-                                                       (implicit loggedUser: LoggedUser): (ProcessId, LoggedUser) =
-    (id, loggedUser)
+  protected implicit def attachImplicitUserToProcessId(id: ProcessId)(implicit loggedUser: LoggedUser): (ProcessId, LoggedUser) = (id, loggedUser)
 
-  protected implicit def attachImplicitUserToProcessIdWithName(id: ProcessIdWithName)
-                                                              (implicit loggedUser: LoggedUser): (ProcessId, LoggedUser) =
-    (id.id, loggedUser)
+  protected implicit def attachImplicitUserToProcessIdWithName(id: ProcessIdWithName)(implicit loggedUser: LoggedUser): (ProcessId, LoggedUser) = (id.id, loggedUser)
 
   def canDeploy(processIdAndUser: (ProcessId, LoggedUser)): Directive0 = {
     hasUserPermissionInProcess(processIdAndUser, Permission.Deploy)
@@ -25,12 +21,17 @@ trait AuthorizeProcessDirectives {
   def canWrite(processIdAndUser: (ProcessId, LoggedUser)): Directive0 = {
     hasUserPermissionInProcess(processIdAndUser, Permission.Write)
   }
-  private def canInProcess(processId: ProcessId, permission: Permission, user:LoggedUser):Directive0 = {
+
+  private def canInProcess(processId: ProcessId, permission: Permission, user:LoggedUser) :Directive0 = {
     Directives.authorizeAsync(_ => processAuthorizer.check(processId, permission,user))
   }
+
+  def hasAdminPermission(loggedUser: LoggedUser): Directive0 = {
+    Directives.authorize(loggedUser.isAdmin)
+  }
+
   private def hasUserPermissionInProcess(processIdAndUser: (ProcessId, LoggedUser), permission: Permission.Value): Directive0 = {
     val (processId, user) = processIdAndUser
     canInProcess(processId, permission, user)
   }
-
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -251,8 +251,9 @@ class ProcessesResources(val processRepository: FetchingProcessRepository,
           }
         } ~ path("processes" / "category" / Segment / Segment) { (processName, category) =>
           (post & processId(processName)) { processId =>
-            canWrite(processId) {
+            hasAdminPermission(user) {
               complete {
+                // TODO: Validate that category exists at categories list
                 writeRepository.updateCategory(processId = processId.id, category = category).map(toResponse(StatusCodes.OK))
               }
             }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
@@ -2,28 +2,24 @@ package pl.touk.nussknacker.ui.api
 
 import akka.http.scaladsl.server.{Directives, Route}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
-import io.circe.{Decoder, Encoder}
 import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.ui.security.api.LoggedUser
-import io.circe._, io.circe.generic.semiauto._
 
 import scala.concurrent.ExecutionContext
 
-class UserResources(implicit ec: ExecutionContext)
-  extends Directives with FailFastCirceSupport with RouteWithUser {
-
+class UserResources(systemCategories: List[String])(implicit ec: ExecutionContext) extends Directives with FailFastCirceSupport with RouteWithUser {
   def route(implicit user: LoggedUser): Route =
     path("user") {
       get {
         complete {
           DisplayableUser(
             id = user.id,
-            permissions = user.categoryPermissions.values.flatten.map(_.toString).toList.distinct,
-            categories = user.categoryPermissions.keys.toList,
+            isAdmin = user.isAdmin,
+            categories = systemCategories,
             categoryPermissions = user.categoryPermissions.mapValues(_.map(_.toString)))
         }
       }
     }
-
 }
-@JsonCodec case class DisplayableUser(id: String, permissions: List[String], categories: List[String],categoryPermissions: Map[String, Set[String]])
+
+@JsonCodec case class DisplayableUser(id: String, isAdmin: Boolean, categories: List[String], categoryPermissions: Map[String, Set[String]])

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
@@ -16,7 +16,7 @@ class UserResources(typesForCategories: ProcessTypesForCategories)(implicit ec: 
           DisplayableUser(
             id = user.id,
             isAdmin = user.isAdmin,
-            categories = typesForCategories.getSystemCategories(),
+            categories = typesForCategories.getAllCategories,
             categoryPermissions = user.categoryPermissions.mapValues(_.map(_.toString)))
         }
       }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
@@ -3,11 +3,12 @@ package pl.touk.nussknacker.ui.api
 import akka.http.scaladsl.server.{Directives, Route}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.generic.JsonCodec
+import pl.touk.nussknacker.ui.process.ProcessTypesForCategories
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.ExecutionContext
 
-class UserResources(systemCategories: List[String])(implicit ec: ExecutionContext) extends Directives with FailFastCirceSupport with RouteWithUser {
+class UserResources(typesForCategories: ProcessTypesForCategories)(implicit ec: ExecutionContext) extends Directives with FailFastCirceSupport with RouteWithUser {
   def route(implicit user: LoggedUser): Route =
     path("user") {
       get {
@@ -15,7 +16,7 @@ class UserResources(systemCategories: List[String])(implicit ec: ExecutionContex
           DisplayableUser(
             id = user.id,
             isAdmin = user.isAdmin,
-            categories = systemCategories,
+            categories = typesForCategories.getSystemCategories(),
             categoryPermissions = user.categoryPermissions.mapValues(_.map(_.toString)))
         }
       }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessTypesForCategories.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessTypesForCategories.scala
@@ -20,7 +20,5 @@ class ProcessTypesForCategories(config: Config) {
     categoriesToTypesMap.get(category)
   }
 
-  def getSystemCategories(): List[String] = {
-    categoriesToTypesMap.keys.toList
-  }
+  val getAllCategories = categoriesToTypesMap.keys.toList
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessTypesForCategories.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessTypesForCategories.scala
@@ -20,4 +20,7 @@ class ProcessTypesForCategories(config: Config) {
     categoriesToTypesMap.get(category)
   }
 
+  def getSystemCategories(): List[String] = {
+    categoriesToTypesMap.keys.toList
+  }
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/BasicHttpAuthenticator.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/BasicHttpAuthenticator.scala
@@ -70,7 +70,7 @@ object BasicHttpAuthenticator {
   private[security] case class ConfiguredUser(id: String,
                                               password: Option[String],
                                               encryptedPassword: Option[String],
-                                              categoryPermissions: Map[String, Set[Permission]],
+                                              categoryPermissions: Map[String, Set[Permission]] = Map.empty,
                                               isAdmin: Boolean = false)
 
   private sealed trait Password {
@@ -81,9 +81,7 @@ object BasicHttpAuthenticator {
 
   private case class EncryptedPassword(value: String) extends Password
 
-  private case class UserWithPassword(id: String, password: Password,
-                                      categoryPermissions: Map[String, Set[Permission]],
-                                      isAdmin: Boolean) {
+  private case class UserWithPassword(id: String, password: Password, categoryPermissions: Map[String, Set[Permission]], isAdmin: Boolean) {
     def toLoggedUser = LoggedUser(id, categoryPermissions, isAdmin)
   }
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/BasicHttpAuthenticator.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/BasicHttpAuthenticator.scala
@@ -52,7 +52,7 @@ class BasicHttpAuthenticator(usersList: List[ConfiguredUser]) extends SecurityDi
         case (Some(_), Some(_)) => throw new IllegalStateException("Specified both password and encrypted password for user: " + u.id)
         case (None, None) => throw new IllegalStateException("Neither specified password nor encrypted password for user: " + u.id)
       }
-      u.id -> UserWithPassword(u.id, password, u.categoryPermissions)
+      u.id -> UserWithPassword(u.id, password, u.categoryPermissions, u.isAdmin)
     }.toMap
   }
 
@@ -70,7 +70,8 @@ object BasicHttpAuthenticator {
   private[security] case class ConfiguredUser(id: String,
                                               password: Option[String],
                                               encryptedPassword: Option[String],
-                                              categoryPermissions: Map[String, Set[Permission]])
+                                              categoryPermissions: Map[String, Set[Permission]],
+                                              isAdmin: Boolean = false)
 
   private sealed trait Password {
     def value: String
@@ -80,8 +81,10 @@ object BasicHttpAuthenticator {
 
   private case class EncryptedPassword(value: String) extends Password
 
-  private case class UserWithPassword(id: String, password: Password, categoryPermissions: Map[String, Set[Permission]]) {
-    def toLoggedUser = LoggedUser(id, categoryPermissions)
+  private case class UserWithPassword(id: String, password: Password,
+                                      categoryPermissions: Map[String, Set[Permission]],
+                                      isAdmin: Boolean) {
+    def toLoggedUser = LoggedUser(id, categoryPermissions, isAdmin)
   }
 
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/NussknackerInternalUser.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/NussknackerInternalUser.scala
@@ -1,5 +1,5 @@
 package pl.touk.nussknacker.ui.security
 
-import pl.touk.nussknacker.ui.security.api.{LoggedUser, Permission}
+import pl.touk.nussknacker.ui.security.api.LoggedUser
 
-object NussknackerInternalUser extends LoggedUser("Nussknacker", Map("Default"->Set(Permission.Write, Permission.Admin)))
+object NussknackerInternalUser extends LoggedUser("Nussknacker", Map.empty, true)

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/AppResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/AppResourcesSpec.scala
@@ -117,7 +117,7 @@ class AppResourcesSpec extends FunSuite with ScalatestRouteTest
   }
 
   private def saveProcessWithDeployInfo(id: String) = {
-    implicit val logged = TestFactory.user(testPermissionAdmin)
+    implicit val logged = TestFactory.adminUser("userId")
     writeProcessRepository.saveNewProcess(ProcessName(id), TestFactory.testCategoryName, CustomProcess(""), TestProcessingTypes.Streaming, false)
       .futureValue shouldBe Right(())
     val processId = processRepository.fetchProcessId(ProcessName(id)).futureValue.get

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -37,7 +37,7 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
 
   private def deployedWithVersions(versionIds: Long*) =
     BeMatcher(
-      equal(versionIds.map(l => DeploymentEntry(l, TestFactory.testEnvironment, fixedTime, user().id, buildInfo))).matcher[List[DeploymentEntry]]
+      equal(versionIds.map(l => DeploymentEntry(l, TestFactory.testEnvironment, fixedTime, user("userId").id, buildInfo))).matcher[List[DeploymentEntry]]
     ).compose[List[DeploymentEntry]](_.map(_.copy(deployedAt = fixedTime)))
 
 
@@ -84,8 +84,8 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
             val deploymentHistory = responseAs[List[DeploymentHistoryEntry]]
             val curTime = LocalDateTime.now()
             deploymentHistory.map(_.copy(time = curTime)) shouldBe List(
-              DeploymentHistoryEntry(2, curTime, user().id, DeploymentAction.Cancel, Some(secondCommentId), Map()),
-              DeploymentHistoryEntry(2, curTime, user().id, DeploymentAction.Deploy, Some(firstCommentId), TestFactory.buildInfo)
+              DeploymentHistoryEntry(2, curTime, user("userId").id, DeploymentAction.Cancel, Some(secondCommentId), Map()),
+              DeploymentHistoryEntry(2, curTime, user("userId").id, DeploymentAction.Deploy, Some(firstCommentId), TestFactory.buildInfo)
             )
           }
         }
@@ -101,7 +101,7 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
   }
 
   test("deploy technical process and mark it as deployed") {
-    implicit val loggedUser = user() copy(categoryPermissions = Map(testCategoryName->Set(Permission.Admin, Permission.Write, Permission.Deploy, Permission.Read)))
+    implicit val loggedUser = user("userId") copy(categoryPermissions = Map(testCategoryName->Set(Permission.Write, Permission.Deploy, Permission.Read)))
     val processId = "Process1"
     whenReady(writeProcessRepository.saveNewProcess(ProcessName(processId), testCategoryName, CustomProcess(""), TestProcessingTypes.Streaming, false)) { res =>
       deployProcess(processId) ~> check { status shouldBe StatusCodes.OK }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -56,10 +56,7 @@ trait EspItTest extends LazyLogging with ScalaFutures with WithHsqlDbTesting wit
     Map("streaming" -> Map.empty)
   )
 
-  private implicit val user: LoggedUser = LoggedUser("user", Map(
-    testCategoryName -> Set(Permission.Admin),
-    secondTestCategoryName -> Set(Permission.Admin)
-  ))
+  private implicit val user: LoggedUser = TestFactory.adminUser("user")
 
   val processesRoute = new ProcessesResources(
     processRepository = processRepository,

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -62,13 +62,18 @@ object TestFactory extends TestPermissions{
   def newProcessActivityRepository(db: DbConfig) = new ProcessActivityRepository(db)
 
   def withPermissions(route: RouteWithUser, permissions: TestPermissions.CategorizedPermission) =
-    route.route(user(permissions))
-
-  //FIXME: update
-  def user(testPermissions: CategorizedPermission = testPermissionEmpty) = LoggedUser("userId", testPermissions)
+    route.route(user("userId", permissions))
 
   //FIXME: update
   def withAllPermissions(route: RouteWithUser) = withPermissions(route, testPermissionAll)
+
+  def withAdminPermissions(route: RouteWithUser) =
+    route.route(adminUser("adminId"))
+
+  //FIXME: update
+  def user(userName: String = "userId", testPermissions: CategorizedPermission = testPermissionEmpty) = LoggedUser(userName, testPermissions)
+
+  def adminUser(userName: String = "adminId") = LoggedUser(userName, Map.empty, true)
 
   class MockProcessManager extends FlinkProcessManager(FlinkProcessManagerProvider.defaultModelData(ConfigFactory.load()), false){
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestPermissions.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestPermissions.scala
@@ -16,9 +16,7 @@ trait TestPermissions {
   val testPermissionDeploy: CategorizedPermission = Map(testCategoryName -> Set(Permission.Deploy), secondTestCategoryName -> Set(Permission.Deploy))
   val testPermissionRead: CategorizedPermission = Map(testCategoryName -> Set(Permission.Read), secondTestCategoryName -> Set(Permission.Read))
   val testPermissionWrite: CategorizedPermission = Map(testCategoryName -> Set(Permission.Write), secondTestCategoryName -> Set(Permission.Write))
-  val testPermissionAdmin: CategorizedPermission = Map(testCategoryName -> Set(Permission.Admin), secondTestCategoryName -> Set(Permission.Admin))
-  val testPermissionAll: CategorizedPermission = testPermissionDeploy |+| testPermissionRead |+| testPermissionWrite |+| testPermissionAdmin
-
+  val testPermissionAll: CategorizedPermission = testPermissionDeploy |+| testPermissionRead |+| testPermissionWrite
 }
 
 object TestPermissions {
@@ -27,5 +25,4 @@ object TestPermissions {
   val testCategoryName = "TESTCAT"
 
   val secondTestCategoryName = "TESTCAT2"
-
 }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparerSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparerSpec.scala
@@ -33,7 +33,7 @@ class DefinitionPreparerSpec extends FunSuite with Matchers with TestPermissions
   test("return edge types for subprocess, filters and switches") {
     val subprocessesDetails = TestFactory.sampleSubprocessRepository.loadSubprocesses(Map.empty)
     val edgeTypes = DefinitionPreparer.prepareEdgeTypes(
-      user = LoggedUser("aa", testPermissionAdmin),
+      user = TestFactory.adminUser("aa"),
       processDefinition = ProcessTestData.processDefinition,
       isSubprocess = false,
       subprocessesDetails = subprocessesDetails)
@@ -99,7 +99,7 @@ class DefinitionPreparerSpec extends FunSuite with Matchers with TestPermissions
     val subprocessInputs = Map[String, ObjectDefinition]()
 
     val groups = DefinitionPreparer.prepareNodesToAdd(
-      user = LoggedUser("aa", testPermissionAdmin),
+      user = TestFactory.adminUser("aa"),
       processDefinition = ProcessTestData.processDefinition,
       isSubprocess = false,
       subprocessInputs = subprocessInputs,
@@ -114,7 +114,7 @@ class DefinitionPreparerSpec extends FunSuite with Matchers with TestPermissions
   private def prepareGroupsOfNodes(services: List[String]): List[NodeGroup] = {
 
     val groups = DefinitionPreparer.prepareNodesToAdd(
-      user = LoggedUser("aa", testPermissionAdmin),
+      user = TestFactory.adminUser("aa"),
       processDefinition = services.foldRight(ProcessDefinitionBuilder.empty)((s, p) => p.withService(s)),
       isSubprocess = false,
       subprocessInputs = Map(),

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsSpec.scala
@@ -35,7 +35,7 @@ class UIProcessObjectsSpec extends FunSuite with Matchers {
     })
 
     val processObjects =
-      UIProcessObjects.prepareUIProcessObjects(model, TestFactory.user(), Set(), false)
+      UIProcessObjects.prepareUIProcessObjects(model, TestFactory.user("userId"), Set(), false)
 
     processObjects.nodesConfig("enricher").params shouldBe Some(Map("param" -> ParameterConfig(Some("'default value'"),
       Some(FixedExpressionValues(List(
@@ -70,7 +70,7 @@ class UIProcessObjectsSpec extends FunSuite with Matchers {
     val model : ModelData = LocalModelData(ConfigFactory.load().getConfig("processConfig"), new EmptyProcessConfigCreator())
 
     val processObjects =
-      UIProcessObjects.prepareUIProcessObjects(model, TestFactory.user(), Set(
+      UIProcessObjects.prepareUIProcessObjects(model, TestFactory.user("userId"), Set(
         SubprocessDetails(CanonicalProcess(MetaData("enricher", null, isSubprocess = true), null, List(FlatNode(SubprocessInputDefinition("", List(
           SubprocessParameter("param", SubprocessClazzRef[String])
         )))), None), "")

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActorSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActorSpec.scala
@@ -19,7 +19,7 @@ class ManagementActorSpec extends FunSuite  with Matchers with ScalaFutures with
 
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(1, Seconds)), interval = scaled(Span(100, Millis)))
   private implicit val system: ActorSystem = ActorSystem()
-  private implicit val user: LoggedUser = LoggedUser("user", Map(testCategoryName -> Set(Permission.Admin)))
+  private implicit val user: LoggedUser = TestFactory.adminUser("user")
   private implicit val ds: ExecutionContextExecutor = system.dispatcher
 
   private val env = "test1"

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigratorSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigratorSpec.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.api.StreamMetaData
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
 import pl.touk.nussknacker.engine.graph.node.{Processor, asProcessor}
 import pl.touk.nussknacker.engine.graph.service.ServiceRef
-import pl.touk.nussknacker.ui.api.helpers.{ProcessTestData, TestPermissions, TestProcessingTypes}
+import pl.touk.nussknacker.ui.api.helpers.{ProcessTestData, TestFactory, TestPermissions, TestProcessingTypes}
 import pl.touk.nussknacker.restmodel.process.ProcessId
 import pl.touk.nussknacker.ui.security.api.{LoggedUser, Permission}
 import shapeless.Typeable._
@@ -23,7 +23,7 @@ class ProcessModelMigratorSpec extends FlatSpec with BeforeAndAfterEach with Sca
   val processId = "fooProcess"
 
 
-  private implicit val user = LoggedUser("test1", testPermissionAdmin)
+  private implicit val user = TestFactory.adminUser("test1")
 
   it should "migrate processes to new versions when not migrated" in {
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
@@ -40,7 +40,7 @@ class DBFetchingProcessRepositorySpec
 
   private val fetching = DBFetchingProcessRepository.create(db)
 
-  private implicit val user = TestFactory.user(testPermissionAdmin)
+  private implicit val user = TestFactory.adminUser("userId")
 
   test("fetch processes for category") {
 
@@ -54,7 +54,7 @@ class DBFetchingProcessRepositorySpec
         category = cat
       )
     }
-    val c1Reader = TestFactory.user("c1"->Permission.Read)
+    val c1Reader = TestFactory.user("userId", "c1"->Permission.Read)
 
     saveProcessForCategory("c1")
     saveProcessForCategory("c2")


### PR DESCRIPTION
This PR closes #121 it's connected with old PR: https://github.com/TouK/nussknacker/pull/146

* Remove Permission.Admin
* Add isAdmin property at user config file
* Fetching systemCategories from processDefinition elements
* Add security for changing category, now this can do only admin
* Add some todos
* Some tests refactor