### PR TITLE
Stretch process name text to full column width

### DIFF
--- a/ui/client/containers/Processes.js
+++ b/ui/client/containers/Processes.js
@@ -169,7 +169,7 @@ class Processes extends BaseProcesses {
           {this.state.processes.map((process, index) => {
             return (
               <Tr className="row-hover" key={index}>
-                <Td column="name" value={process.name}>
+                <Td column="name" className="name-column" value={process.name}>
                   <input
                     value={process.editedName != null ? process.editedName : process.name}
                     className="transparent"

--- a/ui/client/stylesheets/processes.styl
+++ b/ui/client/stylesheets/processes.styl
@@ -139,6 +139,10 @@
       opacity: 0.4 !important
       padding: 0
 
+  .name-column
+    input
+      width: 100%
+
   .metrics-column, .reactable-th-metrics
     clickableIconColumn()
 


### PR DESCRIPTION
For some reason nested input in table cell was not taking full width. Long process names were not fully visible.