### PR TITLE
Include deployment comment in /api/processes/:name/deployments endpoint

### DIFF
--- a/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/processdetails.scala
+++ b/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/processdetails.scala
@@ -93,23 +93,23 @@ object processdetails extends JavaTimeEncoders with JavaTimeDecoders {
                                             createDate: LocalDateTime,
                                             user: String,
                                             //TODO: remove, replace with 'currentDeployments'
-                                            deployments: List[DeploymentEntry]
-                                )
+                                            deployments: List[DeploymentEntry])
 
 
   @JsonCodec case class DeploymentEntry(processVersionId: Long,
-                            //TODO: remove, in current usage it's not really needed
-                             environment: String,
-                             deployedAt: LocalDateTime,
-                             user: String,
-                             buildInfo: Map[String, String])
+                                        //TODO: remove, in current usage it's not really needed
+                                        environment: String,
+                                        deployedAt: LocalDateTime,
+                                        user: String,
+                                        buildInfo: Map[String, String])
 
   @JsonCodec case class DeploymentHistoryEntry(processVersionId: Long,
-                             time: LocalDateTime,
-                             user: String,
-                             deploymentAction: DeploymentAction,
-                             commentId: Option[Long],
-                             buildInfo: Map[String, String])
+                                               time: LocalDateTime,
+                                               user: String,
+                                               deploymentAction: DeploymentAction,
+                                               commentId: Option[Long],
+                                               comment: Option[String],
+                                               buildInfo: Map[String, String])
 
 
   object DeploymentAction extends Enumeration {

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -70,7 +70,6 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
 
   test("deploys and cancels with comment") {
     saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
-    val currentMaxComments =
     deployProcess(SampleProcess.process.id, true, Some("deployComment")) ~> check {
       cancelProcess(SampleProcess.process.id, true, Some("cancelComment")) ~> check {
         status shouldBe StatusCodes.OK
@@ -84,8 +83,8 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
             val deploymentHistory = responseAs[List[DeploymentHistoryEntry]]
             val curTime = LocalDateTime.now()
             deploymentHistory.map(_.copy(time = curTime)) shouldBe List(
-              DeploymentHistoryEntry(2, curTime, user("userId").id, DeploymentAction.Cancel, Some(secondCommentId), Map()),
-              DeploymentHistoryEntry(2, curTime, user("userId").id, DeploymentAction.Deploy, Some(firstCommentId), TestFactory.buildInfo)
+              DeploymentHistoryEntry(2, curTime, user("userId").id, DeploymentAction.Cancel, Some(secondCommentId), Some("Stop: cancelComment"), Map()),
+              DeploymentHistoryEntry(2, curTime, user("userId").id, DeploymentAction.Deploy, Some(firstCommentId), Some("Deployment: deployComment"), TestFactory.buildInfo)
             )
           }
         }


### PR DESCRIPTION
Returning merely commentId from this endpoint brings close to no value to the user. In scenario when user wants to read this comment's content they have to fetch all comments for all versions and filter them accordingly. Having explicit endpoint just to fetch comment seems redundant thus this change.