### PR TITLE
LoggedUser refactoring

### DIFF
--- a/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
+++ b/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
@@ -4,7 +4,7 @@ import pl.touk.nussknacker.ui.security.api.Permission.Permission
 
 sealed trait LoggedUser {
   val id: String
-  def hasPermission(category: String, permission: Permission): Boolean
+  def can(category: String, permission: Permission): Boolean
   val isAdmin: Boolean
 }
 
@@ -25,7 +25,7 @@ case class CommonUser(id: String,
     case (category, permissions) if permissions contains permission => category
   }.toSet
 
-  override def hasPermission(category: String, permission: Permission): Boolean = {
+  override def can(category: String, permission: Permission): Boolean = {
     categoryPermissions.get(category).exists(_ contains permission)
   }
 
@@ -33,6 +33,6 @@ case class CommonUser(id: String,
 }
 
 case class AdminUser(id: String) extends LoggedUser {
-  override def hasPermission(category: String, permission: Permission): Boolean = true
+  override def can(category: String, permission: Permission): Boolean = true
   override val isAdmin: Boolean = true
 }

--- a/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
+++ b/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
@@ -2,14 +2,37 @@ package pl.touk.nussknacker.ui.security.api
 
 import pl.touk.nussknacker.ui.security.api.Permission.Permission
 
-case class LoggedUser(
-  id: String,
-  categoryPermissions: Map[String, Set[Permission]] = Map.empty,
-  isAdmin: Boolean = false
-) {
-  private val permissions = categoryPermissions.values.flatten.toSet
+sealed trait LoggedUser {
+  val id: String
+  def hasPermission(category: String, permission: Permission): Boolean
+  val isAdmin: Boolean
+}
 
-  def hasPermission(permission: Permission): Boolean = {
-    isAdmin || permissions.contains(permission)
+object LoggedUser {
+  def apply(id: String, categoryPermissions: Map[String, Set[Permission]] = Map.empty, isAdmin: Boolean = false): LoggedUser = {
+    if (isAdmin) {
+      AdminUser(id)
+    }
+    else {
+      CommonUser(id, categoryPermissions)
+    }
   }
+}
+
+case class CommonUser(id: String,
+                      categoryPermissions: Map[String, Set[Permission]] = Map.empty) extends LoggedUser {
+  def categories(permission: Permission): Set[String] = categoryPermissions.collect {
+    case (category, permissions) if permissions contains permission => category
+  }.toSet
+
+  override def hasPermission(category: String, permission: Permission): Boolean = {
+    categoryPermissions.get(category).exists(_ contains permission)
+  }
+
+  override val isAdmin: Boolean = false
+}
+
+case class AdminUser(id: String) extends LoggedUser {
+  override def hasPermission(category: String, permission: Permission): Boolean = true
+  override val isAdmin: Boolean = true
 }

--- a/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntax.scala
+++ b/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntax.scala
@@ -1,9 +1,0 @@
-package pl.touk.nussknacker.ui.security.api
-
-object PermissionSyntax {
-  implicit class UserPermissionsQuery(user: LoggedUser) {
-    def can(category: String, permission: Permission.Permission): Boolean = {
-      user.hasPermission(category, permission)
-    }
-  }
-}

--- a/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntax.scala
+++ b/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntax.scala
@@ -1,19 +1,9 @@
 package pl.touk.nussknacker.ui.security.api
 
 object PermissionSyntax {
-
   implicit class UserPermissionsQuery(user: LoggedUser) {
-    def can(permission: Permission.Permission): Set[String] =
-      user.categoryPermissions.collect{
-        case (c, p) if user.isAdmin || p.exists(containsPermission(permission)) => c
-      }.toSet
-
-    def can(category:String, permission: Permission.Permission): Boolean =
-      user.isAdmin || user.categoryPermissions
-        .getOrElse(category, Set.empty)
-        .exists(containsPermission(permission))
+    def can(category: String, permission: Permission.Permission): Boolean = {
+      user.hasPermission(category, permission)
+    }
   }
-
-  private[api] def containsPermission(expected: Permission.Permission)(userCategoryPermission: Permission.Permission): Boolean =
-    expected == userCategoryPermission
 }

--- a/engine/security-api/src/test/scala/pl/touk/nussknacker/ui/security/api/LoggedUserTest.scala
+++ b/engine/security-api/src/test/scala/pl/touk/nussknacker/ui/security/api/LoggedUserTest.scala
@@ -5,10 +5,9 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import Permission._
 import org.scalatest.prop.{TableFor3, TableFor4}
 
-class PermissionSyntaxTest extends FunSuite with Matchers {
-  import PermissionSyntax._
+class LoggedUserTest extends FunSuite with Matchers {
 
-  test("Admin permission grands other permissions") {
+  test("Admin permission grants other permissions") {
     def admin(cp: Map[String, Set[Permission]]) = LoggedUser("admin", cp, true)
 
     val perms: TableFor3[LoggedUser, Permission, String] = Table(

--- a/engine/security-api/src/test/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntaxTest.scala
+++ b/engine/security-api/src/test/scala/pl/touk/nussknacker/ui/security/api/PermissionSyntaxTest.scala
@@ -8,19 +8,6 @@ import org.scalatest.prop.{TableFor3, TableFor4}
 class PermissionSyntaxTest extends FunSuite with Matchers {
   import PermissionSyntax._
 
-  test("filter categories by permission") {
-    def u(m: Map[String, Set[Permission]]) = LoggedUser("", categoryPermissions = m)
-
-    val perms: TableFor3[LoggedUser, Permission, Set[String]] = Table(
-      ("categoryPermissions", "permission", "categories"),
-      (u(Map("c1"->Set(Read))), Read, Set("c1")),
-      (u(Map("c2"->Set(Write))), Read, Set.empty)
-    )
-    forAll(perms) { (u: LoggedUser, p: Permission, c: Set[String]) =>
-      u.can(p) shouldEqual c
-    }
-  }
-
   test("Admin permission grands other permissions") {
     def admin(cp: Map[String, Set[Permission]]) = LoggedUser("admin", cp, true)
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -136,7 +136,7 @@ object NussknackerApp extends App with Directives with LazyLogging {
         ManagementResources(counter, managementActor, testResultsMaxSizeInBytes,
           processAuthorizer, processRepository, featureTogglesConfig),
         new ValidationResources(processValidation),
-        new DefinitionResources(modelData, subprocessRepository),
+        new DefinitionResources(modelData, subprocessRepository, typesForCategories),
         new SignalsResources(modelData, processRepository, processAuthorizer),
         new UserResources(typesForCategories),
         new NotificationResources(managementActor, processRepository),

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/AuthorizeProcess.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/AuthorizeProcess.scala
@@ -4,7 +4,6 @@ import pl.touk.nussknacker.restmodel.process.ProcessId
 import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.ui.security.api.Permission.Permission
-import pl.touk.nussknacker.ui.security.api.PermissionSyntax._
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/DefinitionResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/DefinitionResources.scala
@@ -1,14 +1,13 @@
 package pl.touk.nussknacker.ui.api
 
-import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.{Directives, Route}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
 import pl.touk.nussknacker.ui.definition
-import pl.touk.nussknacker.ui.definition.{UIObjectDefinition, UIProcessObjects}
-import pl.touk.nussknacker.ui.process.ProcessObjectsFinder
+import pl.touk.nussknacker.ui.definition.UIProcessObjects
+import pl.touk.nussknacker.ui.process.{ProcessObjectsFinder, ProcessTypesForCategories}
 import pl.touk.nussknacker.ui.process.subprocess.SubprocessRepository
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.ui.util.EspPathMatchers
@@ -16,7 +15,8 @@ import pl.touk.nussknacker.ui.util.EspPathMatchers
 import scala.concurrent.ExecutionContext
 
 class DefinitionResources(modelData: Map[ProcessingType, ModelData],
-                          subprocessRepository: SubprocessRepository)
+                          subprocessRepository: SubprocessRepository,
+                          typesForCategories: ProcessTypesForCategories)
                          (implicit ec: ExecutionContext)
   extends Directives with FailFastCirceSupport with EspPathMatchers with RouteWithUser {
 
@@ -29,7 +29,7 @@ class DefinitionResources(modelData: Map[ProcessingType, ModelData],
               modelData.get(processingType).map { modelDataForType =>
                 val subprocesses = subprocessRepository.loadSubprocesses(subprocessVersions)
                 complete {
-                  UIProcessObjects.prepareUIProcessObjects(modelDataForType, user, subprocesses, isSubprocess)
+                  UIProcessObjects.prepareUIProcessObjects(modelDataForType, user, subprocesses, isSubprocess, typesForCategories)
                 }
               }.getOrElse {
                 complete {

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -34,7 +34,6 @@ import pl.touk.nussknacker.ui.security.api.{LoggedUser, Permission}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-import pl.touk.nussknacker.ui.security.api.PermissionSyntax._
 
 class ProcessesResources(val processRepository: FetchingProcessRepository,
                          writeRepository: WriteProcessRepository,

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ServiceRoutes.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ServiceRoutes.scala
@@ -14,7 +14,6 @@ import pl.touk.nussknacker.ui.security.api.{LoggedUser, Permission}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-import pl.touk.nussknacker.ui.security.api.PermissionSyntax._
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.{Encoder, Json, ObjectEncoder}
 import io.circe.generic.JsonCodec

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.server.{Directives, Route}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.ui.process.ProcessTypesForCategories
-import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.security.api.{AdminUser, CommonUser, LoggedUser, Permission}
 
 import scala.concurrent.ExecutionContext
 
@@ -13,14 +13,29 @@ class UserResources(typesForCategories: ProcessTypesForCategories)(implicit ec: 
     path("user") {
       get {
         complete {
-          DisplayableUser(
-            id = user.id,
-            isAdmin = user.isAdmin,
-            categories = typesForCategories.getAllCategories,
-            categoryPermissions = user.categoryPermissions.mapValues(_.map(_.toString)))
+          DisplayableUser(user, typesForCategories.getAllCategories)
         }
       }
     }
 }
 
-@JsonCodec case class DisplayableUser(id: String, isAdmin: Boolean, categories: List[String], categoryPermissions: Map[String, Set[String]])
+@JsonCodec case class DisplayableUser private(id: String, isAdmin: Boolean, categories: List[String], categoryPermissions: Map[String, Set[String]])
+
+object DisplayableUser {
+  import pl.touk.nussknacker.engine.util.Implicits._
+
+  def apply(user: LoggedUser, allCategories: List[String]): DisplayableUser = user match {
+    case CommonUser(id, categoryPermissions) => new DisplayableUser(
+      id = id,
+      isAdmin = false,
+      categories = allCategories,
+      categoryPermissions = categoryPermissions.mapValuesNow(_.map(_.toString))
+    )
+    case AdminUser(id) => new DisplayableUser(
+      id = id,
+      isAdmin = true,
+      categories = allCategories,
+      categoryPermissions = allCategories.map(category => category -> Permission.ALL_PERMISSIONS.map(_.toString)).toMap
+    )
+  }
+}

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparer.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparer.scala
@@ -18,8 +18,7 @@ import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
 import pl.touk.nussknacker.ui.process.subprocess.SubprocessDetails
 import pl.touk.nussknacker.ui.process.uiconfig.defaults.ParameterEvaluatorExtractor
 import pl.touk.nussknacker.ui.security.api.Permission._
-import pl.touk.nussknacker.ui.security.api.{LoggedUser, PermissionSyntax}
-import PermissionSyntax._
+import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.engine.graph.node
 import pl.touk.nussknacker.engine.graph.variable.Field
 import pl.touk.nussknacker.ui.process.ProcessTypesForCategories

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparer.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparer.scala
@@ -22,6 +22,7 @@ import pl.touk.nussknacker.ui.security.api.{LoggedUser, PermissionSyntax}
 import PermissionSyntax._
 import pl.touk.nussknacker.engine.graph.node
 import pl.touk.nussknacker.engine.graph.variable.Field
+import pl.touk.nussknacker.ui.process.ProcessTypesForCategories
 
 import scala.runtime.BoxedUnit
 
@@ -34,10 +35,11 @@ object DefinitionPreparer {
                         subprocessInputs: Map[String, ObjectDefinition],
                         extractorFactory: ParameterDefaultValueExtractorStrategy,
                         nodesConfig: Map[String, SingleNodeConfig],
-                        nodeCategoryMapping: Map[String, String]
+                        nodeCategoryMapping: Map[String, String],
+                        typesForCategories: ProcessTypesForCategories
                        ): List[NodeGroup] = {
     val evaluator = new ParameterEvaluatorExtractor(extractorFactory)
-    val readCategories = user.can(Read).toList
+    val readCategories = typesForCategories.getAllCategories.filter(user.can(_, Read))
 
     def filterCategories(objectDefinition: ObjectDefinition): List[String] = readCategories.intersect(objectDefinition.categories)
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjects.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjects.scala
@@ -14,7 +14,6 @@ import pl.touk.nussknacker.ui.security.api.LoggedUser
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import net.ceedubs.ficus.readers.EnumerationReader._
-import net.ceedubs.ficus.readers.ValueReader
 import pl.touk.nussknacker.engine.api.definition.ParameterRestriction
 import pl.touk.nussknacker.engine.api.{MetaData, definition}
 import pl.touk.nussknacker.engine.api.typed.ClazzRef
@@ -25,13 +24,15 @@ import pl.touk.nussknacker.engine.definition.{ParameterTypeMapper, ProcessDefini
 import pl.touk.nussknacker.ui.process.subprocess.SubprocessDetails
 import pl.touk.nussknacker.engine.graph.evaluatedparam
 import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition.SubprocessParameter
+import pl.touk.nussknacker.ui.process.ProcessTypesForCategories
 
 object UIProcessObjects {
   
   def prepareUIProcessObjects(modelDataForType: ModelData,
                               user: LoggedUser,
                               subprocessesDetails: Set[SubprocessDetails],
-                              isSubprocess: Boolean): UIProcessObjects = {
+                              isSubprocess: Boolean,
+                              typesForCategories: ProcessTypesForCategories): UIProcessObjects = {
     val processConfig = modelDataForType.processConfig
 
     val chosenProcessDefinition = modelDataForType.processDefinition
@@ -59,7 +60,8 @@ object UIProcessObjects {
         subprocessInputs = subprocessInputs,
         extractorFactory = defaultParametersFactory,
         nodesConfig = nodesConfig,
-        nodeCategoryMapping = nodeCategoryMapping
+        nodeCategoryMapping = nodeCategoryMapping,
+        typesForCategories = typesForCategories
       ),
       processDefinition = uiProcessDefinition,
       nodesConfig = nodesConfig,

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessTypesForCategories.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessTypesForCategories.scala
@@ -22,3 +22,7 @@ class ProcessTypesForCategories(config: Config) {
 
   val getAllCategories = categoriesToTypesMap.keys.toList
 }
+
+object ProcessTypesForCategories {
+  def apply(): ProcessTypesForCategories = new ProcessTypesForCategories(ConfigFactory.load())
+}

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
@@ -15,7 +15,6 @@ import scala.language.higherKinds
 trait ProcessRepository[F[_]] extends Repository[F] with EspTables {
 
   import api._
-  import pl.touk.nussknacker.ui.security.api.PermissionSyntax._
   protected def processTableFilteredByUser(implicit loggedUser: LoggedUser): Query[ProcessEntityFactory#ProcessEntity, ProcessEntityData, Seq] = {
     loggedUser match {
       case user: CommonUser => processesTable.filter(_.processCategory inSet user.categories(Permission.Read))

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
@@ -6,7 +6,7 @@ import pl.touk.nussknacker.restmodel.processdetails.{DeploymentEntry, ProcessHis
 import pl.touk.nussknacker.ui.app.BuildInfo
 import pl.touk.nussknacker.ui.db.EspTables
 import pl.touk.nussknacker.ui.db.entity._
-import pl.touk.nussknacker.ui.security.api.{LoggedUser, Permission}
+import pl.touk.nussknacker.ui.security.api.{AdminUser, CommonUser, LoggedUser, Permission}
 import pl.touk.nussknacker.ui.util.DateUtils
 import pl.touk.nussknacker.ui.{BadRequestError, NotFoundError}
 
@@ -17,8 +17,10 @@ trait ProcessRepository[F[_]] extends Repository[F] with EspTables {
   import api._
   import pl.touk.nussknacker.ui.security.api.PermissionSyntax._
   protected def processTableFilteredByUser(implicit loggedUser: LoggedUser): Query[ProcessEntityFactory#ProcessEntity, ProcessEntityData, Seq] = {
-    val readCategories = loggedUser.can(Permission.Read)
-    if (loggedUser.isAdmin) processesTable else processesTable.filter(_.processCategory inSet readCategories)
+    loggedUser match {
+      case user: CommonUser => processesTable.filter(_.processCategory inSet user.categories(Permission.Read))
+      case _: AdminUser => processesTable
+    }
   }
 
   protected def latestProcessVersions(processId: ProcessId)

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/NussknackerInternalUser.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/NussknackerInternalUser.scala
@@ -1,5 +1,5 @@
 package pl.touk.nussknacker.ui.security
 
-import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.security.api.AdminUser
 
-object NussknackerInternalUser extends LoggedUser("Nussknacker", Map.empty, true)
+object NussknackerInternalUser extends AdminUser("Nussknacker")

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -100,7 +100,7 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
   }
 
   test("deploy technical process and mark it as deployed") {
-    implicit val loggedUser = user("userId") copy(categoryPermissions = Map(testCategoryName->Set(Permission.Write, Permission.Deploy, Permission.Read)))
+    implicit val loggedUser = user("userId", Map(testCategoryName->Set(Permission.Write, Permission.Deploy, Permission.Read)))
     val processId = "Process1"
     whenReady(writeProcessRepository.saveNewProcess(ProcessName(processId), testCategoryName, CustomProcess(""), TestProcessingTypes.Streaming, false)) { res =>
       deployProcess(processId) ~> check { status shouldBe StatusCodes.OK }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -40,7 +40,7 @@ trait EspItTest extends LazyLogging with ScalaFutures with WithHsqlDbTesting wit
   val deploymentProcessRepository = newDeploymentProcessRepository(db)
   val processActivityRepository = newProcessActivityRepository(db)
 
-  val typesForCategories = new ProcessTypesForCategories(ConfigFactory.load())
+  val typesForCategories = ProcessTypesForCategories()
 
   val existingProcessingType = "streaming"
 
@@ -76,7 +76,7 @@ trait EspItTest extends LazyLogging with ScalaFutures with WithHsqlDbTesting wit
 
   val processesExportResources = new ProcessesExportResources(processRepository, processActivityRepository)
   val definitionResources = new DefinitionResources(
-    Map(existingProcessingType ->  FlinkProcessManagerProvider.defaultModelData(ConfigFactory.load())), subprocessRepository)
+    Map(existingProcessingType ->  FlinkProcessManagerProvider.defaultModelData(ConfigFactory.load())), subprocessRepository, typesForCategories)
 
   val processesRouteWithAllPermissions = withAllPermissions(processesRoute)
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparerSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparerSpec.scala
@@ -9,8 +9,8 @@ import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder.ObjectProcess
 import pl.touk.nussknacker.engine.util.loader.ModelClassLoader
 import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.EdgeType._
 import pl.touk.nussknacker.ui.api.helpers.{ProcessTestData, TestFactory, TestPermissions}
+import pl.touk.nussknacker.ui.process.ProcessTypesForCategories
 import pl.touk.nussknacker.ui.process.uiconfig.defaults.{DefaultValueExtractorChain, ParamDefaultValueConfig}
-import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 class DefinitionPreparerSpec extends FunSuite with Matchers with TestPermissions{
 
@@ -105,7 +105,8 @@ class DefinitionPreparerSpec extends FunSuite with Matchers with TestPermissions
       subprocessInputs = subprocessInputs,
       extractorFactory = DefaultValueExtractorChain(ParamDefaultValueConfig(Map()), ModelClassLoader.empty),
       nodesConfig = nodesConfig.mapValues(v => SingleNodeConfig(None, None, None, Some(v))),
-      nodeCategoryMapping = nodeCategoryMapping
+      nodeCategoryMapping = nodeCategoryMapping,
+      typesForCategories = ProcessTypesForCategories()
     )
     groups
   }
@@ -120,7 +121,8 @@ class DefinitionPreparerSpec extends FunSuite with Matchers with TestPermissions
       subprocessInputs = Map(),
       extractorFactory = DefaultValueExtractorChain(ParamDefaultValueConfig(Map()), ModelClassLoader.empty),
       nodesConfig = Map(),
-      nodeCategoryMapping =  Map()
+      nodeCategoryMapping =  Map(),
+      typesForCategories = ProcessTypesForCategories()
     )
     groups
   }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsSpec.scala
@@ -14,6 +14,7 @@ import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition.{Subproce
 import pl.touk.nussknacker.engine.graph.node.{Enricher, SubprocessInput, SubprocessInputDefinition}
 import pl.touk.nussknacker.engine.testing.{EmptyProcessConfigCreator, LocalModelData}
 import pl.touk.nussknacker.ui.api.helpers.TestFactory
+import pl.touk.nussknacker.ui.process.ProcessTypesForCategories
 import pl.touk.nussknacker.ui.process.subprocess.SubprocessDetails
 
 import scala.concurrent.Future
@@ -35,7 +36,7 @@ class UIProcessObjectsSpec extends FunSuite with Matchers {
     })
 
     val processObjects =
-      UIProcessObjects.prepareUIProcessObjects(model, TestFactory.user("userId"), Set(), false)
+      UIProcessObjects.prepareUIProcessObjects(model, TestFactory.user("userId"), Set(), false, ProcessTypesForCategories())
 
     processObjects.nodesConfig("enricher").params shouldBe Some(Map("param" -> ParameterConfig(Some("'default value'"),
       Some(FixedExpressionValues(List(
@@ -74,7 +75,7 @@ class UIProcessObjectsSpec extends FunSuite with Matchers {
         SubprocessDetails(CanonicalProcess(MetaData("enricher", null, isSubprocess = true), null, List(FlatNode(SubprocessInputDefinition("", List(
           SubprocessParameter("param", SubprocessClazzRef[String])
         )))), None), "")
-      ), false)
+      ), false, ProcessTypesForCategories())
 
     processObjects.processDefinition.subprocessInputs("enricher").parameters.map(p => (p.name, p.restriction)).toMap shouldBe Map(
       "param" -> Some(FixedExpressionValues(List(


### PR DESCRIPTION
New permissions system introduced bug where admin user sees no elements in control panel. I've decided to redesign LoggedUser class to explicitly handle admin case on type level. The major problem currently is the need for categoryPermissions map for non-admin users. When admin is concerned, he shall always be permitted to do every action he needs and thus returning list of categories for which the permission is granted is redundant and has been removed.

Fixes #206 