### PR TITLE
Fixing /api/processes/import/:processName route

### DIFF
--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.server._
 import akka.stream.Materializer
 import cats.data.Validated.{Invalid, Valid}
 import cats.instances.future._
-import cats.data.EitherT
+import cats.data.{EitherT, Validated}
 import cats.syntax.either._
 import pl.touk.nussknacker.engine.api.deployment.GraphProcess
 import pl.touk.nussknacker.ui.api.ProcessesResources.{UnmarshallError, WrongProcessId}
@@ -24,6 +24,7 @@ import pl.touk.nussknacker.ui.validation.{FatalValidationError, ProcessValidatio
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
 import pl.touk.nussknacker.ui.process._
 import pl.touk.nussknacker.engine.api.process.ProcessName
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
 import pl.touk.nussknacker.restmodel.process.{ProcessId, ProcessIdWithName}
 import pl.touk.nussknacker.restmodel.processdetails.{BaseProcessDetails, BasicProcess, ProcessDetails, ValidatedProcessDetails}
@@ -148,22 +149,11 @@ class ProcessesResources(val processRepository: FetchingProcessRepository,
         } ~ path("processes" / "import" / Segment) { processName =>
           processId(processName) { processId =>
             (canWrite(processId) & post) {
-              fileUpload("process") { case (metadata, byteSource) =>
+              fileUpload("process") { case (_, byteSource) =>
                 complete {
                   MultipartUtils.readFile(byteSource).map[ToResponseMarshallable] { json =>
-                    (ProcessMarshaller.fromJson(json) match {
-                      case Valid(process) if process.metaData.id != processId.name.value => Invalid(WrongProcessId(processId.name.value, process.metaData.id))
-                      case Valid(process) => Valid(process)
-                      case Invalid(unmarshallError) => Invalid(UnmarshallError(unmarshallError.msg))
-                    }) match {
-                      case Valid(process) =>
-                        processRepository.fetchLatestProcessDetailsForProcessIdEither[Unit](processId.id).map { detailsXor =>
-                          val validatedProcess = detailsXor
-                            .map(details => ProcessConverter.toDisplayable(process, details.processingType))
-                            .map(processValidation.toValidated)
-                          toResponseXor(validatedProcess)
-                        }
-
+                    validateJsonForImport(processId, json) match {
+                      case Valid(process) => importProcess(processId, process)
                       case Invalid(error) => EspErrorToHttp.espErrorToHttp(error)
                     }
                   }
@@ -300,6 +290,26 @@ class ProcessesResources(val processRepository: FetchingProcessRepository,
         }
       }
   }
+
+  private def validateJsonForImport(processId: ProcessIdWithName, json: String): Validated[EspError, CanonicalProcess] = {
+    ProcessMarshaller.fromJson(json) match {
+      case Valid(process) if process.metaData.id != processId.name.value =>
+    Invalid(WrongProcessId(processId.name.value, process.metaData.id))
+      case Valid(process) => Valid(process)
+      case Invalid(unmarshallError) => Invalid(UnmarshallError(unmarshallError.msg))
+    }
+  }
+
+  private def importProcess(processId: ProcessIdWithName, process: CanonicalProcess)
+                           (implicit user: LoggedUser): Future[ToResponseMarshallable] = {
+    processRepository.fetchLatestProcessDetailsForProcessIdEither[Unit](processId.id).map { detailsXor =>
+      val validatedProcess = detailsXor
+        .map(details => ProcessConverter.toDisplayable(process, details.processingType))
+        .map(processValidation.toValidated)
+      toResponseXor(validatedProcess)
+    }
+  }
+
   private def writeArchive(processId: ProcessId, isArchived: Boolean) = {
     writeRepository.archive(processId = processId, isArchived = isArchived)
       .map(toResponse(StatusCodes.OK))

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.ui.api.helpers
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
 
+import akka.http.scaladsl.server.Route
 import com.typesafe.config.ConfigFactory
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.{DeploymentId, ProcessDeploymentData, ProcessState, RunningState}
@@ -60,6 +61,10 @@ object TestFactory extends TestPermissions{
     Map(TestProcessingTypes.Streaming -> buildInfo))
 
   def newProcessActivityRepository(db: DbConfig) = new ProcessActivityRepository(db)
+
+  def asAdmin(route: RouteWithUser): Route = {
+    route.route(adminUser())
+  }
 
   def withPermissions(route: RouteWithUser, permissions: TestPermissions.CategorizedPermission) =
     route.route(user("userId", permissions))


### PR DESCRIPTION
Instead of importing process currently route` /api/processes/:name/:category` is matched instead.
Just reorganizing routes so that `/api/processes/import/:name` gets matched first.