### PR TITLE
Fix for typing error: #input was available in parameter's expressions + some refactoring

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.api.expression
 
-import cats.data.{NonEmptyList, Validated}
+import cats.data.ValidatedNel
 import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.lazyy.{LazyContext, LazyValuesProvider}
@@ -22,9 +22,9 @@ trait ExpressionParser {
   def languageId: String
 
   def parse(original: String, ctx: ValidationContext, expectedType: TypingResult):
-  Validated[NonEmptyList[ExpressionParseError], TypedExpression]
+  ValidatedNel[ExpressionParseError, TypedExpression]
 
-  def parseWithoutContextValidation(original: String, expectedType: TypingResult): Validated[NonEmptyList[ExpressionParseError], Expression]
+  def parseWithoutContextValidation(original: String): ValidatedNel[ExpressionParseError, Expression]
 
 }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompilationResult.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompilationResult.scala
@@ -2,7 +2,10 @@ package pl.touk.nussknacker.engine.compile
 
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, ValidatedNel}
+import cats.kernel.Semigroup
+import cats.instances.map._
 import cats.{Applicative, Traverse}
+import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ProcessUncanonizationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.canonize.{MaybeArtificial, MaybeArtificialExtractor}
@@ -11,6 +14,16 @@ import scala.language.{higherKinds, reflectiveCalls}
 
 case class CompilationResult[+Result](private [compile] val typing: Map[String, ValidationContext],
                                      result: ValidatedNel[ProcessCompilationError, Result]) {
+
+  import CompilationResult._
+
+  def andThen[B](f: Result => CompilationResult[B]): CompilationResult[B] =
+    result match {
+      case Valid(a)       =>
+        val newResult = f(a)
+        newResult.copy(typing = Semigroup.combine(typing, newResult.typing))
+      case i @ Invalid(_) => CompilationResult(typing, i)
+    }
 
   def map[T](action: Result => T) : CompilationResult[T] = copy(result = result.map(action))
 
@@ -29,7 +42,7 @@ object CompilationResult extends Applicative[CompilationResult] {
   override def pure[A](x: A): CompilationResult[A] = CompilationResult(Map(), Valid(x))
 
   override def ap[A, B](ff: CompilationResult[(A) => B])(fa: CompilationResult[A]): CompilationResult[B] =
-    CompilationResult(ff.typing ++ fa.typing, fa.result.ap(ff.result))
+    CompilationResult(Semigroup.combine(fa.typing, ff.typing), fa.result.ap(ff.result))
 
   implicit class CompilationResultTraverseOps[T[_]: Traverse, B](traverse: T[CompilationResult[B]]) {
     def sequence: CompilationResult[T[B]] = {
@@ -45,4 +58,17 @@ object CompilationResult extends Applicative[CompilationResult] {
       }
     }
   }
+
+  implicit def takingLastNodeTypingInfoSemigroup: Semigroup[ValidationContext] = new Semigroup[ValidationContext] with LazyLogging {
+    override def combine(x: ValidationContext, y: ValidationContext): ValidationContext = {
+      logger.whenWarnEnabled {
+        if (x != y) {
+          logger.warn(s"Merging different ValidationContext for the same nodes: $x != $y. This can be a bug in code or duplicated node ids with different node typing info")
+        }
+      }
+      // we should be lax here because we want to detect duplicate nodes and context can be different then
+      y
+    }
+  }
+
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompiledProcess.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompiledProcess.scala
@@ -25,9 +25,11 @@ object CompiledProcess {
     val servicesDefs = definitions.services
 
     val expressionCompiler = ExpressionCompiler.withOptimization(userCodeClassLoader, definitions.expressionConfig)
+    // TODO: rethink if optimization for object's parameters is still a problem here because maybe we can use just ProcessCompiler.apply
+    val objectParametersExpressionCompiler = ExpressionCompiler.withoutOptimization(userCodeClassLoader, definitions.expressionConfig)
     //for testing environment it's important to take classloader from user jar
     val subCompiler = new PartSubGraphCompiler(userCodeClassLoader, expressionCompiler, definitions.expressionConfig, servicesDefs)
-    val processCompiler = new ProcessCompiler(userCodeClassLoader, subCompiler, definitions)
+    val processCompiler = new ProcessCompiler(userCodeClassLoader, subCompiler, definitions, objectParametersExpressionCompiler)
 
     processCompiler.compile(process).result.map { compiledProcess =>
       val globalVariables = definitions.expressionConfig.globalVariables.mapValues(_.obj)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
@@ -4,9 +4,9 @@ import cats.data.Validated.{Valid, invalid, valid}
 import cats.data.ValidatedNel
 import cats.instances.list._
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
-import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, ValidationContext}
+import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, ProcessCompilationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.definition.Parameter
-import pl.touk.nussknacker.engine.api.expression.{ExpressionParser, TypedExpression, TypedExpressionMap}
+import pl.touk.nussknacker.engine.api.expression.{Expression, ExpressionParser, TypedExpression, TypedExpressionMap}
 import pl.touk.nussknacker.engine.api.typed.typing.{TypingResult, Unknown}
 import pl.touk.nussknacker.engine.compiledgraph.evaluatedparam.TypedParameter
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectMetadata
@@ -44,16 +44,16 @@ class ExpressionCompiler(expressionParsers: Map[String, ExpressionParser]) {
   import syntax._
 
   def compileValidatedObjectParameters(parameters: List[evaluatedparam.Parameter],
-                                       ctx: Option[ValidationContext])(implicit nodeId: NodeId)
+                                       ctx: ValidationContext)(implicit nodeId: NodeId)
   : ValidatedNel[PartSubGraphCompilationError, List[compiledgraph.evaluatedparam.Parameter]] =
     compileObjectParameters(parameters.map(p => Parameter(p.name, Unknown, classOf[Any])), parameters, ctx)
 
   def compileObjectParameters(parameterDefinitions: List[Parameter],
                               parameters: List[evaluatedparam.Parameter],
-                              maybeCtx: Option[ValidationContext])
+                              ctx: ValidationContext)
                              (implicit nodeId: NodeId)
   : ValidatedNel[PartSubGraphCompilationError, List[compiledgraph.evaluatedparam.Parameter]] = {
-    compileObjectParameters(parameterDefinitions, parameters, List.empty, maybeCtx, maybeCtx).map(_.map {
+    compileObjectParameters(parameterDefinitions, parameters, List.empty, ctx, ctx).map(_.map {
       case TypedParameter(name, expr: TypedExpression) => compiledgraph.evaluatedparam.Parameter(name, expr.expression, expr.returnType)
     })
   }
@@ -61,7 +61,7 @@ class ExpressionCompiler(expressionParsers: Map[String, ExpressionParser]) {
   def compileObjectParameters(parameterDefinitions: List[Parameter],
                               parameters: List[evaluatedparam.Parameter],
                               branchParameters: List[evaluatedparam.BranchParameters],
-                              maybeCtx: Option[ValidationContext], maybeCtxForLazyParameters: Option[ValidationContext])
+                              ctx: ValidationContext, ctxForLazyParameters: ValidationContext)
                              (implicit nodeId: NodeId)
   : ValidatedNel[PartSubGraphCompilationError, List[compiledgraph.evaluatedparam.TypedParameter]] = {
     val syntax = ValidatedSyntax[PartSubGraphCompilationError]
@@ -75,8 +75,8 @@ class ExpressionCompiler(expressionParsers: Map[String, ExpressionParser]) {
     Validations.validateParameters(definedParamNames, usedParamNames).andThen { _ =>
       val paramDefMap = parameterDefinitions.map(p => p.name -> p).toMap
 
-      def ctxToUse(pName:String) = if (paramDefMap(pName).isLazyParameter) maybeCtxForLazyParameters else maybeCtx
-      
+      def ctxToUse(pName:String) = if (paramDefMap(pName).isLazyParameter) ctxForLazyParameters else ctx
+
       val compiledParams = parameters.map { p =>
         compileParam(p, ctxToUse(p.name), paramDefMap(p.name))
       }
@@ -86,27 +86,27 @@ class ExpressionCompiler(expressionParsers: Map[String, ExpressionParser]) {
       } yield p.name -> (branchParams.branchId, p.expression)).toGroupedMap.toList.map {
         case (paramName, branchIdAndExpressions) =>
           //TODO: handle context for branch parameters correctly...
-          compileParam(branchIdAndExpressions, maybeCtxForLazyParameters, paramDefMap(paramName))
+          compileParam(branchIdAndExpressions, ctxForLazyParameters, paramDefMap(paramName))
       }
       (compiledParams ++ compiledBranchParams).sequence
     }
   }
 
   private def compileParam(param: graph.evaluatedparam.Parameter,
-                           maybeCtx: Option[ValidationContext],
+                           ctx: ValidationContext,
                            definition: Parameter)
                           (implicit nodeId: NodeId): ValidatedNel[PartSubGraphCompilationError, compiledgraph.evaluatedparam.TypedParameter] = {
-    enrichContext(maybeCtx, definition).andThen { finalCtx =>
+    enrichContext(ctx, definition).andThen { finalCtx =>
       compile(param.expression, Some(param.name), finalCtx, definition.typ)
         .map(compiledgraph.evaluatedparam.TypedParameter(param.name, _))
     }
   }
 
   private def compileParam(branchIdAndExpressions: List[(String, expression.Expression)],
-                           maybeCtx: Option[ValidationContext],
+                           ctx: ValidationContext,
                            definition: Parameter)
                           (implicit nodeId: NodeId): ValidatedNel[PartSubGraphCompilationError, TypedParameter] = {
-    enrichContext(maybeCtx, definition).andThen { finalCtx =>
+    enrichContext(ctx, definition).andThen { finalCtx =>
       branchIdAndExpressions.map {
         case (branchId, expression) =>
           // TODO JOIN: branch id on error field level
@@ -115,22 +115,17 @@ class ExpressionCompiler(expressionParsers: Map[String, ExpressionParser]) {
     }
   }
 
-  private def enrichContext(maybeCtx: Option[ValidationContext],
+  private def enrichContext(ctx: ValidationContext,
                             definition: Parameter)
                            (implicit nodeId: NodeId) = {
-    maybeCtx match {
-      case Some(ctx) =>
-        definition.additionalVariables.foldLeft[ValidatedNel[PartSubGraphCompilationError, ValidationContext]](Valid(ctx)) {
-          case (acc, (name, typingResult)) => acc.andThen(_.withVariable(name, typingResult))
-        }.map(Option(_))
-      case None =>
-        Valid(None)
+    definition.additionalVariables.foldLeft[ValidatedNel[PartSubGraphCompilationError, ValidationContext]](Valid(ctx)) {
+      case (acc, (name, typingResult)) => acc.andThen(_.withVariable(name, typingResult))
     }
   }
 
   def compile(n: graph.expression.Expression,
               fieldName: Option[String],
-              maybeValidationCtx: Option[ValidationContext],
+              validationCtx: ValidationContext,
               expectedType: TypingResult)
              (implicit nodeId: NodeId): ValidatedNel[PartSubGraphCompilationError, TypedExpression] = {
     val validParser = expressionParsers
@@ -138,14 +133,22 @@ class ExpressionCompiler(expressionParsers: Map[String, ExpressionParser]) {
       .map(valid)
       .getOrElse(invalid(NotSupportedExpressionLanguage(n.language))).toValidatedNel
 
-    //TODO: make it nicer..
     validParser andThen { parser =>
-      (maybeValidationCtx match {
-        case None =>
-          parser.parseWithoutContextValidation(n.expression, expectedType).map(TypedExpression(_, Unknown))
-        case Some(ctx) =>
-          parser.parse(n.expression, ctx, expectedType)
-      }).leftMap(errs => errs.map(err => ExpressionParseError(err.message, fieldName, n.expression)))
+      parser.parse(n.expression, validationCtx, expectedType).leftMap(errs => errs.map(err => ProcessCompilationError.ExpressionParseError(err.message, fieldName, n.expression)))
+    }
+  }
+
+  def compileWithoutContextValidation(n: graph.expression.Expression,
+                                      fieldName: String)
+                                     (implicit nodeId: NodeId): ValidatedNel[PartSubGraphCompilationError, Expression] = {
+    val validParser = expressionParsers
+      .get(n.language)
+      .map(valid)
+      .getOrElse(invalid(NotSupportedExpressionLanguage(n.language))).toValidatedNel
+
+    validParser andThen { parser =>
+      parser.parseWithoutContextValidation(n.expression)
+        .leftMap(errs => errs.map(err => ProcessCompilationError.ExpressionParseError(err.message, Some(fieldName), n.expression)))
     }
   }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/CustomNodeInvoker.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/CustomNodeInvoker.scala
@@ -23,8 +23,8 @@ private[definition] case class ExpressionLazyParameter[T](nodeId: NodeId,
                                                           returnType: TypingResult) extends CompilerLazyParameter[T] {
   override def prepareEvaluator(compilerInterpreter: CompilerLazyParameterInterpreter)(implicit ec: ExecutionContext): Context => Future[T] = {
     val compiledExpression = compilerInterpreter.deps.expressionCompiler
-              .compile(parameter.expression, Some(parameter.name), None, Unknown)(nodeId)
-              .getOrElse(throw new IllegalArgumentException(s"Cannot compile ${parameter.name}")).expression
+              .compileWithoutContextValidation(parameter.expression, parameter.name)(nodeId)
+              .valueOr(err => throw new IllegalArgumentException(s"Compilation failed with errors: ${err.toList.mkString(", ")}"))
     val evaluator = compilerInterpreter.deps.expressionEvaluator
     context: Context => evaluator.evaluate[T](compiledExpression, parameter.name, nodeId.id, context)(ec, compilerInterpreter.metaData).map(_.value)(ec)
   }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionValidator.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionValidator.scala
@@ -3,38 +3,18 @@ package pl.touk.nussknacker.engine.spel
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, Validated}
 import org.springframework.expression.Expression
-import org.springframework.expression.common.{CompositeStringExpression, LiteralExpression}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.expression.ExpressionParseError
-import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
-import pl.touk.nussknacker.engine.util.validated.ValidatedSyntax
-import cats.implicits._
-import org.springframework.expression.spel.standard
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 
-
-class SpelExpressionValidator(implicit classLoader: ClassLoader) {
-
-  private val typer = new Typer()(classLoader)
+class SpelExpressionValidator(typer: Typer) {
 
   def validate(expr: Expression, ctx: ValidationContext, expectedType: TypingResult): Validated[NonEmptyList[ExpressionParseError], TypingResult] = {
-    val typedExpression = expr match {
-      case e:standard.SpelExpression =>
-        typeExpression(e, ctx)
-      case e:CompositeStringExpression =>
-        val validatedParts = e.getExpressions.toList.map(validate(_, ctx, Unknown)).sequence
-        validatedParts.map(_ => Typed[String])
-      case e:LiteralExpression =>
-        Valid(Typed[String])
-    }
+    val typedExpression = typer.typeExpression(expr, ctx)
     typedExpression.andThen {
       case a: TypingResult if a.canBeSubclassOf(expectedType) || expectedType == Typed[SpelExpressionRepr] => Valid(a)
       case a: TypingResult => Invalid(NonEmptyList.of(ExpressionParseError(s"Bad expression type, expected: ${expectedType.display}, found: ${a.display}")))
     }
-  }
-
-  private def typeExpression(spelExpression: standard.SpelExpression, ctx: ValidationContext): Validated[NonEmptyList[ExpressionParseError], TypingResult] = {
-    Validated.fromOption(Option(spelExpression.getAST), NonEmptyList.of(ExpressionParseError("Empty expression")))
-      .andThen(typer.typeExpression(ctx, _))
   }
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/SqlExpressionParser.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/SqlExpressionParser.scala
@@ -62,7 +62,7 @@ object SqlExpressionParser extends ExpressionParser {
     }
   }
 
-  override def parseWithoutContextValidation(original: String, expectedType: TypingResult): Validated[NonEmptyList[ExpressionParseError], Expression] =
+  override def parseWithoutContextValidation(original: String): Validated[NonEmptyList[ExpressionParseError], Expression] =
     throw new IllegalStateException("shouldn't be used")
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
@@ -31,7 +31,7 @@ class ExpressionServiceQuery(
 
   def invoke(serviceName: String,params: List[evaluatedparam.Parameter])
             (implicit executionContext: ExecutionContext): Future[QueryResult] = {
-    expressionCompiler.compileValidatedObjectParameters(params, Some(ValidationContext.empty)) match {
+    expressionCompiler.compileValidatedObjectParameters(params, ValidationContext.empty) match {
       case Valid(p) => expressionEvaluator
         .evaluateParameters(p, ctx)(nodeId,ServiceQuery.jobData.metaData, executionContext)
         .flatMap {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
@@ -683,9 +683,9 @@ object InterpreterSpec {
     override def languageId: String = "literal"
 
     override def parse(original: String, ctx: ValidationContext, expectedType: typing.TypingResult): Validated[NonEmptyList[ExpressionParseError], TypedExpression] =
-      parseWithoutContextValidation(original, expectedType).map(TypedExpression(_, Typed[String]))
+      parseWithoutContextValidation(original).map(TypedExpression(_, Typed[String]))
 
-    override def parseWithoutContextValidation(original: String, expectedType: typing.TypingResult): Validated[NonEmptyList[ExpressionParseError],
+    override def parseWithoutContextValidation(original: String): Validated[NonEmptyList[ExpressionParseError],
       pl.touk.nussknacker.engine.api.expression.Expression]
       = Valid(LiteralExpression(original))
   }

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -96,7 +96,7 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
     }
 
     compilationResult.variablesInNodes shouldBe Map(
-      "id1" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
+      "id1" -> Map("meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
       "filter1" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
       "filter2" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),
       "filter3" -> Map("input" -> Typed[SimpleRecord], "meta" -> MetaVariables.typingResult(correctProcess.metaData), "processHelper" -> Typed(ClazzRef(ProcessHelper.getClass))),

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -87,9 +87,8 @@ class SpelExpressionSpec extends FunSuite with Matchers {
   }
 
   private def parse[T:TypeTag](expr: String, validationCtx: ValidationContext, flavour: Flavour) : ValidatedNel[ExpressionParseError, TypedExpression] = {
-    val expressionFunctions = Map("today" -> classOf[LocalDate].getDeclaredMethod("now"))
     val imports = List(SampleValue.getClass.getPackage.getName)
-    new SpelExpressionParser(expressionFunctions, imports, getClass.getClassLoader, 1 minute, enableSpelForceCompile = true, flavour)
+    SpelExpressionParser.default(getClass.getClassLoader, enableSpelForceCompile = true, imports, flavour)
       .parse(expr, validationCtx, Typed.fromDetailedType[T])
   }
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/AppResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/AppResources.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.{Config, ConfigRenderOptions}
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
 import pl.touk.nussknacker.ui.process.{JobStatusService, ProcessObjectsFinder}
-import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ProcessStatus}
+import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ProcessStatus, ValidatedDisplayableProcess}
 import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository
 import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.restmodel.process.ProcessIdWithName
@@ -105,7 +105,7 @@ class AppResources(config: Config,
   private def processesWithValidationErrors(implicit ec: ExecutionContext, user: LoggedUser): Future[List[String]] = {
     processRepository.fetchProcessesDetails[DisplayableProcess]().map { processes =>
       val processesWithErrors = processes.flatMap(_.json)
-        .map(processValidation.toValidated)
+        .map(process => new ValidatedDisplayableProcess(process, processValidation.validate(process)))
         .filter(process => !process.validationResult.errors.isEmpty)
       processesWithErrors.map(_.id)
     }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrations.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrations.scala
@@ -17,9 +17,9 @@ class TestModelMigrations(migrations: Map[ProcessingType, ProcessMigrations], pr
     val migratedProcesses = processes.flatMap(migrateProcess)
     val validation = processValidation.withSubprocessResolver(new SubprocessResolver(prepareSubprocessRepository(migratedSubprocesses.map(s => (s.newProcess, s.processCategory)))))
     (migratedSubprocesses ++ migratedProcesses).map { migrationDetails =>
-      val validated = validation.toValidated(migrationDetails.newProcess)
-      val newErrors = extractNewErrors(migrationDetails.oldProcessErrors, validated.validationResult)
-      TestMigrationResult(validated, newErrors, migrationDetails.shouldFail)
+      val validationResult = validation.validate(migrationDetails.newProcess)
+      val newErrors = extractNewErrors(migrationDetails.oldProcessErrors, validationResult)
+      TestMigrationResult(new ValidatedDisplayableProcess(migrationDetails.newProcess, validationResult), newErrors, migrationDetails.shouldFail)
     }
   }
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/ProcessValidation.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/ProcessValidation.scala
@@ -2,14 +2,13 @@ package pl.touk.nussknacker.ui.validation
 
 import cats.data.NonEmptyList
 import cats.data.Validated.{Invalid, Valid}
-import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
 import pl.touk.nussknacker.engine.api.ProcessAdditionalFields
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.compile.ProcessValidator
 import pl.touk.nussknacker.engine.graph.node.{Disableable, NodeData, Source, SubprocessInputDefinition}
-import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ValidatedDisplayableProcess}
+import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
 import pl.touk.nussknacker.restmodel.validation.CustomProcessValidator
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationResult
 import pl.touk.nussknacker.ui.definition.AdditionalProcessProperty
@@ -38,10 +37,6 @@ class ProcessValidation(validators: Map[ProcessingType, ProcessValidator],
   private val additionalPropertiesValidator = new AdditionalPropertiesValidator(additionalFieldsConfig, uiValidationError)
 
   def withSubprocessResolver(subprocessResolver: SubprocessResolver) = new ProcessValidation(validators, additionalFieldsConfig, subprocessResolver, customProcessNodesValidators)
-
-  def toValidated(displayableProcess: DisplayableProcess): ValidatedDisplayableProcess = {
-    new ValidatedDisplayableProcess(displayableProcess, validate(displayableProcess))
-  }
 
   def validate(displayable: DisplayableProcess): ValidationResult = {
     val uiValidationResult = uiValidation(displayable)

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
@@ -80,9 +80,10 @@ object ProcessTestData {
   val validDisplayableProcess : ValidatedDisplayableProcess = toValidatedDisplayable(validProcess)
   val validProcessDetails: ValidatedProcessDetails = toDetails(validDisplayableProcess)
 
-  def toValidatedDisplayable(espProcess: EspProcess) : ValidatedDisplayableProcess =
-    validation.toValidated(ProcessConverter
-     .toDisplayable(ProcessCanonizer.canonize(espProcess), TestProcessingTypes.Streaming))
+  def toValidatedDisplayable(espProcess: EspProcess) : ValidatedDisplayableProcess = {
+    val displayable = ProcessConverter.toDisplayable(ProcessCanonizer.canonize(espProcess), TestProcessingTypes.Streaming)
+    new ValidatedDisplayableProcess(displayable, validation.validate(displayable))
+  }
 
   def toDetails(displayable: DisplayableProcess) : ProcessDetails =
     BaseProcessDetails[DisplayableProcess](

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
@@ -41,7 +41,8 @@ class ProcessConverterSpec extends FunSuite with Matchers with TableDrivenProper
 
   def displayableCanonical(process: DisplayableProcess): ValidatedDisplayableProcess = {
    val canonical = ProcessConverter.fromDisplayable(process)
-   validation.toValidated(ProcessConverter.toDisplayable(canonical, TestProcessingTypes.Streaming))
+    val displayable = ProcessConverter.toDisplayable(canonical, TestProcessingTypes.Streaming)
+    new ValidatedDisplayableProcess(displayable, validation.validate(displayable))
   }
 
   test("be able to convert empty process") {
@@ -104,7 +105,7 @@ class ProcessConverterSpec extends FunSuite with Matchers with TableDrivenProper
         List.empty,
         List.empty,
         Map(
-          "s" -> Map("input" -> Unknown, "meta" -> MetaVariables.typingResult(meta)),
+          "s" -> Map("meta" -> MetaVariables.typingResult(meta)),
           "v" -> Map("input" -> Unknown, "meta" -> MetaVariables.typingResult(meta)),
           "e" -> Map("input" -> Unknown, "meta" -> MetaVariables.typingResult(meta), "test" -> Typed[String]))
       )


### PR DESCRIPTION
Refactoring:

- moved "factory" logic from ProcessCompiler to ProcessCompiler.compile to see which ExpressionCompiler's are used
- moved "factory" logic from SpelExpressionParser to SpelExpressionParser.default
- moved  typing logic from SpelExpressionValidator to Typer
- moved wrapping in dto logic from ProcessValidation to Resources to have one point to every validations in gui
- cleanup: passes ValidationContext to compileValidatedObjectParameters instead of Option[ValidationContext]
- Validated.fold -> Validated.map().valueOr()
- Validated[NonEmptyList[E],A] => ValidatedNel[E,A]