### PR TITLE
Typing ast

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -1,5 +1,8 @@
 package pl.touk.nussknacker.engine.api.context
 
+import cats.Applicative
+import cats.data.ValidatedNel
+
 sealed trait ProcessCompilationError {
   def nodeIds: Set[String]
 }
@@ -9,6 +12,11 @@ sealed trait ProcessUncanonizationError extends ProcessCompilationError
 sealed trait PartSubGraphCompilationError extends ProcessCompilationError
 
 object ProcessCompilationError {
+
+  type ValidatedNelCompilationError[T] = ValidatedNel[ProcessCompilationError, T]
+
+  val ValidatedNelApplicative: Applicative[ValidatedNelCompilationError] =
+    Applicative[ValidatedNelCompilationError]
 
   final val ProcessNodeId = "$process"
 

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
@@ -35,6 +35,8 @@ case class ValueWithLazyContext[T](value: T, lazyContext: LazyContext)
 
 sealed trait TypedValue
 
-case class TypedExpression(expression: Expression, returnType: TypingResult) extends TypedValue
+case class TypedExpression(expression: Expression, returnType: TypingResult, typingInfo: ExpressionTypingInfo) extends TypedValue
 
 case class TypedExpressionMap(valueByKey: Map[String, TypedExpression]) extends TypedValue
+
+trait ExpressionTypingInfo

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
@@ -39,4 +39,8 @@ case class TypedExpression(expression: Expression, returnType: TypingResult, typ
 
 case class TypedExpressionMap(valueByKey: Map[String, TypedExpression]) extends TypedValue
 
+/**
+  * It contains information about intermediate result of typing of expression. Can be used for further processing of expression
+  * like some substitutions base on type...
+  */
 trait ExpressionTypingInfo

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -189,7 +189,7 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
           expressionCompiler.compileObjectParameters(paramDefs, ref.parameters, ctx)
         }
 
-        val expressionTypingInfo = validParams.map(_.map(p => p.name -> p.typingInfo).toMap).valueOr(Map.empty)
+        val expressionTypingInfo = validParams.map(_.map(p => p.name -> p.typingInfo).toMap).valueOr(_ => Map.empty[String, ExpressionTypingInfo])
 
         val combinedValidParams = ProcessCompilationError.ValidatedNelApplicative.map2(combinedValidation, validParams)((_, p) => p)
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.engine.compile
 
+import cats.Applicative
 import cats.data.Validated._
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.instances.list._
@@ -8,6 +9,7 @@ import cats.kernel.Semigroup
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, ProcessCompilationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.definition.Parameter
+import pl.touk.nussknacker.engine.api.expression.ExpressionTypingInfo
 import pl.touk.nussknacker.engine.api.typed.ServiceReturningType
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.api.{Context, MetaData}
@@ -51,13 +53,11 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
 
   protected def createServiceInvoker(obj: ObjectWithMethodDef) = ServiceInvoker(obj)
 
-  private val globalVariableTypes = expressionConfig.globalVariables.mapValues(_.returnType)
-
   def compile(n: SplittedNode[_], ctx: ValidationContext) : CompilationResult[compiledgraph.node.Node] = {
     implicit val nodeId: NodeId = NodeId(n.id)
 
-    def toCompilationResult[T](validated: ValidatedNel[ProcessCompilationError, T]) =
-      CompilationResult(Map(n.id -> ctx), validated)
+    def toCompilationResult[T](validated: ValidatedNel[ProcessCompilationError, T], expressionsTypingInfo: Map[String, ExpressionTypingInfo]) =
+      CompilationResult(Map(n.id -> NodeTypingInfo(ctx, expressionsTypingInfo)), validated)
 
     n match {
       case splittednode.SourceNode(nodeData, next) => handleSourceNode(nodeData, ctx, next)
@@ -65,10 +65,11 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
 
       case splittednode.SplitNode(bareNode, nexts) =>
         val compiledNexts = nexts.map(n => compile(n, ctx)).sequence
-        compiledNexts.andThen(nx => toCompilationResult(Valid(compiledgraph.node.SplitNode(bareNode.id, nx))))
+        compiledNexts.andThen(nx => toCompilationResult(Valid(compiledgraph.node.SplitNode(bareNode.id, nx)), Map.empty))
 
       case splittednode.FilterNode(f@graph.node.Filter(id, expression, _, _), nextTrue, nextFalse) =>
-        CompilationResult.map3(toCompilationResult(compile(expression, None, ctx, Typed[Boolean])._2), compile(nextTrue, ctx), nextFalse.map(next => compile(next, ctx)).sequence)(
+        val (expressionTyping, validatedExpression) = compile(expression, None, ctx, Typed[Boolean])
+        CompilationResult.map3(toCompilationResult(validatedExpression, expressionTyping.toDefaultExpressionTypingInfoEntry.toMap), compile(nextTrue, ctx), nextFalse.map(next => compile(next, ctx)).sequence)(
           (expr, next, nextFalse) =>
             compiledgraph.node.Filter(id = id,
             expression = expr,
@@ -77,12 +78,13 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
             isDisabled = f.isDisabled.contains(true)))
 
       case splittednode.SwitchNode(graph.node.Switch(id, expression, exprVal, _), nexts, defaultNext) =>
-        val (newCtx, compiledExpression) = withVariable(exprVal, ctx, compile(expression, None, ctx, Unknown))
-        CompilationResult.map3(toCompilationResult(compiledExpression), nexts.map(n => compile(n, newCtx)).sequence, defaultNext.map(dn => compile(dn, newCtx)).sequence)(
+        val (expressionTyping, validatedExpression) = compile(expression, None, ctx, Unknown)
+        val (newCtx, combinedValidatedExpression) = withVariableCombined(ctx, exprVal, expressionTyping.typingResult, validatedExpression)
+        CompilationResult.map3(toCompilationResult(combinedValidatedExpression, expressionTyping.toDefaultExpressionTypingInfoEntry.toMap), nexts.map(n => compile(n, newCtx)).sequence, defaultNext.map(dn => compile(dn, newCtx)).sequence)(
           (realCompiledExpression, cases, next) => {
             compiledgraph.node.Switch(id, realCompiledExpression, exprVal, cases, next)
           })
-      case splittednode.EndingNode(data) => toCompilationResult(compileEndingNode(ctx, data))
+      case splittednode.EndingNode(data) => compileEndingNode(ctx, data)
 
     }
   }
@@ -100,60 +102,70 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
     }
   }
 
-  private def compileEndingNode(ctx: ValidationContext, data: EndingNodeData)(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, Node] = data match {
-    case graph.node.Processor(id, ref, disabled, _) =>
-      compile(ref, ctx).map(cn => compiledgraph.node.EndingProcessor(id, cn._1, disabled.contains(true)))
-    case graph.node.Sink(id, ref, optionalExpression, disabled, _) =>
-      optionalExpression.map { oe =>
-        val compiled = compile(oe, None, ctx, Unknown)
-        compiled._2.map((_, compiled._1))
-      }.sequence.map(typed => compiledgraph.node.Sink(id, ref.typ, typed, disabled.contains(true)))
-    //probably this shouldn't occur - otherwise we'd have empty subprocess?
-    case SubprocessInput(id, _, _, _, _) => Invalid(NonEmptyList.of(UnresolvedSubprocess(id)))
-    case SubprocessOutputDefinition(id, name, _) =>
-      //TODO: should we validate it's process?
-      //TODO: does it make sense to validate SubprocessOutput?
-      Valid(compiledgraph.node.Sink(id, name, None, isDisabled = false))
+  private def compileEndingNode(ctx: ValidationContext, data: EndingNodeData)(implicit nodeId: NodeId): CompilationResult[compiledgraph.node.Node] = {
+    def toCompilationResult[T](validated: ValidatedNel[ProcessCompilationError, T], expressionsTypingInfo: Map[String, ExpressionTypingInfo]) =
+      CompilationResult(Map(nodeId.id -> NodeTypingInfo(ctx, expressionsTypingInfo)), validated)
 
-    //TODO JOIN: a lot of additional validations needed here - e.g. that join with that name exists, that it
-    //accepts this join, maybe we should also validate the graph is connected?
-    case BranchEndData(id, joinId) => Valid(compiledgraph.node.BranchEnd(id, joinId.joinId))
+    data match {
+      case graph.node.Processor(id, ref, disabled, _) =>
+        val (typingResult, validatedServiceRef) = compile(ref, ctx)
+        toCompilationResult(validatedServiceRef.map(ref => compiledgraph.node.EndingProcessor(id, ref, disabled.contains(true))), typingResult.expressionsTypingInfo)
+      case graph.node.Sink(id, ref, optionalExpression, disabled, _) =>
+        val (expressionTypingInfoEntry, validatedOptionalExpression) = optionalExpression.map { oe =>
+          val (expressionTyping, validatedExpression) = compile(oe, None, ctx, Unknown)
+          (expressionTyping.toDefaultExpressionTypingInfoEntry, validatedExpression.map(expr => Some((expr, expressionTyping.typingResult))))
+        }.getOrElse {
+          (None, Valid(None))
+        }
+
+        toCompilationResult(validatedOptionalExpression.map(compiledgraph.node.Sink(id, ref.typ, _, disabled.contains(true))), expressionTypingInfoEntry.toMap)
+      //probably this shouldn't occur - otherwise we'd have empty subprocess?
+      case SubprocessInput(id, _, _, _, _) => toCompilationResult(Invalid(NonEmptyList.of(UnresolvedSubprocess(id))), Map.empty)
+      case SubprocessOutputDefinition(id, name, _) =>
+        //TODO: should we validate it's process?
+        //TODO: does it make sense to validate SubprocessOutput?
+        toCompilationResult(Valid(compiledgraph.node.Sink(id, name, None, isDisabled = false)), Map.empty)
+
+      //TODO JOIN: a lot of additional validations needed here - e.g. that join with that name exists, that it
+      //accepts this join, maybe we should also validate the graph is connected?
+      case BranchEndData(id, joinId) => toCompilationResult(Valid(compiledgraph.node.BranchEnd(id, joinId.joinId)), Map.empty)
+    }
   }
 
   private def compileSubsequent(ctx: ValidationContext, data: OneOutputSubsequentNodeData, next: Next)(implicit nodeId: NodeId): CompilationResult[Node] = {
-    def toCompilationResult[T](validated: ValidatedNel[ProcessCompilationError, T]) =
-      CompilationResult(Map(data.id -> ctx), validated)
+    def toCompilationResult[T](validated: ValidatedNel[ProcessCompilationError, T], expressionsTypingInfo: Map[String, ExpressionTypingInfo]) =
+      CompilationResult(Map(data.id -> NodeTypingInfo(ctx, expressionsTypingInfo)), validated)
 
     data match {
       case graph.node.Variable(id, varName, expression, _) =>
-        val (newCtx, compiledExpression) = withVariable(varName, ctx, compile(expression, None, ctx, Unknown))
+        val (expressionTypingResult, validatedExpression) = compile(expression, None, ctx, Unknown)
+        val (newCtx, combinedValidatedExpression) = withVariableCombined(ctx, varName, expressionTypingResult.typingResult, validatedExpression)
 
-        CompilationResult.map2(toCompilationResult(compiledExpression), compile(next, newCtx)) { (compiled, compiledNext) =>
+        CompilationResult.map2(toCompilationResult(combinedValidatedExpression, expressionTypingResult.toDefaultExpressionTypingInfoEntry.toMap), compile(next, newCtx)) { (compiled, compiledNext) =>
           compiledgraph.node.VariableBuilder(id, varName, Left(compiled), compiledNext)
         }
       case graph.node.VariableBuilder(id, varName, fields, _) =>
-        val fieldsCompiled = fields.map(f => compile(f, ctx)).unzip
-        val fieldsTyped = (TypedObjectTypingResult(fieldsCompiled._1.toMap), fieldsCompiled._2.sequence)
+        val (fieldsTyping, compiledFields) = fields.map(f => compile(f, ctx)).unzip
+        val typingResult = TypedObjectTypingResult(fieldsTyping.map(f => f.fieldName -> f.typingResult).toMap)
+        val (newCtx, combinedCompiledFields) = withVariableCombined(ctx, varName, typingResult, compiledFields.sequence)
 
-        val (newCtx, compiledVariable) = withVariable(varName, ctx, fieldsTyped)
+        val expressionsTypingInfo = fieldsTyping.flatMap(_.toExpressionTypingInfoEntry).toMap
 
-        CompilationResult.map2(toCompilationResult(compiledVariable), compile(next, newCtx)) { (compiledFields, compiledNext) =>
+        CompilationResult.map2(toCompilationResult(combinedCompiledFields, expressionsTypingInfo), compile(next, newCtx)) { (compiledFields, compiledNext) =>
           compiledgraph.node.VariableBuilder(id, varName, Right(compiledFields), compiledNext)
         }
 
       case graph.node.Processor(id, ref, isDisabled, _) =>
-        CompilationResult.map2(toCompilationResult(compile(ref, ctx)), compile(next, ctx))((ref, next) =>
-          compiledgraph.node.Processor(id, ref._1, next, isDisabled.contains(true)))
+        val (typingResult, validatedServiceRef) = compile(ref, ctx)
+        CompilationResult.map2(toCompilationResult(validatedServiceRef, typingResult.expressionsTypingInfo), compile(next, ctx))((ref, next) =>
+          compiledgraph.node.Processor(id, ref, next, isDisabled.contains(true)))
 
       case graph.node.Enricher(id, ref, outName, _) =>
-        val compiledRef = compile(ref, ctx)
+        val (typingResult, validatedServiceRef) = compile(ref, ctx)
 
-        val newCtx = compiledRef.andThen { case (_, returnTypeFromRef) =>
-          val returnType = returnTypeFromRef.orElse(services.get(ref.id).map(_.returnType)).getOrElse(Unknown)
-          ctx.withVariable(outName, returnType)
-        }
-        CompilationResult.map3(CompilationResult(newCtx), toCompilationResult(compile(ref, ctx)), compile(next, newCtx.getOrElse(ctx)))((_, ref, next) =>
-                           compiledgraph.node.Enricher(id, ref._1, outName, next))
+        val (newCtx, combinedValidatedServiceRef) = withVariableCombined(ctx, outName, typingResult.returnType, validatedServiceRef)
+        CompilationResult.map2(toCompilationResult(combinedValidatedServiceRef, typingResult.expressionsTypingInfo), compile(next, newCtx))((ref, next) =>
+                           compiledgraph.node.Enricher(id, ref, outName, next))
 
       //here we don't do anything, in subgraphcompiler it's just pass through, we can't add input context here because it contains output variable context (not input)
       case graph.node.CustomNode(id, _, _, _, _) =>
@@ -165,8 +177,10 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
         import cats.implicits.toTraverseOps
 
         val childCtx = ctx.pushNewContext()
-        val newCtx = ref.parameters.foldLeft[ValidatedNel[ProcessCompilationError, ValidationContext]](Valid(childCtx))
-                      { case (accCtx, param) => accCtx.andThen(_.withVariable(param.name, Unknown))}
+        val (newCtx, combinedValidation) = ref.parameters.foldLeft[(ValidationContext, ValidatedNel[ProcessCompilationError, _])]((childCtx, Valid(Unit))) {
+          case ((accCtx, validation), param) =>
+            withVariableCombined(accCtx, param.name, Unknown, validation)
+        }
 
         val validParamDefs =
           ref.parameters.map(p => getSubprocessParamDefinition(subprocessInput, p.name)).sequence
@@ -175,15 +189,18 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
           expressionCompiler.compileObjectParameters(paramDefs, ref.parameters, ctx)
         }
 
-        CompilationResult.map3(
-          f0 = toCompilationResult(validParams),
-          f1 = compile(next, newCtx.getOrElse(childCtx)),
-          f2 = CompilationResult(newCtx))((params, next, _) => compiledgraph.node.SubprocessStart(id, params, next))
+        val expressionTypingInfo = validParams.map(_.map(p => p.name -> p.typingInfo).toMap).valueOr(Map.empty)
+
+        val combinedValidParams = ProcessCompilationError.ValidatedNelApplicative.map2(combinedValidation, validParams)((_, p) => p)
+
+        CompilationResult.map2(toCompilationResult(combinedValidParams, expressionTypingInfo), compile(next, newCtx))((params, next) =>
+          compiledgraph.node.SubprocessStart(id, params, next))
 
       case SubprocessOutput(id, _, _) =>
         //this popContext *really* has to work to be able to extract variable types :|
-        ctx.popContext.map(popContext =>
-          compile(next, popContext).andThen(next => toCompilationResult(Valid(SubprocessEnd(id, next))))).valueOr(error => CompilationResult(Invalid(error)))
+        ctx.popContext
+          .map(popContext => compile(next, popContext).andThen(next => toCompilationResult(Valid(SubprocessEnd(id, next)), Map.empty)))
+          .valueOr(error => CompilationResult(Invalid(error)))
     }
   }
 
@@ -191,62 +208,69 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
     next match {
       case splittednode.NextNode(n) => compile(n, ctx).map(cn => compiledgraph.node.NextNode(cn))
       case splittednode.PartRef(ref) =>
-        CompilationResult(Map(ref -> ctx), Valid(compiledgraph.node.PartRef(ref)))
+        CompilationResult(Map(ref -> NodeTypingInfo(ctx, Map.empty)), Valid(compiledgraph.node.PartRef(ref)))
     }
   }
 
   private def compile(n: graph.service.ServiceRef, ctx: ValidationContext)
-                     (implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, (compiledgraph.service.ServiceRef, Option[TypingResult])] = {
+                     (implicit nodeId: NodeId): (ServiceTypingResult, ValidatedNel[ProcessCompilationError, compiledgraph.service.ServiceRef]) = {
     val service = services.get(n.id).map(Valid(_)).getOrElse(invalid(MissingService(n.id))).toValidatedNel
 
-    service.andThen { objWithMethod =>
+    val validatedServiceWithTypingResult = service.andThen { objWithMethod =>
       expressionCompiler.compileObjectParameters(objWithMethod.parameters, n.parameters, ctx).map { params =>
-          val invoker = createServiceInvoker(objWithMethod)
-          (compiledgraph.service.ServiceRef(n.id, invoker, params), computeReturnType(objWithMethod.obj, params))
+        val invoker = createServiceInvoker(objWithMethod)
+        val returnType = computeReturnType(objWithMethod, params)
+        val typingResult = ServiceTypingResult(returnType, params.map(p => p.name -> p.typingInfo).toMap)
+        (compiledgraph.service.ServiceRef(n.id, invoker, params), typingResult)
       }
+    }
+    validatedServiceWithTypingResult match {
+      case Valid((serviceRef, typingResult)) =>
+        (typingResult, Valid(serviceRef))
+      case invalid@Invalid(_) =>
+        (ServiceTypingResult(Unknown, Map.empty), invalid)
     }
   }
 
-  private def withVariable[R](name: String, validationContext: ValidationContext, typingResult: (TypingResult, ValidatedNel[ProcessCompilationError, R]))(implicit nodeId: NodeId)
+  private def withVariableCombined[R](validationContext: ValidationContext, variableName: String, typingResult: TypingResult,
+                                      validatedResult: ValidatedNel[ProcessCompilationError, R])(implicit nodeId: NodeId)
     : (ValidationContext, ValidatedNel[ProcessCompilationError, R]) = {
-    implicit val firstSemi = new Semigroup[R] { override def combine(x: R, y: R): R = x }
-    validationContext.withVariable(name, typingResult._1) match {
-      case Valid(newCtx) => (newCtx, typingResult._2)
-      case in@Invalid(_) => (validationContext, in.combine(typingResult._2))
-    }
+    val combinedValidationWithNewCtx = ProcessCompilationError.ValidatedNelApplicative.product(validationContext.withVariable(variableName, typingResult), validatedResult)
+    (combinedValidationWithNewCtx.map(_._1).valueOr(_ => validationContext), combinedValidationWithNewCtx.map(_._2))
   }
 
   private def compile(n: splittednode.Case, ctx: ValidationContext)
                      (implicit nodeId: NodeId): CompilationResult[compiledgraph.node.Case] =
     CompilationResult.map2(CompilationResult(compile(n.expression, None, ctx, Typed[Boolean])._2), compile(n.node, ctx))((expr, next) => compiledgraph.node.Case(expr, next))
 
-  private def compile(n: graph.variable.Field, ctx: ValidationContext)
-                     (implicit nodeId: NodeId): ((String, TypingResult), ValidatedNel[ProcessCompilationError, compiledgraph.variable.Field]) = {
-    val compiled = compile(n.expression, Some(n.name), ctx, Unknown)
-    ((n.name, compiled._1), compiled._2.map(compiledgraph.variable.Field(n.name, _)))
+  private def compile(field: graph.variable.Field, ctx: ValidationContext)
+                     (implicit nodeId: NodeId): (FieldExpressionTypingResult, ValidatedNel[ProcessCompilationError, compiledgraph.variable.Field]) = {
+    val (expressionTyping, validatedExpression) = compile(field.expression, Some(field.name), ctx, Unknown)
+    (FieldExpressionTypingResult(field.name, expressionTyping), validatedExpression.map(compiledgraph.variable.Field(field.name, _)))
   }
 
   private def compile(n: graph.expression.Expression,
                       fieldName: Option[String],
                       ctx: ValidationContext,
                       expectedType: TypingResult)
-                     (implicit nodeId: NodeId): (TypingResult, ValidatedNel[ProcessCompilationError, api.expression.Expression]) = {
+                     (implicit nodeId: NodeId): (ExpressionTypingResult, ValidatedNel[ProcessCompilationError, api.expression.Expression]) = {
     expressionCompiler.compile(n, fieldName, ctx, expectedType)
-      .map(res => (res.returnType, Valid(res.expression)))
-      .valueOr(err => (Unknown, Invalid(err)))
+      .map(res => (ExpressionTypingResult(res.returnType, Some(res.typingInfo)), Valid(res.expression)))
+      .valueOr(err => (ExpressionTypingResult(Unknown, None), Invalid(err)))
   }
 
   //this method tries to compute constant parameters if service is ServiceReturningType
   //TODO: is it right way to do this? Maybe we just need to analyze Expression?
-  private def computeReturnType(service: Any,
-                                parameters: List[compiledgraph.evaluatedparam.Parameter]): Option[TypingResult] = service match {
+  private def computeReturnType(objWithMethod: ObjectWithMethodDef,
+                                parameters: List[compiledgraph.evaluatedparam.Parameter]): TypingResult = objWithMethod.obj match {
     case srt: ServiceReturningType =>
 
       val data = parameters.map { param =>
         param.name -> (param.returnType, tryToEvaluateParam(param))
       }.toMap
-      Some(srt.returnType(data))
-    case _ => None
+      srt.returnType(data)
+    case _ =>
+      objWithMethod.returnType
   }
 
   /*
@@ -273,3 +297,21 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
     }
   }
 }
+
+case class ExpressionTypingResult(typingResult: TypingResult, typingInfo: Option[ExpressionTypingInfo]) {
+
+  def toDefaultExpressionTypingInfoEntry: Option[(String, ExpressionTypingInfo)] =
+    typingInfo.map(NodeTypingInfo.DefaultExpressionId -> _)
+
+}
+
+case class FieldExpressionTypingResult(fieldName: String, private val exprTypingResult: ExpressionTypingResult) {
+
+  def typingResult: TypingResult = exprTypingResult.typingResult
+
+  def toExpressionTypingInfoEntry: Option[(String, ExpressionTypingInfo)] =
+    exprTypingResult.typingInfo.map(fieldName -> _)
+
+}
+
+case class ServiceTypingResult(returnType: TypingResult, expressionsTypingInfo: Map[String, ExpressionTypingInfo])

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
@@ -353,7 +353,7 @@ protected trait ProcessCompilerBase {
     val compiledObjectWithTypingInfo = objectParametersExpressionCompiler.compileObjectParameters(nodeDefinition.parameters,
       parameters,
       branchParameters, ctx.clearVariables, ctx).andThen { compiledParameters =>
-        createObject(nodeDefinition, outputVariableNameOpt, compiledParameters).map { obj =>
+        createObject[T](nodeDefinition, outputVariableNameOpt, compiledParameters).map { obj =>
           val typingInfo = compiledParameters.flatMap {
             case TypedParameter(name, TypedExpression(_, _, typingInfo)) =>
               List(name -> typingInfo)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/evaluatedparam.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/evaluatedparam.scala
@@ -1,12 +1,12 @@
 package pl.touk.nussknacker.engine.compiledgraph
 
-import pl.touk.nussknacker.engine.api.expression.{Expression, TypedValue}
+import pl.touk.nussknacker.engine.api.expression.{Expression, ExpressionTypingInfo, TypedValue}
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 
 object evaluatedparam {
 
   case class TypedParameter(name: String, typedValue: TypedValue)
 
-  case class Parameter(name: String, expression: Expression, returnType: TypingResult)
+  case class Parameter(name: String, expression: Expression, returnType: TypingResult, typingInfo: ExpressionTypingInfo)
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ProcessObjectFactory.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ProcessObjectFactory.scala
@@ -35,8 +35,8 @@ class ProcessObjectFactory(expressionEvaluator: ExpressionEvaluator) extends Laz
     val (lazyInterpreterParameters, paramsToEvaluate) = withDefs.partition(p => p._2.isLazyParameter || p._2.branchParam)
 
     val evaluatedParameters = paramsToEvaluate.map {
-      case (TypedParameter(name, TypedExpression(expr, returnType)), paramDef) =>
-        evaluatedparam.Parameter(name, expr, returnType)
+      case (TypedParameter(name, TypedExpression(expr, returnType, typingInfo)), paramDef) =>
+        evaluatedparam.Parameter(name, expr, returnType, typingInfo)
     }
 
     //this has to be synchronous, source/sink/exceptionHandler creation is done only once per process so it doesn't matter
@@ -47,7 +47,7 @@ class ProcessObjectFactory(expressionEvaluator: ExpressionEvaluator) extends Laz
       case (param, definition) =>
         val value = if (definition.branchParam) {
           param.typedValue.asInstanceOf[TypedExpressionMap].valueByKey.mapValuesNow {
-            case TypedExpression(expr, returnType) =>
+            case TypedExpression(expr, returnType, typingInfo) =>
               ExpressionLazyParameter(nodeId, Parameter(
                 param.name,
                 graph.expression.Expression(expr.language, expr.original)), returnType)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
@@ -134,8 +134,8 @@ class SpelExpressionParser(parser: org.springframework.expression.spel.standard.
   override def parse(original: String, ctx: ValidationContext, expectedType: TypingResult): Validated[NonEmptyList[ExpressionParseError], TypedExpression] = {
     baseParse(original).andThen { parsed =>
       validator.validate(parsed, ctx, expectedType).map((_, parsed))
-    }.map { case (typingResult, parsed) =>
-      TypedExpression(expression(ParsedSpelExpression(original, () => baseParse(original), parsed), expectedType), typingResult)
+    }.map { case (combinedResult, parsed) =>
+      TypedExpression(expression(ParsedSpelExpression(original, () => baseParse(original), parsed), expectedType), combinedResult.finalResult, combinedResult.typingInfo)
     }
   }
 
@@ -248,6 +248,7 @@ object SpelExpressionParser extends LazyLogging {
     }
     Collections.singletonList(mr)
   }
+
 
   object ScalaPropertyAccessor extends PropertyAccessor with ReadOnly with Caching {
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionValidator.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionValidator.scala
@@ -9,11 +9,13 @@ import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 
 class SpelExpressionValidator(typer: Typer) {
 
-  def validate(expr: Expression, ctx: ValidationContext, expectedType: TypingResult): Validated[NonEmptyList[ExpressionParseError], TypingResult] = {
+  def validate(expr: Expression, ctx: ValidationContext, expectedType: TypingResult): Validated[NonEmptyList[ExpressionParseError], CollectedTypingResult] = {
     val typedExpression = typer.typeExpression(expr, ctx)
-    typedExpression.andThen {
-      case a: TypingResult if a.canBeSubclassOf(expectedType) || expectedType == Typed[SpelExpressionRepr] => Valid(a)
-      case a: TypingResult => Invalid(NonEmptyList.of(ExpressionParseError(s"Bad expression type, expected: ${expectedType.display}, found: ${a.display}")))
+    typedExpression.andThen { collected =>
+      collected.finalResult match {
+        case a: TypingResult if a.canBeSubclassOf(expectedType) || expectedType == Typed[SpelExpressionRepr] => Valid(collected)
+        case a: TypingResult => Invalid(NonEmptyList.of(ExpressionParseError(s"Bad expression type, expected: ${expectedType.display}, found: ${a.display}")))
+      }
     }
   }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -294,7 +294,7 @@ object Typer {
 
   // This Semigroup is used in combining `intermediateResults: Map[SpelNodeId, TypingResult]` in TYper.
   // If there is no bug in Typer, collisions shouldn't happen
-  private implicit def notAcceptingMergingSemigroup: Semigroup[TypingResult] = new Semigroup[TypingResult] with LazyLogging {
+  implicit def notAcceptingMergingSemigroup: Semigroup[TypingResult] = new Semigroup[TypingResult] with LazyLogging {
     override def combine(x: TypingResult, y: TypingResult): TypingResult = {
       assert(x == y, s"Types not matching during combination of types for spel nodes: $x != $y")
       // merging the same types is not bad but it is a warning that sth went wrong e.g. typer typed something more than one time

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -292,7 +292,9 @@ private[spel] class Typer(classLoader: ClassLoader) extends LazyLogging {
 
 object Typer {
 
-  implicit def notAcceptingMergingSemigroup: Semigroup[TypingResult] = new Semigroup[TypingResult] with LazyLogging {
+  // This Semigroup is used in combining `intermediateResults: Map[SpelNodeId, TypingResult]` in TYper.
+  // If there is no bug in Typer, collisions shouldn't happen
+  private implicit def notAcceptingMergingSemigroup: Semigroup[TypingResult] = new Semigroup[TypingResult] with LazyLogging {
     override def combine(x: TypingResult, y: TypingResult): TypingResult = {
       assert(x == y, s"Types not matching during combination of types for spel nodes: $x != $y")
       // merging the same types is not bad but it is a warning that sth went wrong e.g. typer typed something more than one time

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -6,44 +6,69 @@ import cats.data.NonEmptyList._
 import cats.data.Validated._
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.instances.list._
+import Typer._
+import cats.instances.map._
+import cats.kernel.{Monoid, Semigroup}
 import cats.syntax.traverse._
 import org.springframework.expression.Expression
 import org.springframework.expression.common.{CompositeStringExpression, LiteralExpression}
 import org.springframework.expression.spel.ast._
 import org.springframework.expression.spel.{SpelNode, standard}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
-import pl.touk.nussknacker.engine.api.expression.ExpressionParseError
+import pl.touk.nussknacker.engine.api.expression.{ExpressionParseError, ExpressionTypingInfo}
 import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
 import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.spel.typer.TypeMethodReference
 import pl.touk.nussknacker.engine.types.EspTypeUtils
 
 import scala.reflect.runtime._
+import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.spel.ast.SpelAst.SpelNodeId
+import pl.touk.nussknacker.engine.spel.ast.SpelNodePrettyPrinter
 
-private[spel] class Typer(classLoader: ClassLoader) {
+private[spel] class Typer(classLoader: ClassLoader) extends LazyLogging {
 
-  def typeExpression(expr: Expression, ctx: ValidationContext): ValidatedNel[ExpressionParseError, TypingResult] = {
+  import ast.SpelAst._
+
+  def typeExpression(expr: Expression, ctx: ValidationContext): ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
     expr match {
       case e:standard.SpelExpression =>
         typeExpression(e, ctx)
       case e:CompositeStringExpression =>
         val validatedParts = e.getExpressions.toList.map(typeExpression(_, ctx)).sequence
 
-        validatedParts.map(_ => Typed[String])
+        validatedParts.map(partResults => CollectedTypingResult(Monoid.combineAll(partResults.map(_.intermediateResults)), Typed[String]))
       case e:LiteralExpression =>
-        Valid(Typed[String])
+        Valid(CollectedTypingResult.withEmptyIntermediateResults(Typed[String]))
     }
   }
-  private def typeExpression(spelExpression: standard.SpelExpression, ctx: ValidationContext): ValidatedNel[ExpressionParseError, TypingResult] = {
-    Validated.fromOption(Option(spelExpression.getAST), NonEmptyList.of(ExpressionParseError("Empty expression"))).andThen(typeNode(ctx, _, Nil))
+
+  private def typeExpression(spelExpression: standard.SpelExpression, ctx: ValidationContext): ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
+    Validated.fromOption(Option(spelExpression.getAST), NonEmptyList.of(ExpressionParseError("Empty expression"))).andThen { ast =>
+      val result = typeNode(ctx, ast, TypingContext(List.empty, Map.empty))
+      logger.whenTraceEnabled {
+        result match {
+          case Valid(collectedResult) =>
+            val printer = new SpelNodePrettyPrinter(n => collectedResult.intermediateResults.get(SpelNodeId(n)).map(_.display).getOrElse("NOT_TYPED"))
+            logger.trace("typed valid expression: " + printer.print(ast))
+          case Invalid(errors) =>
+            logger.trace(s"typed invalid expression: ${spelExpression.getExpressionString}, errors: ${errors.toList.mkString(", ")}")
+        }
+      }
+      result
+    }
   }
 
-  private def typeNode(validationContext: ValidationContext, node: SpelNode, current: List[TypingResult])
-  : ValidatedNel[ExpressionParseError, TypingResult] = {
+  private def typeNode(validationContext: ValidationContext, node: SpelNode, current: TypingContext)
+  : ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
+
+    def toResult(typ: TypingResult) = current.toResult(TypedNode(node, typ))
+
+    def valid(typ: TypingResult) = Valid(toResult(typ))
 
     val withTypedChildren = typeChildren(validationContext, node, current) _
 
-    def fixedWithNewCurrent(newCurrent: List[TypingResult]) = typeChildrenAndReturnFixed(validationContext, node, newCurrent) _
+    def fixedWithNewCurrent(newCurrent: TypingContext) = typeChildrenAndReturnFixed(validationContext, node, newCurrent) _
 
     val fixed = fixedWithNewCurrent(current)
 
@@ -56,38 +81,41 @@ private[spel] class Typer(classLoader: ClassLoader) {
 
       case e: Assign => invalid("Value modifications are not supported")
       case e: BeanReference => invalid("Bean reference is not supported")
-      case e: BooleanLiteral => Valid(Typed[Boolean])
+      case e: BooleanLiteral => valid(Typed[Boolean])
       case e: CompoundExpression => e.children match {
-        case first :: rest => rest.foldLeft(typeNode(validationContext, first, current)) {
-          case (Valid(typ), next) => typeNode(validationContext, next, typ :: current)
-          case (invalid, _) => invalid
-        }
+        case first :: rest =>
+          val validatedLastType = rest.foldLeft(typeNode(validationContext, first, current)) {
+            case (Valid(prevResult), next) => typeNode(validationContext, next, current.pushOnStack(prevResult))
+            case (invalid, _) => invalid
+          }
+          validatedLastType.map { lastType =>
+            CollectedTypingResult(lastType.intermediateResults + (SpelNodeId(e) -> lastType.finalResult), lastType.finalResult)
+          }
         //should not happen as CompoundExpression doesn't allow this...
-        case Nil => Valid(Unknown)
+        case Nil => valid(Unknown)
       }
 
       //TODO: what should be here?
       case e: ConstructorReference => fixed(Unknown)
 
       case e: Elvis => withTypedChildren(l => Valid(Typed(l.toSet)))
-      case e: FloatLiteral => Valid(Typed[java.lang.Float])
+      case e: FloatLiteral => valid(Typed[java.lang.Float])
       //TODO: what should be here?
-      case e: FunctionReference => Valid(Unknown)
+      case e: FunctionReference => valid(Unknown)
 
       //TODO: what should be here?
-      case e: Identifier => Valid(Unknown)
+      case e: Identifier => valid(Unknown)
       //TODO: what should be here?
       case e: Indexer =>
-        val result = current match {
-          case TypedClass(clazz, param :: Nil) :: Nil if clazz.isAssignableFrom(classOf[java.util.List[_]]) => param
-          case TypedClass(clazz, keyParam :: valueParam :: Nil):: Nil if clazz.isAssignableFrom(classOf[java.util.Map[_, _]]) => valueParam
-          case _ => Unknown
+        current.stack match {
+          case TypedClass(clazz, param :: Nil) :: Nil if clazz.isAssignableFrom(classOf[java.util.List[_]]) => valid(param)
+          case TypedClass(clazz, keyParam :: valueParam :: Nil):: Nil if clazz.isAssignableFrom(classOf[java.util.Map[_, _]]) => valid(valueParam)
+          case _ => valid(Unknown)
         }
-        Valid(result)
       case e: InlineList => withTypedChildren { children =>
         val childrenTypes = children.toSet
         val genericType = if (childrenTypes.contains(Unknown) || childrenTypes.size != 1) Unknown else childrenTypes.head
-        fixed(TypedClass(classOf[java.util.List[_]], List(genericType)))
+        Valid(TypedClass(classOf[java.util.List[_]], List(genericType)))
       }
 
       case e: InlineMap =>
@@ -103,21 +131,24 @@ private[spel] class Typer(classLoader: ClassLoader) {
         if (literalKeys.size != keys.size) {
           invalid("Currently inline maps with not literal keys (e.g. expressions as keys) are not supported")
         } else {
-          values.map(typeNode(validationContext, _, current)).sequence.map { typedValues =>
-            TypedObjectTypingResult(literalKeys.zip(typedValues).toMap)
+          values.map(typeNode(validationContext, _, current.withoutIntermediateResults)).sequence.andThen { typedValues =>
+            withCombinedIntermediate(typedValues, current) { typedValues =>
+              val typ = TypedObjectTypingResult(literalKeys.zip(typedValues).toMap)
+              Valid(TypedNode(node, typ))
+            }
           }
         }
-      case e: IntLiteral => Valid(Typed[java.lang.Integer])
+      case e: IntLiteral => valid(Typed[java.lang.Integer])
       //case e:Literal => Valid(classOf[Any])
-      case e: LongLiteral => Valid(Typed[java.lang.Long])
+      case e: LongLiteral => valid(Typed[java.lang.Long])
 
       case e: MethodReference =>
-        TypeMethodReference(e, current) match {
-          case Right(typingResult) => fixedWithNewCurrent(current.tail)(typingResult)
+        TypeMethodReference(e, current.stack) match {
+          case Right(typingResult) => fixedWithNewCurrent(current.popStack)(typingResult)
           case Left(errorMsg) => invalid(errorMsg)
         }
 
-      case e: NullLiteral => Valid(Unknown)
+      case e: NullLiteral => valid(Unknown)
 
       case e: OpAnd => withChildrenOfType[Boolean](Typed[Boolean])
       case e: OpDec => withChildrenOfType[Number](commonNumberReference)
@@ -148,35 +179,35 @@ private[spel] class Typer(classLoader: ClassLoader) {
       case e: OperatorNot => withChildrenOfType[Boolean](Typed[Boolean])
       case e: OperatorPower => withChildrenOfType[Number](commonNumberReference)
 
-      case e: Projection => current.headOption match {
+      case e: Projection => current.stackHead match {
         case None => invalid("Cannot do projection here")
         //index, check if can project?
         case Some(iterateType) =>
           val listType = extractListType(iterateType)
-          typeChildren(validationContext, node, listType :: current) {
+          typeChildren(validationContext, node, current.pushOnStack(listType)) {
             case result :: Nil => Valid(TypedClass(classOf[java.util.List[_]], List(result)))
             case other => invalid(s"Wrong selection type: ${other.map(_.display)}")
           }
       }
 
       case e: PropertyOrFieldReference =>
-        current.headOption.map(extractProperty(e)).getOrElse {
+        current.stackHead.map(head => extractProperty(e, head).map(toResult)).getOrElse {
           invalid(s"Non reference '${e.toStringAST}' occurred. Maybe you missed '#' in front of it?")
         }
       //TODO: what should be here?
       case e: QualifiedIdentifier => fixed(Unknown)
 
-      case e: RealLiteral => Valid(Typed[java.lang.Double])
-      case e: Selection => current.headOption match {
+      case e: RealLiteral => valid(Typed[java.lang.Double])
+      case e: Selection => current.stackHead match {
         case None => invalid("Cannot do selection here")
         case Some(iterateType) =>
-          typeChildren(validationContext, node, extractListType(iterateType) :: current) {
+          typeChildren(validationContext, node, current.pushOnStack(extractListType(iterateType))) {
             case result :: Nil if result.canBeSubclassOf(Typed[Boolean]) => Valid(iterateType)
             case other => invalid(s"Wrong selection type: ${other.map(_.display)}")
           }
       }
 
-      case e: StringLiteral => Valid(Typed[String])
+      case e: StringLiteral => valid(Typed[String])
 
       case e: Ternary => withTypedChildren {
         case condition :: onTrue :: onFalse :: Nil if condition.canBeSubclassOf(Typed[Boolean]) => Valid(Typed(onTrue, onFalse))
@@ -188,15 +219,14 @@ private[spel] class Typer(classLoader: ClassLoader) {
       case e: VariableReference =>
         //only sane way of getting variable name :|
         val name = e.toStringAST.substring(1)
-        validationContext.get(name).orElse(current.headOption.filter(_ => name == "this")) match {
-          case Some(result) => Valid(result)
+        validationContext.get(name).orElse(current.stackHead.filter(_ => name == "this")) match {
+          case Some(result) => valid(result)
           case None => invalid(s"Unresolved reference $name")
         }
     }
   }
 
-  private def extractProperty(e: PropertyOrFieldReference)
-                             (t: TypingResult): ValidatedNel[ExpressionParseError, TypingResult] = t match {
+  private def extractProperty(e: PropertyOrFieldReference, t: TypingResult): ValidatedNel[ExpressionParseError, TypingResult] = t match {
     case typed: TypingResult if typed.canHasAnyPropertyOrField => Valid(Unknown)
     case Unknown => Valid(Unknown)
     case s: SingleTypingResult =>
@@ -227,16 +257,28 @@ private[spel] class Typer(classLoader: ClassLoader) {
     case _ => Unknown
   }
 
-  private def typeChildrenAndReturnFixed(validationContext: ValidationContext, node: SpelNode, current: List[TypingResult])(result: TypingResult)
-  : ValidatedNel[ExpressionParseError, TypingResult] = {
+  private def typeChildrenAndReturnFixed(validationContext: ValidationContext, node: SpelNode, current: TypingContext)(result: TypingResult)
+  : Validated[NonEmptyList[ExpressionParseError], CollectedTypingResult] = {
     typeChildren(validationContext, node, current)(_ => Valid(result))
   }
 
-  private def typeChildren(validationContext: ValidationContext, node: SpelNode, current: List[TypingResult])
+  private def typeChildren(validationContext: ValidationContext, node: SpelNode, current: TypingContext)
                           (result: List[TypingResult] => ValidatedNel[ExpressionParseError, TypingResult])
-  : ValidatedNel[ExpressionParseError, TypingResult] = {
-    val data = node.children.map(child => typeNode(validationContext, child, current)).sequence
-    data.andThen(result)
+  : ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
+    val data = node.children.map(child => typeNode(validationContext, child, current.withoutIntermediateResults)).sequence
+    data.andThen { collectedChildrenResults =>
+      withCombinedIntermediate(collectedChildrenResults, current) { childrenResults =>
+        result(childrenResults).map(TypedNode(node, _))
+      }
+    }
+  }
+
+  private def withCombinedIntermediate(intermediate: List[CollectedTypingResult], current: TypingContext)
+                                      (result: List[TypingResult] => ValidatedNel[ExpressionParseError, TypedNode])
+  : ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
+    val intermediateResultsCombination = Monoid.combineAll(current.intermediateResults :: intermediate.map(_.intermediateResults))
+    val intermediateTypes = intermediate.map(_.finalResult)
+    result(intermediateTypes).map(CollectedTypingResult.withIntermediateAndFinal(intermediateResultsCombination, _))
   }
 
   private def invalid[T](message: String): ValidatedNel[ExpressionParseError, T] =
@@ -246,15 +288,66 @@ private[spel] class Typer(classLoader: ClassLoader) {
     Typed(
       Typed[Double], Typed[Int], Typed[Long], Typed[Float], Typed[Byte], Typed[Short], Typed[BigDecimal], Typed[BigInteger])
 
-  implicit class RichSpelNode(n: SpelNode) {
-    def children: List[SpelNode] = {
-      (0 until n.getChildCount).map(i => n.getChild(i))
-    }.toList
+}
 
-    def childrenHead: SpelNode = {
-      n.getChild(0)
+object Typer {
+
+  implicit def notAcceptingMergingSemigroup: Semigroup[TypingResult] = new Semigroup[TypingResult] with LazyLogging {
+    override def combine(x: TypingResult, y: TypingResult): TypingResult = {
+      assert(x == y, s"Types not matching during combination of types for spel nodes: $x != $y")
+      // merging the same types is not bad but it is a warning that sth went wrong e.g. typer typed something more than one time
+      // or spel node's identity is broken
+      logger.warn(s"Merging same types: $x for the same nodes. This shouldn't happen")
+      x
     }
-
   }
+
+}
+
+case class CollectedTypingResult(intermediateResults: Map[SpelNodeId, TypingResult], finalResult: TypingResult) {
+  def typingInfo = SpelExpressionTypingInfo(intermediateResults)
+}
+
+case class SpelExpressionTypingInfo(intermediateResults: Map[SpelNodeId, TypingResult]) extends ExpressionTypingInfo
+
+object CollectedTypingResult {
+
+  def withEmptyIntermediateResults(finalResult: TypingResult): CollectedTypingResult =
+    CollectedTypingResult(Map.empty, finalResult)
+
+  def withIntermediateAndFinal(intermediateResults: Map[SpelNodeId, TypingResult], finalNode: TypedNode): CollectedTypingResult = {
+    CollectedTypingResult(intermediateResults + (finalNode.nodeId -> finalNode.typ), finalNode.typ)
+  }
+
+}
+
+// It contains stack of types for recognition of nested node type
+// intermediateResults are all results that we can collect for intermediate nodes
+case class TypingContext(stack: List[TypingResult], intermediateResults: Map[SpelNodeId, TypingResult]) {
+
+  def pushOnStack(typingResult: TypingResult): TypingContext = copy(stack = typingResult :: stack)
+
+  def pushOnStack(typingResult: CollectedTypingResult): TypingContext =
+    TypingContext(typingResult.finalResult :: stack, intermediateResults ++ typingResult.intermediateResults)
+
+  def popStack: TypingContext = copy(stack = stack.tail)
+
+  def stackHead: Option[TypingResult] = stack.headOption
+
+  def stackTail: List[TypingResult] = stack.tail
+
+  def withoutIntermediateResults: TypingContext = copy(intermediateResults = Map.empty)
+
+  def toResult(finalNode: TypedNode): CollectedTypingResult =
+    CollectedTypingResult(intermediateResults + (finalNode.nodeId -> finalNode.typ), finalNode.typ)
+
+}
+
+case class TypedNode(nodeId: SpelNodeId, typ: TypingResult)
+
+object TypedNode {
+
+  def apply(node: SpelNode, typ: TypingResult): TypedNode =
+    TypedNode(SpelNodeId(node), typ)
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/ast/SpelAst.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/ast/SpelAst.scala
@@ -1,0 +1,38 @@
+package pl.touk.nussknacker.engine.spel.ast
+
+import org.springframework.expression.spel.SpelNode
+
+object SpelAst {
+
+  case class PositionRange(start: Int, end: Int)
+
+  object PositionRange {
+
+    def apply(node: SpelNode): PositionRange =
+      PositionRange(node.getStartPosition, node.getEndPosition)
+
+  }
+
+  // Node identifier in expression. Is it ok? Or mayby we should add some extra info like class?
+  type SpelNodeId = PositionRange
+
+  object SpelNodeId {
+
+    def apply(node: SpelNode): SpelNodeId =
+      PositionRange(node)
+
+  }
+
+  implicit class RichSpelNode(n: SpelNode) {
+
+    def children: List[SpelNode] = {
+      (0 until n.getChildCount).map(i => n.getChild(i))
+      }.toList
+
+    def childrenHead: SpelNode = {
+      n.getChild(0)
+    }
+
+  }
+
+}

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/ast/SpelNodePrettyPrinter.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/ast/SpelNodePrettyPrinter.scala
@@ -1,0 +1,26 @@
+package pl.touk.nussknacker.engine.spel.ast
+
+import org.springframework.expression.spel.SpelNode
+import pl.touk.nussknacker.engine.spel.ast
+
+class SpelNodePrettyPrinter(additionalInformation: SpelNode => String) {
+
+  import ast.SpelAst._
+
+  def print(ast: SpelNode): String = {
+    val builder = new StringBuilder
+    printIndentedAST(builder, ast, "")
+    builder.toString()
+  }
+
+  // From SpringUtilities
+  private def printIndentedAST(sb: StringBuilder, ast: SpelNode, indent: String): Unit = {
+    sb.append(indent).append(ast.getClass.getSimpleName)
+    sb.append("  value:").append(ast.toStringAST)
+    sb.append("  additional:").append(additionalInformation(ast))
+    sb.append(if (ast.getChildCount < 2) "" else "  #children:" + ast.getChildCount)
+    sb.append("\n")
+    ast.children.foreach(child => printIndentedAST(sb, child, indent + "  "))
+  }
+
+}

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/SqlExpressionParser.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/SqlExpressionParser.scala
@@ -6,7 +6,7 @@ import cats.data.Validated._
 import cats.data._
 import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.context.ValidationContext
-import pl.touk.nussknacker.engine.api.expression.{Expression, ExpressionParseError, ExpressionParser, TypedExpression, ValueWithLazyContext}
+import pl.touk.nussknacker.engine.api.expression.{Expression, ExpressionParseError, ExpressionParser, ExpressionTypingInfo, TypedExpression, ValueWithLazyContext}
 import pl.touk.nussknacker.engine.api.lazyy.LazyValuesProvider
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypingResult}
 import pl.touk.nussknacker.engine.api.typed.{ClazzRef, TypedMap, typing}
@@ -47,7 +47,7 @@ object SqlExpressionParser extends ExpressionParser {
 
     val expression = new SqlExpression(original = original, columnModels = colModel)
     val listResult = TypedClass(classOf[List[_]], List(typingResult))
-    TypedExpression(expression, listResult)
+    TypedExpression(expression, listResult, SqlExpressionTypingInfo)
   }
 
   private def getQueryReturnType(original: String, colModel: Map[String, ColumnModel]): Validated[NonEmptyList[ExpressionParseError], TypingResult] = {
@@ -116,6 +116,8 @@ class SqlExpression(private[sql] val columnModels: Map[String, ColumnModel],
 
 }
 
+// empty for now
+case object SqlExpressionTypingInfo extends ExpressionTypingInfo
 
 case class Table(model: ColumnModel, rows: List[List[Any]])
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
@@ -9,7 +9,7 @@ import pl.touk.nussknacker.engine.InterpreterSpec._
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.definition.{ServiceWithExplicitMethod, WithExplicitMethodToInvoke}
 import pl.touk.nussknacker.engine.api.exception.EspExceptionInfo
-import pl.touk.nussknacker.engine.api.expression.{ExpressionParseError, ExpressionParser, TypedExpression, ValueWithLazyContext}
+import pl.touk.nussknacker.engine.api.expression.{ExpressionParseError, ExpressionParser, ExpressionTypingInfo, TypedExpression, ValueWithLazyContext}
 import pl.touk.nussknacker.engine.api.lazyy.{LazyValuesProvider, UsingLazyValues}
 import pl.touk.nussknacker.engine.api.process.{ExpressionConfig, LanguageConfiguration, ProcessConfigCreator, SinkFactory, SourceFactory, WithCategories}
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors
@@ -683,11 +683,13 @@ object InterpreterSpec {
     override def languageId: String = "literal"
 
     override def parse(original: String, ctx: ValidationContext, expectedType: typing.TypingResult): Validated[NonEmptyList[ExpressionParseError], TypedExpression] =
-      parseWithoutContextValidation(original).map(TypedExpression(_, Typed[String]))
+      parseWithoutContextValidation(original).map(TypedExpression(_, Typed[String], LiteralExpressionTypingInfo))
 
     override def parseWithoutContextValidation(original: String): Validated[NonEmptyList[ExpressionParseError],
       pl.touk.nussknacker.engine.api.expression.Expression]
       = Valid(LiteralExpression(original))
   }
+
+  case object LiteralExpressionTypingInfo extends ExpressionTypingInfo
 
 }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
@@ -8,6 +8,7 @@ import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields, Stream
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.canonize.ProcessCanonizer
 import pl.touk.nussknacker.engine.compile.ProcessValidator
+import pl.touk.nussknacker.engine.compile.NodeTypingInfo._
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectDefinition
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.{ExpressionDefinition, ProcessDefinition}
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
@@ -105,6 +106,7 @@ class ProcessConverterSpec extends FunSuite with Matchers with TableDrivenProper
         List.empty,
         List.empty,
         Map(
+          ExceptionHandlerNodeId -> Map("meta" -> MetaVariables.typingResult(meta)),
           "s" -> Map("meta" -> MetaVariables.typingResult(meta)),
           "v" -> Map("input" -> Unknown, "meta" -> MetaVariables.typingResult(meta)),
           "e" -> Map("input" -> Unknown, "meta" -> MetaVariables.typingResult(meta), "test" -> Typed[String]))


### PR DESCRIPTION
This change adds typing info for each expression in each node in process. Typing info depends on used expression parser. Currently is implemented only typing info for SpEL. It contains computed type for each SpEL AST node.