### PR TITLE
Global permissions

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -9,6 +9,13 @@ Each user has id and set of permissions for every process category. There are fo
 * Write - user can modify/add new processes in category
 * Deploy - user can deploy or cancel processes in given category
 
+## Global permissions
+In addition to permission system oriented around processes' categories we provide additional set of permissions.
+This feature is designed to control access to components that have no category attached or it doesn't make sense for them to have one.
+
+Currently supported permissions:
+* AdminTab - shows Admin tab in the UI (right now there are some useful things kept there including search components functionality).
+
 ##Default security module
 
 Default security provider uses users file in following format:
@@ -21,6 +28,7 @@ users: [
       "Category1": ["Read", "Deploy"]
       "Category2": ["Read", "Write"]
     }
+    globalPermissions: ["AdminTab"]
   },
   {
     id: "user2"

--- a/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/GlobalPermission.scala
+++ b/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/GlobalPermission.scala
@@ -1,0 +1,8 @@
+package pl.touk.nussknacker.ui.security.api
+
+object GlobalPermission extends Enumeration {
+  type GlobalPermission = Value
+  val AdminTab = Value("AdminTab")
+
+  final val ALL_PERMISSIONS = Set(AdminTab)
+}

--- a/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
+++ b/engine/security-api/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.ui.security.api
 
+import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
 import pl.touk.nussknacker.ui.security.api.Permission.Permission
 
 sealed trait LoggedUser {
@@ -9,18 +10,22 @@ sealed trait LoggedUser {
 }
 
 object LoggedUser {
-  def apply(id: String, categoryPermissions: Map[String, Set[Permission]] = Map.empty, isAdmin: Boolean = false): LoggedUser = {
+  def apply(id: String,
+            categoryPermissions: Map[String, Set[Permission]] = Map.empty,
+            globalPermissions: List[GlobalPermission] = Nil,
+            isAdmin: Boolean = false): LoggedUser = {
     if (isAdmin) {
       AdminUser(id)
     }
     else {
-      CommonUser(id, categoryPermissions)
+      CommonUser(id, categoryPermissions, globalPermissions)
     }
   }
 }
 
 case class CommonUser(id: String,
-                      categoryPermissions: Map[String, Set[Permission]] = Map.empty) extends LoggedUser {
+                      categoryPermissions: Map[String, Set[Permission]] = Map.empty,
+                      globalPermissions: List[GlobalPermission] = Nil) extends LoggedUser {
   def categories(permission: Permission): Set[String] = categoryPermissions.collect {
     case (category, permissions) if permissions contains permission => category
   }.toSet

--- a/engine/security-api/src/test/scala/pl/touk/nussknacker/ui/security/api/LoggedUserTest.scala
+++ b/engine/security-api/src/test/scala/pl/touk/nussknacker/ui/security/api/LoggedUserTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.prop.{TableFor3, TableFor4}
 class LoggedUserTest extends FunSuite with Matchers {
 
   test("Admin permission grants other permissions") {
-    def admin(cp: Map[String, Set[Permission]]) = LoggedUser("admin", cp, true)
+    def admin(cp: Map[String, Set[Permission]]) = LoggedUser("admin", cp, Nil, true)
 
     val perms: TableFor3[LoggedUser, Permission, String] = Table(
       ("user", "permission", "category"),

--- a/nussknacker-dist/src/universal/conf/docker-users.conf
+++ b/nussknacker-dist/src/universal/conf/docker-users.conf
@@ -25,5 +25,6 @@ users: [
       "FraudDetection": ["Read", "Write"]
       "Recommendations": ["Read", "Write"]
     }
+    globalPermissions: ["AdminTab"]
   }
 ]

--- a/nussknacker-dist/src/universal/conf/users.conf
+++ b/nussknacker-dist/src/universal/conf/users.conf
@@ -17,5 +17,6 @@ users: [
     categoryPermissions: {
       "Default":["Read", "Write"]
     }
+    globalPermissions: ["AdminTab"]
   }
 ]

--- a/ui/client/common/models/User.js
+++ b/ui/client/common/models/User.js
@@ -5,6 +5,7 @@ const User = function User(data) {
   this.categoryPermissions = data.categoryPermissions
   this.categories = data.categories
   this.isAdmin = data.isAdmin
+  this.globalPermissions = data.globalPermissions
   this.id = data.id
 }
 

--- a/ui/client/containers/EspApp.js
+++ b/ui/client/containers/EspApp.js
@@ -111,7 +111,7 @@ class EspApp extends React.Component {
                 }
                 <li><NavLink to={Archive.path}>{Archive.header}</NavLink></li>
                 {
-                  this.props.loggedUser.isAdmin ?
+                  this.props.loggedUser.globalPermissions.adminTab ?
                     <li><NavLink to={AdminPage.path}>{AdminPage.header}</NavLink></li> : null
                 }
               </ul>

--- a/ui/server/develConf/sample/users.conf
+++ b/ui/server/develConf/sample/users.conf
@@ -23,5 +23,6 @@ users: [
       "Category1": ["Read"]
       "Category2": ["Read", "Write"]
     }
+    globalPermissions: ["AdminTab"]
   }
 ]

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
@@ -35,7 +35,7 @@ object GlobalPermissions {
 @JsonCodec case class DisplayableUser private(id: String,
                                               isAdmin: Boolean,
                                               categories: List[String],
-                                              categoryPermissions: Map[String, Set[String]],
+                                              categoryPermissions: Map[String, List[String]],
                                               globalPermissions: GlobalPermissions)
 
 object DisplayableUser {
@@ -45,15 +45,15 @@ object DisplayableUser {
     case CommonUser(id, categoryPermissions, globalPermissions) => new DisplayableUser(
       id = id,
       isAdmin = false,
-      categories = allCategories,
-      categoryPermissions = categoryPermissions.mapValuesNow(_.map(_.toString)),
+      categories = allCategories.sorted,
+      categoryPermissions = categoryPermissions.mapValuesNow(_.map(_.toString).toList.sorted),
       globalPermissions = GlobalPermissions(globalPermissions)
     )
     case AdminUser(id) => new DisplayableUser(
       id = id,
       isAdmin = true,
-      categories = allCategories,
-      categoryPermissions = allCategories.map(category => category -> Permission.ALL_PERMISSIONS.map(_.toString)).toMap,
+      categories = allCategories.sorted,
+      categoryPermissions = allCategories.map(category => category -> Permission.ALL_PERMISSIONS.map(_.toString).toList.sorted).toMap,
       globalPermissions = GlobalPermissions.ALL
     )
   }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/UserResources.scala
@@ -4,7 +4,8 @@ import akka.http.scaladsl.server.{Directives, Route}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.ui.process.ProcessTypesForCategories
-import pl.touk.nussknacker.ui.security.api.{AdminUser, CommonUser, LoggedUser, Permission}
+import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
+import pl.touk.nussknacker.ui.security.api.{AdminUser, CommonUser, GlobalPermission, LoggedUser, Permission}
 
 import scala.concurrent.ExecutionContext
 
@@ -19,23 +20,41 @@ class UserResources(typesForCategories: ProcessTypesForCategories)(implicit ec: 
     }
 }
 
-@JsonCodec case class DisplayableUser private(id: String, isAdmin: Boolean, categories: List[String], categoryPermissions: Map[String, Set[String]])
+@JsonCodec case class GlobalPermissions private(adminTab: Boolean)
+
+object GlobalPermissions {
+  val ALL = apply(GlobalPermission.ALL_PERMISSIONS.toList)
+
+  def apply(permissions: List[GlobalPermission]): GlobalPermissions = {
+    permissions.foldLeft(GlobalPermissions(false)) {
+      case (acc, GlobalPermission.AdminTab) => acc.copy(adminTab = true)
+    }
+  }
+}
+
+@JsonCodec case class DisplayableUser private(id: String,
+                                              isAdmin: Boolean,
+                                              categories: List[String],
+                                              categoryPermissions: Map[String, Set[String]],
+                                              globalPermissions: GlobalPermissions)
 
 object DisplayableUser {
   import pl.touk.nussknacker.engine.util.Implicits._
 
   def apply(user: LoggedUser, allCategories: List[String]): DisplayableUser = user match {
-    case CommonUser(id, categoryPermissions) => new DisplayableUser(
+    case CommonUser(id, categoryPermissions, globalPermissions) => new DisplayableUser(
       id = id,
       isAdmin = false,
       categories = allCategories,
-      categoryPermissions = categoryPermissions.mapValuesNow(_.map(_.toString))
+      categoryPermissions = categoryPermissions.mapValuesNow(_.map(_.toString)),
+      globalPermissions = GlobalPermissions(globalPermissions)
     )
     case AdminUser(id) => new DisplayableUser(
       id = id,
       isAdmin = true,
       categories = allCategories,
-      categoryPermissions = allCategories.map(category => category -> Permission.ALL_PERMISSIONS.map(_.toString)).toMap
+      categoryPermissions = allCategories.map(category => category -> Permission.ALL_PERMISSIONS.map(_.toString)).toMap,
+      globalPermissions = GlobalPermissions.ALL
     )
   }
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/BasicHttpAuthenticator.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/security/BasicHttpAuthenticator.scala
@@ -12,6 +12,7 @@ import net.ceedubs.ficus.readers.EnumerationReader._
 import pl.touk.nussknacker.ui.security.api.Permission.Permission
 import BasicHttpAuthenticator._
 import org.mindrot.jbcrypt.BCrypt
+import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -52,7 +53,7 @@ class BasicHttpAuthenticator(usersList: List[ConfiguredUser]) extends SecurityDi
         case (Some(_), Some(_)) => throw new IllegalStateException("Specified both password and encrypted password for user: " + u.id)
         case (None, None) => throw new IllegalStateException("Neither specified password nor encrypted password for user: " + u.id)
       }
-      u.id -> UserWithPassword(u.id, password, u.categoryPermissions, u.isAdmin)
+      u.id -> UserWithPassword(u.id, password, u.categoryPermissions, u.globalPermissions, u.isAdmin)
     }.toMap
   }
 
@@ -71,6 +72,7 @@ object BasicHttpAuthenticator {
                                               password: Option[String],
                                               encryptedPassword: Option[String],
                                               categoryPermissions: Map[String, Set[Permission]] = Map.empty,
+                                              globalPermissions: List[GlobalPermission] = Nil,
                                               isAdmin: Boolean = false)
 
   private sealed trait Password {
@@ -81,8 +83,8 @@ object BasicHttpAuthenticator {
 
   private case class EncryptedPassword(value: String) extends Password
 
-  private case class UserWithPassword(id: String, password: Password, categoryPermissions: Map[String, Set[Permission]], isAdmin: Boolean) {
-    def toLoggedUser = LoggedUser(id, categoryPermissions, isAdmin)
+  private case class UserWithPassword(id: String, password: Password, categoryPermissions: Map[String, Set[Permission]], globalPermissions: List[GlobalPermission], isAdmin: Boolean) {
+    def toLoggedUser = LoggedUser(id, categoryPermissions, globalPermissions, isAdmin)
   }
 
 }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/UsersResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/UsersResourcesSpec.scala
@@ -1,0 +1,51 @@
+package pl.touk.nussknacker.ui.api
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import io.circe.Json
+import org.scalatest._
+import org.scalatest.time.{Millis, Seconds, Span}
+import pl.touk.nussknacker.ui.api.helpers.EspItTest
+
+class UsersResourcesSpec extends FunSuite with ScalatestRouteTest with FailFastCirceSupport
+  with Matchers with EspItTest {
+
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(100, Millis)))
+
+  test("fetch user info") {
+    getUser ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json] shouldBe Json.obj(
+        "id" -> Json.fromString("userId"),
+        "isAdmin" -> Json.fromBoolean(false),
+        "categories" -> Json.arr(
+          List(
+            "Category2",
+            "ReqRes",
+            "Category1",
+            "TESTCAT",
+            "TESTCAT2"
+          ).map(Json.fromString): _*
+        ),
+        "categoryPermissions" -> Json.obj(
+          "TESTCAT" -> Json.arr(
+            List(
+              "Deploy",
+              "Read",
+              "Write"
+            ).map(Json.fromString): _*),
+          "TESTCAT2" -> Json.arr(
+            List(
+              "Deploy",
+              "Read",
+              "Write"
+            ).map(Json.fromString): _*)
+        ),
+        "globalPermissions" -> Json.obj(
+          "adminTab" -> Json.fromBoolean(false)
+        )
+      )
+    }
+  }
+}

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/UsersResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/UsersResourcesSpec.scala
@@ -14,36 +14,57 @@ class UsersResourcesSpec extends FunSuite with ScalatestRouteTest with FailFastC
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(100, Millis)))
 
   test("fetch user info") {
-    getUser ~> check {
+    getUser(isAdmin = false) ~> check {
       status shouldBe StatusCodes.OK
       responseAs[Json] shouldBe Json.obj(
         "id" -> Json.fromString("userId"),
         "isAdmin" -> Json.fromBoolean(false),
         "categories" -> Json.arr(
-          List(
-            "Category2",
-            "ReqRes",
-            "Category1",
-            "TESTCAT",
-            "TESTCAT2"
-          ).map(Json.fromString): _*
+          List("Category1", "Category2", "ReqRes", "TESTCAT", "TESTCAT2").map(Json.fromString): _*
         ),
         "categoryPermissions" -> Json.obj(
           "TESTCAT" -> Json.arr(
-            List(
-              "Deploy",
-              "Read",
-              "Write"
-            ).map(Json.fromString): _*),
+            List("Deploy", "Read", "Write").map(Json.fromString): _*
+          ),
           "TESTCAT2" -> Json.arr(
-            List(
-              "Deploy",
-              "Read",
-              "Write"
-            ).map(Json.fromString): _*)
+            List("Deploy", "Read", "Write").map(Json.fromString): _*
+          )
         ),
         "globalPermissions" -> Json.obj(
           "adminTab" -> Json.fromBoolean(false)
+        )
+      )
+    }
+  }
+
+  test("fetch admin info") {
+    getUser(isAdmin = true) ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json] shouldBe Json.obj(
+        "id" -> Json.fromString("adminId"),
+        "isAdmin" -> Json.fromBoolean(true),
+        "categories" -> Json.arr(
+          List("Category1", "Category2", "ReqRes", "TESTCAT", "TESTCAT2").map(Json.fromString): _*
+        ),
+        "categoryPermissions" -> Json.obj(
+          "Category2" -> Json.arr(
+            List("Deploy", "Read", "Write").map(Json.fromString): _*
+          ),
+          "ReqRes" -> Json.arr(
+            List("Deploy", "Read", "Write").map(Json.fromString): _*
+          ),
+          "Category1" -> Json.arr(
+            List("Deploy", "Read", "Write").map(Json.fromString): _*
+          ),
+          "TESTCAT" -> Json.arr(
+            List("Deploy", "Read", "Write").map(Json.fromString): _*
+          ),
+          "TESTCAT2" -> Json.arr(
+            List("Deploy", "Read", "Write").map(Json.fromString): _*
+          )
+        ),
+        "globalPermissions" -> Json.obj(
+          "adminTab" -> Json.fromBoolean(true)
         )
       )
     }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -73,6 +73,7 @@ trait EspItTest extends LazyLogging with ScalaFutures with WithHsqlDbTesting wit
   val featureTogglesConfig = FeatureTogglesConfig.create(config)
   val typeToConfig = ProcessingTypeDeps(config, featureTogglesConfig.standaloneMode)
   val settingsRoute = new SettingsResources(featureTogglesConfig, typeToConfig)
+  val usersRoute = new UserResources(typesForCategories)
 
   val processesExportResources = new ProcessesExportResources(processRepository, processActivityRepository)
   val definitionResources = new DefinitionResources(
@@ -182,6 +183,10 @@ trait EspItTest extends LazyLogging with ScalaFutures with WithHsqlDbTesting wit
 
   def getSettings = {
     Get(s"/settings") ~> settingsRouteWithAllPermissions
+  }
+
+  def getUser = {
+    Get("/user") ~> withAllPermissions(usersRoute)
   }
 
   def getProcessDefinitionData(processingType: String, subprocessVersions: Json) = {

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -185,8 +185,8 @@ trait EspItTest extends LazyLogging with ScalaFutures with WithHsqlDbTesting wit
     Get(s"/settings") ~> settingsRouteWithAllPermissions
   }
 
-  def getUser = {
-    Get("/user") ~> withAllPermissions(usersRoute)
+  def getUser(isAdmin: Boolean) = {
+    Get("/user") ~> (if (isAdmin) withAdminPermissions(usersRoute) else withAllPermissions(usersRoute))
   }
 
   def getProcessDefinitionData(processingType: String, subprocessVersions: Json) = {

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -73,7 +73,7 @@ object TestFactory extends TestPermissions{
   //FIXME: update
   def user(userName: String = "userId", testPermissions: CategorizedPermission = testPermissionEmpty) = LoggedUser(userName, testPermissions)
 
-  def adminUser(userName: String = "adminId") = LoggedUser(userName, Map.empty, true)
+  def adminUser(userName: String = "adminId") = LoggedUser(userName, Map.empty, Nil, isAdmin = true)
 
   class MockProcessManager extends FlinkProcessManager(FlinkProcessManagerProvider.defaultModelData(ConfigFactory.load()), false){
 


### PR DESCRIPTION
This PR introduces additional permissions configuration for use cases where one want to control access to certain functionalities but it is impossible or makes no sense to assign it to some category. 

Motivating example: admin tab in the UI. At the moment just admin user can access it but it also has pretty useful components for the end user - namely search / unused components and services. 

I was thinking about moving `custom processes` to a different place and eventually renaming `Admin` tab to something different. To make such change I'd like to discuss it with you guys first.