### PR TITLE
Fix modal height on Mozilla

### DIFF
--- a/ui/client/stylesheets/graph.styl
+++ b/ui/client/stylesheets/graph.styl
@@ -80,10 +80,10 @@ espCheckbox(checkboxWidth)
       color #fff
 
 .espModal
-  max-height modalMaxHeight
+  max-height fit-content
   max-width modalMaxWidth
   width modalMaxWidth
-  height fit-content
+  height -moz-max-content
   position relative
   background modalBkgColor
   background-color modalBkgColor
@@ -595,6 +595,3 @@ espPanelButton()
       margin-right 5px
     &.fieldRemove
       width: 5%
-
-    
-


### PR DESCRIPTION
Fix for not working property height : 'fit-content' on Mozilla browser