### PR TITLE
Fix input edition after modal move

### DIFF
--- a/ui/client/components/AddProcessDialog.js
+++ b/ui/client/components/AddProcessDialog.js
@@ -11,6 +11,7 @@ import "../stylesheets/visualization.styl";
 import HttpService from "../http/HttpService";
 import * as VisualizationUrl from '../common/VisualizationUrl';
 import Draggable from 'react-draggable';
+import {preventFromMoveSelectors} from "./modals/GenericModalDialog";
 
 //TODO: Consider integrating with GenericModalDialog 
 class AddProcessDialog extends React.Component {
@@ -53,7 +54,7 @@ class AddProcessDialog extends React.Component {
              shouldCloseOnOverlayClick={false}
              onRequestClose={this.closeDialog}>
         <div className="draggable-container">
-          <Draggable bounds="parent">
+          <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
             <div className="espModal">
               <div className="modalHeader">
                 <div className="modal-title" style={titleStyles}>

--- a/ui/client/components/graph/EdgeDetailsModal.js
+++ b/ui/client/components/graph/EdgeDetailsModal.js
@@ -10,6 +10,7 @@ import NodeUtils from './NodeUtils';
 import EspModalStyles from '../../common/EspModalStyles'
 import EdgeDetailsContent from "./EdgeDetailsContent";
 import Draggable from "react-draggable";
+import {preventFromMoveSelectors} from "../modals/GenericModalDialog";
 
 //TODO: this is still pretty switch-specific. 
 class EdgeDetailsModal extends React.Component {
@@ -103,7 +104,7 @@ class EdgeDetailsModal extends React.Component {
                shouldCloseOnOverlayClick={false}
                onRequestClose={this.closeModal}>
           <div className="draggable-container">
-            <Draggable bounds="parent">
+            <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
               <div className="espModal">
                 <div className="modalHeader" style={headerStyles}>
                   <div className="modal-title">

--- a/ui/client/components/graph/NodeDetailsModal.js
+++ b/ui/client/components/graph/NodeDetailsModal.js
@@ -18,6 +18,7 @@ import ProcessUtils from "../../common/ProcessUtils";
 import PropTypes from 'prop-types';
 import nodeAttributes from "../../assets/json/nodeAttributes"
 import Draggable from "react-draggable";
+import {preventFromMoveSelectors} from "../modals/GenericModalDialog";
 
 class NodeDetailsModal extends React.Component {
 
@@ -88,10 +89,11 @@ class NodeDetailsModal extends React.Component {
     const nodeIds = this.props.processToDisplay.nodes.map(node => node.id);
     const displayedNodeId = this.props.nodeToDisplay.id;
     const editedNode = this.state.editedNode;
+    const nodeIsProperties = NodeUtils.nodeIsProperties(editedNode);
     if (_.isEmpty(this.state.editedNode)) {
       return true
     }
-    return ((!nodeIds.includes(editedNode.id) && displayedNodeId !== editedNode.id)
+    return nodeIsProperties || ((!nodeIds.includes(editedNode.id) && displayedNodeId !== editedNode.id)
         || (nodeIds.includes(editedNode.id) && displayedNodeId === editedNode.id))
   }
 
@@ -193,7 +195,7 @@ class NodeDetailsModal extends React.Component {
                isOpen={isOpen}
                onRequestClose={this.closeModal}>
           <div className="draggable-container">
-            <Draggable bounds="parent" cancel=".fieldsControl">
+            <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
               <div className="espModal">
                 <div className="modalHeader">
                   <div className="modal-title" style={titleStyles}>

--- a/ui/client/components/modals/ConfirmDialog.js
+++ b/ui/client/components/modals/ConfirmDialog.js
@@ -6,6 +6,7 @@ import ProcessUtils from '../../common/ProcessUtils';
 import "../../stylesheets/visualization.styl";
 import ProcessDialogWarnings from "./ProcessDialogWarnings";
 import Draggable from "react-draggable";
+import {preventFromMoveSelectors} from "./GenericModalDialog";
 
 //TODO: consider extending GenericModalDialog
 class ConfirmDialog extends React.Component {
@@ -35,7 +36,7 @@ class ConfirmDialog extends React.Component {
              shouldCloseOnOverlayClick={false}
              onRequestClose={this.closeDialog}>
         <div className="draggable-container">
-          <Draggable bounds="parent">
+          <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
             <div className="espModal confirmationModal modalContentDark">
               <p>{confirmDialog.text}</p>
               <ProcessDialogWarnings processHasWarnings={this.props.processHasWarnings}/>

--- a/ui/client/components/modals/GenericModalDialog.js
+++ b/ui/client/components/modals/GenericModalDialog.js
@@ -56,7 +56,7 @@ class GenericModalDialog extends React.Component {
              shouldCloseOnOverlayClick={false}
              onRequestClose={this.closeDialog}>
         <div className="draggable-container">
-          <Draggable bounds="parent">
+          <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
             <div className={style}>
               {this.props.header ? (<div className="modal-title" style={{color: 'white', 'backgroundColor': '#70c6ce'}}>
                 <span>{this.props.header}</span>
@@ -86,6 +86,8 @@ function mapState(state) {
     modalDialog: state.ui.modalDialog || {},
   }
 }
+
+export const preventFromMoveSelectors = "input, textarea, #brace-editor, .datePickerContainer, svg"
 
 export default connect(mapState, ActionsUtils.mapDispatchWithEspActions)(GenericModalDialog);
 

--- a/ui/client/components/modals/PreventExitDialog.js
+++ b/ui/client/components/modals/PreventExitDialog.js
@@ -3,6 +3,7 @@ import Modal from "react-modal";
 import DialogMessages from "../../common/DialogMessages";
 import PropTypes from 'prop-types';
 import Draggable from "react-draggable";
+import {preventFromMoveSelectors} from "./GenericModalDialog";
 
 class PreventExitDialog extends React.Component {
 
@@ -27,7 +28,7 @@ class PreventExitDialog extends React.Component {
              shouldCloseOnOverlayClick={false}
              onRequestClose={this.closeDialog}>
         <div className="draggable-container">
-          <Draggable bounds="parent">
+          <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
             <div className="espModal confirmationModal modalContentDark">
               <p>{DialogMessages.unsavedProcessChanges()}</p>
               <div className="confirmationButtons">

--- a/ui/client/stylesheets/graph.styl
+++ b/ui/client/stylesheets/graph.styl
@@ -81,9 +81,11 @@ espCheckbox(checkboxWidth)
 
 .espModal
   max-height fit-content
+  max-height -moz-max-content
+  height -moz-max-content
+  height -webkit-max-content
   max-width modalMaxWidth
   width modalMaxWidth
-  height -moz-max-content
   position relative
   background modalBkgColor
   background-color modalBkgColor
@@ -190,7 +192,6 @@ common-node-input(padding)
 
 modalContent(modalBkgColor,warningColor,modalLabelTextColor,testResultsColor,modalInputTextColor,processesHoverColor,hrColor,modalInputBkgColor)
   overflow auto
-  max-height modalContentMaxHeight
   background-color: modalBkgColor
   labelWidth = 20%
   .warning


### PR DESCRIPTION
This fixes input edition after modal move
This fixes modal sizes on different browsers
This fixed "save" button availability in "property" modal