### PR TITLE
Explicitly handle problems with requests to InfluxDB

### DIFF
--- a/engine/httpUtils/src/main/scala/pl/touk/nussknacker/engine/sttp/SttpJson.scala
+++ b/engine/httpUtils/src/main/scala/pl/touk/nussknacker/engine/sttp/SttpJson.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.engine.sttp
 
-import io.circe
-import io.circe.Decoder
+import io.circe.{Decoder, Error}
 import sttp.client.circe.deserializeJson
 import sttp.client.{HttpError, Response, ResponseAs, ResponseError, asString}
 import sttp.model.StatusCode
@@ -10,13 +9,13 @@ import scala.concurrent.Future
 
 object SttpJson {
 
-  def failureToFuture[T](response: Response[Either[ResponseError[io.circe.Error], T]]): Future[T] = response.body match {
+  def failureToFuture[T](response: Response[Either[ResponseError[Error], T]]): Future[T] = response.body match {
     case Right(qr) => Future.successful(qr)
     case Left(error) => Future.failed(error)
   }
 
   //we want to handle 404 as None
-  def asOptionalJson[Type: Decoder]: ResponseAs[Either[ResponseError[circe.Error], Option[Type]], Nothing] =
+  def asOptionalJson[Type: Decoder]: ResponseAs[Either[ResponseError[Error], Option[Type]], Nothing] =
     asString.mapWithMetadata[Either[ResponseError[io.circe.Error], Option[Type]]] {
       case (Right(data), _) => ResponseAs.deserializeWithError(deserializeJson[Option[Type]])(data)
       case (Left(_), meta) if meta.code == StatusCode.NotFound => Right(None)


### PR DESCRIPTION
Right now whenever request to influxdb fails (e.g. series does not exist) user is presented with `Internal Server Error` message as this is what API returns. This PR explicitly handles exceptions providing user-friendly messages at the API level (and thus on the FE as these messages are forwarded as-is to the user).