### PR TITLE
Copy global expressions after custom node with join transformation

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ValidationContext.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ValidationContext.scala
@@ -11,6 +11,7 @@ object ValidationContext {
 }
 
 case class ValidationContext(localVariables: Map[String, TypingResult] = Map.empty,
+                            //TODO global variables should not be part of ValidationContext
                              globalVariables: Map[String, TypingResult] = Map.empty,
                              parent: Option[ValidationContext] = None) {
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
@@ -310,13 +310,15 @@ protected trait ProcessCompilerBase {
                                       (implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, ValidationContext] = {
       contextTransformationDefOpt match {
         case Some(transformation: ContextTransformationDef) =>
-          transformation.transform(validationContext)
+          // copying global variables because custom transformation may override them -> todo in ValidationContext
+          transformation.transform(validationContext).map(_.copy(globalVariables = validationContext.globalVariables))
         case Some(transformation: JoinContextTransformationDef) =>
           // TODO JOIN: better error
           val joinNode = node.cast[Join].getOrElse(throw new IllegalArgumentException(s"Should be used join element in node ${nodeId.id}"))
           // TODO JOIN: use correct contexts for branches
           val contexts = joinNode.branchParameters.groupBy(_.branchId).mapValuesNow(_ => validationContext)
-          transformation.transform(contexts)
+          // copying global variables because custom transformation may override them -> todo in ValidationContext
+          transformation.transform(contexts).map(_.copy(globalVariables = validationContext.globalVariables))
         case None =>
           val maybeClearedContext = if (clearsContext) validationContext.clearVariables else validationContext
 


### PR DESCRIPTION
After custom node with join transformation global variables disappear. This is ugly fix - in future global variables should be moved out from ValidationContext  