### PR TITLE
Allow to copy, cut and paste elements across browser's windows

### DIFF
--- a/ui/client/actions/actions.js
+++ b/ui/client/actions/actions.js
@@ -536,10 +536,3 @@ export function handleHTTPError(error) {
     error: error
   }
 }
-
-export function copySelection(selection) {
-  return {
-    type: "COPY_SELECTION",
-    selection: selection
-  }
-}

--- a/ui/client/common/ClipboardUtils.js
+++ b/ui/client/common/ClipboardUtils.js
@@ -1,0 +1,25 @@
+const readText = event => (event.clipboardData || window.clipboardData).getData('text')
+
+// We could have used navigator.clipboard.writeText but it is not defined for
+// content delivered via HTTP. The workaround is to create a hidden element
+// and then write text into it. After that copy command is used to replace
+// clipboard's contents with given text. What is more the hidden element is
+// assigned with given id to be able to differentiate between artificial
+// copy event and the real one triggered by user.
+// Based on https://techoverflow.net/2018/03/30/copying-strings-to-the-clipboard-using-pure-javascript/
+const writeText = (text, elementId) => {
+  const el = document.createElement('textarea');
+  el.value = text;
+  el.setAttribute("id", elementId)
+  el.setAttribute('readonly', '');
+  el.style = {position: 'absolute', left: '-9999px'};
+  document.body.appendChild(el);
+  el.select();
+  document.execCommand('copy');
+  document.body.removeChild(el);
+}
+
+export default {
+  readText,
+  writeText,
+}

--- a/ui/client/components/right-panel/UserRightPanel.js
+++ b/ui/client/components/right-panel/UserRightPanel.js
@@ -34,9 +34,14 @@ class UserRightPanel extends Component {
     zoomOut: PropTypes.func.isRequired,
     featuresSettings: PropTypes.object.isRequired,
     isReady: PropTypes.bool.isRequired,
-    copySelection: PropTypes.func.isRequired,
-    pasteSelection: PropTypes.func.isRequired,
-    cutSelection: PropTypes.func.isRequired
+    selectionActions: PropTypes.shape({
+      copy: PropTypes.func.isRequired,
+      canCopy: PropTypes.bool.isRequired,
+      cut: PropTypes.func.isRequired,
+      canCut: PropTypes.bool.isRequired,
+      paste: PropTypes.func.isRequired,
+      canPaste: PropTypes.bool.isRequired
+    }).isRequired
   };
 
   render() {
@@ -179,17 +184,17 @@ class UserRightPanel extends Component {
           },
           {
             name: "copy",
-            onClick: (event) =>  this.props.copySelection(event, true),
+            onClick: this.props.selectionActions.copy,
             icon: 'copy.svg',
             visible: this.props.capabilities.write,
-            disabled: !NodeUtils.isPlainNode(this.props.nodeToDisplay) || _.isEmpty(this.props.selectionState)
+            disabled: !this.props.selectionActions.canCopy
           },
           {
             name: "cut",
-            onClick: (event) =>  this.props.cutSelection(event),
+            onClick: this.props.selectionActions.cut,
             icon: 'cut.svg',
             visible: this.props.capabilities.write,
-            disabled: !NodeUtils.isPlainNode(this.props.nodeToDisplay) || _.isEmpty(this.props.selectionState)
+            disabled: !this.props.selectionActions.canCut
           },
           {
             name: "delete",
@@ -200,10 +205,10 @@ class UserRightPanel extends Component {
           },
           {
             name: "paste",
-            onClick: (event) =>  this.props.pasteSelection(event),
+            onClick: this.props.selectionActions.paste,
             icon: 'paste.svg',
             visible: this.props.capabilities.write,
-            disabled: !this.props.clipboard
+            disabled: !this.props.selectionActions.canPaste
           }
         ]
       },
@@ -423,7 +428,6 @@ function mapState(state) {
     featuresSettings: state.settings.featuresSettings,
     isSubprocess: _.get(state.graphReducer.processToDisplay, "properties.isSubprocess", false),
     businessView: state.graphReducer.businessView,
-    clipboard: state.graphReducer.clipboard,
     history: state.graphReducer.history
   };
 }

--- a/ui/client/reducers/graph.js
+++ b/ui/client/reducers/graph.js
@@ -297,12 +297,6 @@ export function reducer(state, action) {
         businessView: action.businessView
       }
     }
-    case "COPY_SELECTION": {
-      return {
-        ...state,
-        clipboard: action.selection
-      }
-    }
     default:
       return state
   }


### PR DESCRIPTION
Copied elements are saved in the system clipboard. Paste button is currently supported only in Chrome like browsers and it requires the user to grant access to the clipboard. `Ctrl+V` shortcut should work in most browsers. What's more paste button is always enabled since we cannot easily detect when clipboard content was modified.

Relates to #225.