### PR TITLE
Properly notify successful deploy

### DIFF
--- a/ui/client/http/HttpService.js
+++ b/ui/client/http/HttpService.js
@@ -125,13 +125,7 @@ export default {
   },
 
   deploy(processId, comment) {
-    return api.post(`/processManagement/deploy/${processId}`, comment).then(response => {
-      if (!response.data.ok) {
-        throw Error(response.data.statusText)
-      } else {
-        return response.data.data
-      }
-    }).then(() => {
+    return api.post(`/processManagement/deploy/${processId}`, comment).then(() => {
       this.addInfo(`Process ${processId} was deployed`)
       return {isSuccess: true}
     }).catch((error) => {


### PR DESCRIPTION
Successful deploy was always displayed as failed one. Axios fails promises for responses other than 2xx so additional check if response is successful is not needed, in contrast to fetch.