### PR TITLE
add read only access to process details for listeners

### DIFF
--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
@@ -52,3 +52,14 @@ case class AdminUser(id: String) extends LoggedUser {
   override def can(category: String, permission: Permission): Boolean = true
   override val isAdmin: Boolean = true
 }
+
+case object ReadOnlyTechUser extends LoggedUser {
+  override val id: String = "tech_user"
+
+  override def can(category: String, permission: Permission): Boolean = permission match {
+    case Permission.Read => true
+    case _ => false
+  }
+
+  override val isAdmin: Boolean = false
+}

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
@@ -52,14 +52,3 @@ case class AdminUser(id: String) extends LoggedUser {
   override def can(category: String, permission: Permission): Boolean = true
   override val isAdmin: Boolean = true
 }
-
-case object ReadOnlyTechUser extends LoggedUser {
-  override val id: String = "tech_user"
-
-  override def can(category: String, permission: Permission): Boolean = permission match {
-    case Permission.Read => true
-    case _ => false
-  }
-
-  override val isAdmin: Boolean = false
-}

--- a/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/ProcessChangeListenerFactory.scala
+++ b/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/ProcessChangeListenerFactory.scala
@@ -4,11 +4,12 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
 import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.listener.services.NussknackerServices
 
 import scala.concurrent.ExecutionContext
 
 trait ProcessChangeListenerFactory {
-  def create(config: Config): ProcessChangeListener
+  def create(config: Config, services: NussknackerServices): ProcessChangeListener
 }
 
 object ProcessChangeListenerFactory extends LazyLogging {
@@ -18,8 +19,8 @@ object ProcessChangeListenerFactory extends LazyLogging {
 }
 
 class ProcessChangeListenerAggregatingFactory(val factories: ProcessChangeListenerFactory*) extends ProcessChangeListenerFactory with LazyLogging {
-  final override def create(config: Config): ProcessChangeListener = {
-    val listeners = factories.map(_.create(config))
+  final override def create(config: Config, services: NussknackerServices): ProcessChangeListener = {
+    val listeners = factories.map(_.create(config, services))
     new ProcessChangeListener {
       override def handle(event: ProcessChangeEvent)(implicit ec: ExecutionContext, user: LoggedUser): Unit = {
         def handleSafely(listener: ProcessChangeListener): Unit = {

--- a/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/NussknackerServices.scala
+++ b/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/NussknackerServices.scala
@@ -1,5 +1,3 @@
 package pl.touk.nussknacker.ui.listener.services
 
-import scala.concurrent.Future
-
-case class NussknackerServices(pullProcessRepository: PullProcessRepository[Future])
+case class NussknackerServices(pullProcessRepository: PullProcessRepository)

--- a/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/NussknackerServices.scala
+++ b/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/NussknackerServices.scala
@@ -1,0 +1,5 @@
+package pl.touk.nussknacker.ui.listener.services
+
+import scala.concurrent.Future
+
+case class NussknackerServices(pullProcessRepository: PullProcessRepository[Future])

--- a/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/PullProcessRepository.scala
+++ b/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/PullProcessRepository.scala
@@ -2,13 +2,14 @@ package pl.touk.nussknacker.ui.listener.services
 
 import pl.touk.nussknacker.restmodel.process.ProcessId
 import pl.touk.nussknacker.restmodel.processdetails.BaseProcessDetails
+import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait PullProcessRepository {
   def fetchLatestProcessDetailsForProcessId(id: ProcessId)
-                                           (implicit ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]]
+                                           (implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]]
 
   def fetchProcessDetailsForId(processId: ProcessId, versionId: Long)
-                              (implicit ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]]
+                              (implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]]
 }

--- a/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/PullProcessRepository.scala
+++ b/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/PullProcessRepository.scala
@@ -1,0 +1,15 @@
+package pl.touk.nussknacker.ui.listener.services
+
+import pl.touk.nussknacker.restmodel.process.ProcessId
+import pl.touk.nussknacker.restmodel.processdetails.BaseProcessDetails
+import pl.touk.nussknacker.ui.security.api.LoggedUser
+
+import scala.concurrent.ExecutionContext
+
+trait PullProcessRepository[F[_]] {
+  def fetchLatestProcessDetailsForProcessId(id: ProcessId)
+                                           (implicit loggedUser: LoggedUser, ec: ExecutionContext): F[Option[BaseProcessDetails[Unit]]]
+
+  def fetchProcessDetailsForId(processId: ProcessId, versionId: Long)
+                              (implicit loggedUser: LoggedUser, ec: ExecutionContext): F[Option[BaseProcessDetails[Unit]]]
+}

--- a/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/PullProcessRepository.scala
+++ b/ui/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/services/PullProcessRepository.scala
@@ -2,14 +2,13 @@ package pl.touk.nussknacker.ui.listener.services
 
 import pl.touk.nussknacker.restmodel.process.ProcessId
 import pl.touk.nussknacker.restmodel.processdetails.BaseProcessDetails
-import pl.touk.nussknacker.ui.security.api.LoggedUser
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
-trait PullProcessRepository[F[_]] {
+trait PullProcessRepository {
   def fetchLatestProcessDetailsForProcessId(id: ProcessId)
-                                           (implicit loggedUser: LoggedUser, ec: ExecutionContext): F[Option[BaseProcessDetails[Unit]]]
+                                           (implicit ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]]
 
   def fetchProcessDetailsForId(processId: ProcessId, versionId: Long)
-                              (implicit loggedUser: LoggedUser, ec: ExecutionContext): F[Option[BaseProcessDetails[Unit]]]
+                              (implicit ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]]
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -122,10 +122,10 @@ object NussknackerApp extends App with Directives with LazyLogging {
 
     Initialization.init(modelData.mapValues(_.migrations), db, environment, config.getAs[Map[String, String]]("customProcesses"))
 
-    val processChangeListener = ProcessChangeListenerFactory.serviceLoader(getClass.getClassLoader).create(config,
-      NussknackerServices(
-        new PullProcessRepository(processRepository)
-      ))
+    val processChangeListener = ProcessChangeListenerFactory.serviceLoader(getClass.getClassLoader).create(
+      config,
+      NussknackerServices(new PullProcessRepository(processRepository))
+    )
 
     val managementActor = system.actorOf(
       ManagementActor.props(environment, managers, processRepository, deploymentProcessRepository, subprocessResolver, processChangeListener), "management")

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/PullProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/PullProcessRepository.scala
@@ -1,0 +1,18 @@
+package pl.touk.nussknacker.ui.process.repository
+
+import pl.touk.nussknacker.restmodel.processdetails.BaseProcessDetails
+import pl.touk.nussknacker.restmodel.process
+import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.listener.services.{PullProcessRepository => ListenerPullProcessRepository}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class PullProcessRepository(fetchingProcessRepository: FetchingProcessRepository[Future]) extends ListenerPullProcessRepository[Future] {
+  override def fetchLatestProcessDetailsForProcessId(id: process.ProcessId)
+                                                    (implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
+    fetchingProcessRepository.fetchLatestProcessDetailsForProcessId(id = id, businessView = false)
+
+  override def fetchProcessDetailsForId(processId: process.ProcessId, versionId: Long)
+                                       (implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
+    fetchingProcessRepository.fetchProcessDetailsForId(processId, versionId, businessView = false)
+}

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/PullProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/PullProcessRepository.scala
@@ -2,20 +2,18 @@ package pl.touk.nussknacker.ui.process.repository
 
 import pl.touk.nussknacker.restmodel.processdetails.BaseProcessDetails
 import pl.touk.nussknacker.restmodel.process
-import pl.touk.nussknacker.ui.security.api.ReadOnlyTechUser
 import pl.touk.nussknacker.ui.listener.services.{PullProcessRepository => ListenerPullProcessRepository}
+import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class PullProcessRepository(fetchingProcessRepository: FetchingProcessRepository[Future]) extends ListenerPullProcessRepository {
 
-  private implicit val user = ReadOnlyTechUser
-
   override def fetchLatestProcessDetailsForProcessId(id: process.ProcessId)
-                                                    (implicit ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
+                                                    (implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
     fetchingProcessRepository.fetchLatestProcessDetailsForProcessId(id = id, businessView = false)
 
   override def fetchProcessDetailsForId(processId: process.ProcessId, versionId: Long)
-                                       (implicit ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
+                                       (implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
     fetchingProcessRepository.fetchProcessDetailsForId(processId, versionId, businessView = false)
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/PullProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/PullProcessRepository.scala
@@ -2,17 +2,20 @@ package pl.touk.nussknacker.ui.process.repository
 
 import pl.touk.nussknacker.restmodel.processdetails.BaseProcessDetails
 import pl.touk.nussknacker.restmodel.process
-import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.security.api.ReadOnlyTechUser
 import pl.touk.nussknacker.ui.listener.services.{PullProcessRepository => ListenerPullProcessRepository}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class PullProcessRepository(fetchingProcessRepository: FetchingProcessRepository[Future]) extends ListenerPullProcessRepository[Future] {
+class PullProcessRepository(fetchingProcessRepository: FetchingProcessRepository[Future]) extends ListenerPullProcessRepository {
+
+  private implicit val user = ReadOnlyTechUser
+
   override def fetchLatestProcessDetailsForProcessId(id: process.ProcessId)
-                                                    (implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
+                                                    (implicit ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
     fetchingProcessRepository.fetchLatestProcessDetailsForProcessId(id = id, businessView = false)
 
   override def fetchProcessDetailsForId(processId: process.ProcessId, versionId: Long)
-                                       (implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
+                                       (implicit ec: ExecutionContext): Future[Option[BaseProcessDetails[Unit]]] =
     fetchingProcessRepository.fetchProcessDetailsForId(processId, versionId, businessView = false)
 }


### PR DESCRIPTION
* I've extracted additional trait for accessing process details in listeners module so we are in more controll what operations are avaialble in listener implementations.
* maybe we should also rewrite data to special DTOs instead of providing restmodel classes? (now, UI changes will have impact on listeners implementations)  