### PR TITLE
tip panel styling

### DIFF
--- a/ui/client/components/tips/Errors.js
+++ b/ui/client/components/tips/Errors.js
@@ -59,7 +59,7 @@ export default class Errors extends React.Component {
     return <div className={"node-error-tips"}>
       {
         _.isEmpty(nodeIds) && _.isEmpty(propertiesErrors) ? null :
-          <span className={"error-tip-header"}>Errors in</span>
+          <span className={"error-tip-header"}>Errors in </span>
       }
       <div className={"node-error-links"}>
         {

--- a/ui/client/components/tips/Warnings.js
+++ b/ui/client/components/tips/Warnings.js
@@ -49,5 +49,5 @@ export default class Warnings extends React.Component {
   }
 }
 
-const headerMessageByWarningMessage = new Map([["Node is disabled", "Node disabled:"]]);
+const headerMessageByWarningMessage = new Map([["Node is disabled", "Node disabled: "]]);
 

--- a/ui/client/stylesheets/visualization.styl
+++ b/ui/client/stylesheets/visualization.styl
@@ -20,7 +20,7 @@
     margin: 0 5px 0
 
 tipsPanel(bkrd-color, txt-color = undefined)
-  height: 100px
+  height: 105px
   background-color: bkrd-color
   padding: 10px
   font-weight: light
@@ -39,42 +39,27 @@ tipsPanel(bkrd-color, txt-color = undefined)
 .tipsPanelHighlighted
   tipsPanel(hrColor, black)
 
-.error-tips
-  display inline-flex
-
 .node-error-section
-  display inline-flex
   margin-bottom 5px
-
-.node-error-tips
-  display inline-flex
-  white-space nowrap
-
-.error-tip-header
-  white-space nowrap
-
-.warning-tips
-  display inline-flex
-  white-space nowrap
-
-.node-error-links
-  padding-left 5px
 
 .node-error-link
   color errorColor
   font-weight 600
+  white-space normal!important;
   &:hover
     color lighten(errorColor, 25%)
   &:focus
     color errorColor
     text-decoration none
 
+.node-error-links
 .warning-links
-    margin-left 5px
+  display inline
 
 .node-warning-link
   color warningColor
   font-weight 600
+  white-space normal!important;
   &:hover
     color lighten(warningColor, 25%)
   &:focus


### PR DESCRIPTION
Now errors will wrap as they should, causing no horizontal scrolling situation.
I added blank spaces after `Errors in`, and node `disabled:` to separate it from links that come after.
I also added 5px to tip panel height, which now fits 2 lines of warnings and 2 lines of errors without the need to scroll it vertically.