### PR TITLE
Less restrictive supertype for two TypedObjectTypingResult

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/CommonSupertypeFinder.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/CommonSupertypeFinder.scala
@@ -74,18 +74,7 @@ class CommonSupertypeFinder(classResolutionStrategy: SupertypeClassResolutionStr
 
   private def unionOfFields(l: TypedObjectTypingResult, r: TypedObjectTypingResult)
                            (implicit numberPromotionStrategy: NumberTypesPromotionStrategy) = {
-    (l.fields.toList ++ r.fields.toList).groupBy(_._1).mapValues(_.map(_._2)).flatMap {
-      case (fieldName, leftType :: rightType :: Nil) =>
-        val common = commonSupertype(leftType, rightType)
-        if (common == Typed.empty)
-          None // fields type collision - skipping this field
-        else
-          Some(fieldName -> common)
-      case (fieldName, singleType :: Nil) =>
-        Some(fieldName -> singleType)
-      case (_, longerList) =>
-        throw new IllegalArgumentException("Computing union of more than two fields: " + longerList) // shouldn't happen
-    }
+    (l.fields.toList ++ r.fields.toList).groupBy(_._1).mapValues(_.map(_._2)).mapValues(Typed(_: _*))
   }
 
   // This implementation is because TypedObjectTypingResult has underlying TypedClass instead of TypingResult

--- a/engine/api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
+++ b/engine/api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
@@ -96,11 +96,11 @@ class TypingResultSpec extends FunSuite with Matchers with OptionValues {
     commonSuperTypeFinder.commonSupertype(
       TypedObjectTypingResult(Map("foo" -> Typed[String], "bar" -> Typed[Int], "baz" -> Typed[String])),
       TypedObjectTypingResult(Map("foo" -> Typed[String], "bar" -> Typed[Long], "baz2" -> Typed[String]))) shouldEqual
-      TypedObjectTypingResult(Map("foo" -> Typed[String], "bar" -> Typed[java.lang.Long], "baz" -> Typed[String], "baz2" -> Typed[String]))
+      TypedObjectTypingResult(Map("foo" -> Typed[String], "bar" -> Typed(Typed[Int], Typed[Long]), "baz" -> Typed[String], "baz2" -> Typed[String]))
 
     commonSuperTypeFinder.commonSupertype(
       TypedObjectTypingResult(Map("foo" -> Typed[String])), TypedObjectTypingResult(Map("foo" -> Typed[Long]))) shouldEqual
-      TypedObjectTypingResult(Map.empty[String, TypingResult])
+      TypedObjectTypingResult((Map("foo" -> Typed(Typed[String], Typed[Long]))))
   }
 
   test("find common supertype for complex types with inheritance in classes hierarchy") {


### PR DESCRIPTION
using union in computing value's type instead of looking for common supertype.