### PR TITLE
Fixed conversion of argonaut JsonDecimal to circe

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/ArgonautCirce.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/ArgonautCirce.scala
@@ -13,7 +13,7 @@ object ArgonautCirce {
       {
         case a:JsonLong => CJson.fromLong(a.value)
         case a:JsonBigDecimal => CJson.fromBigDecimal(a.value)
-        case a:JsonDecimal => CJson.fromJsonNumber(JsonNumber.fromIntegralStringUnsafe(a.value))
+        case a:JsonDecimal => CJson.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe(a.value))
       },
       CJson.fromString,
       a => CJson.fromValues(a.map(toCirce)),

--- a/engine/api/src/test/scala/pl/touk/nussknacker/engine/api/ArgonautCirceTest.scala
+++ b/engine/api/src/test/scala/pl/touk/nussknacker/engine/api/ArgonautCirceTest.scala
@@ -1,0 +1,37 @@
+package pl.touk.nussknacker.engine.api
+
+import org.scalatest.{FunSuite, Matchers}
+import argonaut.Argonaut._
+import argonaut.{Json => AJson}
+import io.circe.{Json => CJson}
+
+class ArgonautCirceTest extends FunSuite with Matchers {
+
+  test("Long value argonaut to circe encoding") {
+    val beforeEncoding: Long = 1
+
+    val ajson: AJson = beforeEncoding.asJson
+    val cjson: CJson = ArgonautCirce.toCirce(ajson)
+
+    cjson.asNumber.get.toLong.get shouldBe beforeEncoding
+  }
+
+  test("Big decimal value argonaut to circe encoding") {
+    val beforeEncoding: BigDecimal = 1.1
+
+    val ajson: AJson = beforeEncoding.asJson
+    val cjson: CJson = ArgonautCirce.toCirce(ajson)
+
+    cjson.asNumber.get.toBigDecimal.get shouldBe beforeEncoding
+  }
+
+  test("Double value argonaut to circe encoding") {
+    val beforeEncoding: Double = 22.22
+
+    val ajson: AJson = beforeEncoding.asJson
+    val cjson: CJson = ArgonautCirce.toCirce(ajson)
+
+    cjson.asNumber.get.toDouble shouldBe beforeEncoding
+  }
+
+}


### PR DESCRIPTION
Problem:
Argonaut to circe conversion fails when JsonDecimal value is issued, as toCirce tries to parse the value to long.

Scenario:
1. Create a process with source that has Option[Double] attribute.
2. Prepare test data file with proper json fields, eg. {"foo":1.1}
3. Run test from file