### PR TITLE
ExtremelyPatientScalaFutures in docker tests

### DIFF
--- a/engine/demo/src/test/scala/pl/touk/nussknacker/engine/demo/ExampleItTests.scala
+++ b/engine/demo/src/test/scala/pl/touk/nussknacker/engine/demo/ExampleItTests.scala
@@ -4,8 +4,7 @@ import java.nio.charset.StandardCharsets
 import java.time.{LocalDateTime, ZoneId}
 
 import org.apache.kafka.clients.producer.RecordMetadata
-import org.scalatest.concurrent.Eventually
-import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers, Outcome, fixture}
+import org.scalatest.{BeforeAndAfterAll, Matchers, Outcome, fixture}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.build.EspProcessBuilder
 import pl.touk.nussknacker.engine.graph.EspProcess
@@ -15,7 +14,7 @@ import pl.touk.nussknacker.engine.spel
 import scala.concurrent.Future
 
 //TODO: do we currently need these tests?
-trait ExampleItTests extends fixture.FunSuite with BeforeAndAfterAll with Matchers with Eventually { self: BaseITest =>
+trait ExampleItTests extends fixture.FunSuite with BeforeAndAfterAll with Matchers { self: BaseITest =>
 
   import KafkaUtils._
   import spel.Implicits._

--- a/engine/flink/generic/src/test/scala/pl/touk/nussknacker/genericmodel/GenericItSpec.scala
+++ b/engine/flink/generic/src/test/scala/pl/touk/nussknacker/genericmodel/GenericItSpec.scala
@@ -10,10 +10,8 @@ import io.confluent.kafka.schemaregistry.client.{MockSchemaRegistryClient, Schem
 import io.confluent.kafka.serializers.{KafkaAvroDeserializer, KafkaAvroSerializer}
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
-import org.scalatest.concurrent.Eventually
-import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
 import org.scalatest.{BeforeAndAfterAll, EitherValues, FunSuite, Matchers}
-import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.{MetaData, ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.avro._
 import pl.touk.nussknacker.engine.build.{EspProcessBuilder, GraphBuilder}
 import pl.touk.nussknacker.engine.flink.test.{FlinkTestConfiguration, StoppableExecutionEnvironment}
@@ -24,7 +22,7 @@ import pl.touk.nussknacker.engine.process.FlinkStreamingProcessRegistrar
 import pl.touk.nussknacker.engine.process.compiler.FlinkStreamingProcessCompiler
 import pl.touk.nussknacker.engine.spel
 
-class GenericItSpec extends FunSuite with BeforeAndAfterAll with Matchers with Eventually with KafkaSpec with EitherValues with LazyLogging {
+class GenericItSpec extends FunSuite with BeforeAndAfterAll with Matchers with KafkaSpec with EitherValues with LazyLogging {
 
   import KafkaUtils._
   import MockSchemaRegistry._

--- a/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/QueryableStateTest.scala
+++ b/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/QueryableStateTest.scala
@@ -8,7 +8,6 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.build.EspProcessBuilder
@@ -23,7 +22,7 @@ import pl.touk.nussknacker.test.VeryPatientScalaFutures
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class QueryableStateTest extends FlatSpec with BeforeAndAfterAll with Matchers with Eventually with KafkaSpec with LazyLogging with VeryPatientScalaFutures {
+class QueryableStateTest extends FlatSpec with BeforeAndAfterAll with Matchers with KafkaSpec with LazyLogging with VeryPatientScalaFutures {
 
   private val QueryStateProxyPortLow = AvailablePortFinder.findAvailablePorts(1).head
 

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/DockerTest.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/DockerTest.scala
@@ -1,9 +1,8 @@
 package pl.touk.nussknacker.engine.management
 
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.{Files, Path}
 import java.nio.file.attribute.{PosixFilePermission, PosixFilePermissions}
+import java.nio.file.{Files, Path}
 import java.util.Collections
 
 import com.spotify.docker.client.{DefaultDockerClient, DockerClient}
@@ -15,24 +14,17 @@ import com.whisk.docker.scalatest.DockerTestKit
 import com.whisk.docker.{ContainerLink, DockerContainer, DockerFactory, DockerReadyChecker, LogLineReceiver, VolumeMapping}
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.scalatest.Suite
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
-import pl.touk.nussknacker.engine.kafka.KafkaClient
 import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
+import pl.touk.nussknacker.test.ExtremelyPatientScalaFutures
 
 import scala.concurrent.duration._
 
-trait DockerTest extends DockerTestKit with ScalaFutures with LazyLogging {
+trait DockerTest extends DockerTestKit with ExtremelyPatientScalaFutures with LazyLogging {
   self: Suite =>
 
   private val flinkEsp = s"flinkesp:1.7.2-scala_${ScalaMajorVersionConfig.scalaMajorVersion}"
 
   private val client: DockerClient = DefaultDockerClient.fromEnv().build()
-
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(
-    timeout = Span(90, Seconds),
-    interval = Span(1, Millis)
-  )
 
   override implicit val dockerFactory: DockerFactory = new SpotifyDockerFactory(client)
 

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/batch/FlinkBatchProcessManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/batch/FlinkBatchProcessManagerSpec.scala
@@ -3,7 +3,6 @@ package pl.touk.nussknacker.engine.management.batch
 import java.nio.file.Files
 
 import org.apache.flink.runtime.jobgraph.JobStatus
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.GraphProcess
@@ -13,7 +12,7 @@ import pl.touk.nussknacker.engine.canonize.ProcessCanonizer
 import pl.touk.nussknacker.engine.graph.EspProcess
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
 
-class FlinkBatchProcessManagerSpec extends FunSuite with Matchers with ScalaFutures with Eventually with BatchDockerTest {
+class FlinkBatchProcessManagerSpec extends FunSuite with Matchers with BatchDockerTest {
 
   import pl.touk.nussknacker.engine.spel.Implicits._
 

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessManagerSpec.scala
@@ -7,14 +7,12 @@ import java.util.UUID
 import com.typesafe.config.ConfigValueFactory
 import io.circe.Json
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api.deployment.{CustomProcess, GraphProcess, RunningState}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.{CirceUtil, ProcessVersion}
 import pl.touk.nussknacker.engine.canonize.ProcessCanonizer
 import pl.touk.nussknacker.engine.graph.EspProcess
-import pl.touk.nussknacker.engine.kafka.KafkaClient
 import pl.touk.nussknacker.engine.management.FlinkStreamingProcessManagerProvider
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
 import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
@@ -22,7 +20,7 @@ import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
 import scala.concurrent.duration._
 
 //TODO: get rid of at least some Thread.sleep
-class FlinkStreamingProcessManagerSpec extends FunSuite with Matchers with ScalaFutures with Eventually with StreamingDockerTest {
+class FlinkStreamingProcessManagerSpec extends FunSuite with Matchers with StreamingDockerTest {
 
   import pl.touk.nussknacker.engine.kafka.KafkaUtils._
 

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
@@ -3,8 +3,6 @@ package pl.touk.nussknacker.engine.management.streaming
 import java.util.{Collections, UUID}
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.api.deployment.TestProcess.{NodeResult, ResultContext, TestData}
 import pl.touk.nussknacker.engine.api.process.ProcessName
@@ -13,21 +11,17 @@ import pl.touk.nussknacker.engine.canonize.ProcessCanonizer
 import pl.touk.nussknacker.engine.management.FlinkStreamingProcessManagerProvider
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
 import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
+import pl.touk.nussknacker.test.VeryPatientScalaFutures
 
 import scala.concurrent.Await
 
-class FlinkStreamingProcessTestRunnerSpec extends FlatSpec with Matchers with ScalaFutures with Eventually {
+class FlinkStreamingProcessTestRunnerSpec extends FlatSpec with Matchers with VeryPatientScalaFutures {
 
   private val classPath: String = s"./engine/flink/management/sample/target/scala-${ScalaMajorVersionConfig.scalaMajorVersion}/managementSample.jar"
 
   private val config = ConfigFactory.load()
     .withValue("processConfig.kafka.kafkaAddress", ConfigValueFactory.fromAnyRef("kafka:1234"))
     .withValue("flinkConfig.classpath", ConfigValueFactory.fromIterable(Collections.singletonList(classPath)))
-
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(
-    timeout = Span(10, Seconds),
-    interval = Span(100, Millis)
-  )
 
   it should "run process in test mode" in {
     val processManager = FlinkStreamingProcessManagerProvider.defaultProcessManager(config)

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/JavaConfigProcessManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/JavaConfigProcessManagerSpec.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.engine.management.streaming
 
 
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.GraphProcess
@@ -13,7 +12,7 @@ import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
 
 import scala.concurrent.duration._
 
-class JavaConfigProcessManagerSpec extends FunSuite with Matchers with ScalaFutures with Eventually with StreamingDockerTest {
+class JavaConfigProcessManagerSpec extends FunSuite with Matchers with StreamingDockerTest {
 
   override protected def classPath: String = s"./engine/flink/management/java_sample/target/scala-${ScalaMajorVersionConfig.scalaMajorVersion}/managementJavaSample.jar"
 

--- a/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
+++ b/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
@@ -1,26 +1,22 @@
 package pl.touk.nussknacker.engine.management
 
-import sttp.client.Response
-import sttp.client.testing.SttpBackendStub
 import com.typesafe.config.ConfigFactory
 import io.circe.Json
 import io.circe.Json.fromString
 import org.apache.flink.runtime.jobgraph.JobStatus
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Span}
 import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.{CustomProcess, DeploymentId, ProcessState, RunningState}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.management.flinkRestModel.{ExecutionConfig, JobConfig, JobOverview, JobsResponse}
 import pl.touk.nussknacker.engine.testing.{EmptyProcessConfigCreator, LocalModelData}
+import pl.touk.nussknacker.test.PatientScalaFutures
+import sttp.client.Response
+import sttp.client.testing.SttpBackendStub
 
 import scala.concurrent.duration._
 
-class FlinkRestManagerSpec extends FunSuite with Matchers with ScalaFutures {
-
-  //on travis this test sometimes can take a bit longer...
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(500, Millis)))
+class FlinkRestManagerSpec extends FunSuite with Matchers with PatientScalaFutures {
 
   private val config = FlinkConfig(10 minute, None, None, None, "http://test.pl", None)
 

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/FlinkStreamingProcessRegistrarKafkaSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/FlinkStreamingProcessRegistrarKafkaSpec.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import cats.data.NonEmptyList
 import com.typesafe.scalalogging.LazyLogging
-import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
 import pl.touk.nussknacker.engine.build.GraphBuilder
@@ -26,7 +25,6 @@ class FlinkStreamingProcessRegistrarKafkaSpec
     with KafkaSpec
     with Matchers
     with VeryPatientScalaFutures
-    with Eventually
     with LazyLogging {
 
   import spel.Implicits._

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/FlinkStreamingProcessRegistrarSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/FlinkStreamingProcessRegistrarSpec.scala
@@ -3,7 +3,6 @@ package pl.touk.nussknacker.engine.process
 import java.util.Date
 
 import cats.data.NonEmptyList
-import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.build.GraphBuilder
@@ -11,8 +10,9 @@ import pl.touk.nussknacker.engine.graph.EspProcess
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
 import pl.touk.nussknacker.engine.process.ProcessTestHelpers.{MockService, SimpleRecord, processInvoker}
 import pl.touk.nussknacker.engine.spel
+import pl.touk.nussknacker.test.PatientScalaFutures
 
-class FlinkStreamingProcessRegistrarSpec extends FlatSpec with Matchers with Eventually {
+class FlinkStreamingProcessRegistrarSpec extends FlatSpec with Matchers with PatientScalaFutures {
 
   import spel.Implicits._
 

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/api/EvictableStateTest.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/api/EvictableStateTest.scala
@@ -2,24 +2,21 @@ package pl.touk.nussknacker.engine.process.api
 
 import org.apache.flink.api.common.state.ValueStateDescriptor
 import org.apache.flink.streaming.api.TimeCharacteristic
-import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.util.Collector
-import org.scalatest.concurrent.Eventually
-import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.flink.api.state.EvictableStateFunction
 import pl.touk.nussknacker.engine.flink.test.FlinkTestConfiguration
 import pl.touk.nussknacker.engine.flink.util.source.StaticSource
 import pl.touk.nussknacker.engine.flink.util.source.StaticSource.{Data, Watermark}
+import pl.touk.nussknacker.test.VeryPatientScalaFutures
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class EvictableStateTest extends FlatSpec with Matchers with BeforeAndAfter with Eventually {
-
-  implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(1, Seconds)))
+class EvictableStateTest extends FlatSpec with Matchers with BeforeAndAfter with VeryPatientScalaFutures {
 
   var futureResult: Future[_] = _
 

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/MetricsSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/MetricsSpec.scala
@@ -2,27 +2,20 @@ package pl.touk.nussknacker.engine.process.functional
 
 import java.util.Date
 
-import org.apache.flink.shaded.testutils.org.jboss.netty.handler.codec.socks.SocksMessage.ProtocolVersion
-import org.scalatest.concurrent.Eventually
-import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.build.{EspProcessBuilder, GraphBuilder}
 import pl.touk.nussknacker.engine.graph.EspProcess
 import pl.touk.nussknacker.engine.process.ProcessTestHelpers.{MockService, SimpleRecord, SinkForStrings, processInvoker}
 import pl.touk.nussknacker.engine.spel
+import pl.touk.nussknacker.test.VeryPatientScalaFutures
 
 
-class MetricsSpec extends FlatSpec with Matchers with Eventually with BeforeAndAfterEach {
+class MetricsSpec extends FlatSpec with Matchers with VeryPatientScalaFutures with BeforeAndAfterEach {
 
   override protected def beforeEach(): Unit = {
     TestReporter.reset()
   }
-
-  override implicit val patienceConfig = PatienceConfig(
-    timeout = Span(10, Seconds),
-    interval = Span(100, Millis)
-  )
 
   it should "measure time for service" in {
 

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SqlProcessItTests.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SqlProcessItTests.scala
@@ -2,7 +2,6 @@ package pl.touk.nussknacker.engine.process.functional
 
 import java.util.Date
 
-import org.scalatest.concurrent.Eventually
 import org.scalatest._
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.typed.TypedMap
@@ -14,9 +13,10 @@ import pl.touk.nussknacker.engine.spel
 
 import scala.util.Try
 
-class SqlProcessItTests extends FunSuite with BeforeAndAfterAll with Matchers with Eventually {
+class SqlProcessItTests extends FunSuite with BeforeAndAfterAll with Matchers {
 
   import spel.Implicits._
+
   import scala.collection.JavaConverters._
 
   private implicit class SqlExpression(expression: String) {

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQueryOpenCloseSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQueryOpenCloseSpec.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.engine.util.service.query
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.process.WithCategories
@@ -16,8 +15,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ServiceQueryOpenCloseSpec
   extends FunSuite
     with Matchers
-    with PatientScalaFutures
-    with Eventually {
+    with PatientScalaFutures {
 
   import ServiceQueryOpenCloseSpec._
 

--- a/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/flink/test/StoppableExecutionEnvironment.scala
+++ b/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/flink/test/StoppableExecutionEnvironment.scala
@@ -6,7 +6,6 @@ import org.apache.flink.api.common.{JobExecutionResult, JobID}
 import org.apache.flink.configuration._
 import org.apache.flink.queryablestate.client.QueryableStateClient
 import org.apache.flink.runtime.execution.ExecutionState
-import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex
 import org.apache.flink.runtime.jobgraph.{JobGraph, JobStatus}
 import org.apache.flink.runtime.minicluster.MiniCluster
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
@@ -15,8 +14,8 @@ import org.apache.flink.test.util.{MiniClusterResource, MiniClusterResourceConfi
 import org.apache.flink.util.OptionalFailure
 import org.scalactic.source.Position
 import org.scalatest.Matchers
-import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
+import pl.touk.nussknacker.test.PatientScalaFutures
 
 import scala.collection.JavaConverters._
 
@@ -38,7 +37,7 @@ object StoppableExecutionEnvironment {
 }
 
 abstract class StoppableExecutionEnvironment(userFlinkClusterConfig: Configuration) extends StreamExecutionEnvironment
-  with LazyLogging with Eventually with Matchers {
+  with LazyLogging with PatientScalaFutures with Matchers {
 
   // For backward compatibility with Flink 1.6 we have here MiniClusterResource intstead of MiniClusterWithClientResource
   // TODO after breaking compatibility with 1.6, replace MiniClusterResource with MiniClusterWithClientResource

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ServiceInvokerTest.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ServiceInvokerTest.scala
@@ -3,17 +3,16 @@ package pl.touk.nussknacker.engine.definition
 import java.util.concurrent.Executor
 import java.util.function.Supplier
 
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
-import pl.touk.nussknacker.engine.api.process.WithCategories
-import pl.touk.nussknacker.engine.api.test.InvocationCollectors.NodeContext
 import pl.touk.nussknacker.engine.api._
+import pl.touk.nussknacker.engine.api.test.InvocationCollectors.NodeContext
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectWithMethodDef
+import pl.touk.nussknacker.test.PatientScalaFutures
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class ServiceInvokerTest extends FlatSpec with ScalaFutures with OptionValues with Matchers {
+class ServiceInvokerTest extends FlatSpec with PatientScalaFutures with OptionValues with Matchers {
 
   implicit val metadata = MetaData("proc1", StreamMetaData())
   val jobData = JobData(metadata, ProcessVersion.empty)

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/sql/SqlExpressionTest.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/sql/SqlExpressionTest.scala
@@ -4,17 +4,17 @@ import java.sql.Timestamp
 import java.time.{LocalDateTime, ZoneId}
 import java.util
 
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.lazyy.{LazyContext, LazyValuesProvider}
-import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypedObjectTypingResult, TypingResult}
-import pl.touk.nussknacker.engine.api.typed.{ClazzRef, TypedMap}
+import pl.touk.nussknacker.engine.api.typed.TypedMap
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
+import pl.touk.nussknacker.test.PatientScalaFutures
 
 import scala.collection.JavaConverters._
 
-class SqlExpressionTest extends FunSuite with Matchers with ScalaFutures {
+class SqlExpressionTest extends FunSuite with Matchers with PatientScalaFutures {
 
   private val validationContext = ValidationContext(Map[String, TypingResult](
     "var" -> Typed[String],

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuerySpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuerySpec.scala
@@ -1,15 +1,15 @@
 package pl.touk.nussknacker.engine.util.service.query
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.api.Service
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.testing.{EmptyProcessConfigCreator, LocalModelData}
 import pl.touk.nussknacker.engine.util.service.query.QueryServiceTesting.CreateQuery
 import pl.touk.nussknacker.engine.util.service.query.ServiceQuerySpec.ConcatService
+import pl.touk.nussknacker.test.PatientScalaFutures
 
-class ExpressionServiceQuerySpec extends FlatSpec with Matchers with ScalaFutures {
+class ExpressionServiceQuerySpec extends FlatSpec with Matchers with PatientScalaFutures {
   import pl.touk.nussknacker.engine.spel.Implicits._
 
   override def spanScaleFactor: Double = 2

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQuerySpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQuerySpec.scala
@@ -2,16 +2,16 @@ package pl.touk.nussknacker.engine.util.service.query
 
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.process.WithCategories
 import pl.touk.nussknacker.engine.testing.{EmptyProcessConfigCreator, LocalModelData}
 import pl.touk.nussknacker.engine.util.service.query.ServiceQuery.QueryResult
+import pl.touk.nussknacker.test.PatientScalaFutures
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ServiceQuerySpec extends FunSuite with Matchers with ScalaFutures {
+class ServiceQuerySpec extends FunSuite with Matchers with PatientScalaFutures {
 
   import QueryServiceTesting._
   import ServiceQuerySpec._

--- a/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/management/MultiInstanceStandaloneProcessClientSpec.scala
+++ b/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/management/MultiInstanceStandaloneProcessClientSpec.scala
@@ -1,7 +1,5 @@
 package pl.touk.nussknacker.engine.standalone.management
 
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.{DeploymentId, ProcessState, RunningState}

--- a/engine/test-util/src/main/scala/pl/touk/nussknacker/test/ExtremelyPatientScalaFutures.scala
+++ b/engine/test-util/src/main/scala/pl/touk/nussknacker/test/ExtremelyPatientScalaFutures.scala
@@ -1,0 +1,10 @@
+package pl.touk.nussknacker.test
+
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.time.{Millis, Minutes, Span}
+
+trait ExtremelyPatientScalaFutures extends ScalaFutures with Eventually {
+
+  final override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(100, Millis)))
+
+}

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesChangeListenerSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesChangeListenerSpec.scala
@@ -3,7 +3,6 @@ package pl.touk.nussknacker.ui.api
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import org.scalatest._
-import org.scalatest.concurrent.Eventually
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.restmodel.processdetails.DeploymentAction
 import pl.touk.nussknacker.test.PatientScalaFutures
@@ -15,7 +14,7 @@ import pl.touk.nussknacker.ui.security.api.LoggedUser
 import scala.language.higherKinds
 
 class ProcessesChangeListenerSpec extends FunSuite with ScalatestRouteTest with Matchers with Inside with FailFastCirceSupport
-  with Eventually with PatientScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with EspItTest {
+  with PatientScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with EspItTest {
 
   private val routeWithAllPermissions = withAllPermissions(processesRoute)
   private val routeWithAdminPermissions = withAdminPermissions(processesRoute)

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResourcesSpec.scala
@@ -3,32 +3,29 @@ package pl.touk.nussknacker.ui.api
 import akka.http.scaladsl.model.{ContentTypeRange, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Inside, Matchers}
-import pl.touk.nussknacker.ui.api.helpers.{EspItTest, ProcessTestData}
-import pl.touk.nussknacker.ui.api.helpers.TestFactory._
-import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ValidatedDisplayableProcess}
-import pl.touk.nussknacker.ui.process.migrate.{RemoteEnvironment, RemoteEnvironmentCommunicationError, TestMigrationResult}
-import pl.touk.nussknacker.ui.util.ProcessComparator.{Difference, NodeNotPresentInCurrent, NodeNotPresentInOther}
-import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeValidationErrorType, ValidationResult}
+import cats.instances.all._
 import cats.syntax.semigroup._
-
-import scala.concurrent.{ExecutionContext, Future}
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Inside, Matchers}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.typed.typing.Unknown
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.graph.node.Filter
-import pl.touk.nussknacker.ui.EspError
+import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ValidatedDisplayableProcess}
 import pl.touk.nussknacker.restmodel.processdetails.ProcessHistoryEntry
+import pl.touk.nussknacker.restmodel.validation.ValidationResults
+import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeValidationErrorType, ValidationResult}
+import pl.touk.nussknacker.test.PatientScalaFutures
+import pl.touk.nussknacker.ui.EspError
+import pl.touk.nussknacker.ui.api.helpers.TestFactory._
+import pl.touk.nussknacker.ui.api.helpers.TestPermissions.CategorizedPermission
+import pl.touk.nussknacker.ui.api.helpers.{EspItTest, ProcessTestData}
+import pl.touk.nussknacker.ui.process.migrate.{RemoteEnvironment, RemoteEnvironmentCommunicationError, TestMigrationResult}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.ui.util.ProcessComparator
-import cats.syntax.semigroup._
-import cats.instances.all._
-import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
-import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.restmodel.validation.ValidationResults
-import pl.touk.nussknacker.test.PatientScalaFutures
-import pl.touk.nussknacker.ui.api.helpers.TestPermissions.CategorizedPermission
+import pl.touk.nussknacker.ui.util.ProcessComparator.{Difference, NodeNotPresentInCurrent, NodeNotPresentInOther}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class RemoteEnvironmentResourcesSpec extends FlatSpec with ScalatestRouteTest with PatientScalaFutures with Matchers with FailFastCirceSupport
   with BeforeAndAfterEach with Inside with EspItTest {

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -22,7 +22,6 @@ import pl.touk.nussknacker.restmodel.process
 import pl.touk.nussknacker.ui.api._
 import pl.touk.nussknacker.ui.api.helpers.TestFactory._
 import pl.touk.nussknacker.ui.config.FeatureTogglesConfig
-import pl.touk.nussknacker.ui.listener.{ProcessChangeListener, ProcessChangeEvent}
 import pl.touk.nussknacker.ui.process._
 import pl.touk.nussknacker.ui.process.deployment.ManagementActor
 import pl.touk.nussknacker.ui.processreport.ProcessCounter


### PR DESCRIPTION
Switched all places of usage of Eventually/ScalaFutures to *PatientScalaFutures + added ExtremelyPatientScalaFutures used in docker tests (was waiting for 1,5min, now is waiting for 5min)