### PR TITLE
Fix collapse group on icon click

### DIFF
--- a/ui/client/actions/notificationActions.js
+++ b/ui/client/actions/notificationActions.js
@@ -22,3 +22,12 @@ export function error(message, error, showErrorText) {
     ])
   })
 }
+
+export function info(message) {
+  return Notifications.info({
+    autoDismiss: 10,
+    children: ([
+      <Notification icon={InlinedSvgs.tipsInfo} message={message} key={uuid4()}/>
+    ])
+  })
+}

--- a/ui/client/common/ProcessUtils.js
+++ b/ui/client/common/ProcessUtils.js
@@ -159,7 +159,7 @@ class ProcessUtils {
 
   //TODO: this should be done without these switches..
   findNodeDefinitionId = (node) => {
-    switch (node.type) {
+    switch (_.get(node, "type")) {
       case "Source":
       case "Sink": {
         return node.ref.typ

--- a/ui/client/components/graph/GraphUtils.js
+++ b/ui/client/components/graph/GraphUtils.js
@@ -38,11 +38,11 @@ export function deleteNode(process, id) {
   }
 }
 
-export function canInjectNode(process, source, middleMan, target, processDefinitionData) {
-  const processAfterDisconnection = deleteEdge(process, source.id, target.id)
-  const canConnectSourceToMiddleMan = NodeUtils.canMakeLink(source.id, middleMan.id, processAfterDisconnection, processDefinitionData)
-  const processWithConnectedSourceAndMiddleMan = addEdge(processAfterDisconnection, source.id, middleMan.id)
-  const canConnectMiddleManToTarget = NodeUtils.canMakeLink(middleMan.id, target.id, processWithConnectedSourceAndMiddleMan, processDefinitionData)
+export function canInjectNode(process, sourceId, middleManId, targetId, processDefinitionData) {
+  const processAfterDisconnection = deleteEdge(process, sourceId, targetId)
+  const canConnectSourceToMiddleMan = NodeUtils.canMakeLink(sourceId, middleManId, processAfterDisconnection, processDefinitionData)
+  const processWithConnectedSourceAndMiddleMan = addEdge(processAfterDisconnection, sourceId, middleManId)
+  const canConnectMiddleManToTarget = NodeUtils.canMakeLink(middleManId, targetId, processWithConnectedSourceAndMiddleMan, processDefinitionData)
   return canConnectSourceToMiddleMan && canConnectMiddleManToTarget
 }
 

--- a/ui/client/components/graph/NodeUtils.js
+++ b/ui/client/components/graph/NodeUtils.js
@@ -136,7 +136,7 @@ class NodeUtils {
     const data =  (processDefinitionData.edgesForNodes
       .filter(e => !forInput || e.isForInputDefinition === forInput)
       //here we use == in second comparison, as we sometimes compare null to undefined :|
-      .find(e => e.nodeId.type === node.type && e.nodeId.id == nodeObjectTypeDefinition)) || {edges: [null], canChooseNodes: false}
+      .find(e => e.nodeId.type === _.get(node, "type") && e.nodeId.id == nodeObjectTypeDefinition)) || { edges: [null], canChooseNodes: false}
     return data
   }
 
@@ -204,10 +204,20 @@ class NodeUtils {
     return `${edge.from}-${edge.to}`
   }
 
-  //TODO: methods below should be based on backend data, e.g. Subprocess can have outputs or not - based on individual subprocess...
-  hasInputs = (node) => (node.type !== "Source" && node.type !== "SubprocessInputDefinition")
+  groupIncludesOneOfNodes = (nodeGroup, nodeIds)  => _.some(nodeGroup.nodes, (node) => _.includes(nodeIds, _.get(node, "id") || node))
 
-  hasOutputs = (node) => (node.type !== "Sink" && node.type !== "SubprocessOutputDefinition")
+  groupIncludesAllOfNodes = (nodeGroup, nodeIds) => _.every(nodeGroup.nodes, (node) => _.includes(nodeIds, _.get(node, "id") || node))
+
+  nodesAreInOneGroup = (process, nodeIds) => _.some(this.getAllGroups(process), (group) => this.groupIncludesAllOfNodes(group, nodeIds))
+
+  noInputNodeTypes = ["Source", "SubprocessInputDefinition"]
+
+  noOutputNodeTypes = ["Sink", "SubprocessOutputDefinition"]
+
+  //TODO: methods below should be based on backend data, e.g. Subprocess can have outputs or not - based on individual subprocess...
+  hasInputs = (node) => !_.some(this.noInputNodeTypes, (nodeType) => _.isEqual(nodeType, _.get(node, "type")))
+
+  hasOutputs = (node) => !_.some(this.noOutputNodeTypes, (nodeType) => _.isEqual(nodeType, _.get(node, "type")))
 
 }
 

--- a/ui/client/stylesheets/_variables.styl
+++ b/ui/client/stylesheets/_variables.styl
@@ -40,6 +40,7 @@ processesHoverColor = #b3b3b3
 buttonBlueBkgColor = #0E9AE0
 buttonBlueColor = #FFFFFF
 
+infoColor = #cccccc
 warningColor = #FF9A4D
 errorColor = #f25c6e
 okColor = #8fad60

--- a/ui/client/stylesheets/notifications.styl
+++ b/ui/client/stylesheets/notifications.styl
@@ -31,6 +31,13 @@
         background none
       .cls-error
         fill #3a3a3a
+    &.notification-info
+      background-color infoColor
+      margin-top 10px
+      svg
+        background none
+      .a
+        fill #3a3a3a
     .icon
       min-width 16px
       min-height 16px


### PR DESCRIPTION
This closes #474, closes #511 
![image](https://user-images.githubusercontent.com/26696870/71102906-86a75100-21b9-11ea-8716-bfb17cbcc933.png)
![image](https://user-images.githubusercontent.com/26696870/71102931-9030b900-21b9-11ea-9080-b596244e2475.png)

Now we can drop nodes above and below groups:
![image](https://user-images.githubusercontent.com/26696870/71103012-af2f4b00-21b9-11ea-9f24-8cae5f8f9e3b.png)
![image](https://user-images.githubusercontent.com/26696870/71103059-bd7d6700-21b9-11ea-943c-58e17d67200a.png)
![image](https://user-images.githubusercontent.com/26696870/71103113-d0903700-21b9-11ea-89f2-0a3bd58c56a1.png)
![image](https://user-images.githubusercontent.com/26696870/71103137-df76e980-21b9-11ea-8611-0c64a2b4c1ef.png)

TODO - handle inject of group when is dropped on line