### PR TITLE
Improvements: Remove handlerErrors example params from models

### DIFF
--- a/demo/docker/testData/DetectLargeTransactions.json
+++ b/demo/docker/testData/DetectLargeTransactions.json
@@ -11,13 +11,6 @@
   },
   "exceptionHandlerRef" : {
     "parameters" : [
-      {
-        "name" : "sampleParam",
-        "expression" : {
-          "language" : "spel",
-          "expression" : "'1'"
-        }
-      }
     ]
   },
   "nodes" : [

--- a/demo/docker/testData/DetectLargeTransactionsWithAggregation.json
+++ b/demo/docker/testData/DetectLargeTransactionsWithAggregation.json
@@ -11,13 +11,6 @@
   },
   "exceptionHandlerRef" : {
     "parameters" : [
-      {
-        "name" : "sampleParam",
-        "expression" : {
-          "language" : "spel",
-          "expression" : "'1'"
-        }
-      }
     ]
   },
   "nodes" : [

--- a/demo/docker/testData/DetectLargeTransactionsWithAggregationAndEnricher.json
+++ b/demo/docker/testData/DetectLargeTransactionsWithAggregationAndEnricher.json
@@ -11,13 +11,6 @@
   },
   "exceptionHandlerRef" : {
     "parameters" : [
-      {
-        "name" : "sampleParam",
-        "expression" : {
-          "language" : "spel",
-          "expression" : "'1'"
-        }
-      }
     ]
   },
   "nodes" : [

--- a/engine/demo/src/main/scala/pl/touk/nussknacker/engine/demo/DemoProcessConfigCreator.scala
+++ b/engine/demo/src/main/scala/pl/touk/nussknacker/engine/demo/DemoProcessConfigCreator.scala
@@ -105,9 +105,8 @@ class DemoProcessConfigCreator extends ProcessConfigCreator {
     Seq(LoggingListener)
   }
 
-  override def exceptionHandlerFactory(config: Config): ExceptionHandlerFactory = {
+  override def exceptionHandlerFactory(config: Config): ExceptionHandlerFactory =
     new LoggingExceptionHandlerFactory(config)
-  }
 
   override def expressionConfig(config: Config): ExpressionConfig = {
     val globalProcessVariables = Map(
@@ -132,8 +131,7 @@ class DemoProcessConfigCreator extends ProcessConfigCreator {
 class LoggingExceptionHandlerFactory(config: Config) extends ExceptionHandlerFactory {
 
   @MethodToInvoke
-  def create(metaData: MetaData, @ParamName("sampleParam") sampleParam: String): EspExceptionHandler = {
-    BrieflyLoggingRestartingExceptionHandler(metaData, config, params = Map("sampleParam" -> sampleParam))
-  }
+  def create(metaData: MetaData): EspExceptionHandler =
+    BrieflyLoggingRestartingExceptionHandler(metaData, config)
 
 }

--- a/engine/demo/src/test/scala/pl/touk/nussknacker/engine/demo/ExampleItTests.scala
+++ b/engine/demo/src/test/scala/pl/touk/nussknacker/engine/demo/ExampleItTests.scala
@@ -34,7 +34,7 @@ trait ExampleItTests extends fixture.FunSuite with BeforeAndAfterAll with Matche
     val process = EspProcessBuilder
       .id("example1")
       .parallelism(1)
-      .exceptionHandler("sampleParam" -> "'sampleParamValue'")
+      .exceptionHandler()
       .source("start", "kafka-transaction", "topic" -> s"'$in'")
       .filter("amountFilter", "#input.amount > 1")
       .sink("end", "#UTIL.mapToJson({'clientId': #input.clientId, 'amount': #input.amount})",
@@ -61,7 +61,7 @@ trait ExampleItTests extends fixture.FunSuite with BeforeAndAfterAll with Matche
     val process = EspProcessBuilder
       .id("example2")
       .parallelism(1)
-      .exceptionHandler("sampleParam" -> "'sampleParamValue'")
+      .exceptionHandler()
       .source("start", "kafka-transaction", "topic" -> s"'$in'")
       .enricher("clientEnricher", "client", "clientService", "clientId" -> "#input.clientId")
       .sink("end",
@@ -94,7 +94,7 @@ trait ExampleItTests extends fixture.FunSuite with BeforeAndAfterAll with Matche
     val process =EspProcessBuilder
         .id("example3")
         .parallelism(1)
-        .exceptionHandler("sampleParam" -> "'sampleParamValue'")
+        .exceptionHandler()
         .source("start", "kafka-transaction", "topic" -> s"'$in'")
         .customNode("aggregate", "aggregatedAmount", "transactionAmountAggregator", "clientId" -> "#input.clientId")
         .filter("aggregateFilter", "#aggregatedAmount.amount > 10")
@@ -126,7 +126,7 @@ trait ExampleItTests extends fixture.FunSuite with BeforeAndAfterAll with Matche
     val process = EspProcessBuilder
       .id("example4")
       .parallelism(1)
-      .exceptionHandler("sampleParam" -> "'sampleParamValue'")
+      .exceptionHandler()
       .source("start", "kafka-transaction", "topic" -> s"'$in'")
       .customNode("transactionCounter", "transactionCounts", "eventsCounter", "key" -> "#input.clientId", "length" -> "'1h'")
       .filter("aggregateFilter", "#transactionCounts.count > 1")

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/DevProcessConfigCreator.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/DevProcessConfigCreator.scala
@@ -225,7 +225,8 @@ class DevProcessConfigCreator extends ProcessConfigCreator {
     )
   }
 
-  override def exceptionHandlerFactory(config: Config) = ParamExceptionHandler
+  override def exceptionHandlerFactory(config: Config): ExceptionHandlerFactory =
+    ExceptionHandlerFactory.noParams(BrieflyLoggingExceptionHandler(_))
 
   override def expressionConfig(config: Config) = {
     val dictId = "dict"

--- a/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/QueryableStateTest.scala
+++ b/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/QueryableStateTest.scala
@@ -53,7 +53,7 @@ class QueryableStateTest extends FlatSpec with BeforeAndAfterAll with Matchers w
     val lockProcess = EspProcessBuilder
       .id("queryableStateProc1")
       .parallelism(1)
-      .exceptionHandler("param1" -> "'errors'")
+      .exceptionHandler()
       .source("start", "oneSource")
       .customNode("lock", "lockOutput", "lockStreamTransformer", "input" -> "#input")
       .emptySink("sink", "sendSms")

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
@@ -47,7 +47,7 @@ class FlinkStreamingProcessTestRunnerSpec extends FlatSpec with Matchers with Ve
       .id(processId)
       .exceptionHandler()
       .source("startProcess", "kafka-transaction")
-      .emptySink("endSend", "sendSms")
+      .emptySink("endSend", "sendSmsNotExist")
 
     val processManager = FlinkStreamingProcessManagerProvider.defaultProcessManager(config)
 
@@ -57,7 +57,7 @@ class FlinkStreamingProcessTestRunnerSpec extends FlatSpec with Matchers with Ve
     val caught = intercept[IllegalArgumentException] {
       Await.result(processManager.test(ProcessName(processId), processData, TestData("terefere"), _ => null), patienceConfig.timeout)
     }
-    caught.getMessage shouldBe "Compilation errors: MissingParameters(Set(param1),$exceptionHandler)"
+    caught.getMessage shouldBe "Compilation errors: MissingSinkFactory(sendSmsNotExist,endSend)"
   }
 
 }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/SampleProcess.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/SampleProcess.scala
@@ -12,7 +12,7 @@ object SampleProcess {
   def prepareProcess(id: String) : EspProcess = {
     EspProcessBuilder
       .id(id)
-      .exceptionHandler("param1" -> "'val1'")
+      .exceptionHandler()
       .source("startProcess", "kafka-transaction")
       .filter("nightFilter", "true", endWithMessage("endNight", "Odrzucenie noc"))
       .emptySink("endSend", "sendSms")
@@ -21,7 +21,7 @@ object SampleProcess {
   def kafkaProcess(id: String, topic: String) : EspProcess = {
     EspProcessBuilder
       .id(id)
-      .exceptionHandler("param1" -> "'val1'")
+      .exceptionHandler()
       .source("startProcess", "real-kafka", "topic" -> s"'$topic'")
       .sink("end", "#input", "kafka-string", "topic" -> s"'output-$id'")
   }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/StatefulSampleProcess.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/StatefulSampleProcess.scala
@@ -14,7 +14,7 @@ object StatefulSampleProcess {
 
    EspProcessBuilder
       .id(id)
-     .exceptionHandler("param1" -> "'val1'")
+     .exceptionHandler()
       .source("state", "oneSource")
         .customNode("stateful", "stateVar", "stateful", "keyBy" -> "#input")
         .sink("end", "#stateVar": Expression, "kafka-string", "topic" -> s"'output-$id'")
@@ -24,7 +24,7 @@ object StatefulSampleProcess {
 
    EspProcessBuilder
       .id(id)
-     .exceptionHandler("param1" -> "'val1'")
+     .exceptionHandler()
       .source("state", "oneSource")
         .customNode("stateful", "stateVar", "constantStateTransformer")
         .sink("end", "#stateVar", "kafka-string", "topic" -> s"'output-$id'")
@@ -34,7 +34,7 @@ object StatefulSampleProcess {
 
    EspProcessBuilder
       .id(id)
-     .exceptionHandler("param1" -> "'val1'")
+     .exceptionHandler()
       .source("state", "oneSource")
         .customNode("stateful", "stateVar", "constantStateTransformerLongValue")
         .sink("end", "#stateVar", "kafka-string", "topic" -> s"'output-$id'")

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/build/EspProcessBuilder.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/build/EspProcessBuilder.scala
@@ -31,6 +31,8 @@ class ProcessMetaDataBuilder private[build](metaData: MetaData) {
   def exceptionHandler(params: (String, Expression)*) =
     new ProcessExceptionHandlerBuilder(ExceptionHandlerRef(params.map(evaluatedparam.Parameter.tupled).toList))
 
+  def exceptionHandlerNoParams() = new ProcessExceptionHandlerBuilder(ExceptionHandlerRef(List.empty))
+
   class ProcessExceptionHandlerBuilder private[ProcessMetaDataBuilder](exceptionHandlerRef: ExceptionHandlerRef) {
 
     def source(id: String, typ: String, params: (String, Expression)*): ProcessGraphBuilder =

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -195,7 +195,7 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
         EspProcessBuilder
           .id("sampleProcess")
           .parallelism(1)
-          .exceptionHandler("param1" -> "'ala'")
+          .exceptionHandler()
           .source("startProcess", "csv-source")
           .filter("input", "new java.math.BigDecimal(null) == 0")
           .emptySink("end", "kafka-string", "topic" -> "'end.topic'")

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/SampleProcess.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/SampleProcess.scala
@@ -13,7 +13,7 @@ object SampleProcess {
     EspProcessBuilder
       .id("sampleProcess")
       .parallelism(1)
-      .exceptionHandler("param1" -> "'ala'")
+      .exceptionHandler()
       .source("startProcess", "csv-source")
       .filter("input", "#input != null")
       .to(endWithMessage("suffix", "message"))

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
@@ -125,7 +125,7 @@ class BaseFlowTest extends FunSuite with ScalatestRouteTest with FailFastCirceSu
 
     val process = EspProcessBuilder
       .id(processId)
-      .exceptionHandler("param1" -> "''")
+      .exceptionHandler()
       .source("source", "csv-source")
       .enricher("enricher", "out", "complexReturnObjectService")
       .sink("end", "#input", "sendSms")

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/integration/DictsFlowTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/integration/DictsFlowTest.scala
@@ -102,7 +102,7 @@ class DictsFlowTest extends FunSuite with ScalatestRouteTest with FailFastCirceS
     EspProcessBuilder
       .id(processId)
       .additionalFields(properties = Map("param1" -> "true"))
-      .exceptionHandler("param1" -> "'fooParam1'")
+      .exceptionHandler()
       .source("source", "csv-source")
       .sink(EndNodeId, endResultExpression, "monitor")
 


### PR DESCRIPTION
We don't need example params at errorHandler:
![error-handler-params](https://user-images.githubusercontent.com/907665/71718054-4e8b4980-2e1a-11ea-93ad-2a91e83baa71.png)
After changes:
![error-handler-no-params](https://user-images.githubusercontent.com/907665/71718091-6b278180-2e1a-11ea-9ea5-e6b00be8c9dc.png)
