### PR TITLE
Moving modal on grabbing its name label (#482)

### DIFF
--- a/ui/client/components/AddProcessDialog.js
+++ b/ui/client/components/AddProcessDialog.js
@@ -11,7 +11,6 @@ import "../stylesheets/visualization.styl";
 import HttpService from "../http/HttpService";
 import * as VisualizationUrl from "../common/VisualizationUrl";
 import Draggable from "react-draggable";
-import {preventFromMoveSelectors} from "./modals/GenericModalDialog";
 import {duplicateValue, notEmptyValidator} from "../common/Validators";
 import ValidationLabels from "./modals/ValidationLabels";
 
@@ -57,10 +56,10 @@ class AddProcessDialog extends React.Component {
              shouldCloseOnOverlayClick={false}
              onRequestClose={this.closeDialog}>
         <div className="draggable-container">
-          <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
+          <Draggable bounds="parent" handle=".modal-draggable-handle">
             <div className="espModal">
               <div className="modalHeader">
-                <div className="modal-title" style={titleStyles}>
+                <div className="modal-title modal-draggable-handle" style={titleStyles}>
                   <span>{this.props.message}</span>
                 </div>
               </div>

--- a/ui/client/components/graph/node-modal/EdgeDetailsModal.js
+++ b/ui/client/components/graph/node-modal/EdgeDetailsModal.js
@@ -10,7 +10,6 @@ import NodeUtils from "../NodeUtils";
 import EspModalStyles from "../../../common/EspModalStyles"
 import EdgeDetailsContent from "./EdgeDetailsContent";
 import Draggable from "react-draggable";
-import {preventFromMoveSelectors} from "../../modals/GenericModalDialog";
 
 //TODO: this is still pretty switch-specific. 
 class EdgeDetailsModal extends React.Component {
@@ -97,17 +96,17 @@ class EdgeDetailsModal extends React.Component {
 
   render() {
     const isOpen = !_.isEmpty(this.props.edgeToDisplay) && this.props.showEdgeDetailsModal && this.edgeIsEditable()
-    const headerStyles = EspModalStyles.headerStyles("#2d8e54", "white")
+    const titleStyles = EspModalStyles.headerStyles("#2d8e54", "white")
     return (
       <div className="objectModal">
         <Modal isOpen={isOpen}
                shouldCloseOnOverlayClick={false}
                onRequestClose={this.closeModal}>
           <div className="draggable-container">
-            <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
+            <Draggable bounds="parent" handle=".modal-draggable-handle">
               <div className="espModal">
-                <div className="modalHeader" style={headerStyles}>
-                  <div className="modal-title">
+                <div className="modalHeader">
+                  <div className="edge-modal-title modal-draggable-handle" style={titleStyles}>
                     <span>edge</span>
                   </div>
                 </div>

--- a/ui/client/components/graph/node-modal/NodeDetailsModal.js
+++ b/ui/client/components/graph/node-modal/NodeDetailsModal.js
@@ -16,7 +16,6 @@ import HttpService from "../../../http/HttpService"
 import ProcessUtils from "../../../common/ProcessUtils"
 import PropTypes from "prop-types"
 import Draggable from "react-draggable"
-import {preventFromMoveSelectors} from "../../modals/GenericModalDialog"
 import NodeGroupDetailsContent from "./NodeGroupDetailsContent"
 
 class NodeDetailsModal extends React.Component {
@@ -149,7 +148,7 @@ class NodeDetailsModal extends React.Component {
                isOpen={isOpen}
                onRequestClose={this.closeModal}>
           <div className="draggable-container">
-            <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
+            <Draggable bounds="parent" handle=".modal-draggable-handle">
               <div className="espModal">
                 <NodeDetailsModalHeader node={nodeToDisplay} docsUrl={nodeSetting.docsUrl}/>
                 <div className="modalContentDark" id="modal-content">

--- a/ui/client/components/graph/node-modal/NodeDetailsModalHeader.js
+++ b/ui/client/components/graph/node-modal/NodeDetailsModalHeader.js
@@ -86,9 +86,11 @@ const NodeDetailsModalHeader = (props) => {
 
   return (
     <div className="modalHeader">
-      <div className="modal-title" style={titleStyles}>
-        {nodeIcon ? <SvgDiv className="modal-title-icon" svgFile={nodeIcon}/> : null}
-        <span>{header}</span>
+      <div className="modal-title-container modal-draggable-handle">
+        <div className="modal-title" style={titleStyles}>
+          {nodeIcon ? <SvgDiv className="modal-title-icon" svgFile={nodeIcon}/> : null}
+          <span>{header}</span>
+        </div>
       </div>
       {renderNodeClassDocs(nodeClass, docsUrl)}
     </div>

--- a/ui/client/components/modals/ConfirmDialog.js
+++ b/ui/client/components/modals/ConfirmDialog.js
@@ -5,8 +5,6 @@ import ActionsUtils from "../../actions/ActionsUtils";
 import ProcessUtils from "../../common/ProcessUtils";
 import "../../stylesheets/visualization.styl";
 import ProcessDialogWarnings from "./ProcessDialogWarnings";
-import Draggable from "react-draggable";
-import {preventFromMoveSelectors} from "./GenericModalDialog";
 
 //TODO: consider extending GenericModalDialog
 class ConfirmDialog extends React.Component {
@@ -36,18 +34,16 @@ class ConfirmDialog extends React.Component {
              shouldCloseOnOverlayClick={false}
              onRequestClose={this.closeDialog}>
         <div className="draggable-container">
-          <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
-            <div className="espModal confirmationModal modalContentDark">
-              <p>{confirmDialog.text}</p>
-              <ProcessDialogWarnings processHasWarnings={this.props.processHasWarnings}/>
-              <div className="confirmationButtons">
-                <button type="button" title={confirmDialog.denyText} className="modalButton"
-                        onClick={this.closeDialog}>{confirmDialog.denyText}</button>
-                <button type="button" title={confirmDialog.confirmText} className="modalButton"
-                        onClick={this.confirm}>{confirmDialog.confirmText}</button>
-              </div>
+          <div className="espModal confirmationModal modalContentDark">
+            <p>{confirmDialog.text}</p>
+            <ProcessDialogWarnings processHasWarnings={this.props.processHasWarnings}/>
+            <div className="confirmationButtons">
+              <button type="button" title={confirmDialog.denyText} className='modalButton'
+                      onClick={this.closeDialog}>{confirmDialog.denyText}</button>
+              <button type="button" title={confirmDialog.confirmText} className='modalButton'
+                      onClick={this.confirm}>{confirmDialog.confirmText}</button>
             </div>
-          </Draggable>
+          </div>
         </div>
       </Modal>
     );

--- a/ui/client/components/modals/GenericModalDialog.js
+++ b/ui/client/components/modals/GenericModalDialog.js
@@ -56,9 +56,9 @@ class GenericModalDialog extends React.Component {
              shouldCloseOnOverlayClick={false}
              onRequestClose={this.closeDialog}>
         <div className="draggable-container">
-          <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
+          <Draggable bounds="parent" handle=".modal-draggable-handle">
             <div className={style}>
-              {this.props.header ? (<div className="modal-title" style={{color: "white", backgroundColor: "#70c6ce"}}>
+              {this.props.header ? (<div className="modal-title modal-draggable-handle" style={{color: "white", backgroundColor: "#70c6ce"}}>
                 <span>{this.props.header}</span>
               </div>) : null}
               <div className="modalContentDark">
@@ -86,8 +86,6 @@ function mapState(state) {
     modalDialog: state.ui.modalDialog || {},
   }
 }
-
-export const preventFromMoveSelectors = "input, textarea, #brace-editor, .datePickerContainer, svg, img, .node-value-select, #ace-editor, .row-ace-editor"
 
 export default connect(mapState, ActionsUtils.mapDispatchWithEspActions)(GenericModalDialog);
 

--- a/ui/client/components/modals/PreventExitDialog.js
+++ b/ui/client/components/modals/PreventExitDialog.js
@@ -2,8 +2,6 @@ import React from "react";
 import Modal from "react-modal";
 import DialogMessages from "../../common/DialogMessages";
 import PropTypes from "prop-types";
-import Draggable from "react-draggable";
-import {preventFromMoveSelectors} from "./GenericModalDialog";
 
 class PreventExitDialog extends React.Component {
 
@@ -28,15 +26,13 @@ class PreventExitDialog extends React.Component {
              shouldCloseOnOverlayClick={false}
              onRequestClose={this.closeDialog}>
         <div className="draggable-container">
-          <Draggable bounds="parent" cancel={preventFromMoveSelectors}>
-            <div className="espModal confirmationModal modalContentDark">
-              <p>{DialogMessages.unsavedProcessChanges()}</p>
-              <div className="confirmationButtons">
-                <button type="button" title="NO" className="modalButton" onClick={this.closeDialog}>NO</button>
-                <button type="button" title="DISCARD" className="modalButton" onClick={this.confirm}>DISCARD</button>
-              </div>
+          <div className="espModal confirmationModal modalContentDark">
+            <p>{DialogMessages.unsavedProcessChanges()}</p>
+            <div className="confirmationButtons">
+              <button type="button" title="NO" className='modalButton' onClick={this.closeDialog}>NO</button>
+              <button type="button" title="DISCARD" className='modalButton' onClick={this.confirm}>DISCARD</button>
             </div>
-          </Draggable>
+          </div>
         </div>
       </Modal>
     );

--- a/ui/client/stylesheets/graph.styl
+++ b/ui/client/stylesheets/graph.styl
@@ -175,6 +175,16 @@ espCheckbox(checkboxWidth)
       height 22px
       padding-top 8px
 
+.modal-title-container
+  height modalHeaderHeight
+  float left
+
+.modal-draggable-handle
+  &:hover
+    cursor grab
+  &:active
+    cursor grabbing
+
 .modal-title
   height modalHeaderHeight
   float left
@@ -185,6 +195,10 @@ espCheckbox(checkboxWidth)
     width 18px
     height 18px
     display inline-block
+
+.edge-modal-title
+  @extend .modal-title
+  padding-left 10px
 
 .modal-title-icon
   display inline-block


### PR DESCRIPTION
This closes #482 

Modal is now draggable with hover on modal header title. Modals without header, ConfirmDialog and PreventExitDialog are no longer draggable. 

On hover outside header:
![image](https://user-images.githubusercontent.com/26696870/71969489-077cca00-3207-11ea-9a8e-767710cdecde.png)

On hover header:
![image](https://user-images.githubusercontent.com/26696870/71968891-fd0e0080-3205-11ea-9f15-1160e1430478.png)

On drag:
![image](https://user-images.githubusercontent.com/26696870/71968960-1a42cf00-3206-11ea-820e-b2eb95d962ae.png)

EdgeDetailsModal:
![image](https://user-images.githubusercontent.com/26696870/71969069-42323280-3206-11ea-82bf-d7ec17189375.png)
