### PR TITLE
Make snapshot and cancel process in single action

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
@@ -16,7 +16,9 @@ trait ProcessManager {
   def findJobStatus(name: ProcessName) : Future[Option[ProcessState]]
 
   //TODO: this is very flink specific, how can we handle that differently?
-  def savepoint(name: ProcessName, savepointDir: Option[String], cancelProcess: Boolean): Future[String]
+  def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult]
+
+  def stop(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult]
 
   def cancel(name: ProcessName) : Future[Unit]
 

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
@@ -16,7 +16,7 @@ trait ProcessManager {
   def findJobStatus(name: ProcessName) : Future[Option[ProcessState]]
 
   //TODO: this is very flink specific, how can we handle that differently?
-  def savepoint(name: ProcessName, savepointDir: String): Future[String]
+  def savepoint(name: ProcessName, savepointDir: Option[String], cancelProcess: Boolean): Future[String]
 
   def cancel(name: ProcessName) : Future[Unit]
 

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/SavepointResult.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/SavepointResult.scala
@@ -1,0 +1,3 @@
+package pl.touk.nussknacker.engine.api.deployment
+
+case class SavepointResult(path: String)

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessManagerSpec.scala
@@ -153,7 +153,7 @@ class FlinkStreamingProcessManagerSpec extends FunSuite with Matchers with Strea
     val savepointPath = processManager.stop(ProcessName(processId), savepointDir = None).map(_.path)
 
     eventually {
-      processManager.findJobStatus(ProcessName(processId)).futureValue.map(_.status) shouldBe Some(FlinkStateStatus.Canceled)
+      processManager.findJobStatus(ProcessName(processId)).futureValue.map(_.status) shouldBe Some(FlinkStateStatus.Finished)
     }
 
     deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processId), Some(savepointPath.futureValue))

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkRestManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkRestManager.scala
@@ -197,7 +197,7 @@ class FlinkRestManager(config: FlinkConfig, modelData: ModelData, mainClassName:
   override protected def stop(job: ProcessState, savepointDir: Option[String]): Future[SavepointResult] = {
     val stopRequest = basicRequest
       .post(flinkUrl.path("jobs", job.deploymentId.value, "stop"))
-      .body(StopRequest(targetDirectory = savepointDir))
+      .body(StopRequest(targetDirectory = savepointDir, drain = false))
     processSavepointRequest(job, stopRequest)
   }
 
@@ -244,7 +244,7 @@ object flinkRestModel {
 
   @JsonCodec(encodeOnly = true) case class SavepointTriggerRequest(`target-directory`: Option[String], `cancel-job`: Boolean)
 
-  @JsonCodec(encodeOnly = true) case class StopRequest(targetDirectory: Option[String])
+  @JsonCodec(encodeOnly = true) case class StopRequest(targetDirectory: Option[String], drain: Boolean)
 
   @JsonCodec(decodeOnly = true) case class SavepointTriggerResponse(`request-id`: String)
 

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkRestManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkRestManager.scala
@@ -11,7 +11,7 @@ import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.management.flinkRestModel.{DeployProcessRequest, GetSavepointStatusResponse, JarsResponse, JobConfig, JobsResponse, SavepointTriggerRequest, SavepointTriggerResponse, UploadJarResponse}
+import pl.touk.nussknacker.engine.management.flinkRestModel.{DeployProcessRequest, GetSavepointStatusResponse, JarsResponse, JobConfig, JobsResponse, SavepointTriggerRequest, SavepointTriggerResponse, StopRequest, UploadJarResponse}
 import pl.touk.nussknacker.engine.sttp.SttpJson
 import sttp.client._
 import sttp.client.circe._
@@ -154,7 +154,7 @@ class FlinkRestManager(config: FlinkConfig, modelData: ModelData, mainClassName:
   }
 
   //FIXME: get rid of sleep, refactor?
-  private def waitForSavepoint(jobId: DeploymentId, savepointId: String, timeoutLeft: Long = config.jobManagerTimeout.toMillis): Future[String] = {
+  private def waitForSavepoint(jobId: DeploymentId, savepointId: String, timeoutLeft: Long = config.jobManagerTimeout.toMillis): Future[SavepointResult] = {
     val start = System.currentTimeMillis()
     if (timeoutLeft <= 0) {
       return Future.failed(new Exception(s"Failed to complete savepoint in time for $jobId and trigger $savepointId"))
@@ -170,7 +170,7 @@ class FlinkRestManager(config: FlinkConfig, modelData: ModelData, mainClassName:
         //getOrElse is not really needed since isCompletedSuccessfully returns true only if it's defined
         val location = resp.operation.flatMap(_.location).getOrElse("")
         logger.info(s"Savepoint $savepointId for $jobId finished in $location")
-        Future.successful(location)
+        Future.successful(SavepointResult(location))
       } else if (resp.isFailed) {
         Future.failed(new RuntimeException(s"Failed to complete savepoint: ${resp.operation}"))
       } else {
@@ -187,10 +187,22 @@ class FlinkRestManager(config: FlinkConfig, modelData: ModelData, mainClassName:
       .flatMap(handleUnitResponse)
   }
 
-  override protected def makeSavepoint(job: ProcessState, savepointDir: Option[String], cancelJob: Boolean): Future[String] = {
-    basicRequest
+  override protected def makeSavepoint(job: ProcessState, savepointDir: Option[String]): Future[SavepointResult] = {
+    val savepointRequest = basicRequest
       .post(flinkUrl.path("jobs", job.deploymentId.value, "savepoints"))
-      .body(SavepointTriggerRequest(`target-directory` = savepointDir, `cancel-job` = cancelJob))
+      .body(SavepointTriggerRequest(`target-directory` = savepointDir))
+    processSavepointRequest(job, savepointRequest)
+  }
+
+  override protected def stop(job: ProcessState, savepointDir: Option[String]): Future[SavepointResult] = {
+    val stopRequest = basicRequest
+      .post(flinkUrl.path("jobs", job.deploymentId.value, "stop"))
+      .body(StopRequest(targetDirectory = savepointDir))
+    processSavepointRequest(job, stopRequest)
+  }
+
+  private def processSavepointRequest(job: ProcessState, request: RequestT[Identity, Either[String, String], Nothing]): Future[SavepointResult] = {
+    request
       .response(asJson[SavepointTriggerResponse])
       .send()
       .flatMap(SttpJson.failureToFuture)
@@ -230,7 +242,9 @@ object flinkRestModel {
 
   @JsonCodec(encodeOnly = true) case class DeployProcessRequest(entryClass: String, parallelism: Int, savepointPath: Option[String], programArgs: String, allowNonRestoredState: Boolean)
 
-  @JsonCodec(encodeOnly = true) case class SavepointTriggerRequest(`target-directory`: Option[String], `cancel-job`: Boolean)
+  @JsonCodec(encodeOnly = true) case class SavepointTriggerRequest(`target-directory`: Option[String])
+
+  @JsonCodec(encodeOnly = true) case class StopRequest(targetDirectory: Option[String])
 
   @JsonCodec(decodeOnly = true) case class SavepointTriggerResponse(`request-id`: String)
 

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkRestManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkRestManager.scala
@@ -190,7 +190,7 @@ class FlinkRestManager(config: FlinkConfig, modelData: ModelData, mainClassName:
   override protected def makeSavepoint(job: ProcessState, savepointDir: Option[String]): Future[SavepointResult] = {
     val savepointRequest = basicRequest
       .post(flinkUrl.path("jobs", job.deploymentId.value, "savepoints"))
-      .body(SavepointTriggerRequest(`target-directory` = savepointDir))
+      .body(SavepointTriggerRequest(`target-directory` = savepointDir, `cancel-job` = false))
     processSavepointRequest(job, savepointRequest)
   }
 
@@ -242,7 +242,7 @@ object flinkRestModel {
 
   @JsonCodec(encodeOnly = true) case class DeployProcessRequest(entryClass: String, parallelism: Int, savepointPath: Option[String], programArgs: String, allowNonRestoredState: Boolean)
 
-  @JsonCodec(encodeOnly = true) case class SavepointTriggerRequest(`target-directory`: Option[String])
+  @JsonCodec(encodeOnly = true) case class SavepointTriggerRequest(`target-directory`: Option[String], `cancel-job`: Boolean)
 
   @JsonCodec(encodeOnly = true) case class StopRequest(targetDirectory: Option[String])
 

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -59,7 +59,7 @@ class StandaloneProcessManager(modelData: ModelData, client: StandaloneProcessCl
     }
   }
 
-  override def savepoint(processName: ProcessName, savepointDir: String): Future[String] = {
+  override def savepoint(processName: ProcessName, savepointDir: Option[String], cancelProcess: Boolean): Future[String] = {
     Future.failed(new UnsupportedOperationException("Cannot make savepoint on standalone process"))
   }
 

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -59,8 +59,12 @@ class StandaloneProcessManager(modelData: ModelData, client: StandaloneProcessCl
     }
   }
 
-  override def savepoint(processName: ProcessName, savepointDir: Option[String], cancelProcess: Boolean): Future[String] = {
+  override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] = {
     Future.failed(new UnsupportedOperationException("Cannot make savepoint on standalone process"))
+  }
+
+  override def stop(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] = {
+    Future.failed(new UnsupportedOperationException("Cannot stop standalone process"))
   }
 
   override def test[T](processName: ProcessName, processJson: String, testData: TestData, variableEncoder: Any => T): Future[TestResults[T]] = {

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -118,9 +118,7 @@ class ManagementResources(processCounter: ProcessCounter,
 
   def securedRoute(implicit user: LoggedUser): Route = {
     path("adminProcessManagement" / "snapshot" / Segment) { processName =>
-      println("hmm")
       (post & processId(processName) & parameters('savepointDir.?)) { (processId, savepointDir) =>
-        println("hmm2")
         canDeploy(processId) {
           complete {
             convertSavepointResultToResponse(managementActor ? Snapshot(processId, user, savepointDir))

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
@@ -55,8 +55,10 @@ class ManagementActor(environment: String,
         val deployRes = deployProcess(process.id, savepointPath, comment)(user)
         reply(withDeploymentInfo(process, user, DeploymentActionType.Deployment, comment, deployRes))
       }
-    case Snapshot(id, user, savepointDir, cancelProcess) =>
-      reply(processManager(id.id)(ec, user).flatMap(_.savepoint(id.name, savepointDir, cancelProcess)))
+    case Snapshot(id, user, savepointDir) =>
+      reply(processManager(id.id)(ec, user).flatMap(_.savepoint(id.name, savepointDir)))
+    case Stop(id, user, savepointDir) =>
+      reply(processManager(id.id)(ec, user).flatMap(_.stop(id.name, savepointDir)))
     case Cancel(id, user, comment) =>
       ensureNoDeploymentRunning {
         implicit val loggedUser: LoggedUser = user
@@ -236,7 +238,9 @@ case class Deploy(id: ProcessIdWithName, user: LoggedUser, savepointPath: Option
 
 case class Cancel(id: ProcessIdWithName, user: LoggedUser, comment: Option[String]) extends DeploymentAction
 
-case class Snapshot(id: ProcessIdWithName, user: LoggedUser, savepointPath: Option[String], cancelProcess: Boolean)
+case class Snapshot(id: ProcessIdWithName, user: LoggedUser, savepointDir: Option[String])
+
+case class Stop(id: ProcessIdWithName, user: LoggedUser, savepointDir: Option[String])
 
 case class CheckStatus(id: ProcessIdWithName, user: LoggedUser)
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
@@ -55,8 +55,8 @@ class ManagementActor(environment: String,
         val deployRes = deployProcess(process.id, savepointPath, comment)(user)
         reply(withDeploymentInfo(process, user, DeploymentActionType.Deployment, comment, deployRes))
       }
-    case Snapshot(id, user, savepointDir) =>
-      reply(processManager(id.id)(ec, user).flatMap(_.savepoint(id.name, savepointDir)))
+    case Snapshot(id, user, savepointDir, cancelProcess) =>
+      reply(processManager(id.id)(ec, user).flatMap(_.savepoint(id.name, savepointDir, cancelProcess)))
     case Cancel(id, user, comment) =>
       ensureNoDeploymentRunning {
         implicit val loggedUser: LoggedUser = user
@@ -236,7 +236,7 @@ case class Deploy(id: ProcessIdWithName, user: LoggedUser, savepointPath: Option
 
 case class Cancel(id: ProcessIdWithName, user: LoggedUser, comment: Option[String]) extends DeploymentAction
 
-case class Snapshot(id: ProcessIdWithName, user: LoggedUser, savepointPath: String)
+case class Snapshot(id: ProcessIdWithName, user: LoggedUser, savepointPath: Option[String], cancelProcess: Boolean)
 
 case class CheckStatus(id: ProcessIdWithName, user: LoggedUser)
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -156,6 +156,22 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
     }
   }
 
+  test("snaphots process") {
+    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
+    snapshot(SampleProcess.process.id) ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[String] shouldBe MockProcessManager.savepointPath
+    }
+  }
+
+  test("stops process") {
+    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
+    stop(SampleProcess.process.id) ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[String] shouldBe MockProcessManager.stopSavepointPath
+    }
+  }
+
   test("return test results") {
     saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
     val displayableProcess = ProcessConverter.toDisplayable(ProcessCanonizer.canonize(SampleProcess.process)

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -186,6 +186,14 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
     ) ~> withPermissions(deployRoute(requireComment), testPermissionDeploy |+| testPermissionRead)
   }
 
+  def snapshot(processName: String): RouteTestResult = {
+    Post(s"/adminProcessManagement/snapshot/$processName") ~> withPermissions(deployRoute(), testPermissionDeploy |+| testPermissionRead)
+  }
+
+  def stop(processName: String): RouteTestResult = {
+    Post(s"/adminProcessManagement/stop/$processName") ~> withPermissions(deployRoute(), testPermissionDeploy |+| testPermissionRead)
+  }
+
   def getSampleProcess: RouteTestResult = {
     Get(s"/processes/${SampleProcess.process.id}") ~> withPermissions(processesRoute, testPermissionRead)
   }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -137,7 +137,7 @@ object TestFactory extends TestPermissions{
 
     override protected def cancel(job: ProcessState): Future[Unit] = Future.successful(Unit)
 
-    override protected def makeSavepoint(job: ProcessState, savepointDir: Option[String]): Future[String] = Future.successful("dummy")
+    override protected def makeSavepoint(job: ProcessState, savepointDir: Option[String], cancelJob: Boolean): Future[String] = Future.successful("dummy")
 
     override protected def runProgram(processName: ProcessName, mainClass: String, args: List[String], savepointPath: Option[String]): Future[Unit] = ???
   }


### PR DESCRIPTION
During Flink upgrade it might be wise to snapshot job's state and cancel it in single action to avoid processing duplicates when restoring the job on new version of cluster. It is currently possible in two steps - making a snapshot and then canceling process so some duplicates are possible.

This PR also fixes making a snapshot with custom directory - it is ignored currently.

In next change redeploying a process could be improved by making a snapshot and canceling the job simultaneously.