### PR TITLE
Exposing basic methods for collections in type definitions

### DIFF
--- a/engine/api/src/main/java/pl/touk/nussknacker/engine/javaapi/process/ClassExtractionSettings.java
+++ b/engine/api/src/main/java/pl/touk/nussknacker/engine/javaapi/process/ClassExtractionSettings.java
@@ -1,8 +1,10 @@
 package pl.touk.nussknacker.engine.javaapi.process;
 
+import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings$;
 import pl.touk.nussknacker.engine.api.process.ClassMemberPredicate;
+import pl.touk.nussknacker.engine.api.process.ClassPredicate;
+import scala.collection.JavaConverters;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -10,20 +12,39 @@ import java.util.List;
  */
 public class ClassExtractionSettings {
 
-    public static final ClassExtractionSettings DEFAULT = new ClassExtractionSettings(Collections.emptyList());
+    public static final ClassExtractionSettings DEFAULT = new ClassExtractionSettings(
+            JavaConverters.seqAsJavaListConverter(ClassExtractionSettings$.MODULE$.DefaultBlacklistedClasses()).asJava(),
+            JavaConverters.seqAsJavaListConverter(ClassExtractionSettings$.MODULE$.DefaultBlacklistedMembers()).asJava(),
+            JavaConverters.seqAsJavaListConverter(ClassExtractionSettings$.MODULE$.DefaultWhitelistedMembers()).asJava());
+
+    private final List<ClassPredicate> blacklistedClassPredicates;
 
     private final List<ClassMemberPredicate> blacklistedClassMemberPredicates;
 
+    private final List<ClassMemberPredicate> whitelistedClassMemberPredicates;
+
     /**
      * Creates ClassExtractionSettings
+     * @param blacklistedClassPredicates - list of predicates to recognize blacklisted class
      * @param blacklistedClassMemberPredicates - list of predicates to recognize blacklisted class members
      */
-    public ClassExtractionSettings(List<ClassMemberPredicate> blacklistedClassMemberPredicates) {
+    public ClassExtractionSettings(List<ClassPredicate> blacklistedClassPredicates,
+                                   List<ClassMemberPredicate> blacklistedClassMemberPredicates,
+                                   List<ClassMemberPredicate> whitelistedClassMemberPredicates) {
+        this.blacklistedClassPredicates = blacklistedClassPredicates;
         this.blacklistedClassMemberPredicates = blacklistedClassMemberPredicates;
+        this.whitelistedClassMemberPredicates = whitelistedClassMemberPredicates;
+    }
+
+    public List<ClassPredicate> getBlacklistedClassPredicates() {
+        return blacklistedClassPredicates;
     }
 
     public List<ClassMemberPredicate> getBlacklistedClassMemberPredicates() {
         return blacklistedClassMemberPredicates;
     }
 
+    public List<ClassMemberPredicate> getWhitelistedClassMemberPredicates() {
+        return whitelistedClassMemberPredicates;
+    }
 }

--- a/engine/api/src/main/java/pl/touk/nussknacker/engine/javaapi/process/ClassExtractionSettings.java
+++ b/engine/api/src/main/java/pl/touk/nussknacker/engine/javaapi/process/ClassExtractionSettings.java
@@ -13,38 +13,42 @@ import java.util.List;
 public class ClassExtractionSettings {
 
     public static final ClassExtractionSettings DEFAULT = new ClassExtractionSettings(
-            JavaConverters.seqAsJavaListConverter(ClassExtractionSettings$.MODULE$.DefaultBlacklistedClasses()).asJava(),
-            JavaConverters.seqAsJavaListConverter(ClassExtractionSettings$.MODULE$.DefaultBlacklistedMembers()).asJava(),
-            JavaConverters.seqAsJavaListConverter(ClassExtractionSettings$.MODULE$.DefaultWhitelistedMembers()).asJava());
+            JavaConverters.seqAsJavaListConverter(ClassExtractionSettings$.MODULE$.DefaultExcludedClasses()).asJava(),
+            JavaConverters.seqAsJavaListConverter(ClassExtractionSettings$.MODULE$.DefaultExcludedMembers()).asJava(),
+            JavaConverters.seqAsJavaListConverter(ClassExtractionSettings$.MODULE$.DefaultIncludedMembers()).asJava());
 
-    private final List<ClassPredicate> blacklistedClassPredicates;
+    private final List<ClassPredicate> excludeClassPredicates;
 
-    private final List<ClassMemberPredicate> blacklistedClassMemberPredicates;
+    private final List<ClassMemberPredicate> excludeClassMemberPredicates;
 
-    private final List<ClassMemberPredicate> whitelistedClassMemberPredicates;
+    private final List<ClassMemberPredicate> includeClassMemberPredicates;
 
     /**
      * Creates ClassExtractionSettings
-     * @param blacklistedClassPredicates - list of predicates to recognize blacklisted class
-     * @param blacklistedClassMemberPredicates - list of predicates to recognize blacklisted class members
+     * @param excludeClassPredicates - sequence of predicates to determine hidden classes
+     * @param excludeClassMemberPredicates - sequence of predicates to determine excluded class members - will be
+     *                                       used all predicates that matches given class
+     * @param includeClassMemberPredicates - sequence of predicates to determine included class members - will be
+     *                                       used all predicates that matches given class. If none is matching,
+     *                                       all non-excluded members will be visible.
      */
-    public ClassExtractionSettings(List<ClassPredicate> blacklistedClassPredicates,
-                                   List<ClassMemberPredicate> blacklistedClassMemberPredicates,
-                                   List<ClassMemberPredicate> whitelistedClassMemberPredicates) {
-        this.blacklistedClassPredicates = blacklistedClassPredicates;
-        this.blacklistedClassMemberPredicates = blacklistedClassMemberPredicates;
-        this.whitelistedClassMemberPredicates = whitelistedClassMemberPredicates;
+    public ClassExtractionSettings(List<ClassPredicate> excludeClassPredicates,
+                                   List<ClassMemberPredicate> excludeClassMemberPredicates,
+                                   List<ClassMemberPredicate> includeClassMemberPredicates) {
+        this.excludeClassPredicates = excludeClassPredicates;
+        this.excludeClassMemberPredicates = excludeClassMemberPredicates;
+        this.includeClassMemberPredicates = includeClassMemberPredicates;
     }
 
-    public List<ClassPredicate> getBlacklistedClassPredicates() {
-        return blacklistedClassPredicates;
+    public List<ClassPredicate> getExcludeClassPredicates() {
+        return excludeClassPredicates;
     }
 
-    public List<ClassMemberPredicate> getBlacklistedClassMemberPredicates() {
-        return blacklistedClassMemberPredicates;
+    public List<ClassMemberPredicate> getExcludeClassMemberPredicates() {
+        return excludeClassMemberPredicates;
     }
 
-    public List<ClassMemberPredicate> getWhitelistedClassMemberPredicates() {
-        return whitelistedClassMemberPredicates;
+    public List<ClassMemberPredicate> getIncludeClassMemberPredicates() {
+        return includeClassMemberPredicates;
     }
 }

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/conversion/ProcessConfigCreatorMapping.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/conversion/ProcessConfigCreatorMapping.scala
@@ -56,7 +56,10 @@ object ProcessConfigCreatorMapping {
       }
       override def classExtractionSettings(config: Config): ClassExtractionSettings = {
         val jSettings = jcreator.classExtractionSettings(config)
-        ClassExtractionSettings(jSettings.getBlacklistedClassMemberPredicates.asScala)
+        ClassExtractionSettings(
+          jSettings.getBlacklistedClassPredicates.asScala,
+          jSettings.getBlacklistedClassMemberPredicates.asScala,
+          jSettings.getWhitelistedClassMemberPredicates.asScala)
       }
     }
     creator

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/conversion/ProcessConfigCreatorMapping.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/conversion/ProcessConfigCreatorMapping.scala
@@ -57,9 +57,9 @@ object ProcessConfigCreatorMapping {
       override def classExtractionSettings(config: Config): ClassExtractionSettings = {
         val jSettings = jcreator.classExtractionSettings(config)
         ClassExtractionSettings(
-          jSettings.getBlacklistedClassPredicates.asScala,
-          jSettings.getBlacklistedClassMemberPredicates.asScala,
-          jSettings.getWhitelistedClassMemberPredicates.asScala)
+          jSettings.getExcludeClassPredicates.asScala,
+          jSettings.getExcludeClassMemberPredicates.asScala,
+          jSettings.getIncludeClassMemberPredicates.asScala)
       }
     }
     creator

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassExtractionSettings.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassExtractionSettings.scala
@@ -5,27 +5,131 @@ import java.util.regex.Pattern
 
 /**
   * Settings for class extraction which is done to handle e.g. syntax suggestions in UI
-  * @param blacklistedClassMemberPredicates - sequence of predicates to recognize blacklisted class members
+  * @param blacklistedClassPredicates - sequence of predicates to recognize blacklisted classes
+  * @param blacklistedClassMemberPredicates - sequence of predicates to recognize blacklisted class members - will be
+ *                                            used all predicates that matches given class
+  * @param whitelistedClassMemberPredicates - sequence of predicates to recognize whitelisted class members - will be
+ *                                            used first predicate that matches given class
   */
-case class ClassExtractionSettings(blacklistedClassMemberPredicates: Seq[ClassMemberPredicate]) {
+case class ClassExtractionSettings(blacklistedClassPredicates: Seq[ClassPredicate],
+                                   blacklistedClassMemberPredicates: Seq[ClassMemberPredicate],
+                                   whitelistedClassMemberPredicates: Seq[ClassMemberPredicate]) {
 
-  def isBlacklisted(member: Member): Boolean =
-    blacklistedClassMemberPredicates.exists(_.matches(member))
+  def isBlacklisted(clazz: Class[_]): Boolean =
+    blacklistedClassPredicates.exists(_.matches(clazz))
+
+  def visibleMembersPredicate(clazz: Class[_]): VisibleMembersPredicate =
+    VisibleMembersPredicate(
+      blacklistedClassMemberPredicates.filter(p => p.matchesClass(clazz)),
+      whitelistedClassMemberPredicates.find(p => p.matchesClass(clazz)))
+
+}
+
+case class VisibleMembersPredicate(blacklist: Seq[ClassMemberPredicate], whitelist: Option[ClassMemberPredicate]) {
+
+  def shouldBeVisible(member: Member): Boolean =
+    !blacklist.exists(_.matchesMember(member)) && whitelist.forall(_.matchesMember(member))
 
 }
 
 object ClassExtractionSettings {
 
-  val Default: ClassExtractionSettings = ClassExtractionSettings(AvroBlacklistedMembers)
+  val ToStringMethod = "toString"
 
-  lazy val AvroBlacklistedMembers: List[ClassMemberPatternPredicate] =
+  val Default: ClassExtractionSettings = ClassExtractionSettings(DefaultBlacklistedClasses, DefaultBlacklistedMembers, DefaultWhitelistedMembers)
+
+  lazy val DefaultBlacklistedClasses: List[ClassPredicate] =
+    List(
+      // Void types
+      ClassPatternPredicate(Pattern.compile("void")),
+      ClassPatternPredicate(Pattern.compile("java\\.lang\\.Void")),
+      ClassPatternPredicate(Pattern.compile("scala\\.Unit.*")),
+      ClassPatternPredicate(Pattern.compile("scala\\.runtime\\.BoxedUnit")),
+
+      // In case if there is some public method with flink's TypeInformation on serialization purpose
+      ClassPatternPredicate(Pattern.compile("org\\.apache\\.flink\\.api\\.common\\.typeinfo\\.TypeInformation")),
+      // We use this type only programmable
+      ClassPatternPredicate(Pattern.compile("pl\\.touk\\.nussknacker\\.engine\\.spel\\.SpelExpressionRepr")),
+      // In case if someone use it for kind of meta programming
+      ClassPatternPredicate(Pattern.compile("java\\.lang\\.Class")),
+      // In case if someone return function for lazy evaluation purpose
+      ClassPatternPredicate(Pattern.compile("java\\.util\\.function\\..*")),
+      ClassPatternPredicate(Pattern.compile("scala\\.Function.*")),
+      // java xml api is not easy to use without additional helpers, so we will skip these classes
+      ClassPatternPredicate(Pattern.compile("javax\\.xml\\..*")),
+      // Not sure why these below exclusions are TODO describe why they should be here or remove it
+      ClassPatternPredicate(Pattern.compile("dispatch\\..*")),
+      ClassPatternPredicate(Pattern.compile("cats\\..*"))
+    )
+
+  lazy val DefaultBlacklistedMembers: List[ClassMemberPredicate] = CommonBlacklistedMembers ++ AvroBlacklistedMembers
+
+  lazy val CommonBlacklistedMembers: List[ClassMemberPredicate] =
+    List(
+      // We want to hide all technical methods in every class, toString can be useful so we will leave it
+      AllMethodNamesPredicate(classOf[DumpCaseClass], Set(ToStringMethod))
+    )
+
+  lazy val AvroBlacklistedMembers: List[ClassMemberPredicate] =
     List(
       ClassMemberPatternPredicate(
-        Pattern.compile("org\\.apache\\.avro\\.generic\\.IndexedRecord"),
+        SuperClassPatternPredicate(Pattern.compile("org\\.apache\\.avro\\.generic\\.IndexedRecord")),
         Pattern.compile("(getSchema|compareTo|put)")),
       ClassMemberPatternPredicate(
-        Pattern.compile("org\\.apache\\.avro\\.specific\\.SpecificRecordBase"),
+        SuperClassPatternPredicate(Pattern.compile("org\\.apache\\.avro\\.specific\\.SpecificRecordBase")),
         Pattern.compile("(getConverion|getConversion|writeExternal|readExternal|toByteBuffer|set[A-Z].*)"))
     )
+
+  lazy val DefaultWhitelistedMembers: List[ClassMemberPredicate] = WhitelistedUtilMembers ++ WhitelistedSerializableMembers ++ WhitelistedStdMembers
+
+  lazy val WhitelistedUtilMembers: List[ClassMemberPredicate] =
+    List(
+      // For numeric types, strings an collections, date types we want to see all useful methods
+      ClassMemberPatternPredicate(
+        SuperClassPatternPredicate(Pattern.compile("(java\\.lang\\.Number|java\\.util\\.Date|java\\.util\\.Calendar|java\\.util\\.concurrent\\.TimeUnit)")),
+        Pattern.compile(".*")),
+      ClassMemberPatternPredicate(
+        ClassPatternPredicate(Pattern.compile("java\\.time\\..*")),
+        Pattern.compile(".*")),
+      ClassMemberPatternPredicate(
+        ClassPatternPredicate(Pattern.compile("scala\\.concurrent\\.duration\\..*")),
+        Pattern.compile(".*")),
+      ClassMemberPatternPredicate(
+        SuperClassPatternPredicate(Pattern.compile("java\\.lang\\.CharSequence")),
+        Pattern.compile(s"charAt|compareTo.*|concat|contains|endsWith|equalsIgnoreCase|isEmpty|lastIndexOf|length|matches|" +
+          s"replaceAll|replaceFirst|split|startsWith|substring|toLowerCase|toUpperCase|trim|$ToStringMethod")),
+      ClassMemberPatternPredicate(
+        SuperClassPatternPredicate(Pattern.compile("java\\.util\\.Collection")),
+        Pattern.compile(s"contains|containsAll|get|getOrDefault|indexOf|isEmpty|size|$ToStringMethod")),
+      ClassMemberPatternPredicate(
+        SuperClassPatternPredicate(Pattern.compile("java\\.util\\.Optional")),
+        Pattern.compile(s"get|isPresent|orElse|$ToStringMethod")),
+      ClassMemberPatternPredicate(
+        SuperClassPatternPredicate(Pattern.compile("(scala\\.collection\\.Traversable|scala\\.Option)")),
+        Pattern.compile(s"apply|applyOrElse|contains|get|getOrDefault|indexOf|isDefined|isEmpty|size|$ToStringMethod"))
+    )
+
+  lazy val WhitelistedSerializableMembers: List[ClassMemberPredicate] =
+    List(
+      ClassMemberPatternPredicate(
+        ClassPatternPredicate(Pattern.compile("scala\\.xml\\..*")),
+        Pattern.compile(ToStringMethod)),
+      ClassMemberPatternPredicate(
+        ClassPatternPredicate(Pattern.compile("(io\\.circe\\..*|argonaut\\..*)")),
+        Pattern.compile(s"noSpaces|spaces2|spaces4|$ToStringMethod"))
+    )
+
+  lazy val WhitelistedStdMembers: List[ClassMemberPredicate] =
+    List(
+      // For other std types we don't want to see anything but toString method
+      ClassMemberPatternPredicate(
+        ClassPatternPredicate(Pattern.compile("java\\..*")),
+        Pattern.compile(ToStringMethod)),
+      ClassMemberPatternPredicate(
+        ClassPatternPredicate(Pattern.compile("scala\\..*")),
+        Pattern.compile(ToStringMethod))
+    )
+
+  private case class DumpCaseClass()
 
 }

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassMemberPredicate.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassMemberPredicate.scala
@@ -1,36 +1,43 @@
 package pl.touk.nussknacker.engine.api.process
 
-import java.lang.reflect.{Field, Member, Method}
+import java.lang.reflect.Member
 import java.util.regex.Pattern
-
-import org.apache.commons.lang3.ClassUtils
 
 /**
   * Predicate for class members (fields & methods)
   */
 trait ClassMemberPredicate {
 
-  def matches(member: Member): Boolean
+  def matchesClass(clazz: Class[_]): Boolean
+
+  def matchesMember(member: Member): Boolean
 
 }
 
 /**
-  * Simple implementation of ClassMemberPredicate based on class name pattern and class member's name pattern
-  * @param classPattern - class name pattern
+  * Simple implementation of ClassMemberPredicate based on class member's name pattern
+  * @param classPredicate - class predicate
   * @param classMemberPattern - class member's name pattern
   */
-case class ClassMemberPatternPredicate(classPattern: Pattern, classMemberPattern: Pattern) extends ClassMemberPredicate {
+case class ClassMemberPatternPredicate(classPredicate: ClassPredicate, classMemberPattern: Pattern) extends ClassMemberPredicate {
 
-  override def matches(member: Member): Boolean = classMatches(member) && classMemberPattern.matcher(member.getName).matches()
+  override def matchesClass(clazz: Class[_]): Boolean = classPredicate.matches(clazz)
 
-  private def classMatches(member: Member) =
-    superClasses(member.getDeclaringClass).exists(cl => classPattern.matcher(cl.getName).matches())
+  override def matchesMember(member: Member): Boolean = classMemberPattern.matcher(member.getName).matches()
 
-  private def superClasses(clazz: Class[_]): Seq[Class[_]] = {
-    import scala.collection.JavaConverters._
-    Seq(clazz) ++
-      ClassUtils.getAllSuperclasses(clazz).asScala ++
-      ClassUtils.getAllInterfaces(clazz).asScala
-  }
+}
+
+/**
+ * Implementation of ClassMemberPredicate matching all methods that has the same name as methods in given class
+ * @param clazz - class which method names will match predicate
+ * @param exceptMethodNames - method names that will be excluded from matching
+ */
+case class AllMethodNamesPredicate(clazz: Class[_], exceptMethodNames: Set[String] = Set.empty) extends ClassMemberPredicate {
+
+  private val matchingMethodNames = clazz.getMethods.map(_.getName).toSet -- exceptMethodNames
+
+  override def matchesClass(clazz: Class[_]): Boolean = true
+
+  override def matchesMember(member: Member): Boolean =matchingMethodNames.contains(member.getName)
 
 }

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassMemberPredicate.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassMemberPredicate.scala
@@ -14,6 +14,18 @@ trait ClassMemberPredicate {
 
 }
 
+object ClassMemberPredicate {
+
+  def apply(classPredicate: ClassPredicate, p: PartialFunction[Member, Boolean]): ClassMemberPredicate = new ClassMemberPredicate with Serializable {
+
+    override def matchesClass(clazz: Class[_]): Boolean = classPredicate.matches(clazz)
+
+    override def matchesMember(member: Member): Boolean = p.lift(member).getOrElse(false)
+
+  }
+
+}
+
 /**
   * Simple implementation of ClassMemberPredicate based on class member's name pattern
   * @param classPredicate - class predicate

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassPredicate.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassPredicate.scala
@@ -1,0 +1,43 @@
+package pl.touk.nussknacker.engine.api.process
+
+import java.lang.reflect.Member
+import java.util.regex.Pattern
+
+import org.apache.commons.lang3.ClassUtils
+
+/**
+ * Predicate for classes
+ */
+trait ClassPredicate {
+
+  def matches(clazz: Class[_]): Boolean
+
+}
+
+/**
+ * Simple implementation of ClassPredicate based on pattern of class name
+ * @param classPattern - class name pattern
+ */
+case class ClassPatternPredicate(classPattern: Pattern) extends ClassPredicate {
+
+  override def matches(clazz: Class[_]): Boolean = classPattern.matcher(clazz.getName).matches()
+
+}
+
+/**
+ * Predicate that matches all superclasses and interfaces based on pattern
+ * @param superClassPattern - class name pattern
+ */
+case class SuperClassPatternPredicate(superClassPattern: Pattern) extends ClassPredicate {
+
+  def matches(clazz: Class[_]): Boolean =
+    superClasses(clazz).exists(cl => superClassPattern.matcher(cl.getName).matches())
+
+  private def superClasses(clazz: Class[_]): Seq[Class[_]] = {
+    import scala.collection.JavaConverters._
+    Seq(clazz) ++
+      ClassUtils.getAllSuperclasses(clazz).asScala ++
+      ClassUtils.getAllInterfaces(clazz).asScala
+  }
+
+}

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassPredicate.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassPredicate.scala
@@ -14,6 +14,14 @@ trait ClassPredicate {
 
 }
 
+object ClassPredicate {
+
+  def apply(p: PartialFunction[Class[_], Boolean]): ClassPredicate = new ClassPredicate with Serializable {
+    override def matches(clazz: Class[_]): Boolean = p.lift(clazz).getOrElse(false)
+  }
+
+}
+
 /**
  * Simple implementation of ClassPredicate based on pattern of class name
  * @param classPattern - class name pattern

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/columnmodel/TypedClassColumnModel.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/columnmodel/TypedClassColumnModel.scala
@@ -16,7 +16,7 @@ private[columnmodel] object TypedClassColumnModel {
     getColumns(definition)
   }
 
-  private def classExtractionSettings(claz: Class[_]) = ClassExtractionSettings(Seq(new CreateColumnClassExtractionPredicate(claz)))
+  private def classExtractionSettings(claz: Class[_]) = ClassExtractionSettings(Seq.empty, Seq(new CreateColumnClassExtractionPredicate(claz)), Seq.empty)
 
   private def getColumns(clazzDefinition: ClazzDefinition): ColumnModel = {
     val columns = for {
@@ -26,10 +26,12 @@ private[columnmodel] object TypedClassColumnModel {
     ColumnModel(columns.toList)
   }
 
-  class CreateColumnClassExtractionPredicate(claz: Class[_]) extends ClassMemberPredicate {
-    private val declaredFieldsNames = claz.getDeclaredFields.toList.map(_.getName)
+  class CreateColumnClassExtractionPredicate(clazzDeclaringFields: Class[_]) extends ClassMemberPredicate {
+    private val declaredFieldsNames = clazzDeclaringFields.getDeclaredFields.toList.map(_.getName)
 
-    override def matches(member: Member): Boolean = {
+    override def matchesClass(clazz: Class[_]): Boolean = true
+
+    override def matchesMember(member: Member): Boolean = {
       !declaredFieldsNames.contains(member.getName)
     }
   }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/EspTypeUtils.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/EspTypeUtils.scala
@@ -1,13 +1,11 @@
 package pl.touk.nussknacker.engine.types
 
-import java.lang.reflect
 import java.lang.reflect._
 
-import cats.Eval
 import cats.data.StateT
 import cats.effect.IO
 import org.apache.commons.lang3.{ClassUtils, StringUtils}
-import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
+import pl.touk.nussknacker.engine.api.process.{ClassExtractionSettings, VisibleMembersPredicate}
 import pl.touk.nussknacker.engine.api.typed.ClazzRef
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
 import pl.touk.nussknacker.engine.api.{Documentation, Hidden, HideToString, ParamName}
@@ -17,14 +15,6 @@ import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
 import scala.concurrent.Future
 
 object EspTypeUtils {
-
-  private val blacklistedMethods: Set[String] = {
-    (methodNames(classOf[ScalaCaseClassStub.DumpCaseClass]) ++
-      methodNames(ScalaCaseClassStub.DumpCaseClass.getClass)).toSet.filterNot(
-      //sometimes toString can be pretty useful...
-      List("toString").contains
-    )
-  }
 
   def clazzDefinition(clazz: Class[_])
                      (implicit settings: ClassExtractionSettings): ClazzDefinition =
@@ -65,30 +55,35 @@ object EspTypeUtils {
 
   private def getPublicMethodAndFields(clazz: Class[_])
                                       (implicit settings: ClassExtractionSettings): Map[String, MethodInfo] = {
-    val methods = publicMethods(clazz)
-    val fields = publicFields(clazz)
-    methods ++ fields
+    val membersPredicate = settings.visibleMembersPredicate(clazz)
+    val methods = publicMethods(clazz, membersPredicate)
+    val fields = publicFields(clazz, membersPredicate)
+    val methodsAndFields = methods ++ fields
+    // we not support arrays for now - will looks ugly in UI, so we need to hide it
+    methodsAndFields.filterNot(_._2.refClazz.clazz.isArray)
   }
 
-  private def publicMethods(clazz: Class[_])
+  private def publicMethods(clazz: Class[_], membersPredicate: VisibleMembersPredicate)
                            (implicit settings: ClassExtractionSettings): Map[String, MethodInfo] = {
     val shouldHideToString = classOf[HideToString].isAssignableFrom(clazz)
 
     /* From getMethods javadoc: If this {@code Class} object represents an interface then the returned array
-       does not contain any implicitly declared methods from {@code Object}.
-       The same for primitives - we assume that languages like SpEL will be able to do boxing
-       It could be significant only for toString, as we filter out other Object methods, but to be consistent...
-     */
-    val publicMethods = clazz.getMethods.toList ++ (if (clazz.isInterface || clazz.isPrimitive) classOf[Object].getMethods.toList else List.empty)
+           does not contain any implicitly declared methods from {@code Object}.
+           The same for primitives - we assume that languages like SpEL will be able to do boxing
+           It could be significant only for toString, as we filter out other Object methods, but to be consistent...
+         */
+    val additionalMethods = if (clazz.isInterface) {
+      classOf[Object].getMethods.toList
+    } else if (clazz.isPrimitive) {
+      ClassUtils.primitiveToWrapper(clazz).getMethods.toList
+    } else {
+      List.empty
+    }
+    val publicMethods = clazz.getMethods.toList ++ additionalMethods
 
     val filteredMethods = publicMethods
-      .filterNot(m => Modifier.isStatic(m.getModifiers))
-      .filter(_.getAnnotation(classOf[Hidden]) == null)
+      .filter(shouldBeVisible(membersPredicate))
       .filterNot(m => shouldHideToString && m.getName == "toString" && m.getParameterCount == 0)
-      .filterNot(settings.isBlacklisted)
-      .filter(m =>
-        !blacklistedMethods.contains(m.getName) && !m.getName.contains("$")
-      )
 
     val methodNameAndInfoList = filteredMethods.flatMap { method =>
       methodAccessMethods(method).map(_ -> toMethodInfo(method))
@@ -132,23 +127,25 @@ object EspTypeUtils {
     = MethodInfo(getParameters(method), getReturnClassForMethod(method), getNussknackerDocs(method))
 
   private def methodAccessMethods(method: Method): List[String] = {
-    val isGetter = (method.getName.startsWith("get") || method.getName.startsWith("is")) && method.getParameterCount == 0
+    val isGetter = (method.getName.matches("^(get|is).+")) && method.getParameterCount == 0
     if (isGetter)
       List(method.getName, StringUtils.uncapitalize(method.getName.replaceAll("^get|^is", ""))) else List(method.getName)
   }
 
-  private def publicFields(clazz: Class[_])
+  private def publicFields(clazz: Class[_], membersPredicate: VisibleMembersPredicate)
                           (implicit settings: ClassExtractionSettings): Map[String, MethodInfo] = {
-    val interestingFields = clazz.getFields
-      .filterNot(f => Modifier.isStatic(f.getModifiers))
-      .filter(_.getAnnotation(classOf[Hidden]) == null)
-      .filterNot(settings.isBlacklisted)
-      .filter(m =>
-        !m.getName.contains("$")
-      )
+    val interestingFields = clazz.getFields.filter(shouldBeVisible(membersPredicate))
     interestingFields.map { field =>
       field.getName -> MethodInfo(List.empty, getReturnClassForField(field), getNussknackerDocs(field))
     }.toMap
+  }
+
+  private def shouldBeVisible(membersPredicate: VisibleMembersPredicate)
+                             (m: AccessibleObject with Member): Boolean = {
+    !Modifier.isStatic(m.getModifiers) &&
+      m.getAnnotation(classOf[Hidden]) == null &&
+      !m.getName.contains("$") &&
+      membersPredicate.shouldBeVisible(m)
   }
 
   private def getReturnClassForMethod(method: Method): ClazzRef = {
@@ -207,14 +204,6 @@ object EspTypeUtils {
     } else if (classOf[scala.collection.Iterable[_]].isAssignableFrom(rawType)) {
       ClazzRef(rawType, paramsType.getActualTypeArguments.toList.flatMap(extractClass))
     } else ClazzRef(rawType)
-  }
-
-  private object ScalaCaseClassStub {
-
-    case class DumpCaseClass()
-
-    object DumpCaseClass
-
   }
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/TypesInformationExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/TypesInformationExtractor.scala
@@ -1,18 +1,21 @@
 package pl.touk.nussknacker.engine.types
 
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.lang3.ClassUtils
 import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
 import pl.touk.nussknacker.engine.api.typed.ClazzRef
-import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypedDict, TypedObjectTypingResult, TypedTaggedValue, TypedUnion, TypingResult, Unknown}
-import pl.touk.nussknacker.engine.definition.TypeInfos.{ClazzDefinition, MethodInfo}
+import pl.touk.nussknacker.engine.api.typed.typing._
+import pl.touk.nussknacker.engine.definition.TypeInfos.{ClazzDefinition, MethodInfo, Parameter}
 import pl.touk.nussknacker.engine.types.EspTypeUtils.clazzDefinition
+import pl.touk.nussknacker.engine.util.logging.ExecutionTimeMeasuring
 import pl.touk.nussknacker.engine.variables.MetaVariables
 
-object TypesInformationExtractor {
+import scala.collection.mutable
+
+object TypesInformationExtractor extends LazyLogging with ExecutionTimeMeasuring {
 
   //TODO: this should be somewhere in utils??
   private val primitiveTypes : List[Class[_]] = List(
-    Void.TYPE,
     java.lang.Boolean.TYPE,
     java.lang.Integer.TYPE,
     java.lang.Long.TYPE,
@@ -23,7 +26,7 @@ object TypesInformationExtractor {
     java.lang.Character.TYPE
   )
 
-  //they can always appear...
+  // We have some types that can't be discovered based on model but can by provided using e.g. literals
   //TODO: what else should be here?
   private val mandatoryClasses = (Set(
     classOf[java.util.List[_]],
@@ -32,22 +35,17 @@ object TypesInformationExtractor {
     classOf[Number],
     classOf[String],
     classOf[MetaVariables]
-  ) ++ primitiveTypes ++ primitiveTypes.map(ClassUtils.primitiveToWrapper)).map(ClazzRef(_))
-
-  private val primitiveTypesSimpleNames = primitiveTypes.map(_.getName).toSet
-
-  private val baseClazzPackagePrefix = Set("java", "scala")
-
-  private val blacklistedClazzPackagePrefix = Set(
-    "scala.collection", "scala.Function", "scala.xml",
-    "javax.xml", "java.util",
-    "cats", "argonaut", "dispatch", "io.circe",
-    "org.apache.flink.api.common.typeinfo.TypeInformation"
-  )
+  ) ++
+    // Literals for primitive types are wrapped to boxed representations
+    primitiveTypes.map(ClassUtils.primitiveToWrapper)).map(ClazzRef(_))
 
   def clazzAndItsChildrenDefinition(clazzes: Iterable[TypingResult])
                                    (implicit settings: ClassExtractionSettings): Set[ClazzDefinition] = {
-    (clazzes.flatMap(clazzRefsFromTypingResult) ++ mandatoryClasses).flatMap(clazzAndItsChildrenDefinition(_, Set())).toSet
+    // It's a deep first traversal - to avoid SOF we use mutable collection. It won't be easy to implement it using immutable collections
+    val collectedSoFar = mutable.HashSet.empty[ClazzRef]
+    (clazzes.flatMap(clazzRefsFromTypingResult) ++ mandatoryClasses).flatMap { cl =>
+      clazzAndItsChildrenDefinition(cl)(collectedSoFar, DiscoveryPath(List(Clazz(cl))))
+    }.toSet
   }
 
   private def clazzRefsFromTypingResult(typingResult: TypingResult): Set[ClazzRef] = typingResult match {
@@ -62,40 +60,84 @@ object TypesInformationExtractor {
     case TypedTaggedValue(underlying, _) =>
       clazzRefsFromTypedClass(underlying.objType)
     case Unknown =>
-      Set()
+      Set.empty
   }
 
   private def clazzRefsFromTypedClass(typedClass: TypedClass): Set[ClazzRef]
     = typedClass.params.flatMap(clazzRefsFromTypingResult).toSet + ClazzRef(typedClass.klass)
 
-  private def clazzAndItsChildrenDefinition(clazzRef: ClazzRef, currentSet: Set[ClazzRef])
-                                   (implicit settings: ClassExtractionSettings): Set[ClazzDefinition] = {
-    val clazz = clazzRef.clazz
-    val newSet = currentSet + clazzRef
-
-    val ignoreClass = primitiveTypesSimpleNames.contains(clazzRef.refClazzName) || blacklistedClazzPackagePrefix.exists(clazzRef.refClazzName.startsWith)
-    val ignoreMethods = clazz.isPrimitive || baseClazzPackagePrefix.exists(clazz.getName.startsWith)
-
-    definitionsFromParameters(clazzRef, newSet) ++
-      (if (ignoreClass || ignoreMethods) Set() else definitionsFromMethods(clazzRef, newSet)) ++
-      (if (ignoreClass) Set() else Set(clazzDefinition(clazz)))
+  private def clazzAndItsChildrenDefinition(clazzRef: ClazzRef)
+                                           (collectedSoFar: mutable.Set[ClazzRef], path: DiscoveryPath)
+                                           (implicit settings: ClassExtractionSettings): Set[ClazzDefinition] = {
+    // we not support arrays for now - will looks ugly in UI, so we need to hide it
+    if (clazzRef.clazz.isArray || collectedSoFar.contains(clazzRef)) {
+      Set.empty
+    } else {
+      collectedSoFar += clazzRef
+      val definitionsForClass = if (settings.isBlacklisted(clazzRef.clazz)) {
+        Set.empty
+      } else {
+        val classDefinition = clazzDefinitionWithLogging(clazzRef.clazz)(path)
+        definitionsFromMethods(classDefinition)(collectedSoFar, path) + classDefinition
+      }
+      definitionsForClass ++ definitionsFromGenericParameters(clazzRef)(collectedSoFar, path)
+    }
   }
 
-  private def definitionsFromParameters(clazzRef: ClazzRef, currentSet: Set[ClazzRef])
-                                       (implicit settings: ClassExtractionSettings): Set[ClazzDefinition] = {
-    clazzRef.params.toSet.diff(currentSet)
-      .flatMap((k: ClazzRef) => clazzAndItsChildrenDefinition(k, currentSet))
+  private def definitionsFromGenericParameters(clazzRef: ClazzRef)
+                                              (collectedSoFar: mutable.Set[ClazzRef], path: DiscoveryPath)
+                                              (implicit settings: ClassExtractionSettings): Set[ClazzDefinition] = {
+    clazzRef.params.zipWithIndex.flatMap {
+      case (k, idx) => clazzAndItsChildrenDefinition(k)(collectedSoFar, path.pushSegment(GenericParameter(k, idx)))
+    }.toSet
   }
 
-  private def definitionsFromMethods(clazzRef: ClazzRef, currentSet: Set[ClazzRef])
-                                     (implicit settings: ClassExtractionSettings): Set[ClazzDefinition] = {
+  private def definitionsFromMethods(classDefinition: ClazzDefinition)
+                                    (collectedSoFar: mutable.Set[ClazzRef], path: DiscoveryPath)
+                                    (implicit settings: ClassExtractionSettings): Set[ClazzDefinition] = {
+    classDefinition.methods.values.flatMap { kl =>
+      clazzAndItsChildrenDefinition(kl.refClazz)(collectedSoFar, path.pushSegment(MethodReturnType(kl)))
+      // TODO verify if parameters are need and if they are not, remove this
+//        ++ kl.parameters.flatMap(p => clazzAndItsChildrenDefinition(p.refClazz)(collectedSoFar, path.pushSegment(MethodParameter(p))))
+    }.toSet
+  }
 
-    clazzDefinition(clazzRef.clazz).methods.values.toSet
-            .flatMap((kl: MethodInfo) => kl.refClazz +: kl.parameters.map(_.refClazz))
-            .diff(currentSet)
-            .filterNot(m => m.refClazzName.startsWith("["))
-            .flatMap(m => clazzAndItsChildrenDefinition(m, currentSet))
+  private def clazzDefinitionWithLogging(clazz: Class[_])
+                                        (path: DiscoveryPath)
+                                        (implicit settings: ClassExtractionSettings) = {
+    def message = if (logger.underlying.isTraceEnabled) path.print else clazz.getName
+    measure(message) {
+      clazzDefinition(clazz)
+    }
+  }
 
+  private case class DiscoveryPath(path: List[DiscoverySegment]) {
+    def pushSegment(seg: DiscoverySegment): DiscoveryPath = DiscoveryPath(seg :: path)
+    def print: String = {
+      path.reverse.map(_.print).mkString(" > ")
+    }
+  }
+
+  private sealed trait DiscoverySegment {
+    def print: String
+    protected def classNameWithStrippedPackages(cl: ClazzRef): String =
+      cl.refClazzName.replaceAll("(.).*?\\.", "$1.")
+  }
+
+  private case class Clazz(cl: ClazzRef) extends DiscoverySegment {
+    override def print: String = classNameWithStrippedPackages(cl)
+  }
+
+  private case class GenericParameter(cl: ClazzRef, ix: Int) extends DiscoverySegment {
+    override def print: String = s"[$ix]${classNameWithStrippedPackages(cl)}"
+  }
+
+  private case class MethodReturnType(m: MethodInfo) extends DiscoverySegment {
+    override def print: String = s"ret(${classNameWithStrippedPackages(m.refClazz)})"
+  }
+
+  private case class MethodParameter(p: Parameter) extends DiscoverySegment {
+    override def print: String = s"${p.name}: ${classNameWithStrippedPackages(p.refClazz)}"
   }
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/TypesInformationExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/TypesInformationExtractor.scala
@@ -74,7 +74,7 @@ object TypesInformationExtractor extends LazyLogging with ExecutionTimeMeasuring
       Set.empty
     } else {
       collectedSoFar += clazzRef
-      val definitionsForClass = if (settings.isBlacklisted(clazzRef.clazz)) {
+      val definitionsForClass = if (settings.isHidden(clazzRef.clazz)) {
         Set.empty
       } else {
         val classDefinition = clazzDefinitionWithLogging(clazzRef.clazz)(path)

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -430,6 +430,16 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
     parse[String]("#input.ala", ctxWithMap) shouldNot be ('valid)
   }
 
+  test("be able to convert between primitive types") {
+    val ctxWithMap = ValidationContext
+      .empty
+      .withVariable("input", TypedObjectTypingResult(Map("int" -> Typed[Int]))).toOption.get
+
+    val ctx = Context("").withVariable("input", TypedMap(Map("int" -> 1)))
+
+    parseOrFail[Long]("#input.int.longValue", ctxWithMap).evaluateSyncToValue[Long](ctx) shouldBe 1L
+  }
+
   test("evaluate parsed map") {
     val valCtxWithMap = ValidationContext
       .empty

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/sql/columnmodel/TypedClassColumnModelTest.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/sql/columnmodel/TypedClassColumnModelTest.scala
@@ -46,12 +46,12 @@ class CreateColumnClassExtractionPredicateTest extends FunSuite with Matchers {
 
   def shouldMatchPredicate(member: Member): Unit =
     test(s"member ${member.getName} should match predicate") {
-      predicate.matches(member) shouldBe true
+      predicate.matchesMember(member) shouldBe true
     }
 
   def shouldNotMatchPredicate(member: Member): Unit =
     test(s"member ${member.getName} should not match predicate") {
-      predicate.matches(member) shouldBe false
+      predicate.matchesMember(member) shouldBe false
     }
 
   shouldNotMatchPredicate(ownField)

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
@@ -240,8 +240,21 @@ class EspTypeUtilsSpec extends FunSuite with Matchers with OptionValues {
     scalaOptionDef.methods.get("contains") shouldBe defined
   }
 
+  test("should hide some ugly presented methods") {
+    val classDef = singleClassDefinition[ClassWithWeirdTypesInMethods].value
+    classDef.methods.get("methodReturningArray") shouldBe empty
+    classDef.methods.get("methodWithDollar$") shouldBe empty
+    classDef.methods.get("normalMethod") shouldBe defined
+  }
+
   class EmptyClass {
     def invoke(): Unit = ???
+  }
+
+  class ClassWithWeirdTypesInMethods {
+    def methodReturningArray: Array[Int] = ???
+    def methodWithDollar$: String = ???
+    def normalMethod: String = ???
   }
 
   class ServiceWithMetaSpelParam {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
@@ -80,7 +80,7 @@ class EspTypeUtilsSpec extends FunSuite with Matchers with OptionValues {
     methods.get("toString").value shouldBe MethodInfo(List(), ClazzRef[String], None)
   }
 
-  test("should skip blacklisted properties") {
+  test("should skip hidden properties") {
     val testCasses = Table(("class", "className"),
       (Typed[SampleClass], "SampleClass"),
       (Typed[JavaSampleClass], "JavaSampleClass")
@@ -95,12 +95,12 @@ class EspTypeUtilsSpec extends FunSuite with Matchers with OptionValues {
     forAll(testCasses) { (clazz, clazzName) =>
       forAll(testClassPatterns) { classPattern =>
         val infos = clazzAndItsChildrenDefinition(List(clazz))(ClassExtractionSettings(
-          ClassExtractionSettings.DefaultBlacklistedClasses,
-          ClassExtractionSettings.DefaultBlacklistedMembers ++ Seq(
+          ClassExtractionSettings.DefaultExcludedClasses,
+          ClassExtractionSettings.DefaultExcludedMembers ++ Seq(
           ClassMemberPatternPredicate(SuperClassPatternPredicate(Pattern.compile(classPattern)), Pattern.compile("ba.*")),
           ClassMemberPatternPredicate(SuperClassPatternPredicate(Pattern.compile(classPattern)), Pattern.compile("get.*")),
           ClassMemberPatternPredicate(SuperClassPatternPredicate(Pattern.compile(classPattern)), Pattern.compile("is.*"))
-        ), ClassExtractionSettings.DefaultWhitelistedMembers))
+        ), ClassExtractionSettings.DefaultIncludedMembers))
         val sampleClassInfo = infos.find(_.clazzName.refClazzName.contains(clazzName)).get
 
         sampleClassInfo.methods shouldBe Map(
@@ -225,7 +225,7 @@ class EspTypeUtilsSpec extends FunSuite with Matchers with OptionValues {
     boxedIntDef shouldBe defined
   }
 
-  test("blacklisted by default classes") {
+  test("hidden by default classes") {
     val metaSpelDef = singleClassAndItsChildrenDefinition[ServiceWithMetaSpelParam]
     // These params are used programmable - user can't create instance of this type
     metaSpelDef.exists(_.clazzName.clazz == classOf[SpelExpressionRepr]) shouldBe false

--- a/engine/test-util/src/main/resources/logback-test.xml
+++ b/engine/test-util/src/main/resources/logback-test.xml
@@ -13,6 +13,8 @@
 
     <!-- let's keep here INFO - if it will produce too many logs, we should rather think if our INFO logs are too much verbose... -->
     <logger name="pl.touk.nussknacker" level="INFO"/>
+    <!-- types info extraction can have significant impact on deployment duration - uncomment this log if you want to measure it -->
+<!--    <logger name="pl.touk.nussknacker.engine.types.TypesInformationExtractor" level="TRACE"/>-->
 
     <!-- we are declaring here loggers for libs that not in dependency of this module, but we are doing it for simplicity of logging configurations -->
     <!-- levels below can be sometimes duplicated in root level but let's keep them just in case if we want to change value for root logger -->

--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/logging/ExecutionTimeMeasuring.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/logging/ExecutionTimeMeasuring.scala
@@ -1,0 +1,15 @@
+package pl.touk.nussknacker.engine.util.logging
+
+import com.typesafe.scalalogging.LazyLogging
+
+trait ExecutionTimeMeasuring { self: LazyLogging =>
+
+  def measure[R](additionalMessage: => String)(block: => R): R = {
+    val t0 = System.nanoTime()
+    val result = block
+    val t1 = System.nanoTime()
+    logger.debug(s"Elapsed time during $additionalMessage: ${ (t1 - t0) / 1000 }ms")
+    result
+  }
+
+}


### PR DESCRIPTION
Steps to verify api result:
```
baseurl='TODO'
processingType='streaming'
curl -d '{}' -H 'content-type:application/json' $baseurl/api/processDefinitionData/$processingType?isSubprocess=false | jq -c '.processDefinition.typesInformation[] | { cl: .clazzName.refClazzName, m: .methods | keys }' | sort
```
Before change on dev it looks like:
[staging-before-change.json.txt](https://github.com/TouK/nussknacker/files/4113381/staging-before-change.json.txt)

After change:
[staging-after-change.json.txt](https://github.com/TouK/nussknacker/files/4113518/staging-after-change.json.txt)

Diff:
[staging-diff.json.txt](https://github.com/TouK/nussknacker/files/4113519/staging-diff.json.txt)

Main changes:
- filtering logic moved from deep internals to setting available to reconfigure in user-space logic
- unification of fields/methods extraction
- fixed double discovery of the same type not worked properly during traversal in-breadth
- fixed: was returned method with empty name when there is "get" or "is" method in class
- primitive types now have methods from boxed types (mainly converters)
- collection types have some useful methods (contains and so on)
- method parameters are not discovered now - only method's return type
- array types are filtered out everywhere (from types and methods discovery)
- logging: discovery tracing
- added some tests for default filtering configuration