### PR TITLE
Allow for setting documentation for process properties

### DIFF
--- a/nussknacker-dist/src/universal/conf/dev-application.conf
+++ b/nussknacker-dist/src/universal/conf/dev-application.conf
@@ -100,3 +100,9 @@ commentSettings: ${base.commentSettings}
 attachmentsPath: ${base.attachmentsPath}
 countsSettings: ${base.countsSettings}
 kibanaSettings: ${base.kibanaSettings}
+
+nodes: {
+  "$properties": {
+    docsUrl: "https://nussknacker.io/DesigningProcesses.html#global-process-properties"
+  }
+}

--- a/ui/client/common/ProcessUtils.js
+++ b/ui/client/common/ProcessUtils.js
@@ -185,8 +185,13 @@ class ProcessUtils {
   findNodeDefinitionIdOrType = (node) =>
     this.findNodeDefinitionId(node) || node.type || null
 
+  getNodeBaseTypeCamelCase = (node) => node.type && node.type.charAt(0).toLowerCase() + node.type.slice(1);
+
   findNodeConfigName = (node) => {
-    return this.findNodeDefinitionId(node) || (node.type && node.type.charAt(0).toLowerCase() + node.type.slice(1))
+    // First we try to find id of node (config for specific custom node by id).
+    // If it is falsy then we try to extract config name from node type (config for build-in components e.g. variable, join).
+    // If all above are falsy then it means that node is special process properties node without id and type.
+    return this.findNodeDefinitionId(node) || this.getNodeBaseTypeCamelCase(node) || "$properties"
   }
 
   humanReadableType = (refClazzOrName) => {


### PR DESCRIPTION
I haven't found any other node without id or type, so when it's empty then it's properties node, isn't it?
I prefixed properties with dollar sign, because it could be common to create own components with name properties.