### PR TITLE
Small cleanup of passing kafka properties - getting ready for java11

### DIFF
--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSinkFactory.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSinkFactory.scala
@@ -25,7 +25,7 @@ class KafkaSinkFactory(config: KafkaConfig,
 
   class KafkaSink(topic: String, serializationSchema: KafkaSerializationSchema[Any], clientId: String) extends FlinkSink with Serializable {
     override def toFlinkFunction: SinkFunction[Any] = {
-      PartitionByKeyFlinkKafkaProducer(config.kafkaAddress, topic, serializationSchema, clientId, config.kafkaProperties)
+      PartitionByKeyFlinkKafkaProducer(config, topic, serializationSchema, clientId)
     }
     override def testDataOutput: Option[Any => String] = Option(value =>
       new String(serializationSchema.serialize(value, System.currentTimeMillis()).value(), StandardCharsets.UTF_8))

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/PartitionByKeyFlinkKafkaProducer.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/PartitionByKeyFlinkKafkaProducer.scala
@@ -1,24 +1,21 @@
 package pl.touk.nussknacker.engine.kafka
 
-import java.util.{Optional, Properties}
+import java.util.Properties
 
 import org.apache.flink.streaming.connectors.kafka.{FlinkKafkaProducer, KafkaSerializationSchema}
-import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner
+import pl.touk.nussknacker.engine.kafka.KafkaEspUtils.withPropertiesFromConfig
 
 object PartitionByKeyFlinkKafkaProducer {
 
-  import scala.collection.JavaConverters._
-
-  def apply[T](kafkaAddress: String,
+  def apply[T](config: KafkaConfig,
                topic: String,
                serializationSchema: KafkaSerializationSchema[T],
                clientId: String,
-               kafkaProperties: Option[Map[String, String]] = None,
                semantic: FlinkKafkaProducer.Semantic = FlinkKafkaProducer.Semantic.AT_LEAST_ONCE): FlinkKafkaProducer[T] = {
     val props = new Properties()
-    props.setProperty("bootstrap.servers", kafkaAddress)
+    props.setProperty("bootstrap.servers", config.kafkaAddress)
     props.setProperty("client.id", clientId)
-    kafkaProperties.map(_.asJava).foreach(props.putAll)
+    withPropertiesFromConfig(props, config)
     new FlinkKafkaProducer[T](topic, serializationSchema, props, semantic)
   }
 

--- a/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaEspUtils.scala
+++ b/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaEspUtils.scala
@@ -56,8 +56,7 @@ object KafkaEspUtils extends LazyLogging {
     props.setProperty("bootstrap.servers", config.kafkaAddress)
     props.setProperty("auto.offset.reset", "earliest")
     groupId.foreach(props.setProperty("group.id", _))
-    config.kafkaProperties.map(_.asJava).foreach(props.putAll)
-    props
+    withPropertiesFromConfig(props, config)
   }
 
   def toProducerProperties(config: KafkaConfig, clientId: String): Properties = {
@@ -71,7 +70,11 @@ object KafkaEspUtils extends LazyLogging {
     props.setProperty("linger.ms", "1")
     props.setProperty("buffer.memory", "33554432")
     setClientId(props, clientId)
-    config.kafkaProperties.getOrElse(Map.empty).foreach { case (k, v) =>
+    withPropertiesFromConfig(props, config)
+  }
+
+  def withPropertiesFromConfig(props: Properties, kafkaConfig: KafkaConfig): Properties = {
+    kafkaConfig.kafkaProperties.getOrElse(Map.empty).foreach { case (k, v) =>
       props.setProperty(k, v)
     }
     props


### PR DESCRIPTION
We change
    props.putAll	
to 
   foreach(...props.setProperty)
because in Java11 there are some weird overloading problems with the former. The rest is just code rearrangement