### PR TITLE
[Perf] Extract TypeInformation only once and not in tests, backend etc.

### DIFF
--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/ModelData.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/ModelData.scala
@@ -2,14 +2,14 @@ package pl.touk.nussknacker.engine
 
 import java.net.URL
 
-import com.typesafe.config.{Config, ConfigFactory}
-import pl.touk.nussknacker.engine.api.dict.{DictRegistry, UiDictServices}
+import com.typesafe.config.Config
+import pl.touk.nussknacker.engine.api.dict.UiDictServices
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.process.ProcessConfigCreator
 import pl.touk.nussknacker.engine.compile.ProcessValidator
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectDefinition
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.ProcessDefinition
-import pl.touk.nussknacker.engine.definition.{ConfigCreatorSignalDispatcher, DefinitionExtractor, ProcessDefinitionExtractor}
+import pl.touk.nussknacker.engine.definition.{ConfigCreatorSignalDispatcher, DefinitionExtractor, ProcessDefinitionExtractor, TypeInfos}
 import pl.touk.nussknacker.engine.dict.DictServicesFactoryLoader
 import pl.touk.nussknacker.engine.migration.ProcessMigrations
 import pl.touk.nussknacker.engine.util.ThreadUtils
@@ -63,6 +63,8 @@ trait ModelData extends ConfigCreatorSignalDispatcher {
     }
 
   lazy val processDefinition: ProcessDefinition[ObjectDefinition] = ProcessDefinitionExtractor.toObjectDefinition(processWithObjectsDefinition)
+
+  lazy val typeDefinitions: Set[TypeInfos.ClazzDefinition] = ProcessDefinitionExtractor.extractTypes(processWithObjectsDefinition)
 
   // We can create dict services here because ModelData is fat object that is created once on start
   lazy val dictServices: UiDictServices =

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
@@ -129,15 +129,9 @@ object DefinitionExtractor {
   }
 
   object TypesInformation {
-    def extract(services: Iterable[ObjectWithMethodDef],
-                sourceFactories: Iterable[ObjectWithMethodDef],
-                customNodeTransformers: Iterable[ObjectWithMethodDef],
-                signalsFactories: Iterable[ObjectWithMethodDef],
-                globalProcessVariables: Iterable[TypingResult])
+    def extract(objectToExtractClassesFrom: Iterable[ObjectWithMethodDef])
                (implicit settings: ClassExtractionSettings): Set[TypeInfos.ClazzDefinition] = {
-
-      val objectToExtractClassesFrom = services ++ customNodeTransformers ++ sourceFactories ++ signalsFactories
-      val classesToExtractDefinitions = globalProcessVariables ++ objectToExtractClassesFrom.flatMap(extractTypesFromObjectDefinition)
+      val classesToExtractDefinitions = objectToExtractClassesFrom.flatMap(extractTypesFromObjectDefinition)
       TypesInformationExtractor.clazzAndItsChildrenDefinition(classesToExtractDefinitions)
     }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractor.scala
@@ -3,16 +3,25 @@ package pl.touk.nussknacker.engine.definition
 import com.typesafe.config.{Config, ConfigRenderOptions}
 import pl.touk.nussknacker.engine.api.definition.ParameterEditor
 import pl.touk.nussknacker.engine.api.dict.DictDefinition
-import pl.touk.nussknacker.engine.api.process.{LanguageConfiguration, ProcessConfigCreator, SingleNodeConfig, SinkFactory}
+import pl.touk.nussknacker.engine.api.process.{ClassExtractionSettings, LanguageConfiguration, ProcessConfigCreator, SingleNodeConfig, SinkFactory}
 import pl.touk.nussknacker.engine.api.signal.SignalTransformer
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
 import pl.touk.nussknacker.engine.api.{CirceUtil, CustomStreamTransformer, QueryableStateNames}
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor._
 import pl.touk.nussknacker.engine.definition.MethodDefinitionExtractor.{MethodDefinition, OrderedDependencies}
-import pl.touk.nussknacker.engine.definition.TypeInfos.ClazzDefinition
 import shapeless.syntax.typeable._
                  
 object ProcessDefinitionExtractor {
+
+  //we don't do it inside extractObjectWithMethods because this is needed only on FE, and can be a bit costly
+  def extractTypes(definition: ProcessDefinition[ObjectWithMethodDef]): Set[TypeInfos.ClazzDefinition] = {
+    TypesInformation.extract(definition.services.values ++
+      definition.sourceFactories.values ++
+      definition.customStreamTransformers.values.map(_._1) ++
+      definition.signalsWithTransformers.values.map(_._1) ++
+      definition.expressionConfig.globalVariables.values
+    )(definition.settings)
+  }
 
   import pl.touk.nussknacker.engine.util.Implicits._
   //TODO: move it to ProcessConfigCreator??
@@ -55,12 +64,8 @@ object ProcessDefinitionExtractor {
 
     val globalImportsDefs = expressionConfig.globalImports.map(_.value)
 
-    val typesInformation = TypesInformation.extract(servicesDefs.values,
-      sourceFactoriesDefs.values,
-      customStreamTransformersDefs.values,
-      signalsDefs.values.map(_._1),
-      globalVariablesDefs.values.map(_.methodDef.returnType)
-    )(creator.classExtractionSettings(config))
+    val settings = creator.classExtractionSettings(config)
+
 
     ProcessDefinition[ObjectWithMethodDef](
       servicesDefs, sourceFactoriesDefs,
@@ -72,7 +77,7 @@ object ProcessDefinitionExtractor {
         expressionConfig.optimizeCompilation,
         expressionConfig.strictTypeChecking,
         expressionConfig.dictionaries.mapValuesNow(_.value),
-        expressionConfig.hideMetaVariable), typesInformation)
+        expressionConfig.hideMetaVariable), settings)
   }
 
   def extractNodesConfig(processConfig: Config) : Map[String, SingleNodeConfig] = {
@@ -115,7 +120,7 @@ object ProcessDefinitionExtractor {
                                                     signalsWithTransformers: Map[String, (T, Set[TransformerId])],
                                                     exceptionHandlerFactory: T,
                                                     expressionConfig: ExpressionDefinition[T],
-                                                    typesInformation: Set[ClazzDefinition]) {
+                                                    settings: ClassExtractionSettings) {
     def componentIds: List[String] = {
       val ids = services.keys ++
         sourceFactories.keys ++
@@ -144,7 +149,7 @@ object ProcessDefinitionExtractor {
       definition.signalsWithTransformers.mapValuesNow(sign => (sign._1.objectDefinition, sign._2)),
       definition.exceptionHandlerFactory.objectDefinition,
       expressionDefinition,
-      definition.typesInformation
+      definition.settings
     )
   }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/testing/ProcessDefinitionBuilder.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/testing/ProcessDefinitionBuilder.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.engine.testing
 
 import pl.touk.nussknacker.engine.api.definition.Parameter
-import pl.touk.nussknacker.engine.api.process.LanguageConfiguration
+import pl.touk.nussknacker.engine.api.process.{ClassExtractionSettings, LanguageConfiguration}
 import pl.touk.nussknacker.engine.api.typed.ClazzRef
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.{ObjectDefinition, ObjectWithMethodDef}
@@ -16,7 +16,7 @@ object ProcessDefinitionBuilder {
   def empty: ProcessDefinition[ObjectDefinition] =
     ProcessDefinition(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, ObjectDefinition.noParam,
       ExpressionDefinition(Map.empty, List.empty, languages = LanguageConfiguration(List.empty),
-        optimizeCompilation = true, strictTypeChecking = true, dictionaries = Map.empty, hideMetaVariable = false), Set.empty)
+        optimizeCompilation = true, strictTypeChecking = true, dictionaries = Map.empty, hideMetaVariable = false), ClassExtractionSettings.Default)
 
   def withEmptyObjects(definition: ProcessDefinition[ObjectDefinition]): ProcessDefinition[ObjectWithMethodDef] = {
 
@@ -43,7 +43,7 @@ object ProcessDefinitionBuilder {
       definition.signalsWithTransformers.mapValuesNow(sign => (makeDummyDefinition(sign._1), sign._2)),
       makeDummyDefinition(definition.exceptionHandlerFactory),
       expressionDefinition,
-      definition.typesInformation
+      definition.settings
     )
   }
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -73,7 +73,7 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
       Map("processHelper" -> ObjectDefinition(List(), Typed(ClazzRef(ProcessHelper.getClass)), List("cat1"), SingleNodeConfig.zero)),
       List.empty, LanguageConfiguration.default, optimizeCompilation = false, strictTypeChecking = true, dictionaries = Map.empty, hideMetaVariable = false
     ),
-    TypesInformationExtractor.clazzAndItsChildrenDefinition(List(Typed[SampleEnricher], Typed[SimpleRecord], Typed(ProcessHelper.getClass)))(ClassExtractionSettings.Default)
+    ClassExtractionSettings.Default
   )
 
   test("validated with success") {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractorSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractorSpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.Future
 
 class ProcessDefinitionExtractorSpec extends FunSuite with Matchers {
 
-  val processDefinition =
+  private val processDefinition: ProcessDefinitionExtractor.ProcessDefinition[DefinitionExtractor.ObjectWithMethodDef] =
     ProcessDefinitionExtractor.extractObjectWithMethods(TestCreator, ConfigFactory.load())
 
   test("extract definitions") {
@@ -31,7 +31,8 @@ class ProcessDefinitionExtractorSpec extends FunSuite with Matchers {
   }
 
   test("extract type info from classes from additional variables") {
-    val classDefinition = processDefinition.typesInformation.find(_.clazzName.clazz == classOf[OnlyUsedInAdditionalVariable])
+    val types = ProcessDefinitionExtractor.extractTypes(processDefinition)
+    val classDefinition = types.find(_.clazzName.clazz == classOf[OnlyUsedInAdditionalVariable])
       classDefinition.map(_.methods.keys) shouldBe Some(Set("someField", "toString"))
   }
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjects.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjects.scala
@@ -13,9 +13,9 @@ import pl.touk.nussknacker.engine.api.{MetaData, definition}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectDefinition
-import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.ProcessDefinition
 import pl.touk.nussknacker.engine.definition.TypeInfos.ClazzDefinition
+import pl.touk.nussknacker.engine.definition.{ProcessDefinitionExtractor, TypeInfos}
 import pl.touk.nussknacker.engine.graph.evaluatedparam
 import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition.SubprocessParameter
 import pl.touk.nussknacker.engine.graph.node.{NodeData, SubprocessInputDefinition}
@@ -40,7 +40,7 @@ object UIProcessObjects {
 
     //FIXME: how to handle dynamic configuration of subprocesses??
     val subprocessInputs = fetchSubprocessInputs(subprocessesDetails, modelDataForType.modelClassLoader.classLoader, fixedNodesConfig)
-    val uiProcessDefinition: UIProcessDefinition = UIProcessDefinition(chosenProcessDefinition, subprocessInputs)
+    val uiProcessDefinition: UIProcessDefinition = UIProcessDefinition(chosenProcessDefinition, subprocessInputs, modelDataForType.typeDefinitions)
 
     val dynamicNodesConfig = uiProcessDefinition.allDefinitions.mapValues(_.nodeConfig)
 
@@ -150,7 +150,7 @@ object UIParameter {
 }
 
 object UIProcessDefinition {
-  def apply(processDefinition: ProcessDefinition[ObjectDefinition], subprocessInputs: Map[String, ObjectDefinition]): UIProcessDefinition = {
+  def apply(processDefinition: ProcessDefinition[ObjectDefinition], subprocessInputs: Map[String, ObjectDefinition], types: Set[TypeInfos.ClazzDefinition]): UIProcessDefinition = {
     val uiProcessDefinition = UIProcessDefinition(
       services = processDefinition.services.mapValues(UIObjectDefinition(_)),
       sourceFactories = processDefinition.sourceFactories.mapValues(UIObjectDefinition(_)),
@@ -160,7 +160,7 @@ object UIProcessDefinition {
       signalsWithTransformers = processDefinition.signalsWithTransformers.mapValues(e => UIObjectDefinition(e._1)),
       exceptionHandlerFactory = UIObjectDefinition(processDefinition.exceptionHandlerFactory),
       globalVariables = processDefinition.expressionConfig.globalVariables.mapValues(UIObjectDefinition(_)),
-      typesInformation = processDefinition.typesInformation
+      typesInformation = types
     )
     uiProcessDefinition
   }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparerSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparerSpec.scala
@@ -123,7 +123,7 @@ class DefinitionPreparerSpec extends FunSuite with Matchers with TestPermissions
                             processDefinition: ProcessDefinition[ObjectDefinition] = ProcessTestData.processDefinition): List[NodeGroup] = {
     // TODO: this is a copy paste from UIProcessObjects.prepareUIProcessObjects - should be refactored somehow
     val subprocessInputs = Map[String, ObjectDefinition]()
-    val uiProcessDefinition = UIProcessDefinition(processDefinition, subprocessInputs)
+    val uiProcessDefinition = UIProcessDefinition(processDefinition, subprocessInputs, Set.empty)
     val dynamicNodesConfig = uiProcessDefinition.allDefinitions.mapValues(_.nodeConfig)
     val nodesConfig = NodesConfigCombiner.combine(fixedNodesConfig.mapValues(v => SingleNodeConfig(None, None, None, Some(v))), dynamicNodesConfig)
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.ui.process.marshall
 import cats.data.NonEmptyList
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FunSuite, Matchers}
-import pl.touk.nussknacker.engine.api.process.LanguageConfiguration
+import pl.touk.nussknacker.engine.api.process.{ClassExtractionSettings, LanguageConfiguration}
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, Unknown}
 import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.build.GraphBuilder
@@ -37,7 +37,7 @@ class ProcessConverterSpec extends FunSuite with Matchers with TableDrivenProper
   val validation: ProcessValidation = {
     val processDefinition = ProcessDefinition[ObjectDefinition](Map("ref" -> ObjectDefinition.noParam),
       Map("sourceRef" -> ObjectDefinition.noParam), Map(), Map(), Map(), ObjectDefinition.noParam,
-      ExpressionDefinition(Map.empty, List.empty, LanguageConfiguration.default, optimizeCompilation = false, strictTypeChecking = true, Map.empty, hideMetaVariable = false), Set.empty)
+      ExpressionDefinition(Map.empty, List.empty, LanguageConfiguration.default, optimizeCompilation = false, strictTypeChecking = true, Map.empty, hideMetaVariable = false), ClassExtractionSettings.Default)
     val validator =  ProcessValidator.default(ProcessDefinitionBuilder.withEmptyObjects(processDefinition), new SimpleDictRegistry(Map.empty))
     new ProcessValidation(Map(TestProcessingTypes.Streaming -> validator), Map(TestProcessingTypes.Streaming -> Map()), sampleResolver, Map.empty)
   }


### PR DESCRIPTION
Currently we extract type information each time we create ProcessDefinition - this e.g. includes tests, process runtime etc - while we need it only on UI. This operation can be a bit costly (performance-wise) so we move it to be peformed only when needed