### PR TITLE
Fix: fetching lastAction for process

### DIFF
--- a/ui/client/components/ProcessHistory.tsx
+++ b/ui/client/components/ProcessHistory.tsx
@@ -61,7 +61,7 @@ export class ProcessHistoryComponent extends React.Component<Props, State> {
     return (
       <Scrollbars renderTrackHorizontal={() => <div className="hide"/>} autoHeight autoHeightMax={300} hideTracksWhenNotNeeded={true}>
         <ul id="process-history">
-          {history.map ((version: ProcessVersionType, index: number) => {
+          {history.map((version: ProcessVersionType, index: number) => {
             return (
               <li key={index} className={this.processVersionOnTimeline(version, index)} onClick={this.onChangeProcessVersion(version)}>
                 {`v${version.processVersionId}`} | {version.user}


### PR DESCRIPTION
- Refactor old deployAction namespace to action
- Most important think is change sortBy place at fetchProcessLatestActionsQuery


Example query before:
```
select * from (select * where "process_id" = 20 order by "performed_at" desc) x2 left outer join "process_comments" x10 on x2.x8 = x10."id"
```

Example query after:
```
select * from (select * where "process_id" = 2) x2 left outer join "process_comments" x10 on x2.x8 = x10."id" order by x2.x6 desc
```