### PR TITLE
[FIX] pass exceptions from collector.collect in sync interpretation

### DIFF
--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/FlinkProcessRegistrar.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/FlinkProcessRegistrar.scala
@@ -65,7 +65,7 @@ object FlinkProcessRegistrar {
         case NonFatal(error) => Right(EspExceptionInfo(None, error, input))
       }) match {
         case Left(ir) =>
-          exceptionHandler.handling(None, input)(ir.foreach(collector.collect))
+          ir.foreach(collector.collect)
         case Right(info) =>
           exceptionHandler.handle(info)
       }


### PR DESCRIPTION
We should not handle internal Flink exception thrown from collector.collect - sometimes this can prevent process from cancelling/failing