### PR TITLE
fix overriding ClassExtractionSettings

### DIFF
--- a/engine/flink/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/AvroSchemaSpelExpressionSpec.scala
+++ b/engine/flink/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/AvroSchemaSpelExpressionSpec.scala
@@ -9,6 +9,7 @@ import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
 import pl.touk.nussknacker.engine.avro.typed.AvroSchemaTypeDefinitionExtractor
 import pl.touk.nussknacker.engine.api.expression.{ExpressionParseError, TypedExpression}
+import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser.Standard
@@ -127,7 +128,7 @@ class AvroSchemaSpelExpressionSpec extends FunSpec with Matchers {
 
   private def parse[T:TypeTag](expr: String, validationCtx: ValidationContext) : ValidatedNel[ExpressionParseError, TypedExpression] = {
     SpelExpressionParser.default(getClass.getClassLoader, new SimpleDictRegistry(Map.empty), enableSpelForceCompile = true,
-      strictTypeChecking = true, Nil, Standard, strictMethodsChecking = true).parse(expr, validationCtx, Typed.fromDetailedType[T])
+      strictTypeChecking = true, Nil, Standard, strictMethodsChecking = true)(ClassExtractionSettings.Default).parse(expr, validationCtx, Typed.fromDetailedType[T])
   }
 
   private def wrapWithRecordSchema(fieldsDefinition: String) =

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompiledProcess.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompiledProcess.scala
@@ -29,9 +29,9 @@ object CompiledProcess {
     val dictRegistryFactory = loadDictRegistry(userCodeClassLoader)
     val dictRegistry = dictRegistryFactory.createEngineDictRegistry(definitions.expressionConfig.dictionaries)
 
-    val expressionCompiler = ExpressionCompiler.withOptimization(userCodeClassLoader, dictRegistry, definitions.expressionConfig)
+    val expressionCompiler = ExpressionCompiler.withOptimization(userCodeClassLoader, dictRegistry, definitions.expressionConfig, definitions.settings)
     // TODO: rethink if optimization for object's parameters is still a problem here because maybe we can use just ProcessCompiler.apply
-    val objectParametersExpressionCompiler = ExpressionCompiler.withoutOptimization(userCodeClassLoader, dictRegistry, definitions.expressionConfig)
+    val objectParametersExpressionCompiler = ExpressionCompiler.withoutOptimization(userCodeClassLoader, dictRegistry, definitions.expressionConfig, definitions.settings)
     //for testing environment it's important to take classloader from user jar
     val subCompiler = new PartSubGraphCompiler(userCodeClassLoader, expressionCompiler, definitions.expressionConfig, servicesDefs)
     val processCompiler = new ProcessCompiler(userCodeClassLoader, subCompiler, definitions, objectParametersExpressionCompiler)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
@@ -8,6 +8,7 @@ import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, Pro
 import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.dict.DictRegistry
 import pl.touk.nussknacker.engine.api.expression.{Expression, ExpressionParser, TypedExpression, TypedExpressionMap}
+import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
 import pl.touk.nussknacker.engine.api.typed.typing.{TypingResult, Unknown}
 import pl.touk.nussknacker.engine.compiledgraph.evaluatedparam.TypedParameter
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectMetadata
@@ -21,16 +22,17 @@ import pl.touk.nussknacker.engine.{compiledgraph, graph}
 
 object ExpressionCompiler {
 
-  def withOptimization(loader: ClassLoader, dictRegistry: DictRegistry, expressionConfig: ExpressionDefinition[ObjectMetadata]): ExpressionCompiler
-    = default(loader, dictRegistry, expressionConfig, expressionConfig.optimizeCompilation)
+  def withOptimization(loader: ClassLoader, dictRegistry: DictRegistry, expressionConfig: ExpressionDefinition[ObjectMetadata], settings: ClassExtractionSettings): ExpressionCompiler
+    = default(loader, dictRegistry, expressionConfig, expressionConfig.optimizeCompilation, settings)
 
-  def withoutOptimization(loader: ClassLoader, dictRegistry: DictRegistry, expressionConfig: ExpressionDefinition[ObjectMetadata]): ExpressionCompiler
-      = default(loader, dictRegistry, expressionConfig, optimizeCompilation = false)
+  def withoutOptimization(loader: ClassLoader, dictRegistry: DictRegistry, expressionConfig: ExpressionDefinition[ObjectMetadata], settings: ClassExtractionSettings): ExpressionCompiler
+      = default(loader, dictRegistry, expressionConfig, optimizeCompilation = false, settings)
 
-  private def default(loader: ClassLoader, dictRegistry: DictRegistry, expressionConfig: ExpressionDefinition[ObjectMetadata], optimizeCompilation: Boolean): ExpressionCompiler = {
+  private def default(loader: ClassLoader, dictRegistry: DictRegistry, expressionConfig: ExpressionDefinition[ObjectMetadata],
+                      optimizeCompilation: Boolean, settings: ClassExtractionSettings): ExpressionCompiler = {
     val defaultParsers = Seq(
-      SpelExpressionParser.default(loader, dictRegistry, optimizeCompilation, expressionConfig.strictTypeChecking, expressionConfig.globalImports, SpelExpressionParser.Standard, expressionConfig.strictMethodsChecking),
-      SpelExpressionParser.default(loader, dictRegistry, optimizeCompilation, expressionConfig.strictTypeChecking, expressionConfig.globalImports, SpelExpressionParser.Template, expressionConfig.strictMethodsChecking),
+      SpelExpressionParser.default(loader, dictRegistry, optimizeCompilation, expressionConfig.strictTypeChecking, expressionConfig.globalImports, SpelExpressionParser.Standard, expressionConfig.strictMethodsChecking)(settings),
+      SpelExpressionParser.default(loader, dictRegistry, optimizeCompilation, expressionConfig.strictTypeChecking, expressionConfig.globalImports, SpelExpressionParser.Template, expressionConfig.strictMethodsChecking)(settings),
       SqlExpressionParser)
     val parsersSeq = defaultParsers  ++ expressionConfig.languages.expressionParsers
     val parsers = parsersSeq.map(p => p.languageId -> p).toMap

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
@@ -436,8 +436,8 @@ object ProcessCompiler {
   def apply(classLoader: ClassLoader,
             definitions: ProcessDefinition[ObjectWithMethodDef],
             dictRegistry: DictRegistry,
-            expressionCompilerCreate: (ClassLoader, DictRegistry, ExpressionDefinition[ObjectWithMethodDef]) => ExpressionCompiler): ProcessCompiler = {
-    val expressionCompiler = expressionCompilerCreate(classLoader, dictRegistry, definitions.expressionConfig)
+            expressionCompilerCreate: (ClassLoader, DictRegistry, ExpressionDefinition[ObjectWithMethodDef], ClassExtractionSettings) => ExpressionCompiler): ProcessCompiler = {
+    val expressionCompiler = expressionCompilerCreate(classLoader, dictRegistry, definitions.expressionConfig, definitions.settings)
     val sub = new PartSubGraphCompiler(classLoader, expressionCompiler, definitions.expressionConfig, definitions.services)
     new ProcessCompiler(classLoader, sub, definitions, expressionCompiler)
   }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/TestInfoProvider.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/TestInfoProvider.scala
@@ -32,7 +32,8 @@ class ModelDataTestInfoProvider(modelData: ModelData) extends TestInfoProvider {
 
   private lazy val expressionCompiler = ExpressionCompiler.withoutOptimization(modelData.modelClassLoader.classLoader,
     modelData.dictServices.dictRegistry,
-    modelData.processDefinition.expressionConfig)
+    modelData.processDefinition.expressionConfig,
+    modelData.processDefinition.settings)
 
   private lazy val factory = new ProcessObjectFactory(evaluator)
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
@@ -24,6 +24,7 @@ import pl.touk.nussknacker.engine.api.dict.{DictInstance, DictRegistry}
 import pl.touk.nussknacker.engine.api.exception.NonTransientException
 import pl.touk.nussknacker.engine.api.expression.{ExpressionParseError, ExpressionParser, TypedExpression, ValueWithLazyContext}
 import pl.touk.nussknacker.engine.api.lazyy.{ContextWithLazyValuesProvider, LazyContext, LazyValuesProvider}
+import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
 import pl.touk.nussknacker.engine.api.typed.TypedMap
 import pl.touk.nussknacker.engine.api.typed.supertype.{CommonSupertypeFinder, SupertypeClassResolutionStrategy}
 import pl.touk.nussknacker.engine.api.typed.typing.{SingleTypingResult, TypedClass, TypingResult, Unknown}
@@ -223,7 +224,8 @@ object SpelExpressionParser extends LazyLogging {
               strictTypeChecking: Boolean,
               imports: List[String],
               flavour: Flavour,
-              strictMethodsChecking: Boolean): SpelExpressionParser = {
+              strictMethodsChecking: Boolean)
+             (implicit classExtractionSettings: ClassExtractionSettings): SpelExpressionParser = {
     val functions = Map(
       "today" -> classOf[LocalDate].getDeclaredMethod("now"),
       "now" -> classOf[LocalDateTime].getDeclaredMethod("now"),

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -28,7 +28,7 @@ import pl.touk.nussknacker.engine.types.EspTypeUtils
 import scala.reflect.runtime._
 
 private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: CommonSupertypeFinder,
-                          dictTyper: SpelDictTyper, strictMethodsChecking: Boolean) extends LazyLogging {
+                          dictTyper: SpelDictTyper, strictMethodsChecking: Boolean)(implicit settings: ClassExtractionSettings) extends LazyLogging {
 
   import ast.SpelAst._
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.definition.TypeInfos.{ClazzDefinition, MethodI
 import pl.touk.nussknacker.engine.types.EspTypeUtils
 
 object TypeMethodReference {
-  def apply(methodReference: MethodReference, currentResults: List[TypingResult]): Either[String, TypingResult] =
+  def apply(methodReference: MethodReference, currentResults: List[TypingResult])(implicit settings: ClassExtractionSettings): Either[String, TypingResult] =
     new TypeMethodReference(methodReference, currentResults).call
 }
 
@@ -17,7 +17,7 @@ object TypeMethodReference {
 // different arity, validation is successful when SpEL MethodReference provides the number of parameters greater
 // or equal to method with the smallest arity.
 class TypeMethodReference(methodReference: MethodReference, currentResults: List[TypingResult]) {
-  def call: Either[String, TypingResult] =
+  def call(implicit settings: ClassExtractionSettings): Either[String, TypingResult] =
     currentResults.headOption match {
       case Some(tc: SingleTypingResult) =>
         typeFromClazzDefinitions(extractClazzDefinitions(Set(tc)))
@@ -29,9 +29,9 @@ class TypeMethodReference(methodReference: MethodReference, currentResults: List
 
   private lazy val paramsCount = methodReference.getChildCount
 
-  private def extractClazzDefinitions(typedClasses: Set[SingleTypingResult]): List[ClazzDefinition] =
+  private def extractClazzDefinitions(typedClasses: Set[SingleTypingResult])(implicit settings: ClassExtractionSettings): List[ClazzDefinition] =
     typedClasses.map(typedClass =>
-      EspTypeUtils.clazzDefinition(typedClass.objType.klass)(ClassExtractionSettings.Default)
+      EspTypeUtils.clazzDefinition(typedClass.objType.klass)
     ).toList
 
   private def typeFromClazzDefinitions(clazzDefinitions: List[ClazzDefinition]): Either[String, TypingResult] =

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
@@ -68,6 +68,8 @@ object ExpressionServiceQuery {
     ExpressionCompiler.withoutOptimization(
       modelData.modelClassLoader.classLoader,
       modelData.dictServices.dictRegistry,
-      modelData.processDefinition.expressionConfig)
+      modelData.processDefinition.expressionConfig,
+      modelData.processDefinition.settings
+    )
   }
 }

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionGenSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionGenSpec.scala
@@ -11,6 +11,7 @@ import org.springframework.expression.spel.support.StandardEvaluationContext
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.expression.{ExpressionParseError, TypedExpression}
+import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypedUnion, Unknown}
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 
@@ -96,7 +97,7 @@ class SpelExpressionGenSpec extends FunSuite with ScalaCheckDrivenPropertyChecks
 
   private def validate(expr: String, a: Any, b: Any): ValidatedNel[ExpressionParseError, TypedExpression] = {
     val parser = SpelExpressionParser.default(getClass.getClassLoader, new SimpleDictRegistry(Map.empty), enableSpelForceCompile = false, strictTypeChecking = true,
-      List.empty, SpelExpressionParser.Standard, strictMethodsChecking = true)
+      List.empty, SpelExpressionParser.Standard, strictMethodsChecking = true)(ClassExtractionSettings.Default)
     implicit val nodeId: NodeId = NodeId("fooNode")
     val validationContext = ValidationContext.empty
       .withVariable("a", Typed.fromInstance(a)).toOption.get

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -106,7 +106,7 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
                                 flavour: Flavour, strictMethodsChecking: Boolean): ValidatedNel[ExpressionParseError, TypedExpression] = {
     val imports = List(SampleValue.getClass.getPackage.getName)
     SpelExpressionParser.default(getClass.getClassLoader, new SimpleDictRegistry(dictionaries), enableSpelForceCompile = true,
-      strictTypeChecking = true, imports, flavour, strictMethodsChecking = strictMethodsChecking).parse(expr, validationCtx, Typed.fromDetailedType[T])
+      strictTypeChecking = true, imports, flavour, strictMethodsChecking = strictMethodsChecking)(ClassExtractionSettings.Default).parse(expr, validationCtx, Typed.fromDetailedType[T])
   }
 
   test("invoke simple expression") {


### PR DESCRIPTION
There was hardcoded `ClassExtractionSettings.Default` in `TypeMethodReference` class, therefore it was not possible to provide own implementation