### PR TITLE
Subprocess output returning map variable

### DIFF
--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/FlinkStreamingProcessRegistrarKafkaSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/FlinkStreamingProcessRegistrarKafkaSpec.scala
@@ -10,7 +10,6 @@ import pl.touk.nussknacker.engine.build.GraphBuilder
 import pl.touk.nussknacker.engine.graph.EspProcess
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
 import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaSpec}
-import pl.touk.nussknacker.engine.process.helpers.ProcessTestHelpers
 import pl.touk.nussknacker.engine.process.helpers.SampleNodes.MockService
 import pl.touk.nussknacker.engine.spel
 import pl.touk.nussknacker.test.VeryPatientScalaFutures
@@ -47,7 +46,7 @@ class FlinkStreamingProcessRegistrarKafkaSpec
         .processorEnd("service", "logService", "all" -> "#input"))
     )
 
-    ProcessTestHelpers.processInvoker.invokeWithKafka(
+    helpers.ProcessTestHelpers.processInvoker.invokeWithKafka(
       process, KafkaConfig(kafkaZookeeperServer.kafkaAddress, None, None)
     ) {
       val keys = 10

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SubprocessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SubprocessSpec.scala
@@ -78,14 +78,14 @@ class SubprocessSpec extends FlatSpec with Matchers {
         canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "#param == 'a'"),
         List(canonicalnode.FlatNode(Sink("end1", SinkRef("monitor", List()), Some("'deadEnd'"))))
-      ), canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output"))), None)
+      ), canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))), None)
 
     val subprocessWithSplit = CanonicalProcess(MetaData("splitSubprocess", StreamMetaData()), null,
       List(
         canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
         canonicalnode.SplitNode(Split("split"), List(
           List(canonicalnode.FlatNode(Sink("end1", SinkRef("monitor", List())))),
-          List(canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output")))
+          List(canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output", List.empty)))
         ))
       ), None)
 
@@ -94,7 +94,7 @@ class SubprocessSpec extends FlatSpec with Matchers {
             canonicalnode.FlatNode(SubprocessInputDefinition("start", List())),
             canonicalnode.FilterNode(Filter("f1", "#processHelper.constant == 4"),
             List()
-          ), canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output"))), None)
+          ), canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))), None)
 
     val resolved = SubprocessResolver(Set(subprocessWithSplit, subprocess, subprocessWithGlobalVar)).resolve(ProcessCanonizer.canonize(espProcess))
       .andThen(ProcessCanonizer.uncanonize)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/ProcessNodesRewriter.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/ProcessNodesRewriter.scala
@@ -144,7 +144,13 @@ trait ExpressionRewriter {
       case n: Source =>
         n.copy(
           ref = n.ref.copy(parameters = rewriteParameters(n.ref.parameters)))
-      case _: BranchEndData | _: Split | _: SubprocessInputDefinition | _: SubprocessOutputDefinition | _: SubprocessOutput => data
+      case n: SubprocessOutputDefinition =>
+        n.copy(
+          fields = rewriteFields(n.fields))
+      case n: SubprocessOutput =>
+        n.copy(
+          fields = rewriteFields(n.fields))
+      case _: BranchEndData | _: Split | _: SubprocessInputDefinition => data
     }
 
   private def rewriteFields(list: List[Field])(implicit metaData: MetaData, nodeId: NodeId): List[Field] =

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/SubprocessResolver.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/SubprocessResolver.scala
@@ -35,11 +35,11 @@ case class SubprocessResolver(subprocesses: Map[String, CanonicalProcess]) {
         val output = nextNodesMap.keys.head
         resolveCanonical(idPrefix)(nextNodesMap.values.head).map { resolvedNexts =>
           val outputId = s"${NodeDataFun.nodeIdPrefix(idPrefix)(data).id}-$output"
-          FlatNode(NodeDataFun.nodeIdPrefix(idPrefix)(data))::FlatNode(SubprocessOutput(outputId, output, None))::resolvedNexts
+          FlatNode(NodeDataFun.nodeIdPrefix(idPrefix)(data))::FlatNode(SubprocessOutput(outputId, output, List.empty, None))::resolvedNexts
         }
-      case canonicalnode.Subprocess(subprocessInput@SubprocessInput(dataId, _, _, isDisabled, _), nextNodes) =>
+      case canonicalnode.Subprocess(subprocessInput:SubprocessInput, nextNodes) =>
         subprocesses.get(subprocessInput.ref.id) match {
-          case Some(CanonicalProcess(MetaData(id, _, _, _, _), _, FlatNode(SubprocessInputDefinition(_, parameters, _))::nodes, additionalBranches)) =>
+          case Some(CanonicalProcess(_, _, FlatNode(SubprocessInputDefinition(_, parameters, _))::nodes, _)) =>
             checkProcessParameters(subprocessInput.ref, parameters.map(_.name), subprocessInput.id).andThen { _ =>
               val nextResolvedV = nextNodes.map { case (k, v) =>
                 resolveCanonical(idPrefix)(v).map((k, _))
@@ -65,8 +65,8 @@ case class SubprocessResolver(subprocesses: Map[String, CanonicalProcess]) {
   private def replaceCanonicalList(replacement: Map[String, List[CanonicalNode]]): List[CanonicalNode] => CompilationValid[List[CanonicalNode]] = {
 
     iterateOverCanonicals({
-      case FlatNode(SubprocessOutputDefinition(id, name, add)) => replacement.get(name) match {
-        case Some(nodes) => Valid(FlatNode(SubprocessOutput(id, name, add)) :: nodes)
+      case FlatNode(SubprocessOutputDefinition(id, name, fields, add)) => replacement.get(name) match {
+        case Some(nodes) => Valid(FlatNode(SubprocessOutput(id, name, fields, add)) :: nodes)
         case None => Invalid(NonEmptyList.of(UnknownSubprocessOutput(name, id)))
       }
     }, NodeDataFun.id)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/node.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/node.scala
@@ -41,7 +41,7 @@ object node {
 
   case class SubprocessStart(id: String, params: List[Parameter], next: Next) extends Node
 
-  case class SubprocessEnd(id: String, next: Next) extends Node
+  case class SubprocessEnd(id: String, varName: String, fields: List[Field], next: Next) extends Node
 
   case class SplitNode(id: String, nexts: List[Next]) extends Node
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
@@ -162,7 +162,7 @@ object node {
 
 
   //this is used after resolving subprocess, used for detecting when subprocess ends and context should change
-  case class SubprocessOutput(id: String, outputName: String, additionalFields: Option[UserDefinedAdditionalNodeFields] = None)
+  case class SubprocessOutput(id: String, varName: String, fields: List[Field], additionalFields: Option[UserDefinedAdditionalNodeFields] = None)
     extends OneOutputSubsequentNodeData
 
   //this is used only in subprocess definition
@@ -172,7 +172,7 @@ object node {
     extends SourceNodeData with RealNodeData
 
   //this is used only in subprocess definition
-  case class SubprocessOutputDefinition(id: String, outputName: String, additionalFields: Option[UserDefinedAdditionalNodeFields] = None)
+  case class SubprocessOutputDefinition(id: String, varName: String, fields: List[Field], additionalFields: Option[UserDefinedAdditionalNodeFields] = None)
     extends EndingNodeData with RealNodeData
 
   //we don't use DefinitionExtractor.Parameter here, because this class should be serializable to json and Parameter has TypedResult which has *real* class inside

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
@@ -162,7 +162,7 @@ object node {
 
 
   //this is used after resolving subprocess, used for detecting when subprocess ends and context should change
-  case class SubprocessOutput(id: String, varName: String, fields: List[Field], additionalFields: Option[UserDefinedAdditionalNodeFields] = None)
+  case class SubprocessOutput(id: String, outputName: String, fields: List[Field], additionalFields: Option[UserDefinedAdditionalNodeFields] = None)
     extends OneOutputSubsequentNodeData
 
   //this is used only in subprocess definition
@@ -172,7 +172,7 @@ object node {
     extends SourceNodeData with RealNodeData
 
   //this is used only in subprocess definition
-  case class SubprocessOutputDefinition(id: String, varName: String, fields: List[Field], additionalFields: Option[UserDefinedAdditionalNodeFields] = None)
+  case class SubprocessOutputDefinition(id: String, outputName: String, fields: List[Field] = List.empty, additionalFields: Option[UserDefinedAdditionalNodeFields] = None)
     extends EndingNodeData with RealNodeData
 
   //we don't use DefinitionExtractor.Parameter here, because this class should be serializable to json and Parameter has TypedResult which has *real* class inside

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/SubprocessResolverSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/SubprocessResolverSpec.scala
@@ -36,7 +36,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
     val subprocess =  CanonicalProcess(MetaData("subProcess1", StreamMetaData()), null,
       List(
         canonicalnode.FlatNode(SubprocessInputDefinition("start", suprocessParameters)),
-        canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "output"))) , None
+        canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))) , None
     )
 
     val resolvedValidated = SubprocessResolver(Set(subprocess)).resolve(process)
@@ -67,13 +67,13 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
         canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "#param == 'a'"),
         List(canonicalnode.FlatNode(Sink("deadEnd", SinkRef("sink1", List()), Some("'deadEnd'"))))
-      ), canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output"))), None)
+      ), canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))), None)
 
     val nested =  CanonicalProcess(MetaData("subProcess1", StreamMetaData()), null,
       List(
         canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
         canonicalnode.Subprocess(SubprocessInput("sub2",
-        SubprocessRef("subProcess2", List(Parameter("param", "#param")))), Map("output" -> List(FlatNode(SubprocessOutputDefinition("sub2Out", "output")))))), None
+        SubprocessRef("subProcess2", List(Parameter("param", "#param")))), Map("output" -> List(FlatNode(SubprocessOutputDefinition("sub2Out", "output", List.empty)))))), None
     )
 
     val resolvedValidated = SubprocessResolver(Set(subprocess, nested)).resolve(process)
@@ -103,7 +103,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
     val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData()), null,
       List(
         canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
-        canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "output"))), None
+        canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))), None
     )
 
     val resolvedValidated = SubprocessResolver(Set(subprocess)).resolve(process)
@@ -124,7 +124,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
       null,
       List(
         canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
-        canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "badoutput"))), None
+        canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "badoutput", List.empty))), None
     )
 
     val resolvedValidated = SubprocessResolver(Set(subprocess)).resolve(process)
@@ -151,8 +151,8 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
         canonicalnode.FilterNode(Filter("f1", "false"), List()),
         canonicalnode.SplitNode(
           Split("s"), List(
-            List(FlatNode(SubprocessOutputDefinition("out1", "output"))),
-            List(FlatNode(SubprocessOutputDefinition("out2", "output")))
+            List(FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))),
+            List(FlatNode(SubprocessOutputDefinition("out2", "output", List.empty)))
           )
         )
       ), None
@@ -206,7 +206,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
       List(
         canonicalnode.FlatNode(
           SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
-        FlatNode(SubprocessOutputDefinition("out1", "output"))
+        FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))
       ), None
     )
     val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData(), isSubprocess = true),
@@ -215,7 +215,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
         canonicalnode.FlatNode(
           SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "false"), List()),
-        FlatNode(SubprocessOutputDefinition("out1", "output"))
+        FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))
       ), None
     )
     val resolver = SubprocessResolver(Set(subprocess, emptySubprocess))
@@ -232,7 +232,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
           case e => fail(e.toString)
         }
         flatNodes(2) match {
-          case FlatNode(SubprocessOutput(_, _, _)) =>
+          case FlatNode(SubprocessOutput(_, _, _, _)) =>
             // output id is unpredictable
           case e => fail(e.toString)
         }

--- a/ui/client/components/graph/node-modal/MapVariable.js
+++ b/ui/client/components/graph/node-modal/MapVariable.js
@@ -7,7 +7,7 @@ import LabeledInput from "./editors/field/LabeledInput"
 import LabeledTextarea from "./editors/field/LabeledTextarea"
 import Map from "./editors/map/Map"
 
-const MapVariable = ({isMarked, node, removeElement, addElement, onChange, readOnly, showValidation, errors, renderFieldLabel, varNameLabel}) => {
+const MapVariable = ({isMarked, node, removeElement, addElement, onChange, readOnly, showValidation, errors, renderFieldLabel}) => {
 
   const addField = () => {
     addElement("fields", {name: "", uuid: uuid4(), expression: {expression: "", language: "spel"}})
@@ -25,7 +25,7 @@ const MapVariable = ({isMarked, node, removeElement, addElement, onChange, readO
                     showValidation={showValidation}
                     validators={[mandatoryValueValidator, errorValidator(errors, "id")]}/>
 
-      <LabeledInput renderFieldLabel={() => renderFieldLabel(varNameLabel)}
+      <LabeledInput renderFieldLabel={() => renderFieldLabel("Variable Name")}
                     value={node.varName}
                     onChange={(event) => onInputChange("varName", event)}
                     isMarked={isMarked("varName")}
@@ -64,8 +64,7 @@ MapVariable.propTypes = {
   readOnly: PropTypes.bool,
   showValidation: PropTypes.bool.isRequired,
   errors: PropTypes.array.isRequired,
-  renderFieldLabel: PropTypes.func.isRequired,
-  varNameLabel: PropTypes.string.isRequired
+  renderFieldLabel: PropTypes.func.isRequired
 }
 
 MapVariable.defaultProps = {

--- a/ui/client/components/graph/node-modal/MapVariable.js
+++ b/ui/client/components/graph/node-modal/MapVariable.js
@@ -7,9 +7,7 @@ import LabeledInput from "./editors/field/LabeledInput"
 import LabeledTextarea from "./editors/field/LabeledTextarea"
 import Map from "./editors/map/Map"
 
-const MapVariable = (props) => {
-
-  const {isMarked, node, removeElement, addElement, onChange, readOnly, showValidation, errors, renderFieldLabel} = props
+const MapVariable = ({isMarked, node, removeElement, addElement, onChange, readOnly, showValidation, errors, renderFieldLabel, varNameLabel}) => {
 
   const addField = () => {
     addElement("fields", {name: "", uuid: uuid4(), expression: {expression: "", language: "spel"}})
@@ -27,7 +25,7 @@ const MapVariable = (props) => {
                     showValidation={showValidation}
                     validators={[mandatoryValueValidator, errorValidator(errors, "id")]}/>
 
-      <LabeledInput renderFieldLabel={() => renderFieldLabel("Variable Name")}
+      <LabeledInput renderFieldLabel={() => renderFieldLabel(varNameLabel)}
                     value={node.varName}
                     onChange={(event) => onInputChange("varName", event)}
                     isMarked={isMarked("varName")}
@@ -48,7 +46,7 @@ const MapVariable = (props) => {
            errors={errors}/>
 
       <LabeledTextarea renderFieldLabel={() => renderFieldLabel("Description")}
-                       value={_.get(props.node, "additionalFields.description", "")}
+                       value={_.get(node, "additionalFields.description", "")}
                        onChange={(event) => onInputChange("additionalFields.description", event)}
                        isMarked={isMarked("additionalFields.description")}
                        readOnly={readOnly}
@@ -65,7 +63,9 @@ MapVariable.propTypes = {
   onChange: PropTypes.func.isRequired,
   readOnly: PropTypes.bool,
   showValidation: PropTypes.bool.isRequired,
-  showSwitch: PropTypes.bool,
+  errors: PropTypes.array.isRequired,
+  renderFieldLabel: PropTypes.func.isRequired,
+  varNameLabel: PropTypes.string.isRequired
 }
 
 MapVariable.defaultProps = {

--- a/ui/client/components/graph/node-modal/NodeDetailsContent.js
+++ b/ui/client/components/graph/node-modal/NodeDetailsContent.js
@@ -24,6 +24,7 @@ import TestErrors from "./tests/TestErrors"
 import TestResults from "./tests/TestResults"
 import TestResultsSelect from "./tests/TestResultsSelect"
 import {editorTypes} from "./editors/expression/EditorType"
+import SubprocessOutputDefinition from "./SubprocessOutputDefinition"
 
 //move state to redux?
 // here `componentDidUpdate` is complicated to clear unsaved changes in modal
@@ -178,8 +179,7 @@ export class NodeDetailsContent extends React.Component {
             />
         )
       case "SubprocessOutputDefinition":
-        return <MapVariable
-            varNameLabel={"Output name"}
+        return <SubprocessOutputDefinition
             renderFieldLabel={this.renderFieldLabel}
             removeElement={this.removeElement}
             onChange={this.setNodeDataAt}

--- a/ui/client/components/graph/node-modal/NodeDetailsContent.js
+++ b/ui/client/components/graph/node-modal/NodeDetailsContent.js
@@ -178,19 +178,18 @@ export class NodeDetailsContent extends React.Component {
             />
         )
       case "SubprocessOutputDefinition":
-        return (
-            <div className="node-table-body">
-              {this.createField("input", "Name", "id", true, [mandatoryValueValidator, errorValidator(fieldErrors, "id")])}
-              {this.createField(
-                  "input",
-                  "Output name",
-                  "outputName",
-                  false,
-                  [mandatoryValueValidator, errorValidator(fieldErrors, "outputName")],
-              )}
-              {this.descriptionField()}
-            </div>
-        )
+        return <MapVariable
+            varNameLabel={"Output name"}
+            renderFieldLabel={this.renderFieldLabel}
+            removeElement={this.removeElement}
+            onChange={this.setNodeDataAt}
+            node={this.state.editedNode}
+            addElement={this.addElement}
+            isMarked={this.isMarked}
+            readOnly={!this.props.isEditMode}
+            showValidation={showValidation}
+            errors={fieldErrors}
+        />;
       case "Filter":
         return (
             <div className="node-table-body">
@@ -309,16 +308,17 @@ export class NodeDetailsContent extends React.Component {
         )
       case "VariableBuilder":
         return <MapVariable
-            renderFieldLabel={this.renderFieldLabel}
-            removeElement={this.removeElement}
-            onChange={this.setNodeDataAt}
-            node={this.state.editedNode}
-            addElement={this.addElement}
-            isMarked={this.isMarked}
-            readOnly={!this.props.isEditMode}
-            showValidation={showValidation}
-            errors={fieldErrors}
-        />
+          varNameLabel={"Variable Name"}
+          renderFieldLabel={this.renderFieldLabel}
+          removeElement={this.removeElement}
+          onChange={this.setNodeDataAt}
+          node={this.state.editedNode}
+          addElement={this.addElement}
+          isMarked={this.isMarked}
+          readOnly={!this.props.isEditMode}
+          showValidation={showValidation}
+          errors={fieldErrors}
+        />;
       case "Variable":
         return <Variable
             renderFieldLabel={this.renderFieldLabel}

--- a/ui/client/components/graph/node-modal/SubprocessOutputDefinition.js
+++ b/ui/client/components/graph/node-modal/SubprocessOutputDefinition.js
@@ -1,0 +1,65 @@
+import _ from "lodash"
+import React from "react"
+import {v4 as uuid4} from "uuid"
+import {errorValidator, mandatoryValueValidator} from "./editors/Validators"
+import LabeledInput from "./editors/field/LabeledInput"
+import LabeledTextarea from "./editors/field/LabeledTextarea"
+import Map from "./editors/map/Map"
+import MapVariable from "./MapVariable"
+
+const SubprocessOutputDefinition = ({isMarked, node, removeElement, addElement, onChange, readOnly, showValidation, errors, renderFieldLabel}) => {
+
+    const addField = () => {
+        addElement("fields", {name: "", uuid: uuid4(), expression: {expression: "", language: "spel"}})
+    }
+
+    const onInputChange = (path, event) => onChange(path, event.target.value)
+
+    return (
+        <div className="node-table-body node-variable-builder-body">
+            <LabeledInput renderFieldLabel={() => renderFieldLabel("Name")}
+                          value={node.id}
+                          onChange={(event) => onInputChange("id", event)}
+                          isMarked={isMarked("id")}
+                          readOnly={readOnly}
+                          showValidation={showValidation}
+                          validators={[mandatoryValueValidator, errorValidator(errors, "id")]}/>
+
+            <LabeledInput renderFieldLabel={() => renderFieldLabel("Output name")}
+                          value={node.outputName}
+                          onChange={(event) => onInputChange("outputName", event)}
+                          isMarked={isMarked("outputName")}
+                          readOnly={readOnly}
+                          showValidation={showValidation}
+                          validators={[mandatoryValueValidator, errorValidator(errors, "outputName")]}/>
+
+            <Map label="Fields"
+                 onChange={onChange}
+                 fields={node.fields}
+                 removeField={removeElement}
+                 namespace="fields"
+                 addField={addField}
+                 isMarked={isMarked}
+                 readOnly={readOnly}
+                 showValidation={showValidation}
+                 showSwitch={false}
+                 errors={errors}/>
+
+            <LabeledTextarea renderFieldLabel={() => renderFieldLabel("Description")}
+                             value={_.get(node, "additionalFields.description", "")}
+                             onChange={(event) => onInputChange("additionalFields.description", event)}
+                             isMarked={isMarked("additionalFields.description")}
+                             readOnly={readOnly}
+                             className={"node-input"}/>
+        </div>
+    )
+}
+
+SubprocessOutputDefinition.propTypes = MapVariable.propTypes
+SubprocessOutputDefinition.defaultProps = MapVariable.defaultProps
+SubprocessOutputDefinition.availableFields = (_node_) => {
+    return ["id", "outputName"]
+}
+
+
+export default SubprocessOutputDefinition

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparer.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionPreparer.scala
@@ -108,7 +108,7 @@ object DefinitionPreparer {
     } else {
       NodeGroup("subprocessDefinition", List(
         NodeToAdd("input", "input", SubprocessInputDefinition("", List()), readCategories),
-        NodeToAdd("output", "output", SubprocessOutputDefinition("", "output"), readCategories)
+        NodeToAdd("output", "output", SubprocessOutputDefinition("", "output", List.empty), readCategories)
       ))
     }
 
@@ -172,7 +172,7 @@ object DefinitionPreparer {
 
     val subprocessOutputs = if (isSubprocess) List() else subprocessesDetails.map(_.canonical).map { process =>
       val outputs = ProcessConverter.findNodes(process).collect {
-        case SubprocessOutputDefinition(_, name, _) => name
+        case SubprocessOutputDefinition(_, name, _, _) => name
       }
       //TODO: enable choice of output type
       NodeEdges(NodeTypeId("SubprocessInput", Some(process.metaData.id)), outputs.map(EdgeType.SubprocessOutput),

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
@@ -235,7 +235,7 @@ object ProcessTestData {
   val sampleSubprocessOneOut = {
     CanonicalProcess(MetaData("sub1", StreamMetaData(), isSubprocess = true), ExceptionHandlerRef(List()), List(
       FlatNode(SubprocessInputDefinition("in", List(SubprocessParameter("param1", SubprocessClazzRef[String])))),
-      canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output"))
+      canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))
     ), None)
   }
 
@@ -243,8 +243,8 @@ object ProcessTestData {
     CanonicalProcess(MetaData("sub1", StreamMetaData(), isSubprocess = true), ExceptionHandlerRef(List()), List(
       FlatNode(SubprocessInputDefinition("in", List(SubprocessParameter("param1", SubprocessClazzRef[String])))),
       SplitNode(Split("split"), List(
-        List(FlatNode(SubprocessOutputDefinition("out", "out1"))),
-        List(FlatNode(SubprocessOutputDefinition("out2", "out2")))
+        List(FlatNode(SubprocessOutputDefinition("out", "out1", List.empty))),
+        List(FlatNode(SubprocessOutputDefinition("out2", "out2", List.empty)))
       ))
     ), Some(List()))
   }
@@ -253,9 +253,9 @@ object ProcessTestData {
     CanonicalProcess(MetaData("sub1", StreamMetaData(), isSubprocess = true), ExceptionHandlerRef(List()), List(
       FlatNode(SubprocessInputDefinition("in", List(SubprocessParameter("param2", SubprocessClazzRef[String])))),
       SplitNode(Split("split"), List(
-        List(FlatNode(SubprocessOutputDefinition("out", "out1"))),
-        List(FlatNode(SubprocessOutputDefinition("out2", "out2"))),
-        List(FlatNode(SubprocessOutputDefinition("out3", "out2")))
+        List(FlatNode(SubprocessOutputDefinition("out", "out1", List.empty))),
+        List(FlatNode(SubprocessOutputDefinition("out2", "out2", List.empty))),
+        List(FlatNode(SubprocessOutputDefinition("out3", "out2", List.empty)))
       ))
     ), Some(List()))
   }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
@@ -121,7 +121,7 @@ class BaseFlowTest extends FunSuite with ScalatestRouteTest with FailFastCirceSu
       id = processId,
       properties = ProcessProperties(StreamMetaData(), ExceptionHandlerRef(List()), isSubprocess = true, subprocessVersions = Map()),
       nodes = List(SubprocessInputDefinition("input1", List(SubprocessParameter("badParam", SubprocessClazzRef("i.do.not.exist")))),
-        SubprocessOutputDefinition("output1", "out1")),
+        SubprocessOutputDefinition("output1", "out1", List.empty)),
       edges = List(Edge("input1", "output1", None)),
       processingType = TestProcessingTypes.Streaming
     )

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/ProcessObjectsFinderTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/ProcessObjectsFinderTest.scala
@@ -25,7 +25,7 @@ class ProcessObjectsFinderTest extends FunSuite with Matchers with TableDrivenPr
   val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData(), isSubprocess = true), null,
     List(
       canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
-      canonicalnode.FlatNode(CustomNode("f1", None, otherExistingStreamTransformer2, List.empty)), FlatNode(SubprocessOutputDefinition("out1", "output"))), None
+      canonicalnode.FlatNode(CustomNode("f1", None, otherExistingStreamTransformer2, List.empty)), FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))), None
   )
 
   val subprocessDetails = toDetails(ProcessConverter.toDisplayable(subprocess, TestProcessingTypes.Streaming))

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/processreport/ProcessCounterTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/processreport/ProcessCounterTest.scala
@@ -69,7 +69,7 @@ class ProcessCounterTest extends FlatSpec with Matchers {
             FlatNode(SubprocessInputDefinition("subInput1", List())),
             FlatNode(Filter("subFilter1", "")),
             FlatNode(Filter("subFilter2", "")),
-            FlatNode(SubprocessOutputDefinition("outId1", "out1"))), None
+            FlatNode(SubprocessOutputDefinition("outId1", "out1", List.empty))), None
         )
     )))
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/validation/ProcessValidationSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/validation/ProcessValidationSpec.scala
@@ -1,10 +1,11 @@
 package pl.touk.nussknacker.ui.validation
 
-import org.scalatest.{FlatSpec, FunSuite, Matchers}
 import pl.touk.nussknacker.engine.{ProcessingTypeData, spel}
+import org.scalatest.{FunSuite, Matchers}
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult}
 import pl.touk.nussknacker.engine.api.{Group, MetaData, ProcessAdditionalFields, StreamMetaData}
-import pl.touk.nussknacker.engine.canonicalgraph.{CanonicalProcess, canonicalnode}
-import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.{CanonicalNode, FlatNode}
+import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.compile.ProcessValidator
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
@@ -15,6 +16,7 @@ import pl.touk.nussknacker.engine.graph.node._
 import pl.touk.nussknacker.engine.graph.sink.SinkRef
 import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.graph.subprocess.SubprocessRef
+import pl.touk.nussknacker.engine.graph.variable.Field
 import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder
 import pl.touk.nussknacker.ui.definition.AdditionalProcessProperty
 import pl.touk.nussknacker.ui.api.helpers.TestFactory.{SampleSubprocessRepository, sampleResolver}
@@ -27,6 +29,7 @@ import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeValidatio
 import pl.touk.nussknacker.ui.process.subprocess.SubprocessResolver
 
 class ProcessValidationSpec extends FunSuite with Matchers {
+  import spel.Implicits._
   import pl.touk.nussknacker.ui.definition.PropertyType._
 
   private val validator = TestFactory.processValidation
@@ -237,7 +240,19 @@ class ProcessValidationSpec extends FunSuite with Matchers {
   }
 
   test("validates subprocess input definition") {
-    val (processValidation, process) = mockProcessValidationAndProcess(subprocessDisabled = false)
+    val invalidSubprocess = CanonicalProcess(
+      MetaData("sub1", StreamMetaData(), isSubprocess = true),
+      ExceptionHandlerRef(List.empty),
+      nodes = List(
+        FlatNode(
+          SubprocessInputDefinition(
+            "in", List(SubprocessParameter("param1", SubprocessClazzRef[Long])))),
+        FlatNode(Variable(id = "subVar", varName = "subVar", value = "#nonExistingVar")),
+        FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))
+      ),
+      additionalBranches = None
+    )
+    val (processValidation, process) = mockProcessValidationAndProcess(subprocess = invalidSubprocess)
 
     processValidation.validate(process) should matchPattern {
       case ValidationResult(ValidationErrors(invalidNodes, Nil, Nil), ValidationWarnings.success, _, _
@@ -246,12 +261,45 @@ class ProcessValidationSpec extends FunSuite with Matchers {
   }
 
   test("validates disabled subprocess with parameters") {
-    val (processValidation, process) = mockProcessValidationAndProcess(subprocessDisabled = true)
+    val invalidSubprocess = CanonicalProcess(
+      MetaData("sub1", StreamMetaData(), isSubprocess = true),
+      ExceptionHandlerRef(List.empty),
+      nodes = List(
+        FlatNode(
+          SubprocessInputDefinition(
+            "in", List(SubprocessParameter("param1", SubprocessClazzRef[Long])))),
+        FlatNode(Variable(id = "subVar", varName = "subVar", value = "#nonExistingVar")),
+        FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))
+      ),
+      additionalBranches = None
+    )
+    val (processValidation, process) = mockProcessValidationAndProcess(subprocess = invalidSubprocess, subprocessDisabled = true)
 
     val validationResult = processValidation.validate(process)
     validationResult.errors.invalidNodes shouldBe 'empty
     validationResult.errors.globalErrors shouldBe 'empty
     validationResult.saveAllowed shouldBe true
+  }
+
+  test("validates and returns type info of subprocess output fields") {
+    val subprocess = CanonicalProcess(
+        MetaData("sub1", StreamMetaData(), isSubprocess = true),
+        ExceptionHandlerRef(List()),
+        nodes = List(
+          FlatNode(SubprocessInputDefinition(
+            "in", List(SubprocessParameter("param1", SubprocessClazzRef[String]))
+          )),
+          FlatNode(SubprocessOutputDefinition(
+            "out1", "output", List(Field("foo", "42L"))
+          ))
+        ),
+        additionalBranches = None)
+    val (processValidation, process) = mockProcessValidationAndProcess(subprocess)
+    val validationResult = processValidation.validate(process)
+    validationResult.errors.invalidNodes shouldBe 'empty
+    validationResult.variableTypes("out")("output") shouldBe TypedObjectTypingResult(Map(
+      "foo" -> Typed(classOf[java.lang.Long])
+    ))
   }
 
   private def createProcess(nodes: List[NodeData],
@@ -272,9 +320,9 @@ class ProcessValidationSpec extends FunSuite with Matchers {
     )
   }
 
-  private def mockProcessValidationAndProcess(subprocessDisabled: Boolean): (ProcessValidation, DisplayableProcess) = {
+  private def mockProcessValidationAndProcess(subprocess: CanonicalProcess,
+                                              subprocessDisabled: Boolean = false): (ProcessValidation, DisplayableProcess) = {
     import ProcessDefinitionBuilder._
-    import spel.Implicits._
 
     val process = createProcess(
       nodes = List(
@@ -288,25 +336,12 @@ class ProcessValidationSpec extends FunSuite with Matchers {
         Edge("subIn", "out", Some(EdgeType.SubprocessOutput("output"))))
     )
 
-    val invalidSubprocess =
-      CanonicalProcess(
-        MetaData("sub1", StreamMetaData(), isSubprocess = true),
-        ExceptionHandlerRef(List()),
-        nodes = List(
-          FlatNode(
-            SubprocessInputDefinition(
-              "in", List(SubprocessParameter("param1", SubprocessClazzRef[Long])))),
-          FlatNode(Variable(id = "subVar", varName = "subVar", value = "#nonExistingVar")),
-          canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output"))
-        ),
-        additionalBranches = None)
-
     val processDefinition = ProcessDefinitionBuilder.empty.withSourceFactory("processSource").withSinkFactory("processSink")
     val validator = ProcessValidator.default(ProcessDefinitionBuilder.withEmptyObjects(processDefinition), new SimpleDictRegistry(Map.empty))
     val processValidation: ProcessValidation = new ProcessValidation(
       validators = Map(TestProcessingTypes.Streaming -> validator),
       Map(TestProcessingTypes.Streaming -> Map()),
-      subprocessResolver = new SubprocessResolver(new SampleSubprocessRepository(Set(invalidSubprocess))),
+      subprocessResolver = new SubprocessResolver(new SampleSubprocessRepository(Set(subprocess))),
       Map.empty)
 
     (processValidation, process)


### PR DESCRIPTION
Allow subprocess outputs to return value.
Subprocess can behave as MapVariable and pass fields to process.