### PR TITLE
Fix: Mandatory validator

### DIFF
--- a/ui/client/components/graph/node-modal/editors/expression/Editor.ts
+++ b/ui/client/components/graph/node-modal/editors/expression/Editor.ts
@@ -65,14 +65,14 @@ export enum EditorType {
 }
 
 const configureValidators = (paramConfig: $TodoType): Array<Validator> => {
+  //It's for special nodes like Filter, Switch, etc.. These nodes don't have params and all fields are required
   if (paramConfig == null) {
     return [
       mandatoryValueValidator,
-      notBlankValueValidator,
     ]
   }
 
-  return paramConfig.validators || []
+  return (paramConfig.validators || [])
     .map(v => validators[v.type])
     .filter(v => v != null)
     .map(v => v(paramConfig.editor.possibleValues))

--- a/ui/client/components/graph/node-modal/editors/expression/Editor.ts
+++ b/ui/client/components/graph/node-modal/editors/expression/Editor.ts
@@ -65,17 +65,17 @@ export enum EditorType {
 }
 
 const configureValidators = (paramConfig: $TodoType): Array<Validator> => {
-  const defaultValidators = [
-    mandatoryValueValidator,
-    notBlankValueValidator,
-  ]
+  if (paramConfig == null) {
+    return [
+      mandatoryValueValidator,
+      notBlankValueValidator,
+    ]
+  }
 
-  const configuredValidators = paramConfig?.validators
+  return paramConfig.validators || []
     .map(v => validators[v.type])
     .filter(v => v != null)
     .map(v => v(paramConfig.editor.possibleValues))
-
-  return isEmpty(configuredValidators) ? defaultValidators : configuredValidators
 }
 
 const simpleEditorValidators = (paramConfig: $TodoType, errors: Array<Error>, fieldLabel: string): Array<Validator> => {


### PR DESCRIPTION
When at BE we don't have any validators (ex. `@NotNull`) then FE set Mandatory and NotBlank Validators.. It should have place only when paramConfig is null - it's  situation for special nodes like:  Filter / Switch. 