### PR TITLE
Ending custom nodes flink support

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/CustomStreamTransformer.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/CustomStreamTransformer.scala
@@ -29,7 +29,7 @@ abstract class CustomStreamTransformer {
   // TODO: remove after full switch to ContextTransformation API
   def canHaveManyInputs: Boolean = false
 
-  // For now it is only option in API interpreted by compiler but actually not supported by Flink and standalone runtime.
+  // For now it is only supported by Flink streaming runtime
   def canBeEnding: Boolean = false 
   
 }

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
@@ -30,6 +30,25 @@ class CustomNodeProcessSpec extends FunSuite with Matchers {
 
   }
 
+  test("be able to use maps, lists and output var after optional ending custom nodes") {
+    val process = EspProcessBuilder.id("proc1")
+      .exceptionHandler()
+      .source("id", "input")
+      .buildSimpleVariable("map", "map", "{:}")
+      .buildSimpleVariable("list", "list", "{}")
+      .buildSimpleVariable("str", "strVar", "'someStr'")
+      .customNode("custom", "outRec", "optionalEndingCustom", "param" -> "#strVar")
+      .buildSimpleVariable("mapToString", "mapToString", "#map.toString()")
+      .buildSimpleVariable("listToString", "listToString", "#list.toString()")
+      .buildSimpleVariable("outputVarToString", "outRecToString", "#outRec.toString()")
+      .emptySink("out", "monitor")
+
+    val data = List(SimpleRecord("1", 3, "a", new Date(0)))
+
+    //without certain hack (see SpelHack & SpelMapHack) this throws exception.
+    processInvoker.invokeWithSampleData(process, data)
+  }
+
   test("fire alert when aggregate threshold exceeded") {
 
     val process = EspProcessBuilder.id("proc1")
@@ -254,6 +273,7 @@ class CustomNodeProcessSpec extends FunSuite with Matchers {
     thrown.getMessage shouldBe s"Compilation errors: ExpressionParseError(There is no property 'value999' in type: ${classOf[SimpleRecord].getName},delta,Some($$expression),#outRec.record.value999 > #outRec.previous + 5)"
   }
 
+
   test("should evaluate blank expression used in lazy parameter as a null") {
     val process = EspProcessBuilder.id("proc1")
       .exceptionHandler()
@@ -267,6 +287,21 @@ class CustomNodeProcessSpec extends FunSuite with Matchers {
     processInvoker.invokeWithSampleData(process, data)
 
     MockService.data shouldBe List(null)
+  }
+
+  test("be able to end process with optional ending custom node") {
+    val process = EspProcessBuilder.id("proc1")
+      .exceptionHandler()
+      .source("id", "input")
+      .buildSimpleVariable("map", "map", "{:}")
+      .buildSimpleVariable("list", "list", "{}")
+      .endingCustomNode("custom", None, "optionalEndingCustom", "param" -> "#input.id")
+
+    val data = List(SimpleRecord("1", 3, "a", new Date(0)))
+
+    //without certain hack (see SpelHack & SpelMapHack) this throws exception.
+    processInvoker.invokeWithSampleData(process, data)
+    MockService.data shouldBe List("1")
   }
 
 }

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/ProcessTestHelpers.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/ProcessTestHelpers.scala
@@ -94,7 +94,8 @@ object ProcessTestHelpers {
         "joinBranchExpression" -> WithCategories(CustomJoinUsingBranchExpressions),
         "signalReader" -> WithCategories(CustomSignalReader),
         "transformWithTime" -> WithCategories(TransformerWithTime),
-        "transformWithNullable" -> WithCategories(TransformerWithNullableParam)
+        "transformWithNullable" -> WithCategories(TransformerWithNullableParam),
+        "optionalEndingCustom" -> WithCategories(OptionalEndingCustom)
       )
 
       override def listeners(config: Config) = List()

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -311,6 +311,20 @@ object SampleNodes {
 
   }
 
+  object OptionalEndingCustom extends CustomStreamTransformer {
+    
+    override def canBeEnding: Boolean = true
+
+    @MethodToInvoke
+    def execute(@ParamName("param") @Nullable param: LazyParameter[String]) =
+      FlinkCustomStreamTransformation((start: DataStream[Context], context: FlinkCustomNodeContext) => {
+        val afterMap = start.map(context.lazyParameterHelper.lazyMapFunction[Any](param))
+        afterMap.addSink(element => MockService.add(element.value))
+        afterMap
+      })
+
+  }
+  
   class TestProcessSignalFactory(val kafkaConfig: KafkaConfig, val signalsTopic: String)
     extends FlinkProcessSignalSender with KafkaSignalStreamConnector {
 


### PR DESCRIPTION
After reusing CutomNodePart in compile/splitted graph support in flink streaming seems to be out-of-the-box, so I just added few tests.
I'm opening this PR to have a place for discussion about other thinks that may be missed for full support of optional ending custom nodes.