### PR TITLE
error indicator restyling (#803)

### DIFF
--- a/ui/client/stylesheets/visualization.styl
+++ b/ui/client/stylesheets/visualization.styl
@@ -39,7 +39,11 @@ tipsPanel(bkrd-color, txt-color = undefined)
   tipsPanel(#4D4D4D)
 
 .tipsPanelHighlighted
-  tipsPanel(hrColor, black)
+  tipsPanel(alpha(errorColor,0.1), defaultTextColor)
+
+.tipsPanelHighlighted
+  outline: 2px solid errorColor
+  outline-offset -2px
 
 .node-error-section
   margin-bottom 5px


### PR DESCRIPTION
it looks like this now:
![2020-03-24 12_46_51-Nussknacker](https://user-images.githubusercontent.com/8850099/77422517-e1aa9e80-6dcd-11ea-9a74-0d9b6f92d20b.png)

This resolved #803