### PR TITLE
Fix checking status of Flink job

### DIFF
--- a/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
+++ b/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
@@ -133,6 +133,15 @@ class FlinkRestManagerSpec extends FunSuite with Matchers with PatientScalaFutur
     ))
   }
 
+  test("return running status if cancelled job has last-modification date later then running job") {
+    statuses = List(JobOverview("2343", "p1", 20L, 10L, JobStatus.RUNNING), JobOverview("1111", "p1", 30L, 5L, JobStatus.CANCELED))
+
+    val manager = createManager(statuses)
+    manager.findJobStatus(ProcessName("p1")).futureValue shouldBe Some(processState(
+      manager, DeploymentId("2343"), FlinkStateStatus.Running, startTime = Some(10L)
+    ))
+  }
+
   test("return last terminal state if not running") {
     statuses = List(JobOverview("2343", "p1", 40L, 10L, JobStatus.FINISHED), JobOverview("1111", "p1", 35L, 30L, JobStatus.FINISHED))
 


### PR DESCRIPTION
Fix check status when deployment of new version is finished before cancelling previous job on Flink. (Cancelled version has later
last-modification date then the new running version)