### PR TITLE
Make FixedValuesEditor more explicit about current value

### DIFF
--- a/ui/client/components/graph/node-modal/editors/expression/FixedValuesEditor.tsx
+++ b/ui/client/components/graph/node-modal/editors/expression/FixedValuesEditor.tsx
@@ -38,13 +38,11 @@ export default class FixedValuesEditor extends React.Component<Props> {
   }
 
   currentOption = () => {
-    const {expressionObj, defaultValue, param} = this.props
-    //TODO: is it ok to put not-existing option here?
-    const defaultOption = {
-      value: _.get(_.head(_.get(param, "editor.possibleValues")), "expression") || expressionObj && expressionObj.expression || defaultValue && defaultValue.expression || "",
-      label: _.get(_.head(_.get(param, "editor.possibleValues")), "label") || expressionObj && expressionObj.expression || defaultValue && defaultValue.label || "",
-    }
-    return this.options.find((option) => expressionObj && option.value === expressionObj.expression) || defaultOption
+    const {expressionObj, param} = this.props
+
+    return expressionObj && this.options.find((option) => option.value === expressionObj.expession) ||  // current value with label taken from options
+        expressionObj && {value: expressionObj.expression, label: expressionObj.expression} ||          // current value is no longer valid option? Show it anyway, let user know. Validation should take care
+        null                                                                                            // just leave undefined and let the user explicitly select one
   }
 
   render() {


### PR DESCRIPTION
Problem I've found.
Editor would render the first option when the current value is invalid or blank.
It's misleading, user has no idea that the true value in process (as seen with
JSON export) is different

I've simplified the FixedValuesEditor so that it renders what it gets.
What in case the value is no longer valid?
  Validation should take care and force user to select a new value.
What about default value?
  I think it should be set on process/node creation time. It has nothing to do with render time.