### PR TITLE
[Performance] first benchmarks and some SpEL performance fixes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -462,6 +462,14 @@ lazy val interpreter = (project in engine("interpreter")).
   ).
   dependsOn(util, testUtil % "test")
 
+lazy val benchmarks = (project in engine("benchmarks")).
+  settings(commonSettings).
+  enablePlugins(JmhPlugin).
+  settings(
+    name := "nussknacker-benchmarks",
+  ).dependsOn(interpreter)
+
+
 lazy val kafka = (project in engine("kafka")).
   settings(commonSettings).
   settings(

--- a/engine/benchmarks/Readme.md
+++ b/engine/benchmarks/Readme.md
@@ -1,0 +1,15 @@
+Microbenchmarks
+---------------
+Benchmarks in this module are suitable for things like:
+- performance of SpEL evaluation
+- handling Context operations
+and probably not for more end to end scenarios - like testing Flink process
+
+Docs:
+-----
+https://github.com/ktoso/sbt-jmh
+
+Running in sbt:
+---------------
+benchmarks/jmh:run -i 8 -wi 3 -f1 -t2 .*SampleSpelBenchmark.*
+

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/spel/ScalaAccessorBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/spel/ScalaAccessorBenchmark.scala
@@ -1,0 +1,22 @@
+package pl.touk.nussknacker.engine.benchmarks.spel
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Thread)
+class ScalaAccessorBenchmark {
+
+  //This is basic SpEL expression, we can check e.g. if bytecode is properly generated for operators or scala accessors
+  private val setup = new SpelBenchmarkSetup("#input.value + 15", Map("input" -> SampleCaseClass(15)))
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def benchmark(): AnyRef = {
+    setup.test()
+  }
+
+}
+
+case class SampleCaseClass(value: Int)

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/spel/SpelBenchmarkSetup.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/spel/SpelBenchmarkSetup.scala
@@ -1,0 +1,62 @@
+package pl.touk.nussknacker.engine.benchmarks.spel
+
+import java.util.concurrent.TimeUnit
+
+import cats.data.Validated.{Invalid, Valid}
+import cats.effect.IO
+import org.openjdk.jmh.annotations._
+import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
+import pl.touk.nussknacker.engine.api.context.ValidationContext
+import pl.touk.nussknacker.engine.api.lazyy.{LazyContext, LazyValuesProvider}
+import pl.touk.nussknacker.engine.api.process.{ClassExtractionSettings, LanguageConfiguration}
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, Unknown}
+import pl.touk.nussknacker.engine.compile.ExpressionCompiler
+import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.ExpressionDefinition
+import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
+import pl.touk.nussknacker.engine.graph.expression.Expression
+
+/* This is helper class for testing SpEL expressions, see SampleSpelBenchmark for usage */
+class SpelBenchmarkSetup(expression: String, vars: Map[String, AnyRef]) {
+
+  private val expressionDefinition = ExpressionDefinition(globalVariables = Map(), globalImports = Nil,
+    languages = LanguageConfiguration.default, optimizeCompilation = true,
+    strictTypeChecking = true, dictionaries = Map.empty, hideMetaVariable = false, strictMethodsChecking = true)
+
+  private val expressionCompiler = ExpressionCompiler.withOptimization(
+    getClass.getClassLoader, new SimpleDictRegistry(Map.empty), expressionDefinition, settings = ClassExtractionSettings.Default)
+
+  private val provider = new LazyValuesProvider {
+    override def apply[T](context: LazyContext, serviceId: String, params: Seq[(String, Any)]): IO[(LazyContext, T)] = ???
+  }
+
+  private val validationContext = ValidationContext(vars.mapValues(Typed.fromInstance), Map.empty)
+
+  private val compiledExpression = expressionCompiler.compile(Expression(language = "spel", expression = expression),
+    None, validationContext, Unknown)(NodeId("")) match {
+    case Valid(a) => a.expression
+    case Invalid(e) => throw new IllegalArgumentException(s"Failed to parse: $e")
+  }
+
+  private val ctx = Context("id", vars, LazyContext(""), None)
+
+  def test(): AnyRef = {
+    compiledExpression.evaluate[AnyRef](ctx, provider).value.get.get.value
+  }
+
+}
+
+
+@State(Scope.Thread)
+class SampleSpelBenchmark {
+
+  private val setup = new SpelBenchmarkSetup("#input.substring(0, 3)", Map("input" -> "one"))
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def benchmark(): AnyRef = {
+    setup.test()
+  }
+}
+

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
@@ -81,6 +81,8 @@ class ExpressionEvaluator(globalVariablesPreparer: GlobalVariablesPreparer,
   def evaluate[R](expr: Expression, expressionId: String, nodeId: String, ctx: Context)
                  (implicit ec: ExecutionContext, metaData: MetaData): Future[ValueWithContext[R]] = {
     val lazyValuesProvider = lazyValuesProviderCreator(ec, metaData, nodeId)
+    //FIXME: this is *not* performant when we have some global variables, we should not add to map here, but e.g. push
+    //lookup logic down to expressions
     val ctxWithGlobals = ctx.withVariables(globalVariablesPreparer.prepareGlobalVariables(metaData).mapValues(_.obj))
 
     expr.evaluate[R](ctxWithGlobals, lazyValuesProvider).map { valueWithLazyContext =>

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/internal/OptimizedEvaluationContext.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/internal/OptimizedEvaluationContext.scala
@@ -1,0 +1,64 @@
+package pl.touk.nussknacker.engine.spel.internal
+
+import java.lang.reflect.Method
+import java.util
+import java.util.Collections
+
+import org.springframework.core.convert.TypeDescriptor
+import org.springframework.expression.{EvaluationContext, MethodExecutor, MethodResolver, PropertyAccessor}
+import org.springframework.expression.spel.support.{ReflectiveMethodExecutor, ReflectiveMethodResolver, StandardEvaluationContext, StandardTypeLocator}
+import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.lazyy.LazyValuesProvider
+import pl.touk.nussknacker.engine.spel.{OmitAnnotationsMethodExecutor, SpelExpressionParser}
+
+import scala.collection.JavaConverters._
+
+class EvaluationContextPreparer(classLoader: ClassLoader,
+                                expressionImports: List[String],
+                                propertyAccessors: Seq[PropertyAccessor],
+                                expressionFunctions: Map[String, Method]) {
+
+  //this method is evaluated for *each* expression evaluation, we want to extract as much as possible to fields in this class
+  def prepareEvaluationContext(ctx: Context, lazyValuesProvider: LazyValuesProvider): EvaluationContext = {
+    val optimized = new OptimizedEvaluationContext(ctx, lazyValuesProvider, expressionFunctions)
+    optimized.setTypeLocator(locator)
+    optimized.setPropertyAccessors(propertyAccessorsList)
+    optimized.setMethodResolvers(optimizedMethodResolvers)
+    optimized
+  }
+
+  private val propertyAccessorsList = propertyAccessors.asJava
+
+  private val locator: StandardTypeLocator = new StandardTypeLocator(classLoader) {
+    expressionImports.foreach(registerImport)
+  }
+
+  private val optimizedMethodResolvers: java.util.List[MethodResolver] = {
+    val mr = new ReflectiveMethodResolver {
+      override def resolve(context: EvaluationContext, targetObject: scala.Any, name: String, argumentTypes: util.List[TypeDescriptor]): MethodExecutor = {
+        val methodExecutor = super.resolve(context, targetObject, name, argumentTypes).asInstanceOf[ReflectiveMethodExecutor]
+        new OmitAnnotationsMethodExecutor(methodExecutor)
+      }
+    }
+    Collections.singletonList(mr)
+  }
+
+}
+
+class OptimizedEvaluationContext(ctx: Context, lazyValuesProvider: LazyValuesProvider, expressionFunctions: Map[String, Method]) extends StandardEvaluationContext {
+
+  @volatile private var lazyCtx: AnyRef = ctx.lazyContext
+
+  //We *don't* want to initialize any Maps here, as this code is in our tightest loop
+  override def lookupVariable(name: String): AnyRef = {
+    if (name == SpelExpressionParser.LazyContextVariableName) return lazyCtx
+    if (name == SpelExpressionParser.LazyValuesProviderVariableName) return lazyValuesProvider
+    ctx.get(name)
+      .orElse(expressionFunctions.get(name))
+      .orNull.asInstanceOf[AnyRef]
+  }
+
+  override def setVariable(name: String, value: AnyRef): Unit = if (name == SpelExpressionParser.LazyContextVariableName) {
+    lazyCtx = value
+  } else throw new IllegalArgumentException(s"Cannot set variable: $name")
+}

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/internal/propertyAccessors.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/internal/propertyAccessors.scala
@@ -1,0 +1,226 @@
+package pl.touk.nussknacker.engine.spel.internal
+
+import java.lang.reflect.{Method, Modifier}
+import java.util.concurrent.TimeoutException
+
+import cats.data.{State, StateT}
+import cats.effect.IO
+import org.springframework.expression.{EvaluationContext, PropertyAccessor, TypedValue}
+import org.springframework.expression.spel.support.ReflectivePropertyAccessor
+import pl.touk.nussknacker.engine.api.dict.DictInstance
+import pl.touk.nussknacker.engine.api.exception.NonTransientException
+import pl.touk.nussknacker.engine.api.lazyy.{ContextWithLazyValuesProvider, LazyContext, LazyValuesProvider}
+import pl.touk.nussknacker.engine.api.typed.TypedMap
+import pl.touk.nussknacker.engine.spel.SpelExpressionParser.{LazyContextVariableName, LazyValuesProviderVariableName}
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration._
+
+object propertyAccessors {
+
+  def configured(): Seq[PropertyAccessor] = {
+    //FIXME: configurable timeout...
+    val lazyValuesTimeout = 1 minute
+
+    Seq(
+      new ReflectivePropertyAccessor(),
+      NullPropertyAccessor, //must come before other non-standard ones
+      new ScalaLazyPropertyAccessor(lazyValuesTimeout), // must be before scalaPropertyAccessor
+      ScalaOptionOrNullPropertyAccessor, // // must be before scalaPropertyAccessor
+      ScalaPropertyAccessor,
+      StaticPropertyAccessor,
+      MapPropertyAccessor,
+      TypedMapPropertyAccessor,
+      TypedDictInstancePropertyAccessor,
+      // it can add performance overhead so it will be better to keep it on the bottom
+      MapLikePropertyAccessor
+    )
+  }
+
+  object NullPropertyAccessor extends PropertyAccessor with ReadOnly {
+
+    override def getSpecificTargetClasses: Array[Class[_]] = null
+
+    override def canRead(context: EvaluationContext, target: Any, name: String): Boolean = target == null
+
+    override def read(context: EvaluationContext, target: Any, name: String): TypedValue =
+      //can we extract anything else here?
+      throw NonTransientException(name, s"Cannot invoke method/property $name on null object")
+  }
+
+  /* PropertyAccessor for case classes
+    This one is a bit tricky. We extend ReflectivePropertyAccessor, as it's the only sensible way to make it compilable,
+    however it's not so easy to extend and in interpreted mode we skip original implementation
+   */
+  object ScalaPropertyAccessor extends ReflectivePropertyAccessor with ReadOnly with Caching {
+
+    override def findGetterForProperty(propertyName: String, clazz: Class[_], mustBeStatic: Boolean): Method = {
+      findMethodFromClass(propertyName, clazz).orNull
+    }
+
+    override protected def reallyFindMethod(name: String, target: Class[_]) : Option[Method] =
+      target.getMethods.find(m => m.getParameterCount == 0 && m.getName == name)
+
+    override protected def invokeMethod(propertyName: String, method: Method, target: Any, context: EvaluationContext): AnyRef = {
+      method.invoke(target)
+    }
+
+    override def getSpecificTargetClasses: Array[Class[_]] = null
+  }
+
+  object StaticPropertyAccessor extends PropertyAccessor with ReadOnly with StaticMethodCaching {
+
+    override protected def reallyFindMethod(name: String, target: Class[_]): Option[Method] = {
+      target.asInstanceOf[Class[_]].getMethods.find(m =>
+        m.getParameterCount == 0 && m.getName == name && Modifier.isStatic(m.getModifiers)
+      )
+    }
+
+    override protected def invokeMethod(propertyName: String, method: Method, target: Any, context: EvaluationContext): Any = {
+      method.invoke(target)
+    }
+
+    override def getSpecificTargetClasses: Array[Class[_]] = null
+  }
+
+  object ScalaOptionOrNullPropertyAccessor extends PropertyAccessor with ReadOnly with Caching {
+
+    override protected def reallyFindMethod(name: String, target: Class[_]) : Option[Method] = {
+      target.getMethods.find(m => m.getParameterCount == 0 && m.getName == name && classOf[Option[_]].isAssignableFrom(m.getReturnType))
+    }
+
+    override protected def invokeMethod(propertyName: String, method: Method, target: Any, context: EvaluationContext): Any = {
+      method.invoke(target).asInstanceOf[Option[Any]].orNull
+    }
+
+    override def getSpecificTargetClasses: Array[Class[_]] = null
+  }
+
+
+  class ScalaLazyPropertyAccessor(lazyValuesTimeout: Duration) extends PropertyAccessor with ReadOnly with Caching {
+
+    override protected def reallyFindMethod(name: String, target: Class[_]) : Option[Method] = {
+      target.getMethods.find(
+        m => m.getParameterCount == 0 &&
+        m.getReturnType == classOf[State[_,_]] &&
+        m.getName == name)
+    }
+
+    override protected def invokeMethod(propertyName: String, method: Method, target: Any, context: EvaluationContext): Any = {
+      val f = method
+        .invoke(target)
+        .asInstanceOf[StateT[IO, ContextWithLazyValuesProvider, Any]]
+      val lazyProvider = context.lookupVariable(LazyValuesProviderVariableName).asInstanceOf[LazyValuesProvider]
+      val ctx = context.lookupVariable(LazyContextVariableName).asInstanceOf[LazyContext]
+      val futureResult = f.run(ContextWithLazyValuesProvider(ctx, lazyProvider))
+      //TODO: async invocation :)
+      val (modifiedContext, value) = futureResult.unsafeRunTimed(lazyValuesTimeout)
+        .getOrElse(throw new TimeoutException(s"Timout on evaluation ${method.getDeclaringClass}:${method.getName}"))
+      context.setVariable(LazyContextVariableName, modifiedContext.context)
+      value
+    }
+
+    override def getSpecificTargetClasses: Array[Class[_]] = null
+
+  }
+
+  object MapPropertyAccessor extends PropertyAccessor with ReadOnly {
+
+    override def canRead(context: EvaluationContext, target: scala.Any, name: String): Boolean =
+      target.asInstanceOf[java.util.Map[_, _]].containsKey(name)
+
+    override def read(context: EvaluationContext, target: scala.Any, name: String) =
+      new TypedValue(target.asInstanceOf[java.util.Map[_, _]].get(name))
+
+    override def getSpecificTargetClasses: Array[Class[_]] = Array(classOf[java.util.Map[_, _]])
+  }
+
+  object TypedMapPropertyAccessor extends PropertyAccessor with ReadOnly {
+    //in theory this always happends, because we typed it properly ;)
+    override def canRead(context: EvaluationContext, target: scala.Any, name: String): Boolean =
+      target.asInstanceOf[TypedMap].fields.contains(name)
+
+    override def read(context: EvaluationContext, target: scala.Any, name: String) =
+      new TypedValue(target.asInstanceOf[TypedMap].fields(name))
+
+    override def getSpecificTargetClasses: Array[Class[_]] = Array(classOf[TypedMap])
+  }
+
+  object TypedDictInstancePropertyAccessor extends PropertyAccessor with ReadOnly {
+    //in theory this always happends, because we typed it properly ;)
+    override def canRead(context: EvaluationContext, target: scala.Any, key: String) =
+      true
+
+    // we already replaced dict's label with keys so we can just return value based on key
+    override def read(context: EvaluationContext, target: scala.Any, key: String) =
+      new TypedValue(target.asInstanceOf[DictInstance].value(key))
+
+    override def getSpecificTargetClasses: Array[Class[_]] = Array(classOf[DictInstance])
+  }
+
+  // mainly for avro's GenericRecord purpose
+  object MapLikePropertyAccessor extends PropertyAccessor with Caching with ReadOnly {
+
+    override protected def invokeMethod(propertyName: String, method: Method, target: Any, context: EvaluationContext): Any = {
+      method.invoke(target, propertyName)
+    }
+
+    override protected def reallyFindMethod(name: String, target: Class[_]): Option[Method] = {
+      target.getMethods.find(m => m.getName == "get" && (m.getParameterTypes sameElements Array(classOf[String])))
+    }
+
+    override def getSpecificTargetClasses: Array[Class[_]] = null
+  }
+
+  trait Caching extends CachingBase { self: PropertyAccessor =>
+
+    override def canRead(context: EvaluationContext, target: scala.Any, name: String): Boolean =
+      !target.isInstanceOf[Class[_]] && findMethod(name, target).isDefined
+
+    override protected def extractClassFromTarget(target: Any): Option[Class[_]] =
+      Option(target).map(_.getClass)
+  }
+
+  trait StaticMethodCaching extends CachingBase { self: PropertyAccessor =>
+    override def canRead(context: EvaluationContext, target: scala.Any, name: String): Boolean =
+      target.isInstanceOf[Class[_]] && findMethod(name, target).isDefined
+
+    override protected def extractClassFromTarget(target: Any): Option[Class[_]] = Option(target).map(_.asInstanceOf[Class[_]])
+  }
+
+  trait CachingBase { self: PropertyAccessor =>
+    private val methodsCache = new TrieMap[(String, Class[_]), Option[Method]]()
+
+    override def read(context: EvaluationContext, target: scala.Any, name: String): TypedValue =
+      findMethod(name, target)
+        .map { method =>
+          new TypedValue(invokeMethod(name, method, target, context))
+        }
+        .getOrElse(throw new IllegalAccessException("Property is not readable"))
+
+    protected def findMethod(name: String, target: Any): Option[Method] = {
+      //this should *not* happen as we have NullPropertyAccessor
+      val targetClass = extractClassFromTarget(target).getOrElse(throw new IllegalArgumentException(s"Null target for $name"))
+      findMethodFromClass(name, targetClass)
+    }
+
+    protected def findMethodFromClass(name: String, targetClass: Class[_]): Option[Method] = {
+      methodsCache.getOrElseUpdate((name, targetClass), reallyFindMethod(name, targetClass))
+    }
+
+
+    protected def extractClassFromTarget(target: Any): Option[Class[_]]
+    protected def invokeMethod(propertyName: String, method: Method, target: Any, context: EvaluationContext): Any
+    protected def reallyFindMethod(name: String, target: Class[_]) : Option[Method]
+  }
+
+  trait ReadOnly { self: PropertyAccessor =>
+
+    override def write(context: EvaluationContext, target: scala.Any, name: String, newValue: scala.Any) =
+      throw new IllegalAccessException("Property is not writeable")
+
+    override def canWrite(context: EvaluationContext, target: scala.Any, name: String) = false
+
+  }
+
+}

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/preparevalues/ReadObjectField.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/preparevalues/ReadObjectField.scala
@@ -1,12 +1,13 @@
 package pl.touk.nussknacker.engine.sql.preparevalues
 
-import java.sql.Timestamp
-import java.time.{LocalDateTime, ZoneId}
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 
-import org.springframework.expression.PropertyAccessor
-import org.springframework.expression.spel.support.{ReflectivePropertyAccessor, StandardEvaluationContext}
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser.{MapPropertyAccessor, ScalaPropertyAccessor, StaticPropertyAccessor, TypedMapPropertyAccessor}
+import org.springframework.expression.spel.support.StandardEvaluationContext
+import pl.touk.nussknacker.engine.spel.internal.propertyAccessors
 import pl.touk.nussknacker.engine.sql.TimestampUtils
+
+import scala.annotation.tailrec
 
 private[preparevalues] trait ReadObjectField {
   def readField(obj:Any, name: String) : Any
@@ -15,7 +16,7 @@ private[preparevalues] trait ReadObjectField {
 private[preparevalues] object ReadObjectField extends ReadObjectField {
 
   //we do it with spring accessors, because field name extraction is spel-compatible, so here we should also respect same rules
-  private val accessors = List[PropertyAccessor](TypedMapPropertyAccessor, MapPropertyAccessor, ScalaPropertyAccessor, StaticPropertyAccessor, new ReflectivePropertyAccessor)
+  private val accessors = propertyAccessors.configured()
 
   private val ec = new StandardEvaluationContext()
 
@@ -30,6 +31,7 @@ private[preparevalues] object ReadObjectField extends ReadObjectField {
   }
 
 
+  @tailrec
   private def additionalConversions(value: Any): Any = {
     value match {
       case bd: scala.math.BigDecimal =>

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/variables/GlobalVariablesPreparer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/variables/GlobalVariablesPreparer.scala
@@ -11,6 +11,7 @@ class GlobalVariablesPreparer(userDefinedGlobalVariables: Map[String, ObjectWith
     if (hideMetaVariable) {
       userDefinedGlobalVariables
     } else {
+      //FIXME: this is *not* performant, currently we do it for *each* expression execution
       userDefinedGlobalVariables + (Interpreter.MetaParamName -> MetaVariables.withType(metaData))
     }
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.5.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")


### PR DESCRIPTION
Optimizations: 
- ScalaPropertyAccessor is now compilable 
- more performant EvaluationContext initialization

Results for ScalaAccessorBenchmark:
avgt    8  0.978 ± 0.126  us/op  ==> base
avgt    8  0.618 ± 0.036  us/op  ==> with ScalaPropertyAccessor overriding ReflectivePropertyAccessor
avgt    8  0.122 ± 0.010  us/op  ==> with above + avoiding costly EvaluationContextInitialization