### PR TITLE
Fix: Same date for each travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     - AWS_DEFAULT_REGION=eu-west-1
     - SOURCE_BRANCH=`[ "${TRAVIS_PULL_REQUEST_BRANCH}" != "" ] && echo "${TRAVIS_PULL_REQUEST_BRANCH}" || echo "${TRAVIS_BRANCH}"`
     - SANITIZED_BRANCH=`echo ${SOURCE_BRANCH} | sed 's/[^a-zA-Z0-9]/\_/g' | awk '{print tolower($0)}'`
-    - FORMATTED_DATE=`date '+%Y_%m_%d_%H_%M'`
+    - FORMATTED_DATE=$(git show -s --date=format:'%Y-%m-%d-%H-%M' --format=%cd $TRAVIS_COMMIT)
     - BUILD_VERSION=$(if [[ -n $TRAVIS_TAG ]]; then echo "${SANITIZED_BRANCH}"; else echo "${FORMATTED_DATE}-${SANITIZED_BRANCH}-$TRAVIS_COMMIT"; fi)
     - DOCKER_SOURCE_TAG=`echo ${DOCKER_PACKAGE_USERNAME}/${DOCKER_PACKAGENAME}:${BUILD_VERSION}`
     - DOCKER_REPOSITORY=`echo ${DOCKER_PACKAGE_USERNAME}/${DOCKER_PACKAGENAME}`


### PR DESCRIPTION
When some job failed then date for release can be different. So we have to use date of last commit.