### PR TITLE
CustomTransformers and Sinks should have access to ValidationContext

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -60,6 +60,7 @@ To see biggest differences please consult the [changelog](Changelog.md).
 * [#841](https://github.com/TouK/nussknacker/pull/841) `ProcessConfigCreator` API changed; note that currently all process objects are invoked with `ProcessObjectDependencies` as a parameter. The APIs of `KafkaSinkFactory`, `KafkaSourceFactory`, and all their implementations were changed. `Config` is available as property of `ProcessObjectDependencies` instance.
 * [#863](https://github.com/TouK/nussknacker/pull/863) `restUrl` in `engineConfig` need to be preceded with protocol. Host with port only is not allowed anymore.
 * Rename `grafanaSettings` to `metricsSettings` in configuration.
+* [#874](https://github.com/TouK/nussknacker/pull/874 `FlinkSink` receives `FlinkSinkContext` instead of `FlinkLazyParameterFunctionHelper`, which is available in `FlinkSinkContext` as field 
 
 ## In version 0.0.12
 

--- a/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkCustomNodeContext.scala
+++ b/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkCustomNodeContext.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.flink.api.process
 
 import pl.touk.nussknacker.engine.api.MetaData
+import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.flink.api.signal.FlinkProcessSignalSender
 
 import scala.concurrent.duration.FiniteDuration
@@ -10,7 +11,9 @@ case class FlinkCustomNodeContext(metaData: MetaData,
                                   nodeId: String,
                                   timeout: FiniteDuration,
                                   lazyParameterHelper: FlinkLazyParameterFunctionHelper,
-                                  signalSenderProvider: FlinkProcessSignalSenderProvider)
+                                  signalSenderProvider: FlinkProcessSignalSenderProvider,
+                                  validationContext: Either[ValidationContext, Map[String, ValidationContext]]
+                                 )
 
 case class SignalSenderKey(id: String, klass: Class[_])
 

--- a/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkSink.scala
+++ b/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkSink.scala
@@ -5,6 +5,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.scala._
 import pl.touk.nussknacker.engine.api.InterpretationResult
+import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.process.Sink
 
 /**
@@ -13,9 +14,11 @@ import pl.touk.nussknacker.engine.api.process.Sink
 trait FlinkSink extends Sink {
 
   def registerSink(dataStream: DataStream[InterpretationResult],
-                   lazyParameterFunctionHelper: FlinkLazyParameterFunctionHelper): DataStreamSink[_]
+                   sinkContext: FlinkSinkContext): DataStreamSink[_]
 
 }
+
+case class FlinkSinkContext(lazyParameterFunctionHelper: FlinkLazyParameterFunctionHelper, validationContext: ValidationContext)
 
 /**
  * This is basic Flink sink, which just uses *output* expression from sink definition
@@ -23,7 +26,7 @@ trait FlinkSink extends Sink {
 trait BasicFlinkSink extends FlinkSink {
 
   override def registerSink(dataStream: DataStream[InterpretationResult],
-                            lazyParameterFunctionHelper: FlinkLazyParameterFunctionHelper): DataStreamSink[_] = {
+                            sinkContext: FlinkSinkContext): DataStreamSink[_] = {
     dataStream.map(_.output).addSink(toFlinkFunction)
   }
 

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -342,10 +342,10 @@ object SampleNodes {
     @MethodToInvoke
     def createSink(@ParamName("intParam") value: LazyParameter[Int]): Sink = new FlinkSink {
 
-      override def registerSink(dataStream: DataStream[InterpretationResult], lazyParameterFunctionHelper: FlinkLazyParameterFunctionHelper): DataStreamSink[_] = {
+      override def registerSink(dataStream: DataStream[InterpretationResult], sinkContext: FlinkSinkContext): DataStreamSink[_] = {
         dataStream
           .map(_.finalContext)
-          .map(lazyParameterFunctionHelper.lazyMapFunction(value))
+          .map(sinkContext.lazyParameterFunctionHelper.lazyMapFunction(value))
           .map(_.value.asInstanceOf[Any])
           .addSink(SinkForInts.toFlinkFunction)
       }


### PR DESCRIPTION
Sometimes it would be nice to have access to ValidationContext in custom transformers or sinks - e.g. to prepare better serializers etc.