### PR TITLE
[Improvement] Possibility to use unions in diamond-shaped subprocesses

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -193,6 +193,8 @@ object ProcessCompilationError {
 
   case class InvalidSubprocess(id: String, nodeId: String) extends ProcessCompilationError with InASingleNode
 
+  case class CustomNodeError(nodeId: String, message: String, paramName: Option[String]) extends ProcessCompilationError with InASingleNode
+
   case class FatalUnknownError(message: String) extends ProcessCompilationError {
     override def nodeIds: Set[String] = Set()
   }

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/FlinkStreamingProcessRegistrar.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/FlinkStreamingProcessRegistrar.scala
@@ -14,7 +14,6 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper
 import org.apache.flink.metrics.Gauge
 import org.apache.flink.runtime.state.StateBackend
-import org.apache.flink.streaming.api.datastream
 import org.apache.flink.streaming.api.environment.RemoteStreamEnvironment
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.functions.async.{ResultFuture, RichAsyncFunction}
@@ -37,7 +36,7 @@ import pl.touk.nussknacker.engine.flink.api.NkGlobalParameters
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomJoinTransformation, _}
 import pl.touk.nussknacker.engine.flink.util.metrics.{InstantRateMeterWithCount, MetricUtils}
-import pl.touk.nussknacker.engine.graph.{EspProcess, node}
+import pl.touk.nussknacker.engine.graph.EspProcess
 import pl.touk.nussknacker.engine.graph.node.BranchEndDefinition
 import pl.touk.nussknacker.engine.process.FlinkStreamingProcessRegistrar._
 import pl.touk.nussknacker.engine.process.compiler.{CompiledProcessWithDeps, FlinkProcessCompiler}
@@ -48,7 +47,6 @@ import pl.touk.nussknacker.engine.splittedgraph.splittednode.SplittedNode
 import pl.touk.nussknacker.engine.util.metrics.RateMeter
 import shapeless.syntax.typeable._
 
-import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -56,7 +54,7 @@ import scala.language.implicitConversions
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-class FlinkStreamingProcessRegistrar(compileProcess: (EspProcess, ProcessVersion) => (ClassLoader) => CompiledProcessWithDeps,
+class FlinkStreamingProcessRegistrar(compileProcess: (EspProcess, ProcessVersion) => ClassLoader => CompiledProcessWithDeps,
                                      eventTimeMetricDuration: FiniteDuration,
                                      checkpointConfig: Option[CheckpointConfig],
                                      enableObjectReuse: Boolean,
@@ -117,52 +115,34 @@ class FlinkStreamingProcessRegistrar(compileProcess: (EspProcess, ProcessVersion
       case _ => logger.debug("Using default state backend")
     }
 
-    //TODO JOIN - here we need recursion for nested joins
-    @tailrec
-    def registerBranchEnds(branchEnds: Map[BranchEndDefinition, DataStream[InterpretationResult]]): Unit = {
-      if (branchEnds.isEmpty) {
-        return
-      }
-      println(s"registering branch ends: ${branchEnds.keys}")
-      val nextParts = branchEnds.groupBy(_._1.joinId).map {
-        case (joinId, inputs) =>
-          val joinPart = processWithDeps.sources.toList
-            .collect { case e: CustomNodePart if e.id == joinId => e } match {
-            case head :: Nil => head
-            case Nil => throw new IllegalArgumentException(s"Invalid process structure, no $joinId defined")
-            case moreThanOne => throw new IllegalArgumentException(s"Invalid process structure, more than one $joinId defined: $moreThanOne")
-          }
-          println(s"registering: ${joinId} ${joinPart}")
-
-
-          val transformer = joinPart.transformer match {
-            case joinTransformer: FlinkCustomJoinTransformation => joinTransformer
-            case JoinContextTransformation(_, impl: FlinkCustomJoinTransformation) => impl
-            case other =>
-              throw new IllegalArgumentException(s"Unknown join node transformer: $other")
-          }
-
-          val outputVar = joinPart.node.data.outputVar.get
-          val newContextFun = (ir: ValueWithContext[_]) => ir.context.withVariable(outputVar, ir.value)
-
-          val newStart = transformer.transform(inputs
-            .map(kv => (kv._1.id, kv._2.map(_.finalContext))), nodeContext(joinId)).map(newContextFun)
-
-          val afterSplit = wrapAsync(newStart, joinPart.node, joinPart.validationContext, globalParameters, "branchInterpretation")
-          val branchEnds = joinPart.ends.flatMap(_.cast[BranchEnd]).map(be =>  be.definition ->
-            afterSplit.getSideOutput(OutputTag[InterpretationResult](be.nodeId))).toMap
-
-          registerParts(afterSplit, joinPart.nextParts, joinPart.ends) ++ branchEnds
-      }.foldLeft(Map[BranchEndDefinition, DataStream[InterpretationResult]]()){ _ ++ _}
-      println(s"next parts: ${nextParts.keys}")
-      registerBranchEnds(nextParts)
-    }
     {
-      val branchEnds = processWithDeps.sources.toList
-        .collect { case e: SourcePart => e }
-        .map(registerSourcePart).foldLeft(Map[BranchEndDefinition, DataStream[InterpretationResult]]()){ _ ++ _}
+      //it is *very* important that source are in correct order here - see ProcessCompiler.compileSources comments
+      processWithDeps.sources.toList.foldLeft(Map.empty[BranchEndDefinition, DataStream[InterpretationResult]]) {
+        case (branchEnds, next:SourcePart) => branchEnds ++ registerSourcePart(next)
+        case (branchEnds, joinPart:CustomNodePart) => branchEnds ++ registerJoinPart(joinPart, branchEnds)
+      }
+    }
 
-      registerBranchEnds(branchEnds)
+    //thanks to correct sorting, we know that branchEnds contain all edges to joinPart
+    def registerJoinPart(joinPart: CustomNodePart, branchEnds: Map[BranchEndDefinition, DataStream[InterpretationResult]]): Map[BranchEndDefinition, DataStream[InterpretationResult]] = {
+      val inputs: Map[String, DataStream[Context]] = branchEnds.collect {
+        case (BranchEndDefinition(id, joinId), stream) if joinPart.id == joinId => id -> stream.map(_.finalContext)
+      }
+
+      val transformer = joinPart.transformer match {
+        case joinTransformer: FlinkCustomJoinTransformation => joinTransformer
+        case JoinContextTransformation(_, impl: FlinkCustomJoinTransformation) => impl
+        case other =>
+          throw new IllegalArgumentException(s"Unknown join node transformer: $other")
+      }
+
+      val outputVar = joinPart.node.data.outputVar.get
+      val newContextFun = (ir: ValueWithContext[_]) => ir.context.withVariable(outputVar, ir.value)
+
+      val newStart = transformer.transform(inputs, nodeContext(joinPart.id)).map(newContextFun)
+
+      val afterSplit = wrapAsync(newStart, joinPart.node, joinPart.validationContext, globalParameters, "branchInterpretation")
+      registerNextParts(afterSplit, joinPart)
     }
 
     def registerSourcePart(part: SourcePart): Map[BranchEndDefinition, DataStream[InterpretationResult]] = {
@@ -177,28 +157,30 @@ class FlinkStreamingProcessRegistrar(compileProcess: (EspProcess, ProcessVersion
 
       val asyncAssigned = wrapAsync(start, part.node, part.validationContext, globalParameters, "interpretation")
 
-      val branchEnds = part.ends.flatMap(_.cast[BranchEnd]).map(be =>  be.definition ->
-        asyncAssigned.getSideOutput(OutputTag[InterpretationResult](be.nodeId))).toMap
-
-      registerParts(asyncAssigned, part.nextParts, part.ends) ++ branchEnds
+      registerNextParts(asyncAssigned, part)
     }
 
-    def registerParts(start: DataStream[Unit],
-                      nextParts: Seq[SubsequentPart],
-                      ends: Seq[End]) : Map[BranchEndDefinition, DataStream[InterpretationResult]] = {
+    //the method returns all possible branch ends in part, together with DataStream leading to them
+    def registerNextParts(start: DataStream[Unit], part: PotentiallyStartPart) : Map[BranchEndDefinition, DataStream[InterpretationResult]] = {
+      val ends = part.ends
+      val nextParts = part.nextParts
 
       start.getSideOutput(OutputTag[InterpretationResult](EndId))
         .addSink(new EndRateMeterFunction(ends))
-      nextParts.map { part =>
+
+      val branchesForParts = nextParts.map { part =>
         registerSubsequentPart(start.getSideOutput(OutputTag[InterpretationResult](part.id)), part)
       }.foldLeft(Map[BranchEndDefinition, DataStream[InterpretationResult]]()){_ ++ _}
+      val branchForEnds = part.ends.flatMap(_.cast[BranchEnd]).map(be =>  be.definition ->
+        start.getSideOutput(OutputTag[InterpretationResult](be.nodeId))).toMap
+      branchesForParts ++ branchForEnds
     }
 
     def registerSubsequentPart[T](start: DataStream[InterpretationResult],
                                   processPart: SubsequentPart): Map[BranchEndDefinition, DataStream[InterpretationResult]] =
       processPart match {
 
-        case part@SinkPart(sink: FlinkSink, sinkDef, validationContext) => {
+        case part@SinkPart(sink: FlinkSink, _, validationContext) =>
           val startAfterSinkEvaluated = wrapAsync(start.map(_.finalContext), part.node, validationContext, globalParameters, "function")
             .getSideOutput(OutputTag[InterpretationResult](EndId))
             .map(new EndRateMeterFunction(part.ends))
@@ -217,11 +199,10 @@ class FlinkStreamingProcessRegistrar(compileProcess: (EspProcess, ProcessVersion
 
           withSinkAdded.name(s"${metaData.id}-${part.id}-sink")
           Map()
-        }
 
         case part:SinkPart =>
           throw new IllegalArgumentException(s"Process can only use flink sinks, instead given: ${part.obj}")
-        case part@CustomNodePart(transformerObj, node, validationContext, nextParts, ends) =>
+        case part@CustomNodePart(transformerObj, node, validationContext, _, _) =>
 
           val transformer = transformerObj match {
             case t: FlinkCustomStreamTransformation => t
@@ -240,18 +221,14 @@ class FlinkStreamingProcessRegistrar(compileProcess: (EspProcess, ProcessVersion
               .map(newContextFun)
           val afterSplit = wrapAsync(newStart, node, validationContext, globalParameters, "customNodeInterpretation")
 
-          val branchEnds = part.ends.flatMap(_.cast[BranchEnd]).map(be =>  be.definition ->
-            afterSplit.getSideOutput(OutputTag[InterpretationResult](be.nodeId))).toMap
-          println(s"BranchEnds aftersplit: ${branchEnds}")
-
-          registerParts(afterSplit, nextParts, ends) ++ branchEnds
+          registerNextParts(afterSplit, part)
       }
 
     def wrapAsync(beforeAsync: DataStream[Context], node: SplittedNode[_], validationContext: ValidationContext, globalParameters: Option[NkGlobalParameters], name: String) : DataStream[Unit] = {
       (if (streamMetaData.shouldUseAsyncInterpretation) {
         val asyncFunction = new AsyncInterpretationFunction(compiledProcessWithDeps, node, validationContext, asyncExecutionContextPreparer)
         ExplicitUidInOperatorsSupport.setUidIfNeed(ExplicitUidInOperatorsSupport.defaultExplicitUidInStatefulOperators(globalParameters), node.id + "-$async")(
-          new DataStream(datastream.AsyncDataStream.orderedWait(beforeAsync.javaStream, asyncFunction,
+          new DataStream(org.apache.flink.streaming.api.datastream.AsyncDataStream.orderedWait(beforeAsync.javaStream, asyncFunction,
             processWithDeps.processTimeout.toMillis, TimeUnit.MILLISECONDS, asyncExecutionContextPreparer.bufferSize)))
       } else {
         beforeAsync.flatMap(new SyncInterpretationFunction(compiledProcessWithDeps, node, validationContext))
@@ -314,7 +291,7 @@ object FlinkStreamingProcessRegistrar {
                                (runtimeContext: RuntimeContext) =>
     new FlinkCompilerLazyInterpreterCreator(runtimeContext, compiledProcessWithDepsProvider(runtimeContext.getUserCodeClassLoader))
 
-  class AsyncInterpretationFunction(val compiledProcessWithDepsProvider: (ClassLoader) => CompiledProcessWithDeps,
+  class AsyncInterpretationFunction(val compiledProcessWithDepsProvider: ClassLoader => CompiledProcessWithDeps,
                                     node: SplittedNode[_], validationContext: ValidationContext, asyncExecutionContextPreparer: AsyncExecutionContextPreparer)
     extends RichAsyncFunction[Context, InterpretationResult] with LazyLogging with WithCompiledProcessDeps {
 
@@ -341,7 +318,7 @@ object FlinkStreamingProcessRegistrar {
     }
 
     override def asyncInvoke(input: Context, collector: ResultFuture[InterpretationResult]) : Unit = {
-      implicit val ec = executionContext
+      implicit val ec: ExecutionContext = executionContext
       try {
         interpreter.interpret(compiledNode, metaData, input)
           .onComplete {
@@ -365,11 +342,12 @@ object FlinkStreamingProcessRegistrar {
 
   }
 
-  class CollectingSinkFunction(val compiledProcessWithDepsProvider: (ClassLoader) => CompiledProcessWithDeps,
+  class CollectingSinkFunction(val compiledProcessWithDepsProvider: ClassLoader => CompiledProcessWithDeps,
                                collectingSink: SinkInvocationCollector, sink: SinkPart)
     extends RichSinkFunction[InterpretationResult] with WithCompiledProcessDeps {
 
-    override def invoke(value: InterpretationResult) = {
+
+    override def invoke(value: InterpretationResult, context: SinkFunction.Context[_]): Unit = {
       compiledProcessWithDeps.exceptionHandler.handling(Some(sink.id), value.finalContext) {
         collectingSink.collect(value)
       }
@@ -443,7 +421,7 @@ object FlinkStreamingProcessRegistrar {
       value
     }
 
-    override def invoke(value: InterpretationResult) = {
+    override def invoke(value: InterpretationResult, context: SinkFunction.Context[_]): Unit = {
       map(value)
     }
   }

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/ProcessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/ProcessSpec.scala
@@ -113,16 +113,25 @@ class ProcessSpec extends FunSuite with Matchers {
 
   test("should do join with branch expressions") {
     val process = EspProcess(MetaData("proc1", StreamMetaData()), ExceptionHandlerRef(List()), NonEmptyList.of(
-      GraphBuilder.source("id", "intInputWithParam", "param" -> "#processHelper.add(2, 3)")
+      GraphBuilder.source("idInt", "intInputWithParam", "param" -> "#processHelper.add(2, 3)")
         .branchEnd("end1", "join1"),
-      GraphBuilder.source("id2", "input")
+      GraphBuilder.source("idOtherInt", "intInputWithParam", "param" -> "15")
         .branchEnd("end2", "join1"),
-      GraphBuilder.branch("join1", "joinBranchExpression", Some("input33"),
+      
+      GraphBuilder.source("id2", "input")
+        .branchEnd("end1", "join2"),
+      GraphBuilder.branch("join1", "joinBranchExpression", Some("input2"),
         List(
           "end1" -> List("value" -> "#input"),
           "end2" -> List("value" -> "#input")
+        )).branchEnd("end2", "join2"),
+
+      GraphBuilder.branch("join2", "joinBranchExpression", Some("input3"),
+        List(
+          "end1" -> List("value" -> "#input"),
+          "end2" -> List("value" -> "#input2")
         ))
-        .processorEnd("proc2", "logService", "all" -> "#input33")
+        .processorEnd("proc2", "logService", "all" -> "#input3")
     ))
 
     val rec = SimpleRecord("1", 3, "a", new Date(0))
@@ -130,7 +139,7 @@ class ProcessSpec extends FunSuite with Matchers {
 
     processInvoker.invokeWithSampleData(process, data)
 
-    MockService.data.toSet shouldBe Set(5, rec)
+    MockService.data.toSet shouldBe Set(5, 15, rec)
   }
 
   test("should handle diamond-like process") {

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SubprocessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SubprocessSpec.scala
@@ -2,24 +2,26 @@ package pl.touk.nussknacker.engine.process.functional
 
 import java.util.Date
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
 import pl.touk.nussknacker.engine.build.EspProcessBuilder
+import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
 import pl.touk.nussknacker.engine.canonicalgraph.{CanonicalProcess, canonicalnode}
 import pl.touk.nussknacker.engine.canonize.ProcessCanonizer
 import pl.touk.nussknacker.engine.compile.SubprocessResolver
 import pl.touk.nussknacker.engine.graph.EspProcess
+import pl.touk.nussknacker.engine.graph.evaluatedparam.{BranchParameters, Parameter}
 import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition.{SubprocessClazzRef, SubprocessParameter}
 import pl.touk.nussknacker.engine.graph.node._
 import pl.touk.nussknacker.engine.graph.sink.SinkRef
 import pl.touk.nussknacker.engine.process.helpers.ProcessTestHelpers.processInvoker
 import pl.touk.nussknacker.engine.process.helpers.SampleNodes._
 
-class SubprocessSpec extends FlatSpec with Matchers {
+class SubprocessSpec extends FunSuite with Matchers {
 
   import pl.touk.nussknacker.engine.spel.Implicits._
 
-  it should "should accept same id in subprocess and main process " in {
+  test("should accept same id in subprocess and main process ") {
 
     val process = resolve(EspProcessBuilder.id("proc1")
       .exceptionHandler()
@@ -37,7 +39,7 @@ class SubprocessSpec extends FlatSpec with Matchers {
     MockService.data.head shouldBe "a"
   }
 
-  it should "should handle split in subprocess" in {
+  test("should handle split in subprocess") {
 
     val process = resolve(EspProcessBuilder.id("proc1")
       .exceptionHandler()
@@ -55,11 +57,28 @@ class SubprocessSpec extends FlatSpec with Matchers {
     MockService.data.head shouldBe "a"
   }
 
-  it should "be possible to use global vars in subprocess" in {
+  test("be possible to use global vars in subprocess") {
     val process = resolve(EspProcessBuilder.id("proc1")
       .exceptionHandler()
       .source("id", "input")
       .subprocessOneOut("sub", "subProcessGlobal", "output")
+      .processorEnd("end1", "logService", "all" -> "#input.value2"))
+
+    val data = List(
+      SimpleRecord("1", 12, "a", new Date(0))
+    )
+
+    processInvoker.invokeWithSampleData(process, data)
+
+    MockService.data shouldNot be('empty)
+    MockService.data.head shouldBe "a"
+  }
+
+  test("be possible to use diamond subprocesses") {
+    val process = resolve(EspProcessBuilder.id("proc1")
+      .exceptionHandler()
+      .source("id", "input")
+      .subprocessOneOut("sub", "diamondSubprocess", "output33", "ala" -> "#input.id")
       .processorEnd("end1", "logService", "all" -> "#input.value2"))
 
     val data = List(
@@ -96,7 +115,25 @@ class SubprocessSpec extends FlatSpec with Matchers {
             List()
           ), canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))), None)
 
-    val resolved = SubprocessResolver(Set(subprocessWithSplit, subprocess, subprocessWithGlobalVar)).resolve(ProcessCanonizer.canonize(espProcess))
+    val diamondSubprocess = CanonicalProcess(MetaData("diamondSubprocess", StreamMetaData()), null,
+      List(
+        FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
+        canonicalnode.SplitNode(Split("split"),
+          List(
+            List(canonicalnode.FilterNode(Filter("filter2a", "true"), Nil), FlatNode(BranchEndData(BranchEndDefinition("end1", "join1")))),
+            List(canonicalnode.FilterNode(Filter("filter2b", "true"), Nil), FlatNode(BranchEndData(BranchEndDefinition("end2", "join1")))),
+          )
+        )
+      ), Some(List(
+        FlatNode(Join("join1", Some("output"), "joinBranchExpression", Nil, List(
+          BranchParameters("end1", List(Parameter("value", "#ala"))),
+          BranchParameters("end2", List(Parameter("value", "#ala"))),
+        ), None)),
+        FlatNode(SubprocessOutputDefinition("output22", "output33", Nil, None))
+      ):: Nil)
+    )
+    
+    val resolved = SubprocessResolver(Set(subprocessWithSplit, subprocess, subprocessWithGlobalVar, diamondSubprocess)).resolve(ProcessCanonizer.canonize(espProcess))
       .andThen(ProcessCanonizer.uncanonize)
 
     resolved shouldBe 'valid

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SubprocessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SubprocessSpec.scala
@@ -121,7 +121,7 @@ class SubprocessSpec extends FunSuite with Matchers {
         canonicalnode.SplitNode(Split("split"),
           List(
             List(canonicalnode.FilterNode(Filter("filter2a", "true"), Nil), FlatNode(BranchEndData(BranchEndDefinition("end1", "join1")))),
-            List(canonicalnode.FilterNode(Filter("filter2b", "true"), Nil), FlatNode(BranchEndData(BranchEndDefinition("end2", "join1")))),
+            List(canonicalnode.FilterNode(Filter("filter2b", "true"), Nil), FlatNode(BranchEndData(BranchEndDefinition("end2", "join1"))))
           )
         )
       ), Some(List(

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SubprocessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/SubprocessSpec.scala
@@ -127,7 +127,7 @@ class SubprocessSpec extends FunSuite with Matchers {
       ), Some(List(
         FlatNode(Join("join1", Some("output"), "joinBranchExpression", Nil, List(
           BranchParameters("end1", List(Parameter("value", "#ala"))),
-          BranchParameters("end2", List(Parameter("value", "#ala"))),
+          BranchParameters("end2", List(Parameter("value", "#ala")))
         ), None)),
         FlatNode(SubprocessOutputDefinition("output22", "output33", Nil, None))
       ):: Nil)

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -207,7 +207,8 @@ object SampleNodes {
       ContextTransformation
         .join.definedBy { contexts =>
         val newType = Typed(contexts.keys.toList.map(branchId => valueByBranchId(branchId).returnType): _*)
-        Valid(ValidationContext(Map(variableName -> newType)))
+        val parent = contexts.values.flatMap(_.parent).headOption
+        Valid(ValidationContext(Map(variableName -> newType), Map.empty, parent))
       }.implementedBy(
         new FlinkCustomJoinTransformation {
           override def transform(inputs: Map[String, DataStream[Context]],

--- a/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformer.scala
+++ b/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformer.scala
@@ -37,10 +37,10 @@ case object UnionTransformer extends CustomStreamTransformer with LazyLogging {
   }.mkString
 
   private def findUniqueParent(contextMap: Map[String, ValidationContext])(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, Option[ValidationContext]] = {
-    contextMap.values.toList.distinct match {
+    contextMap.values.map(_.parent).toList.distinct match {
       case Nil => Valid(None)
-      case a::Nil => Valid(Some(a))
-      case more => Invalid(NonEmptyList.of(CustomNodeError(nodeId.id, "Not consistent parent contexts", None)))
+      case a::Nil => Valid(a)
+      case more => Invalid(NonEmptyList.of(CustomNodeError(nodeId.id, s"Not consistent parent contexts: ${more}", None)))
     }
 
   }

--- a/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformer.scala
+++ b/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformer.scala
@@ -40,12 +40,13 @@ case object UnionTransformer extends CustomStreamTransformer with LazyLogging {
               @OutputVariableName variableName: String): JoinContextTransformation =
     ContextTransformation
       .join.definedBy { contexts =>
+      val parent = contexts.values.flatMap(_.parent).headOption
       val newType = TypedObjectTypingResult(contexts.map {
           case (branchId, _) =>
             sanitizeBranchName(branchId) -> valueByBranchId(branchId).returnType
         } + (KeyField -> Typed[String]))
 
-      Valid(ValidationContext(Map(variableName -> newType)))
+      Valid(ValidationContext(Map(variableName -> newType), Map.empty, parent))
     }.implementedBy(
       new FlinkCustomJoinTransformation {
         override def transform(inputs: Map[String, DataStream[Context]], context: FlinkCustomNodeContext): DataStream[ValueWithContext[Any]] = {

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/SubprocessResolver.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/SubprocessResolver.scala
@@ -1,9 +1,8 @@
 package pl.touk.nussknacker.engine.compile
 
 import cats.data.Validated.{Invalid, Valid}
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.{NonEmptyList, Validated, ValidatedNel, Writer, WriterT}
 import cats.implicits._
-import pl.touk.nussknacker.engine.api.MetaData
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.{CanonicalNode, FlatNode}
@@ -20,15 +19,43 @@ case class SubprocessResolver(subprocesses: Map[String, CanonicalProcess]) {
 
   type CompilationValid[A] = ValidatedNel[ProcessCompilationError, A]
 
-  def resolve(canonicalProcess: CanonicalProcess): ValidatedNel[ProcessCompilationError, CanonicalProcess] =
-    canonicalProcess.mapAllNodesValidated(resolveCanonical(List()))
+  type CanonicalBranch = List[CanonicalNode]
 
-  private def resolveCanonical(idPrefix: List[String]) :List[CanonicalNode] => ValidatedNel[ProcessCompilationError, List[CanonicalNode]] = {
+  type WithAdditionalBranches[T] = Writer[List[CanonicalBranch], T]
+
+  type ValidatedWithBranches[T] = WriterT[CompilationValid, List[CanonicalBranch], T]
+
+  def additionalApply[T](value: CompilationValid[T]): ValidatedWithBranches[T] = WriterT[CompilationValid, List[CanonicalBranch], T](value.map((Nil, _)))
+
+  def validBranches[T](value: T): ValidatedWithBranches[T] = WriterT[CompilationValid, List[CanonicalBranch], T](Valid(Nil, value))
+
+  def invalidBranches[T](value: ProcessCompilationError): ValidatedWithBranches[T] = WriterT[CompilationValid, List[CanonicalBranch], T](Invalid(NonEmptyList.of(value)))
+
+  private implicit class RichValidatedWithBranches[T](value: ValidatedWithBranches[T]) {
+    def andThen[Y](fun: T => ValidatedWithBranches[Y]): ValidatedWithBranches[Y] = {
+      WriterT[CompilationValid, List[CanonicalBranch], Y](value.run.andThen { case (additional, iValue) =>
+        val result = fun(iValue)
+        result.mapWritten(additional ++ _).run
+      })
+    }
+  }
+
+
+
+  def resolve(canonicalProcess: CanonicalProcess): ValidatedNel[ProcessCompilationError, CanonicalProcess] = {
+    val output: ValidatedWithBranches[NonEmptyList[CanonicalBranch]] = canonicalProcess.allStartNodes.map(resolveCanonical(Nil)).sequence
+    output.run.map { case (additional, original) =>
+      val allBranches = additional.foldLeft(original)(_.append(_))
+      canonicalProcess.withNodes(allBranches)
+    }
+  }
+
+  private def resolveCanonical(idPrefix: List[String]) :CanonicalBranch => ValidatedWithBranches[CanonicalBranch] = {
     iterateOverCanonicals({
       case canonicalnode.Subprocess(SubprocessInput(dataId, _, _, Some(true), _), nextNodes) if nextNodes.values.size > 1=>
-        Invalid(NonEmptyList.of(DisablingManyOutputsSubprocess(dataId, nextNodes.keySet)))
+        invalidBranches(DisablingManyOutputsSubprocess(dataId, nextNodes.keySet))
       case canonicalnode.Subprocess(SubprocessInput(dataId, _, _, Some(true), _), nextNodes) if nextNodes.values.isEmpty =>
-        Invalid(NonEmptyList.of(DisablingNoOutputsSubprocess(dataId)))
+        invalidBranches(DisablingNoOutputsSubprocess(dataId))
       case canonicalnode.Subprocess(data@SubprocessInput(_, _, _, Some(true), _), nextNodesMap) =>
         //TODO: disabling nodes should be in one place
         val output = nextNodesMap.keys.head
@@ -37,57 +64,73 @@ case class SubprocessResolver(subprocesses: Map[String, CanonicalProcess]) {
           FlatNode(NodeDataFun.nodeIdPrefix(idPrefix)(data))::FlatNode(SubprocessOutput(outputId, output, List.empty, None))::resolvedNexts
         }
       case canonicalnode.Subprocess(subprocessInput:SubprocessInput, nextNodes) =>
-        subprocesses.get(subprocessInput.ref.id) match {
-          case Some(CanonicalProcess(_, _, FlatNode(SubprocessInputDefinition(_, parameters, _))::nodes, _)) =>
-            checkProcessParameters(subprocessInput.ref, parameters.map(_.name), subprocessInput.id).andThen { _ =>
-              val nextResolvedV = nextNodes.map { case (k, v) =>
-                resolveCanonical(idPrefix)(v).map((k, _))
-              }.toList.sequence[CompilationValid, (String, List[CanonicalNode])].map(_.toMap)
-              val subResolvedV = resolveCanonical(idPrefix :+ subprocessInput.id)(nodes)
 
-              (nextResolvedV, subResolvedV).mapN { (nodeResolved, nextResolved) =>
-                replaceCanonicalList(nodeResolved)(nextResolved)
-              }.andThen(identity).map(replaced => FlatNode(NodeDataFun.nodeIdPrefix(idPrefix)(subprocessInput.copy(subprocessParams = Some(parameters)))) :: replaced)
+        additionalApply(Validated.fromOption(subprocesses.get(subprocessInput.ref.id), NonEmptyList.of(UnknownSubprocess(id = subprocessInput.ref.id, nodeId = subprocessInput.id))).andThen { subprocess =>
+          val additionalBranches = subprocess.allStartNodes.collect {
+            case a@FlatNode(_: Join)::_ => a
+          }
+          Validated.fromOption(subprocess.allStartNodes.collectFirst {
+            case FlatNode(SubprocessInputDefinition(_, parameters, _))::nodes => (parameters, nodes, additionalBranches)
+          }, NonEmptyList.of(UnknownSubprocess(id = subprocessInput.ref.id, nodeId = subprocessInput.id)))
+        }).andThen { case (parameters, nodes, additionalBranches) =>
+          checkProcessParameters(subprocessInput.ref, parameters.map(_.name), subprocessInput.id).map { _ =>
+            (parameters, nodes, additionalBranches)
+          }
+
+        }.andThen { case (parameters, nodes, additionalBranches) =>
+          val nextResolvedV = nextNodes.map { case (k, v) =>
+            resolveCanonical(idPrefix)(v).map((k, _))
+          }.toList.sequence[ValidatedWithBranches, (String, List[CanonicalNode])].map(_.toMap)
+          val subResolvedV = resolveCanonical(idPrefix :+ subprocessInput.id)(nodes)
+          val additionalResolved = additionalBranches.map(resolveCanonical(idPrefix :+ subprocessInput.id)).sequence
+
+
+          val nexts = (nextResolvedV, subResolvedV, additionalResolved)
+            .mapN { (nodeResolved, nextResolved, additionalResolved) => (replaceCanonicalList(nodeResolved), nextResolved, additionalResolved) }
+            .andThen { case (replacement, nextResolved, additionalResolved) =>
+            //println("NEXT " + nextResolved)
+            //println("ADDITIONAL " + additionalResolved)
+            additionalResolved.map(replacement).sequence.andThen { resolvedAdditional =>
+              replacement(nextResolved).mapWritten(_ ++ resolvedAdditional)
             }
-          case Some(_) =>
-            Invalid(NonEmptyList.of(InvalidSubprocess(id = subprocessInput.ref.id, nodeId = subprocessInput.id)))
-          case _ =>
-            Invalid(NonEmptyList.of(UnknownSubprocess(id = subprocessInput.ref.id, nodeId = subprocessInput.id)))
+          }
+          nexts.map(replaced => FlatNode(NodeDataFun.nodeIdPrefix(idPrefix)(subprocessInput.copy(subprocessParams = Some(parameters)))) :: replaced)
         }
     }, NodeDataFun.nodeIdPrefix(idPrefix))
   }
 
-  private def checkProcessParameters(ref: SubprocessRef, parameters: List[String], nodeId: String): CompilationValid[Unit] = {
-    Validations.validateSubProcessParameters[ProcessCompilationError](parameters.toSet, ref.parameters.map(_.name).toSet)(NodeId(nodeId))
+  private def checkProcessParameters(ref: SubprocessRef, parameters: List[String], nodeId: String): ValidatedWithBranches[Unit] = {
+    val results = Validations.validateSubProcessParameters[ProcessCompilationError](parameters.toSet, ref.parameters.map(_.name).toSet)(NodeId(nodeId))
+    WriterT[CompilationValid, List[CanonicalBranch], Unit](results.map((Nil, _)))
   }
 
-  private def replaceCanonicalList(replacement: Map[String, List[CanonicalNode]]): List[CanonicalNode] => CompilationValid[List[CanonicalNode]] = {
+  private def replaceCanonicalList(replacement: Map[String, List[CanonicalNode]]): List[CanonicalNode] => ValidatedWithBranches[List[CanonicalNode]] = {
 
     iterateOverCanonicals({
       case FlatNode(SubprocessOutputDefinition(id, name, fields, add)) => replacement.get(name) match {
-        case Some(nodes) => Valid(FlatNode(SubprocessOutput(id, name, fields, add)) :: nodes)
-        case None => Invalid(NonEmptyList.of(UnknownSubprocessOutput(name, id)))
+        case Some(nodes) => validBranches(FlatNode(SubprocessOutput(id, name, fields, add)) :: nodes)
+        case None => invalidBranches(UnknownSubprocessOutput(name, id))
       }
     }, NodeDataFun.id)
   }
 
-  private def iterateOverCanonicals(action: PartialFunction[CanonicalNode, CompilationValid[List[CanonicalNode]]], dataAction: NodeDataFun)  =
-    (l:List[CanonicalNode]) => l.map(iterateOverCanonical(action, dataAction)).sequence[CompilationValid, List[CanonicalNode]].map(_.flatten)
+  private def iterateOverCanonicals(action: PartialFunction[CanonicalNode, ValidatedWithBranches[List[CanonicalNode]]], dataAction: NodeDataFun):
+    List[CanonicalNode] => ValidatedWithBranches[List[CanonicalNode]] =
+    (l:List[CanonicalNode]) => l.map(iterateOverCanonical(action, dataAction)).sequence[ValidatedWithBranches, List[CanonicalNode]].map(_.flatten)
 
-  private def iterateOverCanonical(action: PartialFunction[CanonicalNode, CompilationValid[List[CanonicalNode]]],
-                                     dataAction: NodeDataFun)
-  : (CanonicalNode => CompilationValid[List[CanonicalNode]]) = cnode => {
+  private def iterateOverCanonical(action: PartialFunction[CanonicalNode, ValidatedWithBranches[CanonicalBranch]],
+                                   dataAction: NodeDataFun): CanonicalNode => ValidatedWithBranches[CanonicalBranch] = cnode => {
     val listFun = iterateOverCanonicals(action, dataAction)
-      action.applyOrElse[CanonicalNode, CompilationValid[List[CanonicalNode]]](cnode, {
-        case FlatNode(data) => Valid(List(FlatNode(dataAction(data))))
+      action.applyOrElse[CanonicalNode, ValidatedWithBranches[CanonicalBranch]](cnode, {
+        case FlatNode(data) => validBranches(List(FlatNode(dataAction(data))))
         case canonicalnode.FilterNode(data, nextFalse) =>
           listFun(nextFalse).map(canonicalnode.FilterNode(dataAction(data), _)).map(List(_))
         case canonicalnode.SplitNode(data, nexts) =>
-          nexts.map(listFun).sequence[CompilationValid, List[CanonicalNode]]
+          nexts.map(listFun).sequence[ValidatedWithBranches, List[CanonicalNode]]
             .map(canonicalnode.SplitNode(dataAction(data), _)).map(List(_))
         case canonicalnode.SwitchNode(data, nexts, defaultNext) =>
           (
-            nexts.map(cas => listFun(cas.nodes).map(replaced => canonicalnode.Case(cas.expression, replaced))).sequence[CompilationValid, canonicalnode.Case],
+            nexts.map(cas => listFun(cas.nodes).map(replaced => canonicalnode.Case(cas.expression, replaced))).sequence[ValidatedWithBranches, canonicalnode.Case],
             listFun(defaultNext)
           ).mapN { (resolvedCases, resolvedDefault) =>
             List(canonicalnode.SwitchNode(dataAction(data), resolvedCases, resolvedDefault))
@@ -95,7 +138,7 @@ case class SubprocessResolver(subprocesses: Map[String, CanonicalProcess]) {
         case canonicalnode.Subprocess(data, nodes) =>
           nodes.map { case (k, v) =>
             listFun(v).map(k -> _)
-          }.toList.sequence[CompilationValid, (String, List[CanonicalNode])].map(replaced => List(canonicalnode.Subprocess(dataAction(data), replaced.toMap)))
+          }.toList.sequence[ValidatedWithBranches, (String, List[CanonicalNode])].map(replaced => List(canonicalnode.Subprocess(dataAction(data), replaced.toMap)))
       }
     )
   }
@@ -105,10 +148,10 @@ case class SubprocessResolver(subprocesses: Map[String, CanonicalProcess]) {
   }
 
   object NodeDataFun {
-    val id = new NodeDataFun {
+    val id: NodeDataFun = new NodeDataFun {
       override def apply[T <: NodeData](n: T): T = n
     }
-    def nodeIdPrefix(prefix:List[String]) = new NodeDataFun {
+    def nodeIdPrefix(prefix:List[String]): NodeDataFun = new NodeDataFun {
       override def apply[T <: NodeData](n: T): T = {
         pl.touk.nussknacker.engine.graph.node.prefixNodeId(prefix, n)
       }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/part.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/part.scala
@@ -14,6 +14,7 @@ object part {
     def node: SplittedNode[T]
     def validationContext: ValidationContext
     def id: String = node.id
+    def ends: List[End]
   }
 
   sealed trait PotentiallyStartPart extends ProcessPart {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/canonicalgraph/CanonicalProcessTest.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/canonicalgraph/CanonicalProcessTest.scala
@@ -33,7 +33,7 @@ class CanonicalProcessTest extends FunSuite with Matchers {
       MetaData("process1", StreamMetaData()),
       ExceptionHandlerRef(Nil),
       nodes = nodes,
-      additionalBranches = None)
+      additionalBranches = Some(List()))
 
   test("#withoutDisabledNodes when all nodes are enabled") {
     val withNodesEnabled = process(

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/SubprocessResolverSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/SubprocessResolverSpec.scala
@@ -35,7 +35,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
 
     val subprocess =  CanonicalProcess(MetaData("subProcess1", StreamMetaData()), null,
       List(
-        canonicalnode.FlatNode(SubprocessInputDefinition("start", suprocessParameters)),
+        FlatNode(SubprocessInputDefinition("start", suprocessParameters)),
         canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))) , None
     )
 
@@ -64,14 +64,14 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
 
     val subprocess = CanonicalProcess(MetaData("subProcess2", StreamMetaData()), null,
       List(
-        canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
+        FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "#param == 'a'"),
-        List(canonicalnode.FlatNode(Sink("deadEnd", SinkRef("sink1", List()), Some("'deadEnd'"))))
-      ), canonicalnode.FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))), None)
+        List(FlatNode(Sink("deadEnd", SinkRef("sink1", List()), Some("'deadEnd'"))))
+      ), FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))), None)
 
     val nested =  CanonicalProcess(MetaData("subProcess1", StreamMetaData()), null,
       List(
-        canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
+        FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
         canonicalnode.Subprocess(SubprocessInput("sub2",
         SubprocessRef("subProcess2", List(Parameter("param", "#param")))), Map("output" -> List(FlatNode(SubprocessOutputDefinition("sub2Out", "output", List.empty)))))), None
     )
@@ -102,7 +102,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
 
     val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData()), null,
       List(
-        canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
+        FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("param", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))), None
     )
 
@@ -123,7 +123,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
     val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData()),
       null,
       List(
-        canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
+        FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(SubprocessOutputDefinition("out1", "badoutput", List.empty))), None
     )
 
@@ -146,7 +146,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
     val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData(), isSubprocess = true),
       null,
       List(
-        canonicalnode.FlatNode(
+        FlatNode(
           SubprocessInputDefinition("start",List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "false"), List()),
         canonicalnode.SplitNode(
@@ -173,10 +173,10 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
     val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData(), isSubprocess = true),
       null,
       List(
-        canonicalnode.FlatNode(
+        FlatNode(
           SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "false"), List()),
-        canonicalnode.FlatNode(Sink("disabledSubprocessMockedSink", SinkRef("disabledSubprocessMockedSink", List()), Some("'result'")))
+        FlatNode(Sink("disabledSubprocessMockedSink", SinkRef("disabledSubprocessMockedSink", List()), Some("'result'")))
       ), None
     )
 
@@ -204,7 +204,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
     val emptySubprocess = CanonicalProcess(MetaData("emptySubprocess", StreamMetaData(), isSubprocess = true),
       null,
       List(
-        canonicalnode.FlatNode(
+        FlatNode(
           SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
         FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))
       ), None
@@ -212,7 +212,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
     val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData(), isSubprocess = true),
       null,
       List(
-        canonicalnode.FlatNode(
+        FlatNode(
           SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "false"), List()),
         FlatNode(SubprocessOutputDefinition("out1", "output", List.empty))
@@ -260,7 +260,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
 
     val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData()), null,
       List(
-        canonicalnode.FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
+        FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
         canonicalnode.FilterNode(Filter("f1", "false"), List()), FlatNode(Sink("end", SinkRef("sink1", List())))) , None
     )
 
@@ -287,8 +287,36 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
     resolvedValidated shouldBe Invalid(NonEmptyList.of(UnknownSubprocess(id = "subProcessId", nodeId = "nodeSubprocessId")))
   }
 
+  test("should resolve diamond subprocesses") {
+    val process = ProcessCanonizer.canonize(EspProcessBuilder.id("test")
+      .exceptionHandler()
+      .source("source", "source1")
+      .subprocess("sub", "subProcess1", List("ala" -> "'makota'"), Map("output" ->
+      GraphBuilder.emptySink("sink", "type"))))
+
+    val subprocess = CanonicalProcess(MetaData("subProcess1", StreamMetaData()), null,
+      List(
+        FlatNode(SubprocessInputDefinition("start", List(SubprocessParameter("ala", SubprocessClazzRef[String])))),
+        canonicalnode.SplitNode(Split("split"),
+          List(
+            List(FlatNode(Filter("filter2a", "false")), FlatNode(BranchEndData(BranchEndDefinition("join2a", "join1")))),
+            List(FlatNode(Filter("filter2b", "false")), FlatNode(BranchEndData(BranchEndDefinition("join2b", "join1")))),
+          )
+        )
+      ), Some(List(
+        FlatNode(Join("join1", None, "union", Nil, Nil, None)),
+        FlatNode(SubprocessOutputDefinition("output", "output", Nil, None))
+      ):: Nil)
+    )
+
+    val resolvedValidated = SubprocessResolver(Set(subprocess)).resolve(process).toOption.get.allStartNodes
+    resolvedValidated.toList.foreach { branch =>
+      println(branch)
+    }
+  }
+
   //FIXME: not sure if it's good way.
-  private implicit class DisabledSubpocess[R](builder: GraphBuilder[R]) extends GraphBuilder[R] {
+  private implicit class DisabledSubprocess[R](builder: GraphBuilder[R]) extends GraphBuilder[R] {
     def subprocessDisabled(id: String, subProcessId: String, output: String, params: (String, Expression)*): GraphBuilder[R] =
       build(node => builder.creator(SubprocessNode(SubprocessInput(id, SubprocessRef(subProcessId, params.map(Parameter.tupled).toList), isDisabled = Some(true)), Map(output -> node))))
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/SubprocessResolverSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/SubprocessResolverSpec.scala
@@ -300,7 +300,7 @@ class SubprocessResolverSpec extends FunSuite with Matchers with Inside{
         canonicalnode.SplitNode(Split("split"),
           List(
             List(FlatNode(Filter("filter2a", "false")), FlatNode(BranchEndData(BranchEndDefinition("join2a", "join1")))),
-            List(FlatNode(Filter("filter2b", "false")), FlatNode(BranchEndData(BranchEndDefinition("join2b", "join1")))),
+            List(FlatNode(Filter("filter2b", "false")), FlatNode(BranchEndData(BranchEndDefinition("join2b", "join1"))))
           )
         )
       ), Some(List(

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverter.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverter.scala
@@ -115,8 +115,7 @@ object ProcessConverter {
         val nodes = nextInner._1.flatten
         val edges = nextInner._2.flatten
         val connecting = outputs
-          .flatMap{ case (name, outputEdges) =>
-            outputEdges.headOption.map(_.id).map(displayablenode.Edge(data.id, _, Some(SubprocessOutput(name))))}.toList
+          .flatMap{ case (name, outputEdges) => createNextEdge(data.id, outputEdges, Some(SubprocessOutput(name))) }.toList
         (data :: nodes ::: tailNodes, connecting ::: edges ::: tailEdges)
       case Nil =>
         (List(),List())

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/PrettyValidationErrors.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/PrettyValidationErrors.scala
@@ -65,6 +65,7 @@ object PrettyValidationErrors {
       case MissingRequiredProperty(fieldName, label, _) => missingRequiredProperty(typ, fieldName, label)
       case UnknownProperty(propertyName, _) => unknownProperty(typ, propertyName)
       case InvalidPropertyFixedValue(fieldName, label, value, values, _) => invalidPropertyFixedValue(typ, fieldName, label, value, values)
+      case CustomNodeError(_, message, paramName) => NodeValidationError(typ, message, message, paramName, NodeValidationErrorType.SaveAllowed)
     }
   }
 


### PR DESCRIPTION
This fixes some bugs/deficiencies in joins/subprocesses. 
Most notably:
- in diagram there can be > 1 join
- some forms of joins can be used in subprocesses (most important - split/switch => union - in diamond shape)
To achieve this some refactoring of FlinkStreamingProcessRegistrar and SubprocessResolver had to be made...