### PR TITLE
allow to match deployCommentPattern more then once

### DIFF
--- a/ui/client/components/ValidateDeployComment.js
+++ b/ui/client/components/ValidateDeployComment.js
@@ -7,7 +7,7 @@ export default (comment, {requireComment, matchExpression}) => {
     validated = {isValid: false, toolTip: "Comment is required."}
   } else if (requireComment && !_.isEmpty(matchExpression)) {
     const match = comment.match(new RegExp(matchExpression, "g"))
-    if (!match || match.length > 1) {
+    if (!match) {
       validated = {isValid: false, toolTip: "Comment does not match required pattern."}
     }
   }

--- a/ui/client/test/ValidateDeployComment-test.js
+++ b/ui/client/test/ValidateDeployComment-test.js
@@ -28,8 +28,8 @@ describe("validating comments on deploy", () => {
     expect(validated).toEqual({ isValid: true, toolTip: undefined })
   })
 
-  it("is invalid if comment matches provided pattern more than once", () => {
+  it("is valid if comment matches provided pattern more than once", () => {
     const validated = ValidateDeployComment("Some comment jira-123 jira-234", { requireComment: true, matchExpression: pattern })
-    expect(validated).toEqual({ isValid: false, toolTip: "Comment does not match required pattern." })
+    expect(validated).toEqual({ isValid: true, toolTip: undefined })
   })
 })


### PR DESCRIPTION
Logic how many matches is allowed should be controlled by regular expression and not be hardcoded to 1. 