### PR TITLE
Add custom node validation (e.g. for parameters cross validation)

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -201,4 +201,15 @@ object ProcessCompilationError {
 
   case class CannotCreateObjectError(message: String, nodeId: String) extends ProcessCompilationError with InASingleNode
 
+  case class CustomParameterValidationError(message: String, description: String, paramName: String, nodeId: String) extends ParameterValidationError with InASingleNode
+
+  object CustomParameterValidationError{
+    def apply (message: String, description: String, paramName: String)(implicit nodeId: NodeId): CustomParameterValidationError = CustomParameterValidationError(message, description, paramName, nodeId.id)
+  }
+
+  case class CustomServiceValidationError(message: String, nodeId: String) extends ProcessCompilationError with InASingleNode
+
+  object CustomServiceValidationError {
+    def apply (message: String)(implicit nodeId: NodeId): CustomServiceValidationError = CustomServiceValidationError(message, nodeId.id)
+  }
 }

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -195,21 +195,13 @@ object ProcessCompilationError {
 
   case class CustomNodeError(nodeId: String, message: String, paramName: Option[String]) extends ProcessCompilationError with InASingleNode
 
+  object CustomNodeError {
+    def apply(message: String, paramName: Option[String])(implicit nodeId: NodeId): CustomNodeError = CustomNodeError(nodeId.id, message, paramName)
+  }
+
   case class FatalUnknownError(message: String) extends ProcessCompilationError {
     override def nodeIds: Set[String] = Set()
   }
 
   case class CannotCreateObjectError(message: String, nodeId: String) extends ProcessCompilationError with InASingleNode
-
-  case class CustomParameterValidationError(message: String, description: String, paramName: String, nodeId: String) extends ParameterValidationError with InASingleNode
-
-  object CustomParameterValidationError{
-    def apply (message: String, description: String, paramName: String)(implicit nodeId: NodeId): CustomParameterValidationError = CustomParameterValidationError(message, description, paramName, nodeId.id)
-  }
-
-  case class CustomServiceValidationError(message: String, nodeId: String) extends ProcessCompilationError with InASingleNode
-
-  object CustomServiceValidationError {
-    def apply (message: String)(implicit nodeId: NodeId): CustomServiceValidationError = CustomServiceValidationError(message, nodeId.id)
-  }
 }

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/ReturningType.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/ReturningType.scala
@@ -37,6 +37,4 @@ trait ServiceReturningType {
 
 }
 
-case class CustomParameterValidationException(message: String, description: String, paramName: String) extends Exception(message)
-
-case class CustomServiceValidationException(message: String) extends Exception(message)
+case class CustomNodeValidationException(message: String, paramName: Option[String]) extends Exception(message)

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/ReturningType.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/ReturningType.scala
@@ -20,6 +20,9 @@ trait ReturningType {
   * depending on input (as in dependent types in CS).
   * @see ReturningDependentTypeService in tests
   *
+  * You can implement custom validation at parameter or service level by throwing
+  * CustomParameterValidationException or CustomServiceValidationException respectively
+  *
   * This trait is more complex, as Service is not factory but is invoked directly
   */
 // TODO: Replace with EagerService with LazyParameter's and ContextTransformation API
@@ -33,3 +36,7 @@ trait ServiceReturningType {
   def returnType(parameters: Map[String, (TypingResult, Option[Any])]): TypingResult
 
 }
+
+case class CustomParameterValidationException(message: String, description: String, paramName: String) extends Exception(message)
+
+case class CustomServiceValidationException(message: String) extends Exception(message)

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/DevProcessConfigCreator.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/DevProcessConfigCreator.scala
@@ -105,7 +105,8 @@ class DevProcessConfigCreator extends ProcessConfigCreator {
     "campaignService" -> features(CampaignService),
     "configuratorService" -> features(ConfiguratorService),
     "meetingService" -> features(MeetingService),
-    "dynamicService" -> categories(new DynamicService)
+    "dynamicService" -> categories(new DynamicService),
+    "customValidatedService" -> categories(new CustomValidatedService)
   )
 
   override def customStreamTransformers(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[CustomStreamTransformer]] = Map(

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/CustomValidatedService.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/CustomValidatedService.scala
@@ -1,52 +1,31 @@
 package pl.touk.nussknacker.engine.management.sample.service
 
-import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomServiceValidationError
 import pl.touk.nussknacker.engine.api.{MethodToInvoke, ParamName, Service}
-import pl.touk.nussknacker.engine.api.typed.{CustomParameterValidationException, CustomServiceValidationException, ServiceReturningType}
+import pl.touk.nussknacker.engine.api.typed.{CustomNodeValidationException, ServiceReturningType}
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult, TypingResult}
 
 import scala.concurrent.Future
 
 class CustomValidatedService extends Service with ServiceReturningType {
 
-  private val templates = Map(
-    1 -> "Hello {name}",
-    2 -> "Buenos Dias {name}"
-  )
-
-  private val param = "\\{(\\w+)}".r
-
   @MethodToInvoke
-  def invoke(@ParamName("index") index: Int,
+  def invoke(@ParamName("age") age: Int,
              @ParamName("fields") fields: java.util.Map[String, String]): Future[String] = {
-    Future.successful(param.replaceAllIn(templates(index), { matcher =>
-      fields.get(matcher.group(1))
-    }))
+    Future.successful(s"name: ${fields.get("name")}, age: $age")
   }
 
   def returnType(params: Map[String, (TypingResult, Option[Any])]): TypingResult = {
-    val index = params("index")._2.map(_.asInstanceOf[Int]).getOrElse(throw new IllegalArgumentException("Missing index"))
-    if (!templates.contains(index)) {
-      throw CustomParameterValidationException(s"No template for index = $index", "Not found", "index")
-    } else {
-      val templateParams = param.findAllMatchIn(templates(index)).map(_.group(1)).toSet
-      val (fieldsType, _) = params("fields")
-      fieldsType match {
-        case TypedObjectTypingResult(fields, _) =>
-          val missingFields = templateParams.diff(fields.keys.toSet)
-          val nonStringFields = fields.values.filter(_ != Typed.typedClass[String])
-          if (missingFields.nonEmpty) {
-            throw CustomServiceValidationException("Missing fields: " + missingFields.mkString(", "))
-          } else if (nonStringFields.nonEmpty) {
-            throw CustomParameterValidationException("Every value should be a string, please fix the following: " + nonStringFields.mkString(", "), "", "fields")
-          } else {
-            Typed.typedClass[String]
-          }
-        case TypedObjectTypingResult(fields, _) if fields.values.exists(_ != Typed.typedClass[String]) =>
-          throw CustomServiceValidationException("All values of map must be strings")
-        case _ =>
-          throw new IllegalArgumentException("Unexpected type")
-      }
+    if (params("age")._2.get.asInstanceOf[Int] < 18) {
+      throw CustomNodeValidationException("Too young", Some("age"))
+    }
+    params("fields")._1 match {
+      case TypedObjectTypingResult(fields, _) if fields.contains("invalid") =>
+        throw CustomNodeValidationException("Service is invalid", None)
+      case TypedObjectTypingResult(fields, _) if fields.values.exists(_ != Typed.typedClass[String]) =>
+        throw CustomNodeValidationException("All of fields values should be strings", Some("fields"))
+      case TypedObjectTypingResult(fields, _) if !fields.keys.exists(_ == "name") =>
+        throw CustomNodeValidationException("Missing name", Some("fields"))
+      case _ => Typed.typedClass[String]
     }
   }
 }

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/CustomValidatedService.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/CustomValidatedService.scala
@@ -1,0 +1,52 @@
+package pl.touk.nussknacker.engine.management.sample.service
+
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomServiceValidationError
+import pl.touk.nussknacker.engine.api.{MethodToInvoke, ParamName, Service}
+import pl.touk.nussknacker.engine.api.typed.{CustomParameterValidationException, CustomServiceValidationException, ServiceReturningType}
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult, TypingResult}
+
+import scala.concurrent.Future
+
+class CustomValidatedService extends Service with ServiceReturningType {
+
+  private val templates = Map(
+    1 -> "Hello {name}",
+    2 -> "Buenos Dias {name}"
+  )
+
+  private val param = "\\{(\\w+)}".r
+
+  @MethodToInvoke
+  def invoke(@ParamName("index") index: Int,
+             @ParamName("fields") fields: java.util.Map[String, String]): Future[String] = {
+    Future.successful(param.replaceAllIn(templates(index), { matcher =>
+      fields.get(matcher.group(1))
+    }))
+  }
+
+  def returnType(params: Map[String, (TypingResult, Option[Any])]): TypingResult = {
+    val index = params("index")._2.map(_.asInstanceOf[Int]).getOrElse(throw new IllegalArgumentException("Missing index"))
+    if (!templates.contains(index)) {
+      throw CustomParameterValidationException(s"No template for index = $index", "Not found", "index")
+    } else {
+      val templateParams = param.findAllMatchIn(templates(index)).map(_.group(1)).toSet
+      val (fieldsType, _) = params("fields")
+      fieldsType match {
+        case TypedObjectTypingResult(fields, _) =>
+          val missingFields = templateParams.diff(fields.keys.toSet)
+          val nonStringFields = fields.values.filter(_ != Typed.typedClass[String])
+          if (missingFields.nonEmpty) {
+            throw CustomServiceValidationException("Missing fields: " + missingFields.mkString(", "))
+          } else if (nonStringFields.nonEmpty) {
+            throw CustomParameterValidationException("Every value should be a string, please fix the following: " + nonStringFields.mkString(", "), "", "fields")
+          } else {
+            Typed.typedClass[String]
+          }
+        case TypedObjectTypingResult(fields, _) if fields.values.exists(_ != Typed.typedClass[String]) =>
+          throw CustomServiceValidationException("All values of map must be strings")
+        case _ =>
+          throw new IllegalArgumentException("Unexpected type")
+      }
+    }
+  }
+}

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, ProcessCompilationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.expression.{ExpressionParser, ExpressionTypingInfo}
-import pl.touk.nussknacker.engine.api.typed.{CustomParameterValidationException, CustomServiceValidationException, ServiceReturningType}
+import pl.touk.nussknacker.engine.api.typed.{CustomNodeValidationException, ServiceReturningType}
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.api.{Context, MetaData}
 import pl.touk.nussknacker.engine.compiledgraph.node
@@ -250,10 +250,8 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
       expressionCompiler.compileEagerObjectParameters(objWithMethod.parameters, n.parameters, ctx).andThen { params =>
         (Try(computeReturnType(objWithMethod, params)) match {
           case Success(returnType) => valid((params, returnType))
-          case Failure(CustomParameterValidationException(message, description, paramName)) =>
-            invalid(CustomParameterValidationError(message, description, paramName))
-          case Failure(CustomServiceValidationException(message)) =>
-            invalid(CustomServiceValidationError(message))
+          case Failure(CustomNodeValidationException(message, paramName)) =>
+            invalid(CustomNodeError(message, paramName))
           case Failure(NonFatal(exception)) =>
             invalid(FatalUnknownError(exception.getMessage))
         }).toValidatedNel

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, ProcessCompilationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.expression.{ExpressionParser, ExpressionTypingInfo}
-import pl.touk.nussknacker.engine.api.typed.ServiceReturningType
+import pl.touk.nussknacker.engine.api.typed.{CustomParameterValidationException, CustomServiceValidationException, ServiceReturningType}
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.api.{Context, MetaData}
 import pl.touk.nussknacker.engine.compiledgraph.node
@@ -24,6 +24,7 @@ import pl.touk.nussknacker.engine.util.validated.ValidatedSyntax
 import pl.touk.nussknacker.engine.{api, compiledgraph, _}
 
 import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 import PartSubGraphCompiler._
 import NodeTypingInfo.DefaultExpressionId
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
@@ -246,9 +247,18 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
     val service = services.get(n.id).map(Valid(_)).getOrElse(invalid(MissingService(n.id))).toValidatedNel
 
     val validatedServiceWithTypingResult = service.andThen { objWithMethod =>
-      expressionCompiler.compileEagerObjectParameters(objWithMethod.parameters, n.parameters, ctx).map { params =>
+      expressionCompiler.compileEagerObjectParameters(objWithMethod.parameters, n.parameters, ctx).andThen { params =>
+        (Try(computeReturnType(objWithMethod, params)) match {
+          case Success(returnType) => valid((params, returnType))
+          case Failure(CustomParameterValidationException(message, description, paramName)) =>
+            invalid(CustomParameterValidationError(message, description, paramName))
+          case Failure(CustomServiceValidationException(message)) =>
+            invalid(CustomServiceValidationError(message))
+          case Failure(NonFatal(exception)) =>
+            invalid(FatalUnknownError(exception.getMessage))
+        }).toValidatedNel
+      }.map { case (params, returnType) =>
         val invoker = createServiceInvoker(objWithMethod)
-        val returnType = computeReturnType(objWithMethod, params)
         val typingResult = ServiceTypingResult(returnType, params.map(p => p.name -> p.typingInfo).toMap)
         (compiledgraph.service.ServiceRef(n.id, invoker, params), typingResult)
       }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/PrettyValidationErrors.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/PrettyValidationErrors.scala
@@ -66,7 +66,6 @@ object PrettyValidationErrors {
       case UnknownProperty(propertyName, _) => unknownProperty(typ, propertyName)
       case InvalidPropertyFixedValue(fieldName, label, value, values, _) => invalidPropertyFixedValue(typ, fieldName, label, value, values)
       case CustomNodeError(_, message, paramName) => NodeValidationError(typ, message, message, paramName, NodeValidationErrorType.SaveAllowed)
-      case CustomServiceValidationError(message, _) => node(message, "")
     }
   }
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/PrettyValidationErrors.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/validation/PrettyValidationErrors.scala
@@ -66,6 +66,7 @@ object PrettyValidationErrors {
       case UnknownProperty(propertyName, _) => unknownProperty(typ, propertyName)
       case InvalidPropertyFixedValue(fieldName, label, value, values, _) => invalidPropertyFixedValue(typ, fieldName, label, value, values)
       case CustomNodeError(_, message, paramName) => NodeValidationError(typ, message, message, paramName, NodeValidationErrorType.SaveAllowed)
+      case CustomServiceValidationError(message, _) => node(message, "")
     }
   }
 


### PR DESCRIPTION
I'd like to be able to add custom validation logic at a single node level.

simple use cases:
 * check with external service
 * parameter cross validation

The idea is to implement `WithCustomValidation.validate`.
I want it to be invoked after compilation, so we have access to both parameter Expression as well as it's TypingResult.

This is a rather dirty implementation, but just want to check if it makes sense at all