### PR TITLE
Refactor: EspTypeUtils

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -2,6 +2,12 @@
 
 To see biggest differences please consult the [changelog](Changelog.md).
 
+## In version 0.1.1 (not released yet)
+
+* [#914](https://github.com/TouK/nussknacker/pull/914) `pl.touk.nussknacker.engine.api.definition.Parameter` has deprecated
+ main factory method with `runtimeClass` parameter. Now should be passed `isLazyParameter` instead. Also were removed `runtimeClass`
+ from variances of factory methods prepared for easy testing (`optional` method and so on).
+
 ## In version 0.1.0
 
 * [#755](https://github.com/TouK/nussknacker/pull/755) Default async execution context does not depend on parallelism.

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/definition/NodeDependency.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/definition/NodeDependency.scala
@@ -14,37 +14,46 @@ case object OutputVariableNameDependency extends NodeDependency
 
 object Parameter {
 
-  def apply[T: ClassTag](name: String): Parameter = Parameter(name, Typed[T], implicitly[ClassTag[T]].runtimeClass)
-
-  def apply(name: String, typ: TypingResult, runtimeClass: Class[_], validators: List[ParameterValidator]): Parameter =
-    Parameter(name, typ, runtimeClass, editor = None, validators = validators, additionalVariables = Map.empty, branchParam = false)
+  def apply[T: ClassTag](name: String): Parameter = Parameter(name, Typed[T])
 
   // we want to have mandatory parameters by default because it can protect us from NPE in some cases)
-  def apply(name: String, typ: TypingResult, runtimeClass: Class[_]): Parameter =
-    Parameter(name, typ, runtimeClass, validators = List(MandatoryParameterValidator))
+  def apply(name: String, typ: TypingResult): Parameter =
+    Parameter(name, typ, validators = List(MandatoryParameterValidator))
+
+  def apply(name: String, typ: TypingResult, validators: List[ParameterValidator]): Parameter =
+    Parameter(name, typ, editor = None, validators = validators, additionalVariables = Map.empty, branchParam = false, isLazyParameter = false)
+
+  @deprecated("Passing runtimeClass to Parameter.apply is deprecated in favor of passing isLazyParameter")
+  def apply(name: String,
+            typ: TypingResult,
+            runtimeClass: Class[_],
+            editor: Option[ParameterEditor],
+            validators: List[ParameterValidator],
+            additionalVariables: Map[String, TypingResult],
+            branchParam: Boolean): Parameter = {
+    val isLazyParameter = classOf[LazyParameter[_]].isAssignableFrom(runtimeClass)
+    Parameter(name, typ, editor, validators, additionalVariables, branchParam, isLazyParameter)
+  }
 
   def optional[T:ClassTag](name: String): Parameter =
-    Parameter.optional(name, Typed[T], implicitly[ClassTag[T]].runtimeClass)
+    Parameter.optional(name, Typed[T])
 
-  def optional(name: String, typ: TypingResult, runtimeClass: Class[_]): Parameter =
-    Parameter(name, typ, runtimeClass, editor = None, validators = List.empty, additionalVariables = Map.empty, branchParam = false)
+  def optional(name: String, typ: TypingResult): Parameter =
+    Parameter(name, typ, editor = None, validators = List.empty, additionalVariables = Map.empty, branchParam = false, isLazyParameter = false)
 
 }
 
 object NotBlankParameter {
 
-  def apply(name: String, typ: TypingResult, runtimeClass: Class[_]): Parameter =
-    Parameter(name, typ, runtimeClass, validators = List(NotBlankParameterValidator))
+  def apply(name: String, typ: TypingResult): Parameter =
+    Parameter(name, typ, validators = List(NotBlankParameterValidator))
 
 }
 
 case class Parameter(name: String,
                      typ: TypingResult,
-                     runtimeClass: Class[_],
                      editor: Option[ParameterEditor],
                      validators: List[ParameterValidator],
                      additionalVariables: Map[String, TypingResult],
-                     branchParam: Boolean) extends NodeDependency {
-
-  def isLazyParameter: Boolean = classOf[LazyParameter[_]].isAssignableFrom(runtimeClass)
-}
+                     branchParam: Boolean,
+                     isLazyParameter: Boolean) extends NodeDependency

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
@@ -41,7 +41,7 @@ object typing {
       TypedObjectTypingResult(definition.fields.map { case (k, v) => (k, Typed(v))})
 
     def apply(fields: Map[String, TypingResult]): TypedObjectTypingResult =
-      TypedObjectTypingResult(fields, Typed.typedClass[java.util.Map[_, _]])
+      TypedObjectTypingResult(fields, TypedClass(classOf[java.util.Map[_, _]], List(Typed[String], Unknown)))
 
   }
 

--- a/engine/demo/src/main/scala/pl/touk/nussknacker/engine/demo/UtilProcessHelper.scala
+++ b/engine/demo/src/main/scala/pl/touk/nussknacker/engine/demo/UtilProcessHelper.scala
@@ -17,6 +17,11 @@ object UtilProcessHelper extends HideToString {
   @Documentation(description = "Get random number")
   def random(@ParamName("To (exclusive)") to: Int): Unit = {
     Random.nextInt(to)
-
   }
+
+  @Documentation(description = "Wrap param in Unknown type to make it usable in places where type checking is too much restrictive")
+  def toUnknown(@ParamName("value") value: Any): Any = {
+    value
+  }
+
 }

--- a/engine/flink/generic/src/main/scala/pl/touk/nussknacker/genericmodel/GenericConfigCreator.scala
+++ b/engine/flink/generic/src/main/scala/pl/touk/nussknacker/genericmodel/GenericConfigCreator.scala
@@ -73,6 +73,7 @@ class GenericConfigCreator extends EmptyProcessConfigCreator {
       Map(
         "GEO" -> defaultCategory(geo),
         "NUMERIC" -> defaultCategory(numeric),
+        "CONV" -> defaultCategory(conversion),
         "DATE" -> defaultCategory(date),
         "AVRO" -> defaultCategory(new AvroUtils(schemaRegistryClientFactory, kafkaConfig))
       ),

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/util/Serializers.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/util/Serializers.scala
@@ -58,7 +58,7 @@ object Serializers extends LazyLogging {
 
       //TODO: what about case class without parameters??
       if (arity == 0 && constructors.isEmpty) {
-        Try(EspTypeUtils.getCompanionObject(obj)).recover {
+        Try(EspTypeUtils.companionObject(obj)).recover {
           case e => logger.error(s"Failed to load companion for ${obj.getClass}"); Failure(e)
         }.get
       } else {

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
@@ -49,7 +49,7 @@ class ExpressionCompiler(expressionParsers: Map[String, ExpressionParser]) {
   def compileValidatedObjectParameters(parameters: List[evaluatedparam.Parameter],
                                        ctx: ValidationContext)(implicit nodeId: NodeId)
   : ValidatedNel[PartSubGraphCompilationError, List[compiledgraph.evaluatedparam.Parameter]] =
-    compileEagerObjectParameters(parameters.map(p => Parameter.optional(p.name, Unknown, classOf[Any])), parameters, ctx)
+    compileEagerObjectParameters(parameters.map(p => Parameter.optional(p.name, Unknown)), parameters, ctx)
 
   def compileEagerObjectParameters(parameterDefinitions: List[Parameter],
                                    parameters: List[evaluatedparam.Parameter],

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -319,7 +319,7 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
     val subParam = subprocessInput.subprocessParams.get.find(_.name == paramName).get
     subParam.typ.toRuntimeClass(classLoader) match {
       case Success(runtimeClass) =>
-        valid(Parameter.optional(paramName, Typed(runtimeClass), runtimeClass))
+        valid(Parameter.optional(paramName, Typed(runtimeClass)))
       case Failure(_) =>
         invalid(
           SubprocessParamClassLoadError(paramName, subParam.typ.refClazzName, subprocessInput.id)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
@@ -160,13 +160,18 @@ object TypeInfos {
 
   @JsonCodec(encodeOnly = true) case class MethodInfo(parameters: List[Parameter], refClazz: TypingResult, description: Option[String])
 
-  @JsonCodec(encodeOnly = true) case class ClazzDefinition(clazzName: TypingResult, methods: Map[String, MethodInfo]) {
+  case class ClazzDefinition(clazzName: TypingResult, methods: Map[String, List[MethodInfo]]) {
 
     def getPropertyOrFieldType(methodName: String): Option[TypingResult] = {
-      val filteredMethods = methods.filter(_._2.parameters.isEmpty)
-      val methodInfoes = filteredMethods.get(methodName)
-      methodInfoes.map(_.refClazz)
+      val filtered = methods.get(methodName).toList
+        .flatMap(_.filter(_.parameters.isEmpty))
+        .map(_.refClazz)
+      filtered match {
+        case Nil => None
+        case nonEmpty => Some(Typed(nonEmpty.toSet))
+      }
     }
+
   }
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/MethodDefinitionExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/MethodDefinitionExtractor.scala
@@ -67,7 +67,7 @@ private[definition] trait AbstractMethodDefinitionExtractor[T] extends MethodDef
         val name = (nodeParamNames orElse branchParamName)
           .getOrElse(throw new IllegalArgumentException(s"Parameter $p of $obj and method : ${method.getName} has missing @ParamName or @BranchParamName annotation"))
         // TODO JOIN: for branchParams we should rather look at Map's value type
-        val rawParamType = EspTypeUtils.getTypeForParameter(p)
+        val rawParamType = EspTypeUtils.extractParameterType(p)
         val (paramType, isLazyParameter) = determineIfLazyParameter(rawParamType)
         val extractedEditor = EditorExtractor.extract(p)
         val validators = tryToDetermineValidators(p, paramType, extractedEditor)
@@ -107,7 +107,7 @@ private[definition] trait AbstractMethodDefinitionExtractor[T] extends MethodDef
       .filterNot(_ == classOf[Object])
       .map[TypingResult](Typed(_))
     val typeFromSignature = {
-      val rawType = EspTypeUtils.getReturnClassForMethod(method)
+      val rawType = EspTypeUtils.extractMethodReturnType(method)
       (expectedReturnType, rawType) match {
         // uwrap Future, Source and so on
         case (Some(monadGenericType), TypedClass(cl, genericParam :: Nil)) if monadGenericType.isAssignableFrom(cl) => Some(genericParam)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/internal/propertyAccessors.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/internal/propertyAccessors.scala
@@ -99,6 +99,8 @@ object propertyAccessors {
 
   class ScalaLazyPropertyAccessor(lazyValuesTimeout: Duration) extends PropertyAccessor with ReadOnly with Caching {
 
+    // TODO: handle methods with multiple args or at least validate that they can't be called
+    //       - see test for similar case for Futures: "usage of methods with some argument returning future"
     override protected def reallyFindMethod(name: String, target: Class[_]) : Option[Method] = {
       target.getMethods.find(
         m => m.getParameterCount == 0 &&

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
@@ -1,22 +1,20 @@
 package pl.touk.nussknacker.engine.spel.typer
 
-import cats.data.NonEmptyList
-import org.springframework.expression.spel.ast.MethodReference
 import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
 import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.definition.TypeInfos.{ClazzDefinition, MethodInfo}
 import pl.touk.nussknacker.engine.types.EspTypeUtils
 
 object TypeMethodReference {
-  def apply(methodReference: MethodReference, currentResults: List[TypingResult])(implicit settings: ClassExtractionSettings): Either[String, TypingResult] =
-    new TypeMethodReference(methodReference, currentResults).call
+  def apply(methodName: String, currentResults: List[TypingResult], params: List[TypingResult])(implicit settings: ClassExtractionSettings): Either[String, TypingResult] =
+    new TypeMethodReference(methodName, currentResults, params).call
 }
 
 // TODO:
 // Currently SpEL methods are naively and optimistically type checked. This is, for overloaded methods with
 // different arity, validation is successful when SpEL MethodReference provides the number of parameters greater
 // or equal to method with the smallest arity.
-class TypeMethodReference(methodReference: MethodReference, currentResults: List[TypingResult]) {
+class TypeMethodReference(methodName: String, currentResults: List[TypingResult], calledParams: List[TypingResult]) {
   def call(implicit settings: ClassExtractionSettings): Either[String, TypingResult] =
     currentResults.headOption match {
       case Some(tc: SingleTypingResult) =>
@@ -27,39 +25,64 @@ class TypeMethodReference(methodReference: MethodReference, currentResults: List
         Right(Unknown)
     }
 
-  private lazy val paramsCount = methodReference.getChildCount
-
   private def extractClazzDefinitions(typedClasses: Set[SingleTypingResult])(implicit settings: ClassExtractionSettings): List[ClazzDefinition] =
     typedClasses.map(typedClass =>
       EspTypeUtils.clazzDefinition(typedClass.objType.klass)
     ).toList
 
-  private def typeFromClazzDefinitions(clazzDefinitions: List[ClazzDefinition]): Either[String, TypingResult] =
-    clazzDefinitions match {
-      case Nil =>
-        Right(Unknown)
-      case _ =>
-        val isClass = clazzDefinitions.map(k => k.clazzName).exists(_.canBeSubclassOf(Typed[Class[_]]))
-        val display = clazzDefinitions.map(k => k.clazzName).map(_.display).mkString(", ")
-        clazzDefinitions.flatMap(_.methods.get(methodReference.getName)) match {
-          //Static method can be invoked - we cannot find them ATM
-          case Nil if isClass => Right(Unknown)
-          case Nil  => Left(s"Unknown method '${methodReference.getName}' in $display")
-          case methodInfoes => typeFromMethodInfoes(methodInfoes)
-        }
-    }
+  private def typeFromClazzDefinitions(clazzDefinitions: List[ClazzDefinition]): Either[String, TypingResult] = {
+    val validatedType = for {
+      nonEmptyClassDefinitions <- validateClassDefinitionsNonEmpty(clazzDefinitions).right
+      nonEmptyMethods <- validateMethodsNonEmpty(nonEmptyClassDefinitions).right
+      methodsWithMatchingArity <- validateMethodArity(nonEmptyMethods).right
+      returnTypesForMatchingParams <- validateMethodParameterTypes(methodsWithMatchingArity).right
+    } yield Typed(returnTypesForMatchingParams.toSet)
 
-  //TODO: we check only arity, but don't check if any of overloaded methods has matching signature
-  //this will lead to erros if we have different return types for different signatures!
-  private def typeFromMethodInfoes(methodInfoes: List[MethodInfo]): Either[String, TypingResult] =
-    methodInfoes.filter(_.parameters.size <= paramsCount) match {
+    validatedType match {
+      case Left(None) => Right(Unknown) // we use Left(None) to indicate situation when we want to skip further validations because of lack of some knowledge
+      case Left(Some(message)) => Left(message)
+      case Right(returnType) => Right(returnType)
+    }
+  }
+
+  private def validateClassDefinitionsNonEmpty(clazzDefinitions: List[ClazzDefinition]): Either[Option[String], List[ClazzDefinition]] =
+    if (clazzDefinitions.isEmpty) Left(None) else Right(clazzDefinitions)
+
+  private def validateMethodsNonEmpty(clazzDefinitions: List[ClazzDefinition]): Either[Option[String], List[MethodInfo]] = {
+    def displayableType = clazzDefinitions.map(k => k.clazzName).map(_.display).mkString(", ")
+    def isClass = clazzDefinitions.map(k => k.clazzName).exists(_.canBeSubclassOf(Typed[Class[_]]))
+    clazzDefinitions.flatMap(_.methods.get(methodName)) match {
+      //Static method can be invoked - we cannot find them ATM
+      case Nil if isClass => Left(None)
+      case Nil => Left(Some(s"Unknown method '$methodName' in $displayableType"))
+      case methodInfoes => Right(methodInfoes)
+    }
+  }
+
+  private def validateMethodArity(methodInfoes: List[MethodInfo]): Either[Option[String], List[MethodInfo]] = {
+    methodInfoes.filter(_.parameters.size <= calledParams.size) match {
       case Nil =>
-        Left(s"Invalid arity for '${methodReference.getName}'")
+        Left(Some(s"Invalid arity for '$methodName'"))
       case nonEmpty =>
-        val returnTypes = nonEmpty.map(_.refClazz)
-        val typingResult = Typed(returnTypes.toSet)
-        Right(typingResult)
+        Right(nonEmpty)
     }
+  }
 
+  private def validateMethodParameterTypes(methodInfoes: List[MethodInfo]): Either[Option[String], List[TypingResult]] = {
+    val returnTypesForMatchingMethods = methodInfoes.flatMap { m =>
+      val allMatching = m.parameters.map(_.refClazz).zip(calledParams).forall {
+        case (declaredType, passedType) => passedType.canBeSubclassOf(declaredType)
+      }
+      if (allMatching) Some(m.refClazz) else None
+    }
+    returnTypesForMatchingMethods match {
+      case Nil =>
+        def toSignature(params: List[TypingResult]) = params.map(_.display).mkString(s"$methodName(", ", ", ")")
+        val methodVariances = methodInfoes.map(_.parameters.map(_.refClazz))
+        Left(Some(s"Mismatch parameter types. Found: ${toSignature(calledParams)}. Required: ${methodVariances.map(toSignature).mkString(" or ")}"))
+      case nonEmpty =>
+        Right(nonEmpty)
+    }
+  }
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
@@ -10,10 +10,6 @@ object TypeMethodReference {
     new TypeMethodReference(methodName, currentResults, params).call
 }
 
-// TODO:
-// Currently SpEL methods are naively and optimistically type checked. This is, for overloaded methods with
-// different arity, validation is successful when SpEL MethodReference provides the number of parameters greater
-// or equal to method with the smallest arity.
 class TypeMethodReference(methodName: String, currentResults: List[TypingResult], calledParams: List[TypingResult]) {
   def call(implicit settings: ClassExtractionSettings): Either[String, TypingResult] =
     currentResults.headOption match {
@@ -34,8 +30,7 @@ class TypeMethodReference(methodName: String, currentResults: List[TypingResult]
     val validatedType = for {
       nonEmptyClassDefinitions <- validateClassDefinitionsNonEmpty(clazzDefinitions).right
       nonEmptyMethods <- validateMethodsNonEmpty(nonEmptyClassDefinitions).right
-      methodsWithMatchingArity <- validateMethodArity(nonEmptyMethods).right
-      returnTypesForMatchingParams <- validateMethodParameterTypes(methodsWithMatchingArity).right
+      returnTypesForMatchingParams <- validateMethodParameterTypes(nonEmptyMethods).right
     } yield Typed(returnTypesForMatchingParams.toSet)
 
     validatedType match {
@@ -51,7 +46,7 @@ class TypeMethodReference(methodName: String, currentResults: List[TypingResult]
   private def validateMethodsNonEmpty(clazzDefinitions: List[ClazzDefinition]): Either[Option[String], List[MethodInfo]] = {
     def displayableType = clazzDefinitions.map(k => k.clazzName).map(_.display).mkString(", ")
     def isClass = clazzDefinitions.map(k => k.clazzName).exists(_.canBeSubclassOf(Typed[Class[_]]))
-    clazzDefinitions.flatMap(_.methods.get(methodName)) match {
+    clazzDefinitions.flatMap(_.methods.get(methodName).toList.flatten) match {
       //Static method can be invoked - we cannot find them ATM
       case Nil if isClass => Left(None)
       case Nil => Left(Some(s"Unknown method '$methodName' in $displayableType"))
@@ -59,21 +54,12 @@ class TypeMethodReference(methodName: String, currentResults: List[TypingResult]
     }
   }
 
-  private def validateMethodArity(methodInfoes: List[MethodInfo]): Either[Option[String], List[MethodInfo]] = {
-    methodInfoes.filter(_.parameters.size <= calledParams.size) match {
-      case Nil =>
-        Left(Some(s"Invalid arity for '$methodName'"))
-      case nonEmpty =>
-        Right(nonEmpty)
-    }
-  }
-
   private def validateMethodParameterTypes(methodInfoes: List[MethodInfo]): Either[Option[String], List[TypingResult]] = {
     val returnTypesForMatchingMethods = methodInfoes.flatMap { m =>
-      val allMatching = m.parameters.map(_.refClazz).zip(calledParams).forall {
+      lazy val allMatching = m.parameters.map(_.refClazz).zip(calledParams).forall {
         case (declaredType, passedType) => passedType.canBeSubclassOf(declaredType)
       }
-      if (allMatching) Some(m.refClazz) else None
+      if (m.parameters.size == calledParams.size && allMatching) Some(m.refClazz) else None
     }
     returnTypesForMatchingMethods match {
       case Nil =>

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/columnmodel/TypedClassColumnModel.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/columnmodel/TypedClassColumnModel.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.sql.columnmodel
 import java.lang.reflect.Member
 
 import pl.touk.nussknacker.engine.api.process.{ClassExtractionSettings, ClassMemberPredicate, PropertyFromGetterExtractionStrategy}
-import pl.touk.nussknacker.engine.api.typed.typing.TypedClass
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass}
 import pl.touk.nussknacker.engine.definition.TypeInfos.ClazzDefinition
 import pl.touk.nussknacker.engine.sql.columnmodel.CreateColumnModel.ClazzToSqlType
 import pl.touk.nussknacker.engine.sql.{Column, ColumnModel}
@@ -21,8 +21,8 @@ private[columnmodel] object TypedClassColumnModel {
 
   private def getColumns(clazzDefinition: ClazzDefinition): ColumnModel = {
     val columns = for {
-      (name, method) <- clazzDefinition.methods
-      typ <- ClazzToSqlType.convert(name, method.refClazz, clazzDefinition.clazzName.display)
+      (name, methods) <- clazzDefinition.methods
+      typ <- ClazzToSqlType.convert(name, Typed(methods.map(_.refClazz).toSet), clazzDefinition.clazzName.display)
     } yield Column(name, typ)
     ColumnModel(columns.toList)
   }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/EspTypeUtils.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/EspTypeUtils.scala
@@ -32,28 +32,18 @@ object EspTypeUtils {
 
   def clazzDefinition(clazz: Class[_])
                      (implicit settings: ClassExtractionSettings): ClazzDefinition =
-    ClazzDefinition(Typed(clazz), getPublicMethodAndFields(clazz))
+    ClazzDefinition(Typed(clazz), extractPublicMethodAndFields(clazz))
 
-  def getCompanionObject[T](klazz: Class[T]): T = {
-    klazz.getField("MODULE$").get(null).asInstanceOf[T]
-  }
-
-  def getGenericType(genericReturnType: Type): Option[TypingResult] = {
-    val hasGenericReturnType = genericReturnType.isInstanceOf[ParameterizedTypeImpl]
-    if (hasGenericReturnType) inferGenericMonadType(genericReturnType.asInstanceOf[ParameterizedTypeImpl])
-    else None
-  }
-
-  private def getPublicMethodAndFields(clazz: Class[_])
-                                      (implicit settings: ClassExtractionSettings): Map[String, List[MethodInfo]] = {
+  private def extractPublicMethodAndFields(clazz: Class[_])
+                                          (implicit settings: ClassExtractionSettings): Map[String, List[MethodInfo]] = {
     val membersPredicate = settings.visibleMembersPredicate(clazz)
-    val methods = publicMethods(clazz, membersPredicate)
-    val fields = publicFields(clazz, membersPredicate).mapValuesNow(List(_))
+    val methods = extractPublicMethods(clazz, membersPredicate)
+    val fields = extractPublicFields(clazz, membersPredicate).mapValuesNow(List(_))
     methods ++ fields
   }
 
-  private def publicMethods(clazz: Class[_], membersPredicate: VisibleMembersPredicate)
-                           (implicit settings: ClassExtractionSettings): Map[String, List[MethodInfo]] = {
+  private def extractPublicMethods(clazz: Class[_], membersPredicate: VisibleMembersPredicate)
+                                  (implicit settings: ClassExtractionSettings): Map[String, List[MethodInfo]] = {
     /* From getMethods javadoc: If this {@code Class} object represents an interface then the returned array
            does not contain any implicitly declared methods from {@code Object}.
            The same for primitives - we assume that languages like SpEL will be able to do boxing
@@ -71,7 +61,8 @@ object EspTypeUtils {
     val filteredMethods = publicMethods.filter(membersPredicate.shouldBeVisible)
 
     val methodNameAndInfoList = filteredMethods.flatMap { method =>
-      methodAccessMethods(method).map(_ -> toMethodInfo(method))
+      val extractedMethod = extractMethod(method)
+      collectMethodNames(method).map(_ -> extractedMethod)
     }
 
     deduplicateMethodsWithGenericReturnType(methodNameAndInfoList)
@@ -103,11 +94,9 @@ object EspTypeUtils {
     }.toGroupedMap
   }
 
-  private def toMethodInfo(method: Method)
-    = MethodInfo(getParameters(method), getReturnClassForMethod(method), getNussknackerDocs(method))
-
-  private def methodAccessMethods(method: Method)
-                                 (implicit settings: ClassExtractionSettings): List[String] = {
+  // SpEL is able to access getters using property name so you can write `obj.foo` instead of `obj.getFoo`
+  private def collectMethodNames(method: Method)
+                                (implicit settings: ClassExtractionSettings): List[String] = {
     val isGetter = method.getName.matches("^(get|is).+") && method.getParameterCount == 0
     if (isGetter) {
       val propertyMethod = StringUtils.uncapitalize(method.getName.replaceAll("^get|^is", ""))
@@ -121,58 +110,70 @@ object EspTypeUtils {
     }
   }
 
-  private def publicFields(clazz: Class[_], membersPredicate: VisibleMembersPredicate)
-                          (implicit settings: ClassExtractionSettings): Map[String, MethodInfo] = {
+  private def extractMethod(method: Method)
+    = MethodInfo(extractParameters(method), extractMethodReturnType(method), extractNussknackerDocs(method))
+
+  private def extractPublicFields(clazz: Class[_], membersPredicate: VisibleMembersPredicate)
+                                 (implicit settings: ClassExtractionSettings): Map[String, MethodInfo] = {
     val interestingFields = clazz.getFields.filter(membersPredicate.shouldBeVisible)
     interestingFields.map { field =>
-      field.getName -> MethodInfo(List.empty, getReturnClassForField(field), getNussknackerDocs(field))
+      field.getName -> MethodInfo(List.empty, extractFieldReturnType(field), extractNussknackerDocs(field))
     }.toMap
   }
 
-  def getReturnClassForMethod(method: Method): TypingResult = {
-    getGenericType(method.getGenericReturnType).orElse(extractClass(method.getGenericReturnType)).getOrElse(Typed(method.getReturnType))
+  private def extractNussknackerDocs(accessibleObject: AccessibleObject): Option[String] = {
+    Option(accessibleObject.getAnnotation(classOf[Documentation])).map(_.description())
   }
 
-  private def getParameters(method: Method): List[Parameter] = {
+  private def extractParameters(method: Method): List[Parameter] = {
     for {
       param <- method.getParameters.toList
       annotationOption = Option(param.getAnnotation(classOf[ParamName]))
       name = annotationOption.map(_.value).getOrElse(param.getName)
-      paramType = getTypeForParameter(param)
+      paramType = extractParameterType(param)
     } yield Parameter(name, paramType)
   }
 
-  def getTypeForParameter(javaParam: java.lang.reflect.Parameter): TypingResult = {
+  def extractParameterType(javaParam: java.lang.reflect.Parameter): TypingResult = {
     extractClass(javaParam.getParameterizedType).getOrElse(Typed(javaParam.getType))
   }
 
-  private def getNussknackerDocs(accessibleObject: AccessibleObject): Option[String] = {
-    Option(accessibleObject.getAnnotation(classOf[Documentation])).map(_.description())
+  private def extractFieldReturnType(field: Field): TypingResult = {
+    extractGenericReturnType(field.getGenericType).orElse(extractClass(field.getGenericType)).getOrElse(Typed(field.getType))
   }
 
-  private def getReturnClassForField(field: Field): TypingResult = {
-    getGenericType(field.getGenericType).orElse(extractClass(field.getGenericType)).getOrElse(Typed(field.getType))
+  def extractMethodReturnType(method: Method): TypingResult = {
+    extractGenericReturnType(method.getGenericReturnType).orElse(extractClass(method.getGenericReturnType)).getOrElse(Typed(method.getReturnType))
   }
 
-  //TODO this is not correct for primitives and complicated hierarchies, but should work in most cases
-  //http://docs.oracle.com/javase/8/docs/api/java/lang/reflect/ParameterizedType.html#getActualTypeArguments--
-  private def inferGenericMonadType(genericMethodType: ParameterizedTypeImpl): Option[TypingResult] = {
-    val rawType = genericMethodType.getRawType
+  private def extractGenericReturnType(typ: Type): Option[TypingResult] = {
+    typ match {
+      case t: ParameterizedTypeImpl => extractGenericMonadReturnType(t)
+      case t => None
+    }
+  }
+
+  // This method should be used only for method's and field's return type - for method's parameters such unwrapping has no sense
+  private def extractGenericMonadReturnType(genericReturnType: ParameterizedTypeImpl): Option[TypingResult] = {
+    val rawType = genericReturnType.getRawType
 
     // see ScalaLazyPropertyAccessor
     if (classOf[StateT[IO, _, _]].isAssignableFrom(rawType)) {
-      val returnType = genericMethodType.getActualTypeArguments.apply(3) // it's IndexedStateT[IO, ContextWithLazyValuesProvider, ContextWithLazyValuesProvider, A]
+      val returnType = genericReturnType.getActualTypeArguments.apply(3) // it's IndexedStateT[IO, ContextWithLazyValuesProvider, ContextWithLazyValuesProvider, A]
       extractClass(returnType)
     }
+    // see ScalaOptionOrNullPropertyAccessor
     else if (classOf[Option[_]].isAssignableFrom(rawType)) {
-      val optionGenericType = genericMethodType.getActualTypeArguments.apply(0)
+      val optionGenericType = genericReturnType.getActualTypeArguments.apply(0)
       extractClass(optionGenericType)
     }
     else None
   }
 
-  private def extractClass(futureGenericType: Type): Option[TypingResult] = {
-    futureGenericType match {
+  //TODO this is not correct for primitives and complicated hierarchies, but should work in most cases
+  //http://docs.oracle.com/javase/8/docs/api/java/lang/reflect/ParameterizedType.html#getActualTypeArguments--
+  private def extractClass(typ: Type): Option[TypingResult] = {
+    typ match {
       case t: Class[_] => Some(Typed(t))
       case t: ParameterizedTypeImpl => Some(extractGenericParams(t))
       case t => None
@@ -185,6 +186,10 @@ object EspTypeUtils {
       .find(_.isAssignableFrom(rawType))
       .map(_ => Typed.genericTypeClass(rawType, paramsType.getActualTypeArguments.toList.map(p => extractClass(p).getOrElse(Unknown))))
       .getOrElse(Typed(rawType))
+  }
+
+  def companionObject[T](klazz: Class[T]): T = {
+    klazz.getField("MODULE$").get(null).asInstanceOf[T]
   }
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/TypesInformationExtractor.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/types/TypesInformationExtractor.scala
@@ -104,7 +104,7 @@ object TypesInformationExtractor extends LazyLogging with ExecutionTimeMeasuring
   private def definitionsFromMethods(classDefinition: ClazzDefinition)
                                     (collectedSoFar: mutable.Set[TypingResult], path: DiscoveryPath)
                                     (implicit settings: ClassExtractionSettings): Set[ClazzDefinition] = {
-    classDefinition.methods.values.flatMap { kl =>
+    classDefinition.methods.values.flatten.flatMap { kl =>
       clazzAndItsChildrenDefinitionIfNotCollectedSoFar(kl.refClazz)(collectedSoFar, path.pushSegment(MethodReturnType(kl)))
       // TODO verify if parameters are need and if they are not, remove this
 //        ++ kl.parameters.flatMap(p => clazzAndItsChildrenDefinition(p.refClazz)(collectedSoFar, path.pushSegment(MethodParameter(p))))

--- a/engine/interpreter/src/test/java/pl/touk/nussknacker/engine/types/JavaClassWithVarargs.java
+++ b/engine/interpreter/src/test/java/pl/touk/nussknacker/engine/types/JavaClassWithVarargs.java
@@ -1,0 +1,13 @@
+package pl.touk.nussknacker.engine.types;
+
+public class JavaClassWithVarargs {
+
+    public int addAll(int... values) {
+        int sum = 0;
+        for (int i = 0; i < values.length; i++) {
+            sum += values[i];
+        }
+        return sum;
+    }
+
+}

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -94,7 +94,7 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
         "mapVariable" -> "{ Field1: 'Field1Value', Field2: 'Field2Value', Field3: #input.plainValue }",
         "spelVariable" -> "(#input.list.?[plainValue == 5]).![plainValue].contains(5)"
       )
-      .sink("id2", "#processHelper.add(#processHelper, 2)", "sink")
+      .sink("id2", "#processHelper.add(1, 2)", "sink")
 
     val compilationResult = validate(correctProcess, baseDefinition)
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -51,25 +51,29 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
         "typedMapSource" -> ObjectDefinition(List(Parameter[TypedObjectDefinition]("type")), Typed[TypedMap], List())
     ),
     Map("sink" -> (ObjectDefinition.noParam, SinkAdditionalData(true)),
-      "sinkWithLazyParam" -> (ObjectDefinition.withParams(List(Parameter("lazyString", Typed[String], classOf[LazyParameter[_]]))), SinkAdditionalData(true))),
+      "sinkWithLazyParam" -> (ObjectDefinition.withParams(List(Parameter[String]("lazyString").copy(isLazyParameter = true))), SinkAdditionalData(true))),
 
     Map("customTransformer" -> (ObjectDefinition(List.empty, Typed[SimpleRecord], List()), emptyQueryNamesData()),
       "withParamsTransformer" -> (ObjectDefinition(List(Parameter[String]("par1")), Typed[SimpleRecord], List()), emptyQueryNamesData()),
       "manyParams" -> (ObjectDefinition(List(
-                Parameter("par1", Typed[String], classOf[LazyParameter[_]]),
+                Parameter[String]("par1").copy(isLazyParameter = true),
                 Parameter[String]("par2"),
-                Parameter("par3", Typed[String], classOf[LazyParameter[_]]),
+                Parameter[String]("par3").copy(isLazyParameter = true),
                 Parameter[String]("par4")), Typed[SimpleRecord], List()), emptyQueryNamesData()),
       "clearingContextTransformer" -> (ObjectDefinition(List.empty, Typed[SimpleRecord], List()), emptyQueryNamesData(true)),
       "withManyParameters" -> (ObjectDefinition(List(
-        Parameter("lazyString", Typed[String], classOf[LazyParameter[_]]), Parameter("lazyInt", Typed[Integer], classOf[LazyParameter[_]]),
+        Parameter[String]("lazyString").copy(isLazyParameter = true), Parameter[Integer]("lazyInt").copy(isLazyParameter = true),
         Parameter[Long]("long"))
       , Typed[SimpleRecord], List()), emptyQueryNamesData(true)),
       "withoutReturnType" -> (ObjectDefinition(List(Parameter[String]("par1")), Typed[Void], List()), emptyQueryNamesData()),
-      "withMandatoryParams" -> (ObjectDefinition.withParams(List(Parameter("mandatoryParam", Typed.typedClass(classOf[String]), classOf[String]))), emptyQueryNamesData()),
-      "withNotBlankParams" -> (ObjectDefinition.withParams(List(NotBlankParameter("notBlankParam", Typed.typedClass(classOf[String]), classOf[String]))), emptyQueryNamesData()),
-      "withNullableLiteralIntegerParam" -> (ObjectDefinition.withParams(List(Parameter("nullableLiteralIntegerParam", Typed.typedClass(classOf[Integer]), classOf[Integer], validators = List(LiteralParameterValidator.integerValidator)))), emptyQueryNamesData()),
-      "withRegExpParam" -> (ObjectDefinition.withParams(List(Parameter("regExpParam", Typed.typedClass(classOf[Integer]), classOf[Integer], validators = List(LiteralParameterValidator.numberValidator)))), emptyQueryNamesData())
+      "withMandatoryParams" -> (ObjectDefinition.withParams(List(Parameter[String]("mandatoryParam"))), emptyQueryNamesData()),
+      "withNotBlankParams" -> (ObjectDefinition.withParams(List(NotBlankParameter("notBlankParam", Typed.typedClass(classOf[String])))), emptyQueryNamesData()),
+      "withNullableLiteralIntegerParam" -> (ObjectDefinition.withParams(List(
+        Parameter[Integer]("nullableLiteralIntegerParam").copy(validators = List(LiteralParameterValidator.integerValidator))
+      )), emptyQueryNamesData()),
+      "withRegExpParam" -> (ObjectDefinition.withParams(List(
+        Parameter[Integer]("regExpParam").copy(validators = List(LiteralParameterValidator.numberValidator))
+      )), emptyQueryNamesData())
     ),
     Map.empty,
     ObjectDefinition.noParam,

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractorSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractorSpec.scala
@@ -50,7 +50,6 @@ class ProcessDefinitionExtractorSpec extends FunSuite with Matchers {
     val definition = processDefinition.customStreamTransformers("transformerWithGenericParam")._1
 
     definition.objectDefinition.parameters should have size 1
-    definition.objectDefinition.parameters.head.runtimeClass shouldEqual classOf[List[_]]
     definition.objectDefinition.parameters.head.typ shouldEqual Typed.fromDetailedType[List[String]]
   }
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ServiceInvokerTest.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ServiceInvokerTest.scala
@@ -33,7 +33,7 @@ class ServiceInvokerTest extends FlatSpec with PatientScalaFutures with OptionVa
     val invoker = ServiceInvoker(definition)
 
     intercept[IllegalArgumentException](
-      invoker.invoke(Map("foo" -> "aa", "bar" -> "terefere"), NodeContext("", "", "", None))).getMessage shouldBe "Parameter bar has invalid class: java.lang.String, should be: int"
+      invoker.invoke(Map("foo" -> "aa", "bar" -> "terefere"), NodeContext("", "", "", None))).getMessage shouldBe "Parameter bar has invalid type: java.lang.String, should be: int"
   }
 
   it should "invoke service method with CompletionStage return type" in {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -177,6 +177,14 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
 
   }
 
+  test("validate MethodReference parameter types") {
+    val parsed = parse[Any]("#processHelper.add(1, 1)", ctxWithGlobal)
+    parsed.isValid shouldBe true
+
+    val invalid = parse[Any]("#processHelper.add('1', 1)", ctxWithGlobal)
+    invalid shouldEqual Invalid(NonEmptyList.of(ExpressionParseError("Mismatch parameter types. Found: add(java.lang.String, java.lang.Integer). Required: add(int, int)")))
+  }
+
   test("skip MethodReference validation without strictMethodsChecking") {
     val parsed = parseWithoutStrictMethodsChecking[Any]("#processHelper.notExistent(1, 1)", ctxWithGlobal)
     parsed.isValid shouldBe true
@@ -305,7 +313,7 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
   test("not allow access to variables without hash in methods") {
     val withNum = ctx.withVariable("a", 5).withVariable("processHelper", SampleGlobalObject)
     parse[Any]("#processHelper.add(a, 1)", withNum) should matchPattern {
-      case Invalid(NonEmptyList(ExpressionParseError("Non reference 'a' occurred. Maybe you missed '#' in front of it?"), Nil)) =>
+      case Invalid(l: NonEmptyList[_]) if l.toList.contains(ExpressionParseError("Non reference 'a' occurred. Maybe you missed '#' in front of it?")) =>
     }
   }
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -10,7 +10,7 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.effect.IO
 import org.scalatest.{EitherValues, FunSuite, Matchers}
-import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.{Context, ParamName}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.dict.embedded.EmbeddedDictDefinition
@@ -22,7 +22,7 @@ import pl.touk.nussknacker.engine.api.typed.TypedMap
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult}
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser.{Flavour, Standard}
-import pl.touk.nussknacker.engine.types.EspTypeUtils
+import pl.touk.nussknacker.engine.types.JavaClassWithVarargs
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Await
@@ -52,7 +52,9 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
   private val ctx = Context("abc").withVariables(
     Map("obj" -> testValue,"strVal" -> "","mapValue" -> Map("foo" -> "bar").asJava)
   )
-  private val ctxWithGlobal : Context = ctx.withVariable("processHelper", SampleGlobalObject)
+  private val ctxWithGlobal : Context = ctx
+    .withVariable("processHelper", SampleGlobalObject)
+    .withVariable("javaClassWithVarargs", new JavaClassWithVarargs)
 
   private def dumbLazyProvider: LazyValuesProvider = new LazyValuesProvider {
     override def apply[T](ctx: LazyContext, serviceId: String, params: Seq[(String, Any)]) = throw new IllegalStateException("Shouln't be invoked")
@@ -178,11 +180,24 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
   }
 
   test("validate MethodReference parameter types") {
-    val parsed = parse[Any]("#processHelper.add(1, 1)", ctxWithGlobal)
-    parsed.isValid shouldBe true
+    parse[Any]("#processHelper.add(1, 1)", ctxWithGlobal) shouldBe 'valid
+    parse[Any]("#processHelper.add(1L, 1)", ctxWithGlobal) shouldBe 'valid
+    parse[Any]("#processHelper.addLongs(1L, 1L)", ctxWithGlobal) shouldBe 'valid
+    parse[Any]("#processHelper.addLongs(1, 1L)", ctxWithGlobal) shouldBe 'valid
+    parse[Any]("#processHelper.add(#processHelper.toUnknown('1'), 1)", ctxWithGlobal) shouldBe 'valid
 
     val invalid = parse[Any]("#processHelper.add('1', 1)", ctxWithGlobal)
     invalid shouldEqual Invalid(NonEmptyList.of(ExpressionParseError("Mismatch parameter types. Found: add(java.lang.String, java.lang.Integer). Required: add(int, int)")))
+  }
+
+  // TODO handle scala varargs
+  ignore("validate MethodReference for scala varargs") {
+    parse[Any]("#processHelper.addAll(1, 2, 3)", ctxWithGlobal) shouldBe 'valid
+  }
+
+  // TODO handle java varargs
+  ignore("validate MethodReference for java varargs") {
+    parse[Any]("#javaClassWithVarargs.addAll(1, 2, 3)", ctxWithGlobal) shouldBe 'valid
   }
 
   test("skip MethodReference validation without strictMethodsChecking") {
@@ -192,21 +207,16 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
 
   test("return invalid type for MethodReference with invalid arity ") {
     val parsed = parse[Any]("#processHelper.add(1)", ctxWithGlobal)
-    val expectedValidation = Invalid("Invalid arity for 'add'")
+    val expectedValidation = Invalid("Mismatch parameter types. Found: add(java.lang.Integer). Required: add(int, int)")
     parsed.isInvalid shouldBe true
     parsed.leftMap(_.head).leftMap(_.message) shouldEqual expectedValidation
   }
 
   test("return invalid type for MethodReference with missing arguments") {
     val parsed = parse[Any]("#processHelper.add()", ctxWithGlobal)
-    val expectedValidation = Invalid("Invalid arity for 'add'")
+    val expectedValidation = Invalid("Mismatch parameter types. Found: add(). Required: add(int, int)")
     parsed.isInvalid shouldBe true
     parsed.leftMap(_.head).leftMap(_.message) shouldEqual expectedValidation
-  }
-
-  test("type optimistically MethodReference") {
-    val parsed = parse[Any]("#processHelper.add(1, 1, 1)", ctxWithGlobal)
-    parsed.isValid shouldBe true
   }
 
   test("return invalid type if PropertyOrFieldReference does not exists") {
@@ -617,9 +627,12 @@ object SimpleEnum extends Enumeration {
 object SampleGlobalObject {
   val constant = 4
   def add(a: Int, b: Int): Int = a + b
+  def addLongs(a: Long, b: Long) = a + b
+  def addAll(a: Int*) = a.sum
   def one() = 1
   def now: LocalDateTime = LocalDateTime.now()
   def identityMap(map: java.util.Map[String, Any]): java.util.Map[String, Any] = map
+  def toUnknown(value: Any): Any = value
 }
 
 class SampleObjectWithGetMethod(map: Map[String, Any]) {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
@@ -19,28 +19,6 @@ import scala.reflect.runtime.universe._
 
 class EspTypeUtilsSpec extends FunSuite with Matchers with OptionValues {
 
-  val signatures = Table(("signature", "value", "matches"),
-    (java.lang.Boolean.TYPE, classOf[java.lang.Boolean], true),
-    (java.lang.Long.TYPE, classOf[java.lang.Long], true),
-    (java.lang.Integer.TYPE, classOf[java.lang.Integer], true),
-    (classOf[java.lang.Long], classOf[java.lang.Integer], true),
-    (classOf[java.lang.Long], java.lang.Integer.TYPE, true),
-    (java.lang.Long.TYPE, java.lang.Integer.TYPE, true),
-    (java.lang.Long.TYPE, classOf[java.lang.Integer], true),
-    (java.lang.Long.TYPE, classOf[java.lang.Integer], true),
-
-    (java.lang.Character.TYPE, classOf[java.lang.Character], true),
-    (classOf[java.lang.Number], classOf[java.lang.Integer], true),
-    (java.lang.Integer.TYPE, classOf[java.lang.Long], false)
-  )
-
-  test("should check if signature is possible") {
-
-    forAll(signatures) { (signature, value, matches) =>
-      EspTypeUtils.signatureElementMatches(signature, value) shouldBe matches
-    }
-  }
-
   case class SampleClass(foo: Int, bar: String) extends SampleAbstractClass with SampleInterface
 
   class Returning {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
@@ -51,9 +51,9 @@ class EspTypeUtilsSpec extends FunSuite with Matchers with OptionValues {
 
     val method = classOf[Returning].getMethod("futureOfList")
 
-    val extractedType = EspTypeUtils.getGenericType(method.getGenericReturnType).get
+    val extractedType = EspTypeUtils.getReturnClassForMethod(method)
 
-    extractedType shouldBe Typed.genericTypeClass[java.util.List[_]](List(Typed[SampleClass]))
+    extractedType shouldBe Typed.fromDetailedType[Future[java.util.List[SampleClass]]]
   }
 
   test("should extract public fields from scala case class") {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
@@ -29,7 +29,7 @@ class EspTypeUtilsSpec extends FunSuite with Matchers with OptionValues {
 
     val method = classOf[Returning].getMethod("futureOfList")
 
-    val extractedType = EspTypeUtils.getReturnClassForMethod(method)
+    val extractedType = EspTypeUtils.extractMethodReturnType(method)
 
     extractedType shouldBe Typed.fromDetailedType[Future[java.util.List[SampleClass]]]
   }

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessInterpreter.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessInterpreter.scala
@@ -47,8 +47,8 @@ object StandaloneProcessInterpreter {
     val creator = modelData.configCreator
     val processObjectDependencies = ProcessObjectDependencies(modelData.processConfig, modelData.objectNaming)
 
-    val definitions = definitionsPostProcessor(ProcessDefinitionExtractor.extractObjectWithMethods(creator,
-      processObjectDependencies))
+    val extractedDefinitions = ProcessDefinitionExtractor.extractObjectWithMethods(creator, processObjectDependencies)
+    val definitions = definitionsPostProcessor(extractedDefinitions)
     val listeners = creator.listeners(processObjectDependencies) ++ additionalListeners
 
     CompiledProcess.compile(process,

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -123,7 +123,10 @@ class StandaloneTestMain(testData: TestData, process: EspProcess, modelData: Mod
     val standaloneInterpreter = StandaloneProcessInterpreter(process, testContext, modelData,
       definitionsPostProcessor = prepareMocksForTest(collectingListener),
       additionalListeners = List(collectingListener)
-    ).toOption.get
+    ) match {
+      case Valid(interpreter) => interpreter
+      case Invalid(errors) => throw new IllegalArgumentException("Error during interpreter preparation: " + errors.toList.mkString(", "))
+    }
 
     val parsedTestData = readTestData(definitions, standaloneInterpreter.source)
 

--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/functions/conversion.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/functions/conversion.scala
@@ -1,0 +1,16 @@
+package pl.touk.nussknacker.engine.util.functions
+
+import pl.touk.nussknacker.engine.api.{Documentation, ParamName}
+
+object conversion {
+
+  @Documentation(description = "Wrap param in Unknown type to make it usable in places where type checking is too much restrictive")
+  def toUnknown(@ParamName("value") value: Any): Any = {
+    value
+  }
+
+  @Documentation(description = "Parse string to number")
+  def toNumber(@ParamName("stringOrNumber") stringOrNumber: Any): java.lang.Number =
+    numeric.toNumber(stringOrNumber)
+
+}

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjects.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjects.scala
@@ -103,7 +103,7 @@ object UIProcessObjects {
     //TODO: currently if we cannot parse parameter class we assume it's unknown
     val typ = runtimeClass.map(Typed(_)).getOrElse(Unknown)
     //subprocess parameter name, editor and validators yet can not be configured via annotation or process creator
-    definition.Parameter.optional(p.name, typ, runtimeClass.toOption.getOrElse(classOf[Any]))
+    definition.Parameter.optional(p.name, typ)
   }
 }
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjects.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjects.scala
@@ -14,7 +14,7 @@ import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectDefinition
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.{CustomTransformerAdditionalData, ProcessDefinition, SinkAdditionalData}
-import pl.touk.nussknacker.engine.definition.TypeInfos.ClazzDefinition
+import pl.touk.nussknacker.engine.definition.TypeInfos.{ClazzDefinition, MethodInfo}
 import pl.touk.nussknacker.engine.definition.{ProcessDefinitionExtractor, TypeInfos}
 import pl.touk.nussknacker.engine.graph.evaluatedparam
 import pl.touk.nussknacker.engine.graph.node.SubprocessInputDefinition.SubprocessParameter
@@ -42,7 +42,7 @@ object UIProcessObjects {
 
     //FIXME: how to handle dynamic configuration of subprocesses??
     val subprocessInputs = fetchSubprocessInputs(subprocessesDetails, modelDataForType.modelClassLoader.classLoader, fixedNodesConfig)
-    val uiProcessDefinition = UIProcessDefinition(chosenProcessDefinition, subprocessInputs, modelDataForType.typeDefinitions)
+    val uiProcessDefinition = UIProcessDefinition(chosenProcessDefinition, subprocessInputs, modelDataForType.typeDefinitions.map(prepareClazzDefinition))
 
     val sinkAdditionalData = chosenProcessDefinition.sinkFactories.map(e => (e._1, e._2._2))
     val customTransformerAdditionalData = chosenProcessDefinition.customStreamTransformers.map(e => (e._1, e._2._2))
@@ -81,6 +81,12 @@ object UIProcessObjects {
         subprocessesDetails = subprocessesDetails))
   }
 
+  private def prepareClazzDefinition(definition: ClazzDefinition): UIClazzDefinition = {
+    // TODO: present all overloaded methods on FE
+    val methodsWithHighestArity = definition.methods.mapValues(_.maxBy(_.parameters.size))
+    UIClazzDefinition(definition.clazzName, methodsWithHighestArity)
+  }
+
   private def fetchSubprocessInputs(subprocessesDetails: Set[SubprocessDetails],
                                     classLoader: ClassLoader,
                                     fixedNodesConfig: Map[String, SingleNodeConfig]): Map[String, ObjectDefinition] = {
@@ -114,7 +120,7 @@ object UIProcessObjects {
                                signalsWithTransformers: Map[String, UIObjectDefinition],
                                exceptionHandlerFactory: UIObjectDefinition,
                                globalVariables: Map[String, UIObjectDefinition],
-                               typesInformation: Set[ClazzDefinition],
+                               typesInformation: Set[UIClazzDefinition],
                                subprocessInputs: Map[String, UIObjectDefinition]) {
   // skipping exceptionHandlerFactory
   val allDefinitions: Map[String, UIObjectDefinition] = services ++ sourceFactories ++ sinkFactories ++
@@ -142,6 +148,8 @@ object UIObjectDefinition {
   }
 }
 
+@JsonCodec(encodeOnly = true) case class UIClazzDefinition(clazzName: TypingResult, methods: Map[String, MethodInfo])
+
 @JsonCodec(encodeOnly = true) case class UIParameter(name: String,
                                                      typ: TypingResult,
                                                      editor: ParameterEditor,
@@ -167,7 +175,7 @@ object UIParameter {
 }
 
 object UIProcessDefinition {
-  def apply(processDefinition: ProcessDefinition[ObjectDefinition], subprocessInputs: Map[String, ObjectDefinition], types: Set[TypeInfos.ClazzDefinition]): UIProcessDefinition = {
+  def apply(processDefinition: ProcessDefinition[ObjectDefinition], subprocessInputs: Map[String, ObjectDefinition], types: Set[UIClazzDefinition]): UIProcessDefinition = {
     val uiProcessDefinition = UIProcessDefinition(
       services = processDefinition.services.mapValues(UIObjectDefinition(_)),
       sourceFactories = processDefinition.sourceFactories.mapValues(UIObjectDefinition(_)),

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/editor/ParameterEditorDeterminerChain.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/editor/ParameterEditorDeterminerChain.scala
@@ -10,7 +10,7 @@ object ParameterEditorDeterminerChain {
     val strategies = Seq(
       new ParameterConfigEditorDeterminer(parameterConfig),
       new ParameterBasedEditorDeterminer(param),
-      new ParameterTypeEditorDeterminerUiDecorator(new ParameterTypeEditorDeterminer(param.runtimeClass))
+      new ParameterTypeEditorDeterminerUiDecorator(new ParameterTypeEditorDeterminer(param.typ))
     )
     new ParameterEditorDeterminerChain(strategies)
   }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/editor/ParameterTypeEditorDeterminerUiDecorator.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/editor/ParameterTypeEditorDeterminerUiDecorator.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.ui.definition.editor
 
 import pl.touk.nussknacker.engine.api.definition.{CronParameterEditor, DualParameterEditor, ParameterEditor, RawParameterEditor}
 import pl.touk.nussknacker.engine.api.editor.DualEditorMode
+import pl.touk.nussknacker.engine.api.typed.typing.Typed
 import pl.touk.nussknacker.engine.definition.{ParameterEditorDeterminer, ParameterTypeEditorDeterminer}
 
 /**
@@ -13,7 +14,7 @@ protected class ParameterTypeEditorDeterminerUiDecorator(determiner: ParameterTy
   override def determine(): Option[ParameterEditor] = {
     determiner.determine() match {
       case Some(editor) => Some(editor)
-      case None if determiner.runtimeClass == classOf[com.cronutils.model.Cron] => Some(DualParameterEditor(
+      case None if determiner.typ.canBeSubclassOf(Typed[com.cronutils.model.Cron]) => Some(DualParameterEditor(
         simpleEditor = CronParameterEditor,
         defaultMode = DualEditorMode.SIMPLE
       ))

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
@@ -70,16 +70,16 @@ object ProcessTestData {
     .withService(otherExistingServiceId)
     .withService(processorId, classOf[Void])
     .withService(otherExistingServiceId2, Parameter("expression"))
-    .withService(otherExistingServiceId3, Parameter("expression", Typed.typedClass(classOf[String]), classOf[String]))
-    .withService(notBlankExistingServiceId, NotBlankParameter("expression", Typed.typedClass(classOf[String]), classOf[String]))
+    .withService(otherExistingServiceId3, Parameter[String]("expression"))
+    .withService(notBlankExistingServiceId, NotBlankParameter("expression", Typed.typedClass(classOf[String])))
     .withService(otherExistingServiceId4, Parameter(
       "expression",
       Typed.typedClass(classOf[JavaSampleEnum]),
-      classOf[JavaSampleEnum],
       Some(FixedValuesParameterEditor(List(FixedExpressionValue("a", "a")))),
       List(FixedValuesValidator(List(FixedExpressionValue("a", "a")))),
       Map.empty,
-      branchParam = false)
+      branchParam = false,
+      isLazyParameter = false)
     )
     .withCustomStreamTransformer(existingStreamTransformer, classOf[String], CustomTransformerAdditionalData(Set("query1", "query2"),
       clearsContext = false, manyInputs = false, canBeEnding = false))

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/defaults/EditorPossibleValuesBasedDefaultValueDeterminerTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/defaults/EditorPossibleValuesBasedDefaultValueDeterminerTest.scala
@@ -45,7 +45,7 @@ class EditorPossibleValuesBasedDefaultValueDeterminerTest extends FunSuite with 
     EditorPossibleValuesBasedDefaultValueDeterminer.determineParameterDefaultValue(
       definition,
       UIParameter(
-        Parameter("id", Typed[String], classOf[String], editor, validators = List.empty, additionalVariables = Map.empty, branchParam = false),
+        Parameter.optional[String]("id").copy(editor = editor),
         ParameterConfig.empty
       )
     )

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/editor/ParameterBasedEditorDeterminerChainTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/editor/ParameterBasedEditorDeterminerChainTest.scala
@@ -16,7 +16,7 @@ class ParameterBasedEditorDeterminerChainTest extends FunSuite with Matchers {
   private val stringEditor = StringParameterEditor
 
   test("determine editor by config") {
-    val param = new Parameter("param", Typed[String], classOf[String], Some(stringEditor), validators = List.empty, additionalVariables = Map.empty, branchParam = false)
+    val param = Parameter.optional[String]("param").copy(editor = Some(stringEditor))
     val config = ParameterConfig(None, Some(fixedValuesEditor), None, None)
 
     val determiner = ParameterEditorDeterminerChain(param, config)
@@ -25,7 +25,7 @@ class ParameterBasedEditorDeterminerChainTest extends FunSuite with Matchers {
   }
 
   test("determine editor by param") {
-    val param = new Parameter("param", Typed[String], classOf[String], Some(stringEditor), validators = List.empty, additionalVariables = Map.empty, branchParam = false)
+    val param = Parameter.optional[String]("param").copy(editor = Some(stringEditor))
     val config = ParameterConfig.empty
 
     val determiner = ParameterEditorDeterminerChain(param, config)


### PR DESCRIPTION
- Consistent naming: extract.* instead of get.*
- Explicitly naming situations where return type is extracted (for methods and filelds)
- MethodType -> ReturnType, because the same logic is for fields
- Comments with anchors to places on SpEL evaluation side where the same logic is done
- Methods ordered like there are using themselves