### PR TITLE
[FIX] Empty inline lists have proper type

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -15,6 +15,7 @@ Nussknacker versions
 * [#879](https://github.com/TouK/nussknacker/pull/879) Metrics can now use Flink variables for better reporting, it's recommended to use InfluxDB native protocol instead of legacy Graphite protocol to send metrics to InfluxDB.
 * [#903](https://github.com/TouK/nussknacker/pull/903) Update Confluent version to 5.4.1
 * [#940](https://github.com/TouK/nussknacker/pull/940) More detailed node errors 
+* [#954](https://github.com/TouK/nussknacker/pull/954) Correct handling of Typed.empty as Nothing type (e.g. in empty inline lists) 
 
 0.1.1
 ------------

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/CanBeSubclassDeterminer.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/CanBeSubclassDeterminer.scala
@@ -31,6 +31,8 @@ private[typed] object CanBeSubclassDeterminer {
     (givenType, superclassCandidate) match {
       case (_, Unknown) => true
       case (Unknown, _) => true
+      //Typed.empty is our Nothing type
+      case (empty, _) if empty == Typed.empty => true
       case (given: SingleTypingResult, superclass: TypedUnion) => canBeSubclassOf(Set(given), superclass.possibleTypes)
       case (given: TypedUnion, superclass: SingleTypingResult) => canBeSubclassOf(given.possibleTypes, Set(superclass))
       case (given: SingleTypingResult, superclass: SingleTypingResult) => singleCanBeSubclassOf(given, superclass)

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
@@ -114,6 +114,7 @@ object typing {
 
     def genericTypeClass[T:ClassTag](params: List[TypingResult]): TypingResult = TypedClass(toRuntime[T], params)
 
+    //Typed.empty is our Nothing type
     def empty: TypedUnion = TypedUnion(Set.empty)
 
     def apply[T: ClassTag]: TypingResult = apply(toRuntime[T])

--- a/engine/api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
+++ b/engine/api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
@@ -186,6 +186,12 @@ class TypingResultSpec extends FunSuite with Matchers with OptionValues with Ins
     }
   }
 
+  test("should handle Typed.empty") {
+    CanBeSubclassDeterminer.canBeSubclassOf(Typed.empty, Typed[String]) shouldBe true
+    CanBeSubclassDeterminer.canBeSubclassOf(Typed.empty, Typed[Long]) shouldBe true
+    CanBeSubclassDeterminer.canBeSubclassOf(Typed.empty, Typed[ClassHierarchy.Pet]) shouldBe true
+  }
+
   object ClassHierarchy {
 
     class Animal extends Serializable

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -126,8 +126,9 @@ private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: Commo
 
 
       case e: InlineList => withTypedChildren { children =>
-        val childrenTypes = children.toSet
-        Valid(Typed.genericTypeClass[java.util.List[_]](List(Typed(childrenTypes))))
+        //We don't want Typed.empty here, as currently it means empty type
+        val elementType = if (children.isEmpty) Unknown else Typed(children.toSet)
+        Valid(Typed.genericTypeClass[java.util.List[_]](List(elementType)))
       }
 
       case e: InlineMap =>

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -126,8 +126,7 @@ private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: Commo
 
 
       case e: InlineList => withTypedChildren { children =>
-        //We don't want Typed.empty here, as currently it means empty type
-        val elementType = if (children.isEmpty) Unknown else Typed(children.toSet)
+        val elementType = Typed(children.toSet)
         Valid(Typed.genericTypeClass[java.util.List[_]](List(elementType)))
       }
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -421,6 +421,12 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
     parse[Any]("{ Field1: 'Field1Value', Field2: 'Field2Value', Field3: #input.value }", ctxWithInput) shouldBe 'valid
   }
 
+  test("validate list literals") {
+    parse[Int]("#processHelper.stringList({})", ctxWithGlobal) shouldBe 'valid
+    parse[Int]("#processHelper.stringList({'aa'})", ctxWithGlobal) shouldBe 'valid
+    parse[Int]("#processHelper.stringList({333})", ctxWithGlobal) shouldNot be ('valid)
+  }
+
   test("type map literals") {
     val ctxWithInput = ctx.withVariable("input", SampleValue(444))
     parse[Any]("{ Field1: 'Field1Value', Field2: #input.value }.Field1", ctxWithInput) shouldBe 'valid
@@ -683,6 +689,7 @@ object SampleGlobalObject {
   def one() = 1
   def now: LocalDateTime = LocalDateTime.now()
   def identityMap(map: java.util.Map[String, Any]): java.util.Map[String, Any] = map
+  def stringList(arg: java.util.List[String]): Int = arg.size()
   def toAny(value: Any): Any = value
   def stringOnStringMap: java.util.Map[String, String] = Map("key1" -> "value1", "key2" -> "value2").asJava
 }


### PR DESCRIPTION
I think we should treat Typed.empty like Nothing type - in particular, it's subclass of all classes :)