### PR TITLE
Improvements: Kafka tools refactor

### DIFF
--- a/engine/demo/src/test/scala/pl/touk/nussknacker/engine/demo/ExampleItTests.scala
+++ b/engine/demo/src/test/scala/pl/touk/nussknacker/engine/demo/ExampleItTests.scala
@@ -8,7 +8,7 @@ import org.scalatest.{BeforeAndAfterAll, Matchers, Outcome, fixture}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.build.EspProcessBuilder
 import pl.touk.nussknacker.engine.graph.EspProcess
-import pl.touk.nussknacker.engine.kafka.KafkaUtils
+import pl.touk.nussknacker.engine.kafka.KafkaZookeeperUtils
 import pl.touk.nussknacker.engine.spel
 
 import scala.concurrent.Future
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 //TODO: do we currently need these tests?
 trait ExampleItTests extends fixture.FunSuite with BeforeAndAfterAll with Matchers { self: BaseITest =>
 
-  import KafkaUtils._
+  import KafkaZookeeperUtils._
   import spel.Implicits._
 
   override type FixtureParam = String

--- a/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/KafkaAvroSourceFactory.scala
+++ b/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/KafkaAvroSourceFactory.scala
@@ -12,7 +12,8 @@ import pl.touk.nussknacker.engine.api.typed.{CustomNodeValidationException, Retu
 import pl.touk.nussknacker.engine.api.{MetaData, MethodToInvoke, ParamName}
 import pl.touk.nussknacker.engine.avro.fixed.FixedKafkaAvroSchemaProvider
 import pl.touk.nussknacker.engine.avro.schemaregistry._
-import pl.touk.nussknacker.engine.kafka.KafkaSourceFactory._
+import pl.touk.nussknacker.engine.avro.BaseKafkaAvroSourceFactory._
+import pl.touk.nussknacker.engine.kafka.BaseKafkaSourceFactory._
 import pl.touk.nussknacker.engine.kafka._
 
 class KafkaAvroSourceFactory[T: TypeInformation](schemaRegistryProvider: SchemaRegistryProvider[T],
@@ -71,10 +72,14 @@ object FixedKafkaAvroSourceFactory {
     new FixedKafkaAvroSourceFactory(processObjectDependencies, formatKey = false, useSpecificAvroReader = false, timestampAssigner = None)
 }
 
+object BaseKafkaAvroSourceFactory {
+  final val VersionParamName = "Schema version"
+}
+
 abstract class BaseKafkaAvroSourceFactory[T: TypeInformation](processObjectDependencies: ProcessObjectDependencies, timestampAssigner: Option[TimestampAssigner[T]])
   extends BaseKafkaSourceFactory(timestampAssigner, TestParsingUtils.newLineSplit, processObjectDependencies) {
 
-  final val VersionParamName = "Schema version"
+
 
   // We currently not using processMetaData and nodeId but it is here in case if someone want to use e.g. some additional fields
   // in their own concrete implementation

--- a/engine/flink/generic/src/test/scala/pl/touk/nussknacker/genericmodel/GenericItSpec.scala
+++ b/engine/flink/generic/src/test/scala/pl/touk/nussknacker/genericmodel/GenericItSpec.scala
@@ -21,7 +21,7 @@ import pl.touk.nussknacker.engine.build.{EspProcessBuilder, GraphBuilder}
 import pl.touk.nussknacker.engine.flink.test.{FlinkTestConfiguration, StoppableExecutionEnvironment}
 import pl.touk.nussknacker.engine.graph.EspProcess
 import pl.touk.nussknacker.engine.graph.exceptionhandler.ExceptionHandlerRef
-import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaSpec, KafkaUtils}
+import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaSpec, KafkaZookeeperUtils}
 import pl.touk.nussknacker.engine.process.FlinkStreamingProcessRegistrar
 import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompiler
 import pl.touk.nussknacker.engine.spel
@@ -29,7 +29,7 @@ import pl.touk.nussknacker.engine.testing.LocalModelData
 
 class GenericItSpec extends FunSuite with BeforeAndAfterAll with Matchers with KafkaSpec with EitherValues with LazyLogging {
 
-  import KafkaUtils._
+  import KafkaZookeeperUtils._
   import MockSchemaRegistry._
   import org.apache.flink.streaming.api.scala._
   import spel.Implicits._

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/signal/KafkaSignalStreamConnector.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/signal/KafkaSignalStreamConnector.scala
@@ -4,7 +4,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.functions.IngestionTimeExtractor
 import org.apache.flink.streaming.api.scala.{ConnectedStreams, DataStream}
-import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaEspUtils}
+import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaUtils}
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer
 
 trait KafkaSignalStreamConnector {
@@ -13,7 +13,7 @@ trait KafkaSignalStreamConnector {
 
   def connectWithSignals[A, B: TypeInformation](start: DataStream[A], processId: String, nodeId: String, schema: DeserializationSchema[B]): ConnectedStreams[A, B] = {
     val signalsSource = new FlinkKafkaConsumer[B](signalsTopic, schema,
-      KafkaEspUtils.toProperties(kafkaConfig, Some(s"$processId-$nodeId-signal")))
+      KafkaUtils.toProperties(kafkaConfig, Some(s"$processId-$nodeId-signal")))
     val signalsStream = start.executionEnvironment
       .addSource(signalsSource).name(s"signals-$processId-$nodeId")
     val withTimestamps = assignTimestampsAndWatermarks(signalsStream)

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaExceptionConsumer.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaExceptionConsumer.scala
@@ -10,11 +10,11 @@ class KafkaExceptionConsumer(val kafkaConfig: KafkaConfig,
                              serializationSchema: SerializationSchema[EspExceptionInfo[NonTransientException]])(implicit metaData: MetaData)
   extends FlinkEspExceptionConsumer {
 
-  private lazy val producer = KafkaEspUtils.createProducer(kafkaConfig, s"exception-${metaData.id}")
+  private lazy val producer = KafkaUtils.createProducer(kafkaConfig, s"exception-${metaData.id}")
 
   def consume(exceptionInfo: EspExceptionInfo[NonTransientException]): Unit = {
     val toSend = serializationSchema.serialize(exceptionInfo)
-    KafkaEspUtils.sendToKafka(topic, Array.empty[Byte], toSend)(producer)
+    KafkaUtils.sendToKafka(topic, Array.empty[Byte], toSend)(producer)
   }
 
   override def close(): Unit = {

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSinkFactory.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSinkFactory.scala
@@ -6,50 +6,51 @@ import javax.validation.constraints.NotBlank
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.connectors.kafka.KafkaSerializationSchema
 import pl.touk.nussknacker.engine.api.editor.{DualEditor, DualEditorMode, SimpleEditor, SimpleEditorType}
-import pl.touk.nussknacker.engine.api.namespaces.{KafkaUsageKey, NamingContext}
 import pl.touk.nussknacker.engine.api.process.{ProcessObjectDependencies, Sink, SinkFactory}
 import pl.touk.nussknacker.engine.api.{MetaData, MethodToInvoke, ParamName}
 import pl.touk.nussknacker.engine.flink.api.process.BasicFlinkSink
-import pl.touk.nussknacker.engine.kafka.KafkaSinkFactory._
 import pl.touk.nussknacker.engine.kafka.serialization.{FixedSerializationSchemaFactory, SerializationSchemaFactory}
+import pl.touk.nussknacker.engine.kafka.BaseKafkaSinkFactory._
 
-  class KafkaSinkFactory(schemaFactory: SerializationSchemaFactory[Any],
-                       processObjectDependencies: ProcessObjectDependencies) extends SinkFactory {
+class KafkaSinkFactory(serializationSchemaFactory: SerializationSchemaFactory[Any], processObjectDependencies: ProcessObjectDependencies)
+  extends BaseKafkaSinkFactory(serializationSchemaFactory, processObjectDependencies) {
 
-  def this(schema: String => KafkaSerializationSchema[Any],
-           processObjectDependencies: ProcessObjectDependencies) =
+  def this(schema: String => KafkaSerializationSchema[Any], processObjectDependencies: ProcessObjectDependencies) =
     this(FixedSerializationSchemaFactory(schema), processObjectDependencies)
 
   @MethodToInvoke
   def create(processMetaData: MetaData,
-             @ParamName(`TopicParamName`)
              @DualEditor(
                simpleEditor = new SimpleEditor(`type` = SimpleEditorType.STRING_EDITOR),
                defaultMode = DualEditorMode.RAW
              )
-             @NotBlank
-             topic: String
-            )(metaData: MetaData): Sink = {
-    val preparedTopic = processObjectDependencies.objectNaming.prepareName(topic,
-      processObjectDependencies.config,
-      new NamingContext(KafkaUsageKey))
-    val kafkaConfig = KafkaConfig.parseConfig(processObjectDependencies.config, "kafka")
-    val serializationSchema = schemaFactory.create(preparedTopic, kafkaConfig)
-    new KafkaSink(preparedTopic, kafkaConfig, serializationSchema, s"${metaData.id}-${preparedTopic}")
+             @ParamName(`TopicParamName`) @NotBlank topic: String
+            ): Sink =
+    createSink(topic, processMetaData)
+}
+
+object BaseKafkaSinkFactory {
+  final val TopicParamName = "topic"
+}
+
+abstract class BaseKafkaSinkFactory(serializationSchemaFactory: SerializationSchemaFactory[Any], processObjectDependencies: ProcessObjectDependencies)
+  extends SinkFactory {
+
+  protected def createSink(topic: String, processMetaData: MetaData): KafkaSink = {
+    val kafkaConfig = KafkaConfig.parseProcessObjectDependencies(processObjectDependencies)
+    val preparedTopic = KafkaUtils.prepareTopic(topic, processObjectDependencies)
+    val serializationSchema = serializationSchemaFactory.create(preparedTopic, kafkaConfig)
+    val clientId = s"${processMetaData.id}-$preparedTopic"
+    new KafkaSink(topic, kafkaConfig, serializationSchema, clientId)
   }
 
-  class KafkaSink(topic: String, kafkaConfig: KafkaConfig, serializationSchema: KafkaSerializationSchema[Any], clientId: String) extends BasicFlinkSink with Serializable {
-    override def toFlinkFunction: SinkFunction[Any] = {
+  class KafkaSink(topic: String, kafkaConfig: KafkaConfig, serializationSchema: KafkaSerializationSchema[Any], clientId: String)
+    extends BasicFlinkSink with Serializable {
+
+    override def toFlinkFunction: SinkFunction[Any] =
       PartitionByKeyFlinkKafkaProducer(kafkaConfig, topic, serializationSchema, clientId)
-    }
+
     override def testDataOutput: Option[Any => String] = Option(value =>
       new String(serializationSchema.serialize(value, System.currentTimeMillis()).value(), StandardCharsets.UTF_8))
   }
-
-}
-
-object KafkaSinkFactory {
-
-  final val TopicParamName = "topic"
-
 }

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSinkFactory.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSinkFactory.scala
@@ -38,7 +38,7 @@ abstract class BaseKafkaSinkFactory(serializationSchemaFactory: SerializationSch
 
   protected def createSink(topic: String, processMetaData: MetaData): KafkaSink = {
     val kafkaConfig = KafkaConfig.parseProcessObjectDependencies(processObjectDependencies)
-    val preparedTopic = KafkaUtils.prepareTopic(topic, processObjectDependencies)
+    val preparedTopic = KafkaUtils.prepareTopicName(topic, processObjectDependencies)
     val serializationSchema = serializationSchemaFactory.create(preparedTopic, kafkaConfig)
     val clientId = s"${processMetaData.id}-$preparedTopic"
     new KafkaSink(topic, kafkaConfig, serializationSchema, clientId)

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSourceFactory.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSourceFactory.scala
@@ -145,7 +145,7 @@ abstract class BaseKafkaSourceFactory[T: TypeInformation](val timestampAssigner:
       }.getOrElse(newStart)
     }
 
-    def preparedTopics: List[String] = topics.map(KafkaUtils.prepareTopic(_, processObjectDependencies))
+    def preparedTopics: List[String] = topics.map(KafkaUtils.prepareTopicName(_, processObjectDependencies))
 
     protected val typeInformation: TypeInformation[T] = implicitly[TypeInformation[T]]
 

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSourceFactory.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaSourceFactory.scala
@@ -4,8 +4,8 @@ import javax.validation.constraints.NotBlank
 import org.apache.flink.api.common.serialization.DeserializationSchema
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.TimeCharacteristic
-import org.apache.flink.streaming.api.functions.{AssignerWithPeriodicWatermarks, AssignerWithPunctuatedWatermarks, TimestampAssigner}
 import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.streaming.api.functions.{AssignerWithPeriodicWatermarks, AssignerWithPunctuatedWatermarks, TimestampAssigner}
 import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaDeserializationSchemaWrapper
 import org.apache.flink.streaming.connectors.kafka.{FlinkKafkaConsumer, KafkaDeserializationSchema}
@@ -13,13 +13,12 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
 import pl.touk.nussknacker.engine.api.editor.{DualEditor, DualEditorMode, SimpleEditor, SimpleEditorType}
-import pl.touk.nussknacker.engine.api.namespaces.{KafkaUsageKey, NamingContext}
 import pl.touk.nussknacker.engine.api.process.{ProcessObjectDependencies, Source, TestDataGenerator, TestDataParserProvider}
 import pl.touk.nussknacker.engine.api.test.{TestDataParser, TestDataSplit}
 import pl.touk.nussknacker.engine.api.{MetaData, MethodToInvoke, ParamName}
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkSource, FlinkSourceFactory}
-import pl.touk.nussknacker.engine.kafka.KafkaSourceFactory._
+import pl.touk.nussknacker.engine.kafka.BaseKafkaSourceFactory._
 import pl.touk.nussknacker.engine.kafka.serialization.{DeserializationSchemaFactory, FixedDeserializationSchemaFactory}
 
 import scala.collection.JavaConverters._
@@ -29,8 +28,8 @@ import scala.collection.JavaConverters._
   * Features:
   *   - fetch latest N records which can be later used to test process in UI
   * Fetching data is defined in [[pl.touk.nussknacker.engine.kafka.BaseKafkaSourceFactory.KafkaSource]] which
-  * extends [[pl.touk.nussknacker.engine.api.process.TestDataGenerator]]. See [[pl.touk.nussknacker.engine.kafka.KafkaEspUtils#readLastMessages]]
-  *   - reset Kafka's offset to latest value - `forceLatestRead` property, see [[pl.touk.nussknacker.engine.kafka.KafkaEspUtils#setOffsetToLatest]]
+  * extends [[pl.touk.nussknacker.engine.api.process.TestDataGenerator]]. See [[pl.touk.nussknacker.engine.kafka.KafkaUtils#readLastMessages]]
+  *   - reset Kafka's offset to latest value - `forceLatestRead` property, see [[pl.touk.nussknacker.engine.kafka.KafkaUtils#setOffsetToLatest]]
   *
   * BaseKafkaSourceFactory comes in two variants:
   *   - KafkaSourceFactory - `topic` parameter has to be passed on frontend
@@ -55,28 +54,21 @@ class KafkaSourceFactory[T: TypeInformation](schemaFactory: DeserializationSchem
 
   @MethodToInvoke
   def create(processMetaData: MetaData,
-             @ParamName(`TopicParamName`)
              @DualEditor(
                simpleEditor = new SimpleEditor(`type` = SimpleEditorType.STRING_EDITOR),
                defaultMode = DualEditorMode.RAW
              )
-             @NotBlank
-             topic: String)(implicit nodeId: NodeId): Source[T] with TestDataGenerator = {
-    val kafkaConfig = KafkaSourceFactory.parseKafkaConfig(processObjectDependencies)
+             @ParamName(`TopicParamName`) @NotBlank topic: String)
+            (implicit nodeId: NodeId): Source[T] with TestDataGenerator = {
+    val kafkaConfig = KafkaConfig.parseProcessObjectDependencies(processObjectDependencies)
     createSource(List(topic), kafkaConfig, schemaFactory.create(List(topic), kafkaConfig), processMetaData, nodeId)
   }
 
 }
 
-object KafkaSourceFactory {
-
+object BaseKafkaSourceFactory {
   final val TopicParamName = "topic"
-
-  def parseKafkaConfig(processObjectDependencies: ProcessObjectDependencies): KafkaConfig =
-    KafkaConfig.parseConfig(processObjectDependencies.config, "kafka")
-
 }
-
 
 class SingleTopicKafkaSourceFactory[T: TypeInformation](topic: String,
                                                         schemaFactory: DeserializationSchemaFactory[T],
@@ -97,7 +89,7 @@ class SingleTopicKafkaSourceFactory[T: TypeInformation](topic: String,
 
   @MethodToInvoke
   def create(processMetaData: MetaData)(implicit nodeId: NodeId): Source[T] with TestDataGenerator = {
-    val kafkaConfig = KafkaSourceFactory.parseKafkaConfig(processObjectDependencies)
+    val kafkaConfig = KafkaConfig.parseProcessObjectDependencies(processObjectDependencies)
     createSource(List(topic), kafkaConfig, schemaFactory.create(List(topic), kafkaConfig), processMetaData, nodeId)
   }
 
@@ -111,7 +103,7 @@ abstract class BaseKafkaSourceFactory[T: TypeInformation](val timestampAssigner:
   @deprecated("Should be used version without process MetaData", "0.1.1")
   protected def createSource(processMetaData: MetaData, topics: List[String],
                              schema: KafkaDeserializationSchema[T]): KafkaSource = {
-    createSource(topics, KafkaSourceFactory.parseKafkaConfig(processObjectDependencies), schema)
+    createSource(topics, KafkaConfig.parseProcessObjectDependencies(processObjectDependencies), schema)
   }
 
   // We currently not using processMetaData and nodeId but it is here in case if someone want to use e.g. some additional fields
@@ -153,25 +145,21 @@ abstract class BaseKafkaSourceFactory[T: TypeInformation](val timestampAssigner:
       }.getOrElse(newStart)
     }
 
-    def preparedTopics: List[String] = topics.map(processObjectDependencies
-                                                    .objectNaming
-                                                    .prepareName(_,
-                                                      processObjectDependencies.config,
-                                                      new NamingContext(KafkaUsageKey)))
+    def preparedTopics: List[String] = topics.map(KafkaUtils.prepareTopic(_, processObjectDependencies))
 
     protected val typeInformation: TypeInformation[T] = implicitly[TypeInformation[T]]
 
     protected def flinkSourceFunction(consumerGroupId: String): SourceFunction[T] = {
-      preparedTopics.foreach(KafkaEspUtils.setToLatestOffsetIfNeeded(kafkaConfig, _, consumerGroupId))
+      preparedTopics.foreach(KafkaUtils.setToLatestOffsetIfNeeded(kafkaConfig, _, consumerGroupId))
       createFlinkSource(consumerGroupId)
     }
 
     protected def createFlinkSource(consumerGroupId: String): FlinkKafkaConsumer[T] = {
-      new FlinkKafkaConsumer[T](preparedTopics.asJava, schema, KafkaEspUtils.toProperties(kafkaConfig, Some(consumerGroupId)))
+      new FlinkKafkaConsumer[T](preparedTopics.asJava, schema, KafkaUtils.toProperties(kafkaConfig, Some(consumerGroupId)))
     }
 
     override def generateTestData(size: Int): Array[Byte] = {
-      val listsFromAllTopics = preparedTopics.map(KafkaEspUtils.readLastMessages(_, size, kafkaConfig))
+      val listsFromAllTopics = preparedTopics.map(KafkaUtils.readLastMessages(_, size, kafkaConfig))
       val merged = ListUtil.mergeListsFromTopics(listsFromAllTopics, size)
       val formatted = recordFormatterOpt.map(formatter => merged.map(formatter.formatRecord)).getOrElse {
         merged.map(_.value())

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/PartitionByKeyFlinkKafkaProducer.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/PartitionByKeyFlinkKafkaProducer.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.kafka
 import java.util.Properties
 
 import org.apache.flink.streaming.connectors.kafka.{FlinkKafkaProducer, KafkaSerializationSchema}
-import pl.touk.nussknacker.engine.kafka.KafkaEspUtils.withPropertiesFromConfig
+import pl.touk.nussknacker.engine.kafka.KafkaUtils.withPropertiesFromConfig
 
 object PartitionByKeyFlinkKafkaProducer {
 

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/generic/sources.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/generic/sources.scala
@@ -13,7 +13,7 @@ import pl.touk.nussknacker.engine.api.test.TestParsingUtils
 import pl.touk.nussknacker.engine.api.typed._
 import pl.touk.nussknacker.engine.api.{CirceUtil, MethodToInvoke, ParamName}
 import pl.touk.nussknacker.engine.flink.util.source.EspDeserializationSchema
-import pl.touk.nussknacker.engine.kafka.{BaseKafkaSourceFactory, KafkaSourceFactory}
+import pl.touk.nussknacker.engine.kafka.{BaseKafkaSourceFactory, KafkaConfig, KafkaSourceFactory}
 import pl.touk.nussknacker.engine.util.Implicits._
 import pl.touk.nussknacker.engine.util.typing.TypingUtils
 
@@ -30,7 +30,7 @@ object sources {
     @MethodToInvoke
     def create(@ParamName("topic") topic: String,
                @ParamName("type") definition: java.util.Map[String, _]): Source[TypedMap] with TestDataGenerator = {
-      val kafkaConfig = KafkaSourceFactory.parseKafkaConfig(processObjectDependencies)
+      val kafkaConfig = KafkaConfig.parseProcessObjectDependencies(processObjectDependencies)
       val schema = new KafkaDeserializationSchemaWrapper(JsonTypedMapDeserialization)
       new KafkaSource(List(topic), kafkaConfig, schema, None, processObjectDependencies) with ReturningType {
         override def returnType: typing.TypingResult = TypingUtils.typeMapDefinition(definition)

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/signal/RemoveLockProcessSignalFactory.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/signal/RemoveLockProcessSignalFactory.scala
@@ -16,7 +16,7 @@ import pl.touk.nussknacker.engine.api.{MethodToInvoke, ParamName, _}
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkCustomStreamTransformation}
 import pl.touk.nussknacker.engine.flink.api.signal.FlinkProcessSignalSender
 import pl.touk.nussknacker.engine.flink.util.signal.KafkaSignalStreamConnector
-import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaEspUtils}
+import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaUtils}
 
 
 class RemoveLockProcessSignalFactory(val kafkaConfig: KafkaConfig, val signalsTopic: String)
@@ -27,7 +27,7 @@ class RemoveLockProcessSignalFactory(val kafkaConfig: KafkaConfig, val signalsTo
   @MethodToInvoke
   def sendSignal(@ParamName("lockId") lockId: String)(processId: String): Unit = {
     val signal = SampleProcessSignal(processId, System.currentTimeMillis(), RemoveLock(lockId))
-    KafkaEspUtils.sendToKafkaWithTempProducer(signalsTopic, Array.empty, Encoder[SampleProcessSignal].apply(signal).noSpaces.getBytes(StandardCharsets.UTF_8))(kafkaConfig)
+    KafkaUtils.sendToKafkaWithTempProducer(signalsTopic, Array.empty, Encoder[SampleProcessSignal].apply(signal).noSpaces.getBytes(StandardCharsets.UTF_8))(kafkaConfig)
   }
 
 }

--- a/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/NamespacedKafkaSourceSinkTest.scala
+++ b/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/NamespacedKafkaSourceSinkTest.scala
@@ -23,7 +23,7 @@ import pl.touk.nussknacker.engine.testing.LocalModelData
 class NamespacedKafkaSourceSinkTest extends FunSuite with BeforeAndAfterAll with KafkaSpec with Matchers {
   private implicit val stringTypeInfo: GenericTypeInfo[String] = new GenericTypeInfo(classOf[String])
 
-  import KafkaUtils._
+  import KafkaZookeeperUtils._
   import spel.Implicits._
 
   private val namespaceName: String = "ns"

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessManagerSpec.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration._
 //TODO: get rid of at least some Thread.sleep
 class FlinkStreamingProcessManagerSpec extends FunSuite with Matchers with StreamingDockerTest {
 
-  import pl.touk.nussknacker.engine.kafka.KafkaUtils._
+  import pl.touk.nussknacker.engine.kafka.KafkaZookeeperUtils._
 
   override protected def classPath: String = s"./engine/flink/management/sample/target/scala-${ScalaMajorVersionConfig.scalaMajorVersion}/managementSample.jar"
 

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -29,9 +29,8 @@ import pl.touk.nussknacker.engine.flink.api.signal.FlinkProcessSignalSender
 import pl.touk.nussknacker.engine.flink.util.service.TimeMeasuringService
 import pl.touk.nussknacker.engine.flink.util.signal.KafkaSignalStreamConnector
 import pl.touk.nussknacker.engine.flink.util.source.{CollectionSource, EspDeserializationSchema}
-import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaEspUtils, KafkaSourceFactory}
+import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaSourceFactory, KafkaUtils}
 import pl.touk.nussknacker.engine.process.SimpleJavaEnum
-import pl.touk.nussknacker.engine.process.helpers.SampleNodes.SinkForStrings.add
 import pl.touk.nussknacker.engine.util.typing.TypingUtils
 
 import scala.collection.JavaConverters._
@@ -335,7 +334,7 @@ object SampleNodes {
 
     @MethodToInvoke
     def sendSignal()(processId: String): Unit = {
-      KafkaEspUtils.sendToKafkaWithTempProducer(signalsTopic, Array.empty[Byte], "".getBytes(StandardCharsets.UTF_8))(kafkaConfig)
+      KafkaUtils.sendToKafkaWithTempProducer(signalsTopic, Array.empty[Byte], "".getBytes(StandardCharsets.UTF_8))(kafkaConfig)
     }
 
   }

--- a/engine/kafka-test-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaClient.scala
+++ b/engine/kafka-test-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaClient.scala
@@ -14,8 +14,8 @@ import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
 
 class KafkaClient(kafkaAddress: String, zkAddress: String, id: String) {
-  val rawProducer = KafkaUtils.createRawKafkaProducer(kafkaAddress, id + "_raw")
-  val producer = KafkaUtils.createKafkaProducer(kafkaAddress, id)
+  val rawProducer = KafkaZookeeperUtils.createRawKafkaProducer(kafkaAddress, id + "_raw")
+  val producer = KafkaZookeeperUtils.createKafkaProducer(kafkaAddress, id)
 
   private val consumers = collection.mutable.HashSet[KafkaConsumer[Array[Byte], Array[Byte]]]()
 
@@ -84,7 +84,7 @@ class KafkaClient(kafkaAddress: String, zkAddress: String, id: String) {
   }
 
   def createConsumer(consumerTimeout: Long = 10000): KafkaConsumer[Array[Byte], Array[Byte]] = {
-    val props = KafkaUtils.createConsumerConnectorProperties(kafkaAddress, consumerTimeout)
+    val props = KafkaZookeeperUtils.createConsumerConnectorProperties(kafkaAddress, consumerTimeout)
     val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](props)
     consumers.add(consumer)
     consumer

--- a/engine/kafka-test-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaZookeeperServer.scala
+++ b/engine/kafka-test-util/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaZookeeperServer.scala
@@ -70,7 +70,7 @@ case class KafkaZookeeperServer(zooKeeperServer: NIOServerCnxnFactory, kafkaServ
   }
 }
 
-object KafkaUtils {
+object KafkaZookeeperUtils {
 
   def createRawKafkaProducer(kafkaAddress: String, id: String): KafkaProducer[Array[Byte], Array[Byte]] = {
     val props: Properties = createCommonProducerProps(kafkaAddress, id)
@@ -94,7 +94,7 @@ object KafkaUtils {
     val props = new Properties()
     props.put("bootstrap.servers", kafkaAddress)
     props.put("batch.size", "100000")
-    KafkaEspUtils.setClientId(props, id)
+    KafkaUtils.setClientId(props, id)
     props
   }
 

--- a/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaConfig.scala
+++ b/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaConfig.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.kafka
 
 import com.typesafe.config.Config
+import pl.touk.nussknacker.engine.api.process.ProcessObjectDependencies
 
 case class KafkaConfig(kafkaAddress: String,
                        kafkaProperties: Option[Map[String, String]],
@@ -22,4 +23,6 @@ object KafkaConfig {
     config.as[KafkaConfig](path)
   }
 
+  def parseProcessObjectDependencies(processObjectDependencies: ProcessObjectDependencies): KafkaConfig =
+    parseConfig(processObjectDependencies.config, "kafka")
 }

--- a/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaConfig.scala
+++ b/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaConfig.scala
@@ -19,10 +19,12 @@ object KafkaConfig {
   import net.ceedubs.ficus.readers.ArbitraryTypeReader._
   import net.ceedubs.ficus.readers.EnumerationReader._
 
+  private val defaultKafkaConfigPath = "kafka"
+
   def parseConfig(config: Config, path: String): KafkaConfig = {
     config.as[KafkaConfig](path)
   }
 
   def parseProcessObjectDependencies(processObjectDependencies: ProcessObjectDependencies): KafkaConfig =
-    parseConfig(processObjectDependencies.config, "kafka")
+    parseConfig(processObjectDependencies.config, defaultKafkaConfigPath)
 }

--- a/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
+++ b/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
@@ -32,7 +32,7 @@ object KafkaUtils extends LazyLogging {
     props.setProperty("client.id", sanitizeClientId(id))
   }
 
-  def prepareTopic(topic :String, processObjectDependencies: ProcessObjectDependencies): String =
+  def prepareTopicName(topic :String, processObjectDependencies: ProcessObjectDependencies): String =
     processObjectDependencies
       .objectNaming
       .prepareName(topic, processObjectDependencies.config, kafkaTopicUsageKey)

--- a/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
+++ b/engine/kafka/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
@@ -9,6 +9,8 @@ import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
+import pl.touk.nussknacker.engine.api.namespaces.{KafkaUsageKey, NamingContext}
+import pl.touk.nussknacker.engine.api.process.ProcessObjectDependencies
 import pl.touk.nussknacker.engine.util.ThreadUtils
 
 import scala.collection.JavaConverters._
@@ -17,16 +19,23 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future, Promise}
 import scala.util.{Failure, Success}
 
-object KafkaEspUtils extends LazyLogging {
+object KafkaUtils extends LazyLogging {
 
   import scala.collection.JavaConverters._
   import scala.concurrent.ExecutionContext.Implicits.global
 
   val defaultTimeoutMillis = 10000
 
+  private val kafkaTopicUsageKey = new NamingContext(KafkaUsageKey)
+
   def setClientId(props: Properties, id: String): Unit = {
     props.setProperty("client.id", sanitizeClientId(id))
   }
+
+  def prepareTopic(topic :String, processObjectDependencies: ProcessObjectDependencies): String =
+    processObjectDependencies
+      .objectNaming
+      .prepareName(topic, processObjectDependencies.config, kafkaTopicUsageKey)
 
   def sanitizeClientId(originalId: String): String =
     //https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/common/Config.scala#L25-L35
@@ -36,7 +45,7 @@ object KafkaEspUtils extends LazyLogging {
     val setToLatestOffset =
       config.kafkaEspProperties.flatMap(_.get("forceLatestRead")).exists(java.lang.Boolean.parseBoolean)
     if (setToLatestOffset) {
-      KafkaEspUtils.setOffsetToLatest(topic, consumerGroupId, config)
+      KafkaUtils.setOffsetToLatest(topic, consumerGroupId, config)
     }
   }
 
@@ -160,12 +169,12 @@ object KafkaEspUtils extends LazyLogging {
 
   def sendToKafka[K, V](topic: String, key: K, value: V)(producer: KafkaProducer[K, V]): Future[RecordMetadata] = {
     val promise = Promise[RecordMetadata]()
-    producer.send(new ProducerRecord(topic, key, value), KafkaEspUtils.producerCallback(promise))
+    producer.send(new ProducerRecord(topic, key, value), KafkaUtils.producerCallback(promise))
     promise.future
   }
 
   def createProducer(kafkaConfig: KafkaConfig, clientId: String): KafkaProducer[Array[Byte], Array[Byte]] = {
-    new KafkaProducer[Array[Byte], Array[Byte]](KafkaEspUtils.toProducerProperties(kafkaConfig, clientId))
+    new KafkaProducer[Array[Byte], Array[Byte]](KafkaUtils.toProducerProperties(kafkaConfig, clientId))
   }
 
   def producerCallback(promise: Promise[RecordMetadata]): Callback =

--- a/engine/kafka/src/test/scala/pl/touk/nussknacker/engine/kafka/KafkaUtilsTest.scala
+++ b/engine/kafka/src/test/scala/pl/touk/nussknacker/engine/kafka/KafkaUtilsTest.scala
@@ -1,9 +1,9 @@
 package pl.touk.nussknacker.engine.kafka
 
 import org.scalatest.{FunSuite, Matchers}
-import pl.touk.nussknacker.engine.kafka.KafkaEspUtils.sanitizeClientId
+import pl.touk.nussknacker.engine.kafka.KafkaUtils.sanitizeClientId
 
-class KafkaEspUtilsTest extends FunSuite with Matchers {
+class KafkaUtilsTest extends FunSuite with Matchers {
 
   test("sanitizes client.id") {
     sanitizeClientId("a b?c.d*e") shouldBe "a_b_c.d_e"


### PR DESCRIPTION
- Rename KafkaEspUtils to KafkaUtils
- Rename KafkaUtils from kafka tests to KafkaZookeeperUtils
- Extract BaseKafkaSinkFactory 
- Add some helper methods like: KafkaConfig.parseProcessObjectDependencies and KafkaUtils.prepareTopic