### PR TITLE
[Improvement] More performant expression evaluation wrt globals

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
@@ -14,7 +14,7 @@ trait Expression {
 
   def original: String
 
-  def evaluate[T](ctx: Context, lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]]
+  def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]]
 }
 
 trait ExpressionParser {

--- a/engine/benchmarks/Readme.md
+++ b/engine/benchmarks/Readme.md
@@ -5,6 +5,11 @@ Benchmarks in this module are suitable for things like:
 - handling Context operations
 and probably not for more end to end scenarios - like testing Flink process
 
+For some benchmarks sample values for 4-core machine are included. They **should not** be considered
+as proper reference, since results will vary a lot between machines/runs. However, if after some changes
+the results are like 10 times worse it's probably worth having a closer look ;)
+
+
 Docs:
 -----
 https://github.com/ktoso/sbt-jmh

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/InterpreterSetup.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/InterpreterSetup.scala
@@ -1,0 +1,73 @@
+package pl.touk.nussknacker.engine.benchmarks.interpreter
+
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.ValidatedNel
+import com.typesafe.config.ConfigFactory
+import pl.touk.nussknacker.engine.api
+import pl.touk.nussknacker.engine.api.{Context, InterpretationResult, MethodToInvoke, ProcessListener, Service}
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
+import pl.touk.nussknacker.engine.api.exception.EspExceptionInfo
+import pl.touk.nussknacker.engine.api.namespaces.DefaultObjectNaming
+import pl.touk.nussknacker.engine.api.process.{ProcessConfigCreator, ProcessObjectDependencies, SinkFactory, SourceFactory, WithCategories}
+import pl.touk.nussknacker.engine.compile.CompiledProcess
+import pl.touk.nussknacker.engine.compiledgraph.part.ProcessPart
+import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor
+import pl.touk.nussknacker.engine.graph.EspProcess
+import pl.touk.nussknacker.engine.testing.EmptyProcessConfigCreator
+import pl.touk.nussknacker.engine.util.Implicits._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
+
+
+class InterpreterSetup[T:ClassTag] {
+
+  def sourceInterpretation(process: EspProcess,
+                           services: Map[String, Service], listeners: Seq[ProcessListener]): (Context, ExecutionContext) => Future[Either[List[InterpretationResult], EspExceptionInfo[_ <: Throwable]]] = {
+    val compiledProcess = compile(services, process, listeners)
+    val interpreter = compiledProcess.interpreter
+    val parts = compiledProcess.parts
+
+    def compileNode(part: ProcessPart) =
+      failOnErrors(compiledProcess.subPartCompiler.compile(part.node, part.validationContext).result)
+    val compiled = compileNode(parts.sources.head)
+    (initialCtx: Context, ec: ExecutionContext) =>
+      interpreter.interpret(compiled, process.metaData, initialCtx)(ec)
+  }
+
+  def compile(servicesToUse: Map[String, Service], process: EspProcess, listeners: Seq[ProcessListener]): CompiledProcess = {
+
+    val configCreator: ProcessConfigCreator = new EmptyProcessConfigCreator {
+
+      override def services(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[Service]] = servicesToUse.mapValuesNow(WithCategories(_))
+
+      override def sourceFactories(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[SourceFactory[_]]] =
+        Map("source" -> WithCategories(new Source))
+
+      override def sinkFactories(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[SinkFactory]]
+      = Map("sink" -> WithCategories(SinkFactory.noParam(new pl.touk.nussknacker.engine.api.process.Sink {
+        override def testDataOutput: Option[(Any) => String] = None
+      })))
+    }
+
+    val definitions = ProcessDefinitionExtractor.extractObjectWithMethods(configCreator,
+      api.process.ProcessObjectDependencies(ConfigFactory.empty(), DefaultObjectNaming))
+
+    failOnErrors(CompiledProcess.compile(process, definitions, listeners, getClass.getClassLoader))
+  }
+
+  private def failOnErrors[Y](obj: ValidatedNel[ProcessCompilationError, Y]): Y = obj match {
+    case Valid(c) => c
+    case Invalid(err) => throw new IllegalArgumentException(err.toList.mkString("Compilation errors: ", ", ", ""))
+  }
+
+  class Source extends SourceFactory[T] {
+
+    override def clazz: Class[_] = implicitly[ClassTag[T]].runtimeClass
+
+    @MethodToInvoke
+    def create(): api.process.Source[T] = null
+
+  }
+
+}

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
@@ -14,8 +14,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 /*
-[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8  56433.663 ± 2941.387  ops/s
-[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  86119.583 ± 7837.837  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8   85822.908 ± 5572.295  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  126208.502 ± 2997.227  ops/s
  */
 @State(Scope.Thread)
 class ManyParamsInterpreterBenchmark {
@@ -103,9 +103,7 @@ object ManyParamsService extends Service {
     if (ec == SynchronousExecutionContext.ctx) {
       Future.failed(new IllegalArgumentException("Should be normal EC..."))
     } else {
-      Future {
-        s1
-      }
+      Future.successful(s1)
     }
   }
 

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
@@ -50,38 +50,7 @@ class ManyParamsInterpreterBenchmark {
     Await.result(interpreterAsync(Context("")), 1 second)
   }
 
-
-
 }
-
-object Test extends App {
-
-  private val ec = SynchronousExecutionContext.create()
-
-  private val process: EspProcess = EspProcessBuilder
-    .id("t1")
-    .exceptionHandlerNoParams()
-    .source("source", "source")
-    .enricher("e1", "out", "service", (1 to 20).map(i => s"p$i" -> ("''": Expression)): _*)
-    .sink("sink", "#out", "sink")
-  private val interpreter = new InterpreterSetup[String].sourceInterpretation(process, Map("service" -> new ManyParamsService(ec)), Nil)
-
-  var i = 0
-  val count = 100 * 1000
-  val start = System.currentTimeMillis()
-
-  while (i<count) {
-    i += 1
-    Await.result(interpreter(Context(""), ec), 1 second)
-    if (i % 1000 == 0) {
-      println(s"Running $i")
-    }
-  }
-  println(s"throughput ${(count * 1000)/(System.currentTimeMillis() - start)}/s")
-
-}
-
-
 
 class ManyParamsService(expectedEc: ExecutionContext) extends Service {
 

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
@@ -14,8 +14,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 /*
-[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8   39365.368 ±  2003.945  ops/s
-[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  112005.904 ± 11842.702  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8  56433.663 ± 2941.387  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  86119.583 ± 7837.837  ops/s
  */
 @State(Scope.Thread)
 class ManyParamsInterpreterBenchmark {
@@ -99,8 +99,14 @@ object ManyParamsService extends Service {
                       @ParamName("p18") s18: String,
                       @ParamName("p19") s19: String,
                       @ParamName("p20") s20: String
-                    ): Future[String] = {
-    Future.successful(s1)
+                    )(implicit ec: ExecutionContext): Future[String] = {
+    if (ec == SynchronousExecutionContext.ctx) {
+      Future.failed(new IllegalArgumentException("Should be normal EC..."))
+    } else {
+      Future {
+        s1
+      }
+    }
   }
 
 }

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
@@ -14,8 +14,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 /*
-[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8   11392.717 ±  148.554  ops/s
-[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  122910.384 ± 2910.959  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8   39365.368 ±  2003.945  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  112005.904 ± 11842.702  ops/s
  */
 @State(Scope.Thread)
 class ManyParamsInterpreterBenchmark {

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
@@ -1,0 +1,106 @@
+package pl.touk.nussknacker.engine.benchmarks.interpreter
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, State}
+import pl.touk.nussknacker.engine.api.{Context, MethodToInvoke, ParamName, Service}
+import pl.touk.nussknacker.engine.build.EspProcessBuilder
+import pl.touk.nussknacker.engine.graph.EspProcess
+import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
+import pl.touk.nussknacker.engine.spel.Implicits._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+/*
+[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8   11392.717 ±  148.554  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  122910.384 ± 2910.959  ops/s
+ */
+@State(Scope.Thread)
+class ManyParamsInterpreterBenchmark {
+
+  private val process: EspProcess = EspProcessBuilder
+    .id("t1")
+    .exceptionHandlerNoParams()
+    .source("source", "source")
+    .enricher("e1", "out", "service", (1 to 20).map(i => s"p$i" -> ("''": Expression)): _*)
+    .sink("sink", "#out", "sink")
+  private val interpreter = new InterpreterSetup[String].sourceInterpretation(process, Map("service" -> ManyParamsService), Nil)
+
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def benchmarkSync(): AnyRef = {
+    Await.result(interpreter(Context(""), SynchronousExecutionContext.ctx), 1 second)
+  }
+
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def benchmarkAsync(): AnyRef = {
+    Await.result(interpreter(Context(""), ExecutionContext.Implicits.global), 1 second)
+  }
+
+
+
+}
+
+object Test extends App {
+
+  private val process: EspProcess = EspProcessBuilder
+    .id("t1")
+    .exceptionHandlerNoParams()
+    .source("source", "source")
+    .enricher("e1", "out", "service", (1 to 20).map(i => s"p$i" -> ("''": Expression)): _*)
+    .sink("sink", "#out", "sink")
+  private val interpreter = new InterpreterSetup[String].sourceInterpretation(process, Map("service" -> ManyParamsService), Nil)
+
+  var i = 0
+  val count = 10 * 1000
+  val start = System.currentTimeMillis()
+
+  while (i<count) {
+    i += 1
+    Await.result(interpreter(Context(""), SynchronousExecutionContext.ctx), 1 second)
+    if (i % 1000 == 0) {
+      println(s"Running $i")
+    }
+  }
+  println(s"throughput ${(count * 1000)/(System.currentTimeMillis() - start)}/s")
+
+}
+
+
+
+object ManyParamsService extends Service {
+
+  @MethodToInvoke
+  def methodToInvoke(
+                      @ParamName("p1") s1: String,
+                      @ParamName("p2") s2: String,
+                      @ParamName("p3") s3: String,
+                      @ParamName("p4") s4: String,
+                      @ParamName("p5") s5: String,
+                      @ParamName("p6") s6: String,
+                      @ParamName("p7") s7: String,
+                      @ParamName("p8") s8: String,
+                      @ParamName("p9") s9: String,
+                      @ParamName("p10") s10: String,
+                      @ParamName("p11") s11: String,
+                      @ParamName("p12") s12: String,
+                      @ParamName("p13") s13: String,
+                      @ParamName("p14") s14: String,
+                      @ParamName("p15") s15: String,
+                      @ParamName("p16") s16: String,
+                      @ParamName("p17") s17: String,
+                      @ParamName("p18") s18: String,
+                      @ParamName("p19") s19: String,
+                      @ParamName("p20") s20: String
+                    ): Future[String] = {
+    Future.successful(s1)
+  }
+
+}

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
@@ -14,8 +14,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 /*
-[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8  136383.766 ± 9897.488  ops/s
-[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  142224.760 ± 7516.919  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8   41268.659 ±  1006.517  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  120031.050 ± 12579.394  ops/s
  */
 @State(Scope.Thread)
 class ManyParamsInterpreterBenchmark {

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/OneParamInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/OneParamInterpreterBenchmark.scala
@@ -13,8 +13,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 /*
-[info] OneParamInterpreterBenchmark.benchmarkAsync  thrpt    8    69390.971 ±   5787.658  ops/s
-[info] OneParamInterpreterBenchmark.benchmarkSync   thrpt    8  1203125.849 ± 162578.399  ops/s
+[info] OneParamInterpreterBenchmark.benchmarkAsync  thrpt    8  1158171.687 ± 72679.302  ops/s
+[info] OneParamInterpreterBenchmark.benchmarkSync   thrpt    8  1236275.402 ± 16378.916  ops/s
  */
 @State(Scope.Thread)
 class OneParamInterpreterBenchmark {

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/OneParamInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/OneParamInterpreterBenchmark.scala
@@ -13,8 +13,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 /*
-[info] OneParamInterpreterBenchmark.benchmarkAsync  thrpt    8  1158171.687 ± 72679.302  ops/s
-[info] OneParamInterpreterBenchmark.benchmarkSync   thrpt    8  1236275.402 ± 16378.916  ops/s
+[info] OneParamInterpreterBenchmark.benchmarkAsync  thrpt    8    80438.667 ±  10106.195  ops/s
+[info] OneParamInterpreterBenchmark.benchmarkSync   thrpt    8  1248502.934 ± 148813.140  ops/s
  */
 @State(Scope.Thread)
 class OneParamInterpreterBenchmark {

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/OneParamInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/OneParamInterpreterBenchmark.scala
@@ -1,0 +1,56 @@
+package pl.touk.nussknacker.engine.benchmarks.interpreter
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import pl.touk.nussknacker.engine.api._
+import pl.touk.nussknacker.engine.build.EspProcessBuilder
+import pl.touk.nussknacker.engine.graph.EspProcess
+import pl.touk.nussknacker.engine.spel.Implicits._
+import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+/*
+[info] OneParamInterpreterBenchmark.benchmarkAsync  thrpt    8    69390.971 ±   5787.658  ops/s
+[info] OneParamInterpreterBenchmark.benchmarkSync   thrpt    8  1203125.849 ± 162578.399  ops/s
+ */
+@State(Scope.Thread)
+class OneParamInterpreterBenchmark {
+
+  private val process: EspProcess = EspProcessBuilder
+    .id("t1")
+    .exceptionHandlerNoParams()
+    .source("source", "source")
+    .enricher("e1", "out", "service", "p1" -> "''")
+    .sink("sink", "#out", "sink")
+  private val interpreter = new InterpreterSetup[String].sourceInterpretation(process, Map("service" -> OneParamService), Nil)
+
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def benchmarkSync(): AnyRef = {
+    Await.result(interpreter(Context(""), SynchronousExecutionContext.ctx), 1 second)
+  }
+
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def benchmarkAsync(): AnyRef = {
+    Await.result(interpreter(Context(""), ExecutionContext.Implicits.global), 1 second)
+  }
+
+
+
+}
+object OneParamService extends Service {
+
+  @MethodToInvoke
+  def methodToInvoke(@ParamName("p1") s: String): Future[String] = {
+    Future.successful(s)
+  }
+
+}

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/spel/SpelBenchmarkSetup.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/spel/SpelBenchmarkSetup.scala
@@ -41,7 +41,7 @@ class SpelBenchmarkSetup(expression: String, vars: Map[String, AnyRef]) {
   private val ctx = Context("id", vars, LazyContext(""), None)
 
   def test(): AnyRef = {
-    compiledExpression.evaluate[AnyRef](ctx, provider).value.get.get.value
+    compiledExpression.evaluate[AnyRef](ctx, Map.empty, provider).value.get.get.value
   }
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
@@ -11,6 +11,7 @@ import pl.touk.nussknacker.engine.compiledgraph.node.{Sink, Source, _}
 import pl.touk.nussknacker.engine.compiledgraph.service._
 import pl.touk.nussknacker.engine.compiledgraph.variable._
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
+import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -18,6 +19,8 @@ import scala.util.control.NonFatal
 class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: ExpressionEvaluator) {
 
   private val expressionName = "expression"
+
+  private val syncEc = SynchronousExecutionContext.ctx
 
   def interpret(node: Node,
                 metaData: MetaData,
@@ -191,7 +194,7 @@ class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: 
         //TODO: what about implicit??
         listeners.foreach(_.serviceInvoked(node.id, ref.id, ctx, metaData, preparedParams, result))
       }
-      resultFuture.map(ValueWithContext(_, newCtx))
+      resultFuture.map(ValueWithContext(_, newCtx))(SynchronousExecutionContext.ctx)
     }
   }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
@@ -11,7 +11,6 @@ import pl.touk.nussknacker.engine.compiledgraph.node.{Sink, Source, _}
 import pl.touk.nussknacker.engine.compiledgraph.service._
 import pl.touk.nussknacker.engine.compiledgraph.variable._
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
-import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -20,27 +19,25 @@ class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: 
 
   private val expressionName = "expression"
 
-  private implicit val syncEc: ExecutionContext = SynchronousExecutionContext.ctx
-
   def interpret(node: Node,
                 metaData: MetaData,
                 ctx: Context)
                (implicit executor: ExecutionContext): Future[Either[List[InterpretationResult], EspExceptionInfo[_<:Throwable]]] = {
-    implicit val impMetaData: MetaData = metaData
-    tryToInterpretNode(node, ctx, executor).map(Left(_))(syncEc).recover {
+    implicit val impMetaData = metaData
+    tryToInterpretNode(node, ctx).map(Left(_)).recover {
       case ex@NodeIdExceptionWrapper(nodeId, exception) =>
         val exInfo = EspExceptionInfo(Some(nodeId), exception, ctx)
         Right(exInfo)
       case NonFatal(ex) =>
         val exInfo = EspExceptionInfo(None, ex, ctx)
         Right(exInfo)
-    }(syncEc)
+    }
   }
 
-  private def tryToInterpretNode(node: Node, ctx: Context, serviceEc: ExecutionContext)
-                           (implicit metaData: MetaData): Future[List[InterpretationResult]] = {
+  private def tryToInterpretNode(node: Node, ctx: Context)
+                           (implicit metaData: MetaData, executor: ExecutionContext): Future[List[InterpretationResult]] = {
     try {
-      interpretNode(node, ctx, serviceEc).transform(identity, transform(node.id))
+      interpretNode(node, ctx).transform(identity, transform(node.id))
     } catch {
       case NonFatal(ex) => Future.failed(transform(node.id)(ex))
     }
@@ -53,22 +50,22 @@ class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: 
 
   private implicit def nodeToId(implicit node: Node) : NodeId = NodeId(node.id)
 
-  private def interpretNode(node: Node, ctx: Context, serviceEc: ExecutionContext)
-                           (implicit metaData: MetaData): Future[List[InterpretationResult]] = {
+  private def interpretNode(node: Node, ctx: Context)
+                           (implicit metaData: MetaData, executor: ExecutionContext): Future[List[InterpretationResult]] = {
     implicit val nodeImplicit = node
     listeners.foreach(_.nodeEntered(node.id, ctx, metaData))
     node match {
       case Source(_, next) =>
-        interpretNext(next, ctx, serviceEc)
+        interpretNext(next, ctx)
       case VariableBuilder(_, varName, Right(fields), next) =>
-        createOrUpdateVariable(ctx, varName, fields).flatMap(interpretNext(next, _, serviceEc))
+        createOrUpdateVariable(ctx, varName, fields).flatMap(interpretNext(next, _))
       case VariableBuilder(_, varName, Left(expression), next) =>
         expressionEvaluator.evaluate[Any](expression, varName, node.id, ctx).flatMap { valueWithModifiedContext =>
-          interpretNext(next, ctx.withVariable(varName, valueWithModifiedContext.value), serviceEc)
+          interpretNext(next, ctx.withVariable(varName, valueWithModifiedContext.value))
         }
       case SubprocessStart(_, params, next) =>
         expressionEvaluator.evaluateParameters(params, ctx).flatMap { case (newCtx, vars) =>
-          interpretNext(next, newCtx.pushNewContext(vars), serviceEc)
+          interpretNext(next, newCtx.pushNewContext(vars))
         }
       case SubprocessEnd(_, varName, fields, next) =>
         createOrUpdateVariable(ctx, varName, fields).flatMap { updatedCtx =>
@@ -76,15 +73,15 @@ class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: 
           val newParentContext = updatedCtx.variables.get(varName).map { value =>
             parentContext.withVariable(varName, value)
           }.getOrElse(parentContext)
-          interpretNext(next, newParentContext, serviceEc)
+          interpretNext(next, newParentContext)
         }
       case Processor(_, ref, next, false) =>
-        invoke(ref, None, ctx, serviceEc).flatMap {
-          case ValueWithContext(_, newCtx) => interpretNext(next, newCtx, serviceEc)
+        invoke(ref, None, ctx).flatMap {
+          case ValueWithContext(_, newCtx) => interpretNext(next, newCtx)
         }
-      case Processor(_, ref, next, true) => interpretNext(next, ctx, serviceEc)
+      case Processor(_, ref, next, true) => interpretNext(next, ctx)
       case EndingProcessor(id, ref, false) =>
-        invoke(ref, None, ctx, serviceEc).map {
+        invoke(ref, None, ctx).map {
           case ValueWithContext(output, newCtx) =>
             List(InterpretationResult(EndReference(id), output, newCtx))
         }
@@ -92,17 +89,17 @@ class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: 
         //FIXME: null??
         Future.successful(List(InterpretationResult(EndReference(id), null, ctx)))
       case Enricher(_, ref, outName, next) =>
-        invoke(ref, Some(outName), ctx, serviceEc).flatMap {
+        invoke(ref, Some(outName), ctx).flatMap {
           case ValueWithContext(out, newCtx) =>
-            interpretNext(next, newCtx.withVariable(outName, out), serviceEc)
+            interpretNext(next, newCtx.withVariable(outName, out))
         }
       case Filter(_, expression, nextTrue, nextFalse, disabled) =>
         val expressionResult = if (disabled) Future.successful(ValueWithContext(true, ctx)) else evaluateExpression[Boolean](expression, ctx, expressionName)
         expressionResult.flatMap { valueWithModifiedContext =>
           if (disabled || valueWithModifiedContext.value)
-            interpretNext(nextTrue, valueWithModifiedContext.context, serviceEc)
+            interpretNext(nextTrue, valueWithModifiedContext.context)
           else
-            interpretOptionalNext(node, nextFalse, valueWithModifiedContext.context, serviceEc)
+            interpretOptionalNext(node, nextFalse, valueWithModifiedContext.context)
         }
       case Switch(_, expression, exprVal, nexts, defaultNext) =>
         val valueWithModifiedContext = evaluateExpression[Any](expression, ctx, expressionName)
@@ -121,9 +118,9 @@ class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: 
           }
         }.flatMap {
           case (accCtx, Some(nextNode)) =>
-            interpretNext(nextNode, accCtx, serviceEc)
+            interpretNext(nextNode, accCtx)
           case (accCtx, None) =>
-            interpretOptionalNext(node, defaultNext, accCtx, serviceEc)
+            interpretOptionalNext(node, defaultNext, accCtx)
         }
       case Sink(id, _, _, true) =>
         Future.successful(List(InterpretationResult(EndReference(id), null, ctx)))
@@ -140,29 +137,29 @@ class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: 
       case BranchEnd(e) =>
         Future.successful(List(InterpretationResult(e.joinReference, null, ctx)))
       case CustomNode(_, next) =>
-        interpretNext(next, ctx, serviceEc)
+        interpretNext(next, ctx)
       case EndingCustomNode(id) =>
         Future.successful(List(InterpretationResult(EndReference(id), null, ctx)))
       case SplitNode(id, nexts) =>
-        Future.sequence(nexts.map(interpretNext(_, ctx, serviceEc))).map(_.flatten)
+        Future.sequence(nexts.map(interpretNext(_, ctx))).map(_.flatten)
     }
   }
 
-  private def interpretOptionalNext(node: Node, optionalNext: Option[Next], ctx: Context, serviceEc: ExecutionContext)
-                                   (implicit metaData: MetaData): Future[List[InterpretationResult]] = {
+  private def interpretOptionalNext(node: Node, optionalNext: Option[Next], ctx: Context)
+                                   (implicit metaData: MetaData, ec: ExecutionContext): Future[List[InterpretationResult]] = {
     optionalNext match {
       case Some(next) =>
-        interpretNext(next, ctx, serviceEc)
+        interpretNext(next, ctx)
       case None =>
         listeners.foreach(_.deadEndEncountered(node.id, ctx, metaData))
         Future.successful(List(InterpretationResult(DeadEndReference(node.id), outputValue(ctx), ctx)))
     }
   }
 
-  private def interpretNext(next: Next, ctx: Context, serviceEc: ExecutionContext)
-                           (implicit metaData: MetaData): Future[List[InterpretationResult]] =
+  private def interpretNext(next: Next, ctx: Context)
+                           (implicit metaData: MetaData, executor: ExecutionContext): Future[List[InterpretationResult]] =
     next match {
-      case NextNode(node) => tryToInterpretNode(node, ctx, serviceEc)
+      case NextNode(node) => tryToInterpretNode(node, ctx)
       case PartRef(ref) => Future.successful(List(InterpretationResult(NextPartReference(ref), outputValue(ctx), ctx)))
     }
 
@@ -171,7 +168,7 @@ class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: 
   ctx.getOrElse[Any](OutputParamName, new java.util.HashMap[String, Any]())
 
   private def createOrUpdateVariable(ctx: Context, varName: String, fields: Seq[Field])
-                                    (implicit metaData: MetaData, node: Node): Future[Context] = {
+                                    (implicit ec: ExecutionContext, metaData: MetaData, node: Node): Future[Context] = {
     val contextWithInitialVariable = ctx.modifyOptionalVariable[java.util.Map[String, Any]](varName, _.getOrElse(new java.util.HashMap[String, Any]()))
 
     fields.foldLeft(Future.successful(contextWithInitialVariable)) {
@@ -186,20 +183,20 @@ class Interpreter private(listeners: Seq[ProcessListener], expressionEvaluator: 
     }
   }
 
-  private def invoke(ref: ServiceRef, outputVariableNameOpt: Option[String], ctx: Context, serviceEc: ExecutionContext)
-                    (implicit metaData: MetaData, node: Node): Future[ValueWithContext[Any]] = {
+  private def invoke(ref: ServiceRef, outputVariableNameOpt: Option[String], ctx: Context)
+                    (implicit executionContext: ExecutionContext, metaData: MetaData, node: Node): Future[ValueWithContext[Any]] = {
     expressionEvaluator.evaluateParameters(ref.parameters, ctx).flatMap { case (newCtx, preparedParams) =>
-      val resultFuture = ref.invoker.invoke(preparedParams, NodeContext(ctx.id, node.id, ref.id, outputVariableNameOpt))(serviceEc, metaData)
+      val resultFuture = ref.invoker.invoke(preparedParams, NodeContext(ctx.id, node.id, ref.id, outputVariableNameOpt))
       resultFuture.onComplete { result =>
         //TODO: what about implicit??
         listeners.foreach(_.serviceInvoked(node.id, ref.id, ctx, metaData, preparedParams, result))
       }
-      resultFuture.map(ValueWithContext(_, newCtx))(SynchronousExecutionContext.ctx)
+      resultFuture.map(ValueWithContext(_, newCtx))
     }
   }
 
   private def evaluateExpression[R](expr: Expression, ctx: Context, name: String)
-                                   (implicit metaData: MetaData, node: Node):  Future[ValueWithContext[R]] = {
+                                   (implicit ec: ExecutionContext, metaData: MetaData, node: Node):  Future[ValueWithContext[R]] = {
     expressionEvaluator.evaluate(expr, name, node.id, ctx)
   }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompiledProcess.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/CompiledProcess.scala
@@ -39,11 +39,7 @@ object CompiledProcess {
     processCompiler.compile(process).result.map { compiledProcess =>
       val globalVariablesPreparer = GlobalVariablesPreparer(definitions.expressionConfig)
 
-      val expressionEvaluator = if (process.metaData.typeSpecificData.allowLazyVars) {
-        ExpressionEvaluator.withLazyVals(globalVariablesPreparer, listeners, servicesDefs)
-      } else {
-        ExpressionEvaluator.withoutLazyVals(globalVariablesPreparer, listeners)
-      }
+      val expressionEvaluator = ExpressionEvaluator.optimizedEvaluator(globalVariablesPreparer, listeners, process.metaData, servicesDefs)
 
       val interpreter = Interpreter(listeners, expressionEvaluator)
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -43,7 +43,7 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
 
   //FIXME: should it be here?
   private val expressionEvaluator =
-    ExpressionEvaluator.withoutLazyVals(GlobalVariablesPreparer(expressionConfig), List.empty)
+    ExpressionEvaluator.unOptimizedEvaluator(GlobalVariablesPreparer(expressionConfig))
 
   def validate(n: splittednode.SplittedNode[_], ctx: ValidationContext): CompilationResult[Unit] = {
     compile(n, ctx).map(_ => ())

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
@@ -24,7 +24,6 @@ import pl.touk.nussknacker.engine.compiledgraph.CompiledProcessParts
 import pl.touk.nussknacker.engine.compiledgraph.evaluatedparam.TypedParameter
 import pl.touk.nussknacker.engine.compiledgraph.part.PotentiallyStartPart
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor._
-import pl.touk.nussknacker.engine.definition.MethodDefinitionExtractor.MissingOutputVariableException
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.{CustomTransformerAdditionalData, ExpressionDefinition, ProcessDefinition}
 import pl.touk.nussknacker.engine.definition._
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
@@ -38,7 +37,6 @@ import pl.touk.nussknacker.engine.split._
 import pl.touk.nussknacker.engine.splittedgraph._
 import pl.touk.nussknacker.engine.splittedgraph.end.NormalEnd
 import pl.touk.nussknacker.engine.splittedgraph.part._
-import pl.touk.nussknacker.engine.splittedgraph.splittednode.SplittedNode
 import pl.touk.nussknacker.engine.util.Implicits._
 import pl.touk.nussknacker.engine.util.ThreadUtils
 import pl.touk.nussknacker.engine.util.validated.ValidatedSyntax
@@ -57,7 +55,7 @@ class ProcessCompiler(protected val classLoader: ClassLoader,
 
   //FIXME: should it be here?
   private val expressionEvaluator =
-    ExpressionEvaluator.withoutLazyVals(GlobalVariablesPreparer(expressionConfig), List.empty)
+    ExpressionEvaluator.unOptimizedEvaluator(GlobalVariablesPreparer(expressionConfig))
 
   override def compile(process: EspProcess): CompilationResult[CompiledProcessParts] = {
     super.compile(process)
@@ -334,7 +332,7 @@ protected trait ProcessCompilerBase {
       customStreamTransformers.get(data.nodeType) match {
         case Some((nodeDefinition, _)) if nodeDefinition.obj.isInstanceOf[SingleInputGenericNodeTransformation[_]] =>
           val nodeValidator = new GenericNodeTransformationValidator(objectParametersExpressionCompiler,
-              ExpressionEvaluator.withoutLazyVals(GlobalVariablesPreparer(expressionConfig), List.empty))
+              ExpressionEvaluator.unOptimizedEvaluator(GlobalVariablesPreparer(expressionConfig)))
           val afterValidation = nodeValidator.validateNode(nodeDefinition.obj.asInstanceOf[SingleInputGenericNodeTransformation[_]], data.parameters, ctx.left.get, data.outputVar).map {
             case TransformationResult(Nil, parameters, outputContext) =>
               val (typingInfo, validProcessObject) = compileProcessObject[AnyRef](nodeDefinition, data.parameters,

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodevalidation/NodeDataValidator.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodevalidation/NodeDataValidator.scala
@@ -69,7 +69,7 @@ class CustomNodeValidator(modelData: ModelData) extends NodeDataValidator[Custom
   )
 
   private val expressionEvaluator
-  = ExpressionEvaluator.withoutLazyVals(GlobalVariablesPreparer(modelData.processWithObjectsDefinition.expressionConfig), List.empty)
+  = ExpressionEvaluator.unOptimizedEvaluator(GlobalVariablesPreparer(modelData.processWithObjectsDefinition.expressionConfig))
 
   private val nodeValidator = new GenericNodeTransformationValidator(expressionCompiler, expressionEvaluator)
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/CustomNodeInvoker.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/CustomNodeInvoker.scala
@@ -28,7 +28,7 @@ case class ExpressionLazyParameter[T](nodeId: NodeId,
               .valueOr(err => throw new IllegalArgumentException(s"Compilation failed with errors: ${err.toList.mkString(", ")}"))
     val evaluator = compilerInterpreter.deps.expressionEvaluator
     //FIXME: use evaluateParam method here, to handle e.g. options properly
-    context: Context => evaluator.evaluate[T](compiledExpression, parameter.name, nodeId.id, context)(ec, compilerInterpreter.metaData).map(_.value)(ec)
+    context: Context => evaluator.evaluate[T](compiledExpression, parameter.name, nodeId.id, context)(compilerInterpreter.metaData).map(_.value)(ec)
   }
 }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/TestInfoProvider.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/TestInfoProvider.scala
@@ -28,7 +28,7 @@ class ModelDataTestInfoProvider(modelData: ModelData) extends TestInfoProvider {
   private lazy val globalVariablesPreparer =
     GlobalVariablesPreparer(modelData.processWithObjectsDefinition.expressionConfig)
 
-  private lazy val evaluator = ExpressionEvaluator.withoutLazyVals(globalVariablesPreparer, List.empty)
+  private lazy val evaluator = ExpressionEvaluator.unOptimizedEvaluator(globalVariablesPreparer)
 
   private lazy val expressionCompiler = ExpressionCompiler.withoutOptimization(modelData.modelClassLoader.classLoader,
     modelData.dictServices.dictRegistry,

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
@@ -100,7 +100,7 @@ class ExpressionEvaluator(globalVariablesPreparer: GlobalVariablesPreparer,
     val lazyValuesProvider = lazyValuesProviderCreator(ecToUse, metaData, nodeId)
     //FIXME: this is *not* performant when we have some global variables, we should not add to map here, but e.g. push
     //lookup logic down to expressions
-    val ctxWithGlobals = ctx.withVariables(globalVariablesPreparer.prepareGlobalVariables(metaData).mapValues(_.obj))
+    val ctxWithGlobals = ctx//ctx.withVariables(globalVariablesPreparer.prepareGlobalVariables(metaData).mapValues(_.obj))
 
     expr.evaluate[R](ctxWithGlobals, lazyValuesProvider).map { valueWithLazyContext =>
       listeners.foreach(_.expressionEvaluated(nodeId, expressionId, expr.original, ctx, metaData, valueWithLazyContext.value))

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/NullExpression.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/NullExpression.scala
@@ -13,6 +13,6 @@ case class NullExpression(original: String,
                           flavour: Flavour) extends api.expression.Expression with LazyLogging {
   override def language: String = flavour.languageId
 
-  override def evaluate[T](ctx: Context, lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]]
+  override def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]]
   = Future.successful(ValueWithLazyContext(null.asInstanceOf[T], ctx.lazyContext))
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
@@ -85,13 +85,13 @@ class SpelExpression(parsed: ParsedSpelExpression,
     }
 
   // TODO: better interoperability with scala type, mainly: scala.math.BigDecimal, scala.math.BigInt and collections
-  override def evaluate[T](ctx: Context,
+  override def evaluate[T](ctx: Context, globals: Map[String, Any],
                            lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]] = logOnException(ctx) {
     if (expectedClass == classOf[SpelExpressionRepr]) {
-      return Future.successful(ValueWithLazyContext(SpelExpressionRepr(parsed.parsed, ctx, original).asInstanceOf[T], ctx.lazyContext))
+      return Future.successful(ValueWithLazyContext(SpelExpressionRepr(parsed.parsed, ctx, globals, original).asInstanceOf[T], ctx.lazyContext))
     }
 
-    val evaluationContext = evaluationContextPreparer.prepareEvaluationContext(ctx, lazyValuesProvider)
+    val evaluationContext = evaluationContextPreparer.prepareEvaluationContext(ctx, globals, lazyValuesProvider)
 
     //TODO: async evaluation of lazy vals...
     val value = parsed.getValue[T](evaluationContext, expectedClass)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionRepr.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionRepr.scala
@@ -8,4 +8,5 @@ import pl.touk.nussknacker.engine.api.Context
  */
 case class SpelExpressionRepr(parsed: org.springframework.expression.Expression,
                               context: Context,
+                              globals: Map[String, Any],
                               original: String)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
@@ -34,7 +34,7 @@ class ExpressionServiceQuery(
             (implicit executionContext: ExecutionContext): Future[QueryResult] = {
     expressionCompiler.compileValidatedObjectParameters(params, ValidationContext.empty) match {
       case Valid(p) => expressionEvaluator
-        .evaluateParameters(p, ctx)(nodeId,ServiceQuery.jobData.metaData, executionContext)
+        .evaluateParameters(p, ctx)(nodeId,ServiceQuery.jobData.metaData)
         .flatMap {
           case (_, vars) =>
             serviceQuery

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
@@ -61,7 +61,7 @@ object ExpressionServiceQuery {
 
   //TODO: extract shared part with TestInfoProvider
   private def expressionEvaluator(modelData: ModelData): ExpressionEvaluator = {
-    ExpressionEvaluator.withoutLazyVals(GlobalVariablesPreparer(modelData.processWithObjectsDefinition.expressionConfig), List.empty)
+    ExpressionEvaluator.unOptimizedEvaluator(GlobalVariablesPreparer(modelData.processWithObjectsDefinition.expressionConfig))
   }
 
   private def expressionCompiler(modelData: ModelData) = {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
@@ -800,7 +800,7 @@ object InterpreterSpec {
     case class LiteralExpression(original: String) extends pl.touk.nussknacker.engine.api.expression.Expression {
       override def language: String = languageId
 
-      override def evaluate[T](ctx: Context, lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]]
+      override def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]]
       = Future.successful(ValueWithLazyContext(original.asInstanceOf[T], ctx.lazyContext))
     }
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -35,7 +35,7 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
 
   private class EvaluateSync(expression: Expression) {
     def evaluateSync[T](ctx: Context = ctx, lvp: LazyValuesProvider = dumbLazyProvider) : ValueWithLazyContext[T]
-      = Await.result(expression.evaluate[T](ctx, lvp), 5 seconds)
+      = Await.result(expression.evaluate[T](ctx, Map.empty, lvp), 5 seconds)
 
     def evaluateSyncToValue[T](ctx: Context = ctx, lvp: LazyValuesProvider = dumbLazyProvider) : T
       = evaluateSync(ctx, lvp).value

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/sql/SqlExpressionTest.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/sql/SqlExpressionTest.scala
@@ -82,7 +82,7 @@ class SqlExpressionTest extends FunSuite with Matchers with PatientScalaFutures 
   }
 
   private def evaluate(expression: String, ctx: Context = ctx, validationContext: ValidationContext = validationContext): List[TypedMap] =
-    parseOrFail(expression, validationContext).evaluate[java.util.List[TypedMap]](ctx, dumbLazyProvider)
+    parseOrFail(expression, validationContext).evaluate[java.util.List[TypedMap]](ctx, Map.empty, dumbLazyProvider)
       .futureValue.value.asScala.toList
 
   private def parseOrFail(expression: String, validationContext: ValidationContext = validationContext): SqlExpression =

--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/SynchronousExecutionContext.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/SynchronousExecutionContext.scala
@@ -6,8 +6,10 @@ import scala.concurrent.ExecutionContext
 
 object SynchronousExecutionContext {
 
-  implicit val ctx : ExecutionContext = ExecutionContext.fromExecutor(new Executor {
-    def execute(task: Runnable) = task.run()
+  implicit val ctx : ExecutionContext = create()
+
+  def create(): ExecutionContext = ExecutionContext.fromExecutor(new Executor {
+    def execute(task: Runnable): Unit = task.run()
   })
 
 }


### PR DESCRIPTION
This change fixes some performance problems with handling global variables, also uses faster synchronous execution context (we don't have any real async there.

I also add two benchmarks. 

There is one change that I reverted: https://github.com/TouK/nussknacker/commit/3b24988035c082ee944d603f5f1ef33d53285cbf
It brings more performance benefits, but I think it needs further consideration...