### PR TITLE
[Improvement] synchronous Expressions for performance improvements

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -23,6 +23,8 @@ Nussknacker versions
 * [#978](https://github.com/TouK/nussknacker/pull/978) Dynamic filter validation
 * [#996](https://github.com/TouK/nussknacker/pull/996) First version of GenericNodeTransformation
 * [#1001](https://github.com/TouK/nussknacker/pull/1001) First version dynamic parameters on UI
+* Performance improvements in interpreter: [#1008](https://github.com/TouK/nussknacker/pull/1008),
+ [#1013](https://github.com/TouK/nussknacker/pull/1013). The second one also removes Future[] from expression evaluation 
 
 0.1.2
 ------------------------

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -72,6 +72,9 @@ Additional changes:
 - (Refactor KafkaAvro API) Renamed AvroKeyValueSerializationSchemaFactory to ConfluentAvroKeyValueSerializationSchemaFactory and moved to avro.schemaregistry.confluent package
 - (Refactor KafkaAvro API) Deleted FixedKafkaAvroSourceFactory and FixedKafkaAvroSinkFactory (now we don't support fixed schema)
 
+* [#1013](https://github.com/TouK/nussknacker/pull/1013) Expression evaluation is synchronous now. It shouldn't cause any problems 
+(all languages were synchronous anyway), but some internal code may have o change.
+
 ## In version 0.1.2
 
 * [#957](https://github.com/TouK/nussknacker/pull/957) Custom node `aggregate` from `generic` model has changed parameter 

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/expression/Expression.scala
@@ -14,7 +14,7 @@ trait Expression {
 
   def original: String
 
-  def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]]
+  def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): ValueWithLazyContext[T]
 }
 
 trait ExpressionParser {

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
@@ -14,8 +14,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 /*
-[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8   41268.659 ±  1006.517  ops/s
-[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  120031.050 ± 12579.394  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkAsync  thrpt    8   69367.885 ±   239.049  ops/s
+[info] ManyParamsInterpreterBenchmark.benchmarkSync   thrpt    8  248268.590 ± 13458.885  ops/s
  */
 @State(Scope.Thread)
 class ManyParamsInterpreterBenchmark {

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/OneParamInterpreterBenchmark.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/OneParamInterpreterBenchmark.scala
@@ -13,8 +13,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 /*
-[info] OneParamInterpreterBenchmark.benchmarkAsync  thrpt    8    80438.667 ±  10106.195  ops/s
-[info] OneParamInterpreterBenchmark.benchmarkSync   thrpt    8  1248502.934 ± 148813.140  ops/s
+[info] OneParamInterpreterBenchmark.benchmarkAsync  thrpt    8    98594.526 ±  884.768  ops/s
+[info] OneParamInterpreterBenchmark.benchmarkSync   thrpt    8  1561340.536 ± 7666.706  ops/s
  */
 @State(Scope.Thread)
 class OneParamInterpreterBenchmark {

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/spel/SpelBenchmarkSetup.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/spel/SpelBenchmarkSetup.scala
@@ -41,7 +41,7 @@ class SpelBenchmarkSetup(expression: String, vars: Map[String, AnyRef]) {
   private val ctx = Context("id", vars, LazyContext(""), None)
 
   def test(): AnyRef = {
-    compiledExpression.evaluate[AnyRef](ctx, Map.empty, provider).value.get.get.value
+    compiledExpression.evaluate[AnyRef](ctx, Map.empty, provider).value
   }
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -318,9 +318,8 @@ class PartSubGraphCompiler(protected val classLoader: ClassLoader,
     import pl.touk.nussknacker.engine.util.SynchronousExecutionContext._
     implicit val meta: MetaData = MetaData("", null)
     Try {
-      val futureValue = expressionEvaluator.evaluateParameter(param, Context(""))
-      futureValue.value.flatMap(_.toOption).map(_.value)
-    }.toOption.flatten
+      expressionEvaluator.evaluateParameter(param, Context("")).value
+    }.toOption
   }
 
   private def getSubprocessParamDefinition(subprocessInput: SubprocessInput, paramName: String): ValidatedNel[PartSubGraphCompilationError, Parameter] = {

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodevalidation/ParameterEvaluator.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodevalidation/ParameterEvaluator.scala
@@ -28,9 +28,9 @@ class ParameterEvaluator(expressionEvaluator: ExpressionEvaluator) {
   private def prepareLazyParameter[T](param: TypedParameter, definition: ParameterDef)(implicit nodeId: NodeId): AnyRef = {
     param.typedValue match {
       case e:TypedExpression if !definition.branchParam =>
-        prepareLazyParameterExpression(param.name, e)
+        prepareLazyParameterExpression(definition, e)
       case TypedExpressionMap(valueByKey) if definition.branchParam =>
-        valueByKey.mapValuesNow(prepareLazyParameterExpression(param.name, _))
+        valueByKey.mapValuesNow(prepareLazyParameterExpression(definition, _))
     }
   }
 
@@ -45,14 +45,13 @@ class ParameterEvaluator(expressionEvaluator: ExpressionEvaluator) {
     }
   }
 
-  private def prepareLazyParameterExpression[T](name: String, exprValue: TypedExpression)(implicit nodeId: NodeId): ExpressionLazyParameter[Nothing] = {
-    ExpressionLazyParameter(nodeId, graph.evaluatedparam.Parameter(name,
-      graph.expression.Expression(exprValue.expression.language, exprValue.expression.original)), exprValue.returnType)
+  private def prepareLazyParameterExpression[T](definition: ParameterDef, exprValue: TypedExpression)(implicit nodeId: NodeId): ExpressionLazyParameter[Nothing] = {
+    ExpressionLazyParameter(nodeId, definition,
+      graph.expression.Expression(exprValue.expression.language, exprValue.expression.original), exprValue.returnType)
   }
 
   private def evaluateSync(param: Parameter)(implicit processMetaData: MetaData, nodeId: NodeId): AnyRef = {
-    import pl.touk.nussknacker.engine.util.SynchronousExecutionContext._
-    Await.result(expressionEvaluator.evaluateParameter(param, contextToUse).map(_.value), 10 seconds)
+    expressionEvaluator.evaluateParameter(param, contextToUse).value
   }
 
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/CustomNodeInvoker.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/CustomNodeInvoker.scala
@@ -1,12 +1,13 @@
 package pl.touk.nussknacker.engine.definition
 
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
-import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
-import pl.touk.nussknacker.engine.api.{LazyParameter, _}
+import pl.touk.nussknacker.engine.api.expression.TypedExpression
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
+import pl.touk.nussknacker.engine.api.{LazyParameter, definition, _}
 import pl.touk.nussknacker.engine.compile.ExpressionCompiler
-import pl.touk.nussknacker.engine.compiledgraph.evaluatedparam.Parameter
+import pl.touk.nussknacker.engine.compiledgraph
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
-import pl.touk.nussknacker.engine.graph.evaluatedparam
+import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
 
 import scala.concurrent.duration.FiniteDuration
@@ -14,21 +15,23 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 private[definition] trait CompilerLazyParameter[T] extends LazyParameter[T] {
 
+  //TODO: get rid of Future[_] as we evaluate parameters synchronously...
   def prepareEvaluator(deps: CompilerLazyParameterInterpreter)(implicit ec: ExecutionContext): Context => Future[T]
 
 }
 
 // This class is public for tests purpose. Be aware that its interface can be changed in the future
 case class ExpressionLazyParameter[T](nodeId: NodeId,
-                                      parameter: evaluatedparam.Parameter,
+                                      parameterDef: definition.Parameter,
+                                      expression: Expression,
                                       returnType: TypingResult) extends CompilerLazyParameter[T] {
   override def prepareEvaluator(compilerInterpreter: CompilerLazyParameterInterpreter)(implicit ec: ExecutionContext): Context => Future[T] = {
     val compiledExpression = compilerInterpreter.deps.expressionCompiler
-              .compileWithoutContextValidation(parameter.expression, parameter.name)(nodeId)
+              .compileWithoutContextValidation(expression, parameterDef.name)(nodeId)
               .valueOr(err => throw new IllegalArgumentException(s"Compilation failed with errors: ${err.toList.mkString(", ")}"))
     val evaluator = compilerInterpreter.deps.expressionEvaluator
-    //FIXME: use evaluateParam method here, to handle e.g. options properly
-    context: Context => evaluator.evaluate[T](compiledExpression, parameter.name, nodeId.id, context)(compilerInterpreter.metaData).map(_.value)(ec)
+    val compiledParameter = compiledgraph.evaluatedparam.Parameter(TypedExpression(compiledExpression, Unknown, null), parameterDef)
+    context: Context => Future.successful(evaluator.evaluateParameter(compiledParameter, context)(nodeId, compilerInterpreter.metaData)).map(_.value.asInstanceOf[T])(ec)
   }
 }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/NullExpression.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/expression/NullExpression.scala
@@ -13,6 +13,6 @@ case class NullExpression(original: String,
                           flavour: Flavour) extends api.expression.Expression with LazyLogging {
   override def language: String = flavour.languageId
 
-  override def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]]
-  = Future.successful(ValueWithLazyContext(null.asInstanceOf[T], ctx.lazyContext))
+  override def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): ValueWithLazyContext[T]
+  = ValueWithLazyContext(null.asInstanceOf[T], ctx.lazyContext)
 }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
@@ -86,9 +86,9 @@ class SpelExpression(parsed: ParsedSpelExpression,
 
   // TODO: better interoperability with scala type, mainly: scala.math.BigDecimal, scala.math.BigInt and collections
   override def evaluate[T](ctx: Context, globals: Map[String, Any],
-                           lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]] = logOnException(ctx) {
+                           lazyValuesProvider: LazyValuesProvider): ValueWithLazyContext[T] = logOnException(ctx) {
     if (expectedClass == classOf[SpelExpressionRepr]) {
-      return Future.successful(ValueWithLazyContext(SpelExpressionRepr(parsed.parsed, ctx, globals, original).asInstanceOf[T], ctx.lazyContext))
+      return ValueWithLazyContext(SpelExpressionRepr(parsed.parsed, ctx, globals, original).asInstanceOf[T], ctx.lazyContext)
     }
 
     val evaluationContext = evaluationContextPreparer.prepareEvaluationContext(ctx, globals, lazyValuesProvider)
@@ -96,7 +96,7 @@ class SpelExpression(parsed: ParsedSpelExpression,
     //TODO: async evaluation of lazy vals...
     val value = parsed.getValue[T](evaluationContext, expectedClass)
     val modifiedLazyContext = evaluationContext.lookupVariable(LazyContextVariableName).asInstanceOf[LazyContext]
-    Future.successful(ValueWithLazyContext(value, modifiedLazyContext))
+    ValueWithLazyContext(value, modifiedLazyContext)
   }
 
   private def logOnException[A](ctx: Context)(block: => A): A = {

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/SqlExpressionParser.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/sql/SqlExpressionParser.scala
@@ -100,12 +100,10 @@ class SqlExpression(private[sql] val columnModels: Map[String, ColumnModel],
     new HsqlSqlQueryableDataBase(original, columnModels)
   }
 
-  override def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]] = {
-    Future.successful {
-      //TODO: optimize if needed
-      val result = evaluate(ctx.variables ++ globals).asJava.asInstanceOf[T]
-      ValueWithLazyContext(result, ctx.lazyContext)
-    }
+  override def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): ValueWithLazyContext[T] = {
+    //TODO: optimize if needed
+    val result = evaluate(ctx.variables ++ globals).asJava.asInstanceOf[T]
+    ValueWithLazyContext(result, ctx.lazyContext)
   }
 
   private def evaluate[T](variables: Map[String, Any]): List[TypedMap] = {

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ExpressionServiceQuery.scala
@@ -33,13 +33,9 @@ class ExpressionServiceQuery(
   def invoke(serviceName: String,params: List[evaluatedparam.Parameter])
             (implicit executionContext: ExecutionContext): Future[QueryResult] = {
     expressionCompiler.compileValidatedObjectParameters(params, ValidationContext.empty) match {
-      case Valid(p) => expressionEvaluator
-        .evaluateParameters(p, ctx)(nodeId,ServiceQuery.jobData.metaData)
-        .flatMap {
-          case (_, vars) =>
-            serviceQuery
-              .invoke(serviceName, vars.toList: _*)
-        }
+      case Valid(p) =>
+        val (_, vars) = expressionEvaluator.evaluateParameters(p, ctx)(nodeId,ServiceQuery.jobData.metaData)
+        serviceQuery.invoke(serviceName, vars.toList: _*)
       case Invalid(e) => Future.failed(ParametersCompilationException(e))
     }
   }

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
@@ -800,8 +800,8 @@ object InterpreterSpec {
     case class LiteralExpression(original: String) extends pl.touk.nussknacker.engine.api.expression.Expression {
       override def language: String = languageId
 
-      override def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): Future[ValueWithLazyContext[T]]
-      = Future.successful(ValueWithLazyContext(original.asInstanceOf[T], ctx.lazyContext))
+      override def evaluate[T](ctx: Context, globals: Map[String, Any], lazyValuesProvider: LazyValuesProvider): ValueWithLazyContext[T]
+      = ValueWithLazyContext(original.asInstanceOf[T], ctx.lazyContext)
     }
 
     override def languageId: String = "literal"

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -35,7 +35,7 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
 
   private class EvaluateSync(expression: Expression) {
     def evaluateSync[T](ctx: Context = ctx, lvp: LazyValuesProvider = dumbLazyProvider) : ValueWithLazyContext[T]
-      = Await.result(expression.evaluate[T](ctx, Map.empty, lvp), 5 seconds)
+      = expression.evaluate[T](ctx, Map.empty, lvp)
 
     def evaluateSyncToValue[T](ctx: Context = ctx, lvp: LazyValuesProvider = dumbLazyProvider) : T
       = evaluateSync(ctx, lvp).value

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/sql/SqlExpressionTest.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/sql/SqlExpressionTest.scala
@@ -83,7 +83,7 @@ class SqlExpressionTest extends FunSuite with Matchers with PatientScalaFutures 
 
   private def evaluate(expression: String, ctx: Context = ctx, validationContext: ValidationContext = validationContext): List[TypedMap] =
     parseOrFail(expression, validationContext).evaluate[java.util.List[TypedMap]](ctx, Map.empty, dumbLazyProvider)
-      .futureValue.value.asScala.toList
+      .value.asScala.toList
 
   private def parseOrFail(expression: String, validationContext: ValidationContext = validationContext): SqlExpression =
     SqlExpressionParser


### PR DESCRIPTION
Excessive use of Futures can cause performance problems due to context shifting. 
We had in theory ability to have asynchronous expression evaluation, but all expression languages were in fact synchronous. Making them synchronous also simplifies code.
If in the future we want to return to async evaluation probably it would be better to explore e.g. cats-effect or sth like that
