### PR TITLE
[Improvement] corrent context is passed for branch parameters on UI

### DIFF
--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
@@ -144,6 +144,8 @@ object node {
   @JsonCodec case class BranchEndDefinition(id: String, joinId: String) {
 
     //in CanonicalProcess and EspProcess we have to add artifical node (BranchEnd), we use this generated, unique id
+    //TODO: we're using this also in BranchParameters.js to get ValidationContext. This should be refactored, so
+    //that we're passing ValidationContext for nodes explicitly
     def artificialNodeId: String = s"$$edge-$id-$joinId"
 
     //TODO: remove it and replace with sth more understandable

--- a/ui/client/components/graph/node-modal/AdditionalProperty.tsx
+++ b/ui/client/components/graph/node-modal/AdditionalProperty.tsx
@@ -45,7 +45,7 @@ export default function AdditionalProperty(props: Props) {
       key={propertyName}
       showSwitch={showSwitch}
       showValidation={showValidation}
-      //FIXME??
+      //AdditionalProperties do not use any variables 
       variableTypes={{}}
       errors={propertyErrors}
     />

--- a/ui/client/components/graph/node-modal/AdditionalProperty.tsx
+++ b/ui/client/components/graph/node-modal/AdditionalProperty.tsx
@@ -45,6 +45,8 @@ export default function AdditionalProperty(props: Props) {
       key={propertyName}
       showSwitch={showSwitch}
       showValidation={showValidation}
+      //FIXME??
+      variableTypes={{}}
       errors={propertyErrors}
     />
   )

--- a/ui/client/components/graph/node-modal/BranchParameters.js
+++ b/ui/client/components/graph/node-modal/BranchParameters.js
@@ -1,7 +1,8 @@
 import PropTypes from "prop-types"
 import React from "react"
 import ExpressionField from "./editors/expression/ExpressionField"
-import ProcessUtils from "../../../common/ProcessUtils"
+
+const validationContextId = (branchId, node) => `$edge-${branchId}-${node.id}`
 
 const BranchParameters = (props) => {
 
@@ -27,7 +28,8 @@ const BranchParameters = (props) => {
                   const paramValue = branchParameter.parameters[paramIndex]
                   const expressionPath = `branchParameters[${branchIndex}].parameters[${paramIndex}].expression`
 
-                  const variables = findAvailableVariables(branchId, param)
+                  const contextId = validationContextId(branchId, node)
+                  const variables = findAvailableVariables(contextId, param)
 
                   return paramValue ? (
                     <div className="branch-parameter-row" key={`${paramName}-${branchId}`}>

--- a/ui/client/components/graph/node-modal/BranchParameters.js
+++ b/ui/client/components/graph/node-modal/BranchParameters.js
@@ -1,11 +1,12 @@
 import PropTypes from "prop-types"
 import React from "react"
 import ExpressionField from "./editors/expression/ExpressionField"
+import ProcessUtils from "../../../common/ProcessUtils"
 
 const BranchParameters = (props) => {
 
   const {node, isMarked, showValidation, errors, showSwitch, isEditMode,
-    parameterDefinitions, setNodeDataAt, testResultsToShow, testResultsToHide, toggleTestResult} = props
+    parameterDefinitions, setNodeDataAt, testResultsToShow, testResultsToHide, toggleTestResult, findAvailableVariables} = props
 
   //TODO: maybe we can rely only on node?
   const branchParameters = parameterDefinitions?.filter(p => p.branchParam)
@@ -25,6 +26,9 @@ const BranchParameters = (props) => {
                   const paramIndex = branchParameter.parameters.findIndex(paramInBranch => paramInBranch.name === paramName)
                   const paramValue = branchParameter.parameters[paramIndex]
                   const expressionPath = `branchParameters[${branchIndex}].parameters[${paramIndex}].expression`
+
+                  const variables = findAvailableVariables(branchId, param)
+
                   return paramValue ? (
                     <div className="branch-parameter-row" key={`${paramName}-${branchId}`}>
                       <div className={"branch-param-label"}>{branchId}</div>
@@ -45,6 +49,7 @@ const BranchParameters = (props) => {
                           testResultsToHide={testResultsToHide}
                           toggleTestResult={toggleTestResult}
                           renderFieldLabel={() => false}
+                          variableTypes={variables}
                           errors={errors}
                         />
                       </div>
@@ -70,6 +75,7 @@ BranchParameters.propTypes = {
   testResultsToShow: PropTypes.any,
   testResultsToHide: PropTypes.any,
   toggleTestResult: PropTypes.func.isRequired,
+  findAvailableVariables: PropTypes.func.isRequired,
 }
 
 BranchParameters.defaultProps = {

--- a/ui/client/components/graph/node-modal/NodeDetailsContent.js
+++ b/ui/client/components/graph/node-modal/NodeDetailsContent.js
@@ -742,11 +742,12 @@ export class NodeDetailsContent extends React.Component {
 }
 
 function mapState(state, props) {
+  const processDefinitionData = state.settings.processDefinitionData || {}
+
   //NOTE: we have to use mainProcess carefully, as we may display details of subprocess node, in this case
   //process is *different* than subprocess itself
+  //TODO: in particular we need it for branches, how to handle it for subprocesses?
   const mainProcess = state.graphReducer.processToDisplay
-  //TODO: we need it for branches, how to handle it for subprocesses?
-  const processDefinitionData = state.settings.processDefinitionData || {}
   const findAvailableVariables = ProcessUtils.findAvailableVariables(processDefinitionData, getProcessCategory(state), mainProcess)
   return {
     additionalPropertiesConfig: processDefinitionData.additionalPropertiesConfig || {},

--- a/ui/client/components/graph/node-modal/editors/EditableEditor.tsx
+++ b/ui/client/components/graph/node-modal/editors/EditableEditor.tsx
@@ -6,6 +6,7 @@ import FixedValuesEditor from "./expression/FixedValuesEditor"
 import {isEmpty} from "lodash"
 import {ExpressionObj} from "./expression/types"
 import {spelFormatters} from "./expression/Formatter"
+import {VariableTypes} from "../../../../types"
 
 type Props = {
   fieldType?: string,
@@ -24,6 +25,7 @@ type Props = {
   showValidation?: boolean,
   onValueChange: Function,
   errors?: Array<Error>,
+  variableTypes: VariableTypes,
 }
 
 type State = {
@@ -51,7 +53,7 @@ class EditableEditor extends React.Component<Props, State> {
   render() {
     const {
       fieldType, expressionObj, rowClassName, valueClassName, showSwitch, param, renderFieldLabel, fieldLabel, readOnly,
-      values, errors, fieldName, showValidation,
+      values, errors, fieldName, showValidation, variableTypes,
     } = this.props
 
     const paramType = fieldType || (param ? ProcessUtils.humanReadableType(param.typ.refClazzName) : "expression")
@@ -76,6 +78,7 @@ class EditableEditor extends React.Component<Props, State> {
           formatter={expressionObj.language === "spel" && spelFormatters[param?.typ.refClazzName] != null ?
             spelFormatters[param.typ.refClazzName] : null}
           showValidation={showValidation}
+          variableTypes={variableTypes}
         />
         {
             param?.editor?.type === EditorType.DUAL_PARAMETER_EDITOR && (

--- a/ui/client/components/graph/node-modal/editors/expression/ExpressionField.tsx
+++ b/ui/client/components/graph/node-modal/editors/expression/ExpressionField.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import ExpressionTestResults from "../../tests/ExpressionTestResults"
 import EditableEditor from "../EditableEditor"
 import {EditorType} from "./Editor"
-import {NodeType, UIParameter} from "../../../../../types"
+import {NodeType, UIParameter, VariableTypes} from "../../../../../types"
 
 type Props = {
   fieldName: string,
@@ -22,6 +22,7 @@ type Props = {
   renderFieldLabel: Function,
   fieldType: string,
   errors: Array<Error>,
+  variableTypes: VariableTypes,
 }
 
 class ExpressionField extends React.Component<Props> {
@@ -30,8 +31,10 @@ class ExpressionField extends React.Component<Props> {
     const {
       fieldName, fieldLabel, exprPath, isEditMode, editedNode, isMarked, showValidation, showSwitch,
       parameterDefinition, setNodeDataAt, testResultsToShow, testResultsToHide, toggleTestResult, renderFieldLabel, fieldType,
-      errors,
+      errors, variableTypes,
     } = this.props
+    console.log("name", fieldName, variableTypes)
+
     const readOnly = !isEditMode
     const exprTextPath = `${exprPath}.expression`
     const expressionObj = _.get(editedNode, exprPath)
@@ -53,6 +56,7 @@ class ExpressionField extends React.Component<Props> {
           readOnly={readOnly}
           onValueChange={(newValue) => setNodeDataAt(exprTextPath, newValue)}
           errors={errors}
+          variableTypes={variableTypes}
           showValidation={showValidation}
         />
       )
@@ -76,6 +80,7 @@ class ExpressionField extends React.Component<Props> {
           showValidation={showValidation}
           showSwitch={showSwitch}
           readOnly={readOnly}
+          variableTypes={variableTypes}
           onValueChange={(newValue) => setNodeDataAt(exprTextPath, newValue)}
           errors={errors}
         />

--- a/ui/client/components/graph/node-modal/editors/expression/ExpressionField.tsx
+++ b/ui/client/components/graph/node-modal/editors/expression/ExpressionField.tsx
@@ -33,7 +33,6 @@ class ExpressionField extends React.Component<Props> {
       parameterDefinition, setNodeDataAt, testResultsToShow, testResultsToHide, toggleTestResult, renderFieldLabel, fieldType,
       errors, variableTypes,
     } = this.props
-    console.log("name", fieldName, variableTypes)
 
     const readOnly = !isEditMode
     const exprTextPath = `${exprPath}.expression`

--- a/ui/client/components/graph/node-modal/editors/expression/ExpressionSuggest.js
+++ b/ui/client/components/graph/node-modal/editors/expression/ExpressionSuggest.js
@@ -32,6 +32,7 @@ class ExpressionSuggest extends React.Component {
     showValidation: PropTypes.bool,
     processingType: PropTypes.string,
     isMarked: PropTypes.bool,
+    variableTypes: PropTypes.object,
   }
 
   customAceEditorCompleter = {
@@ -94,7 +95,8 @@ class ExpressionSuggest extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     return !_.isEqual(this.state.value, nextState.value) ||
         !_.isEqual(this.state.editorFocused, nextState.editorFocused) ||
-        !_.isEqual(this.props.validators, nextProps.validators)
+        !_.isEqual(this.props.validators, nextProps.validators) ||
+        !_.isEqual(this.props.variableTypes, nextProps.variableTypes)
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -105,7 +107,7 @@ class ExpressionSuggest extends React.Component {
   }
 
   createExpressionSuggester = (props) => {
-    return new ExpressionSuggester(props.typesInformation, props.variables, props.processingType, HttpService)
+    return new ExpressionSuggester(props.typesInformation, props.variableTypes, props.processingType, HttpService)
   }
 
   onChange = (newValue) => {
@@ -178,23 +180,13 @@ class ExpressionSuggest extends React.Component {
   setEditorFocus = (focus) => () => this.setState({editorFocused: focus})
 }
 
-function mapState(state, props) {
-  const processCategory = _.get(state.graphReducer.fetchedProcessDetails, "processCategory")
+function mapState(state) {
   const processDefinitionData = !_.isEmpty(state.settings.processDefinitionData) ? state.settings.processDefinitionData : {processDefinition: {typesInformation: []}}
   const dataResolved = !_.isEmpty(state.settings.processDefinitionData)
   const typesInformation = processDefinitionData.processDefinition.typesInformation
-  const variablesForNode = state.graphReducer.nodeToDisplay.id || _.get(state.graphReducer, ".edgeToDisplay.to") || null
-
-  //FIXME: probably validation should return all variables in given param??
-  const additionalVariablesFromValidation = state.nodeDetails?.parameters?.find(p => p.name === props.fieldName)?.additionalVariables || {}
-
-  const baseVariables = ProcessUtils.findAvailableVariables(variablesForNode, state.graphReducer.processToDisplay, processDefinitionData.processDefinition, props.fieldName, processCategory)
-  const variables = _.assign(baseVariables, additionalVariablesFromValidation)
-
   return {
     typesInformation: typesInformation,
     dataResolved: dataResolved,
-    variables: variables,
     processingType: state.graphReducer.processToDisplay.processingType,
   }
 }

--- a/ui/client/components/graph/node-modal/editors/expression/RawEditor.tsx
+++ b/ui/client/components/graph/node-modal/editors/expression/RawEditor.tsx
@@ -2,6 +2,7 @@ import cn from "classnames"
 import React from "react"
 import ExpressionSuggest from "./ExpressionSuggest"
 import {Editor} from "./Editor"
+import {VariableTypes} from "../../../../../types"
 
 type Props = {
   fieldName: string,
@@ -14,13 +15,15 @@ type Props = {
   rows: number,
   cols: number,
   className: string,
+  variableTypes: VariableTypes,
+
 }
 
 const RawEditor = (props: Props) => {
 
   const {
     fieldName, expressionObj, validators, isMarked, showValidation, readOnly,
-    onValueChange, rows = 1, cols = 50, className,
+    onValueChange, rows = 1, cols = 50, className, variableTypes,
   } = props
 
   return (
@@ -36,6 +39,7 @@ const RawEditor = (props: Props) => {
           onValueChange: onValueChange,
           readOnly: readOnly,
         }}
+        variableTypes={variableTypes}
         validators={validators}
         isMarked={isMarked}
         showValidation={showValidation}


### PR DESCRIPTION
Currently suggestion engine in FE doesn't handle BranchParameters well. 
We refactor ExpressionSuggest a bit, so that list of variables is passed from outside. This allows to use other ValidationContext for branch parameters. 
It turns out we *already* pass ValidationContext for different branches for FE, so we use it, however this probably deserves refactoring so it's more explicit
