### PR TITLE
Fix for out-of-memory in travis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,9 @@ val forkSettings = Seq(
   javaOptions := Seq(
     "-Xmx512M",
     "-XX:ReservedCodeCacheSize=128M",
-    "-Xss4M"
+    "-Xss4M",
+    // to prevent travis OOM from killing java
+    "-XX:MaxMetaspaceSize=515G"
   )
 )
 
@@ -457,7 +459,7 @@ lazy val generic = (project in engine("flink/generic")).
 
 lazy val process = (project in engine("flink/process")).
   settings(commonSettings).
-  settings(forkSettings).
+  settings(forkSettings). // without this there are some classloading issues
   settings(
     name := "nussknacker-process",
     libraryDependencies ++= {

--- a/ciRunSbt.sh
+++ b/ciRunSbt.sh
@@ -8,7 +8,7 @@ then
 else
    ARGS="$*"
 fi
-# tuning of sbt test to prevent travis OOM from killing java
-JAVA_OPTS_VAL="-Xmx2G -XX:ReservedCodeCacheSize=256M -Xss6M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled"
-echo "Executing: JAVA_OPTS=\"$JAVA_OPTS_VAL\" sbt $ARGS"
-JAVA_OPTS="$JAVA_OPTS_VAL" sbt $ARGS
+# Tuning of sbt test to prevent travis OOM from killing java. Be aware that using JAVA_OPTS won't work on travis because
+# it has own alias for sbt: https://www.scala-sbt.org/1.x/docs/Travis-CI-with-sbt.html#Custom+JVM+options
+echo "Executing: sbt -J-Xss6M -J-Xms1500M -J-Xmx1500M -J-XX:ReservedCodeCacheSize=256M -J-XX:MaxMetaspaceSize=2500M $ARGS"
+sbt -J-Xss6M -J-Xms1500M -J-Xmx1500M -J-XX:ReservedCodeCacheSize=256M -J-XX:MaxMetaspaceSize=2500M $ARGS

--- a/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/flink/test/FlinkTestConfiguration.scala
+++ b/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/flink/test/FlinkTestConfiguration.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.flink.test
 
-import org.apache.flink.configuration.{ConfigConstants, Configuration, QueryableStateOptions, TaskManagerOptions}
+import org.apache.flink.configuration._
 
 object FlinkTestConfiguration {
 //FIXME: make ports range dynamic and smaller.
@@ -15,6 +15,9 @@ object FlinkTestConfiguration {
     val config = new Configuration
     config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, taskManagersCount)
     config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, taskSlotsCount)
+    // to prevent OutOfMemoryError: Could not allocate enough memory segments for NetworkBufferPool on low memory env (like Travis)
+    config.setString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN, "16m")
+    config.setString(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX, "16m")
     addQueryableStatePortRanges(config)
   }
 


### PR DESCRIPTION
- specified MaxMetaspaceSize
- specified NETWORK_BUFFERS_MEMORY
- switch from JAVA_OPTS to args in sbt invocation