### PR TITLE
Add ContextId to the list of optional service parameters

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/Context.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/Context.scala
@@ -8,7 +8,7 @@ object Context {
 
 }
 
-class ContextId(val id: String) extends AnyRef
+case class ContextId(value: String)
 
 case class Context(id: String, variables: Map[String, Any],
                    lazyContext: LazyContext, parentContext: Option[Context]) {

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/Context.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/Context.scala
@@ -8,6 +8,8 @@ object Context {
 
 }
 
+class ContextId(val id: String) extends AnyRef
+
 case class Context(id: String, variables: Map[String, Any],
                    lazyContext: LazyContext, parentContext: Option[Context]) {
 

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/definition/WithExplicitMethodToInvoke.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/definition/WithExplicitMethodToInvoke.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.api.definition
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors.ServiceInvocationCollector
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
-import pl.touk.nussknacker.engine.api.{MetaData, Service}
+import pl.touk.nussknacker.engine.api.{ContextId, MetaData, Service}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -32,18 +32,19 @@ trait WithExplicitMethodToInvoke {
 
 trait ServiceWithExplicitMethod extends Service with WithExplicitMethodToInvoke {
 
-  override final def additionalDependencies: List[Class[_]] = List(classOf[ExecutionContext], classOf[ServiceInvocationCollector], classOf[MetaData])
+  override final def additionalDependencies: List[Class[_]] = List(classOf[ExecutionContext], classOf[ServiceInvocationCollector], classOf[MetaData], classOf[ContextId])
 
   override final def runtimeClass: Class[_] = classOf[Future[_]]
 
   override def invoke(params: List[AnyRef]): AnyRef = {
-    val normalParams = params.dropRight(3)
-    val implicitParams = params.takeRight(3)
+    val normalParams = params.dropRight(4)
+    val implicitParams = params.takeRight(4)
     invokeService(normalParams)(implicitParams(0).asInstanceOf[ExecutionContext],
                                 implicitParams(1).asInstanceOf[ServiceInvocationCollector],
-                                implicitParams(2).asInstanceOf[MetaData])
+                                implicitParams(2).asInstanceOf[MetaData],
+                                implicitParams(3).asInstanceOf[ContextId])
   }
 
-  def invokeService(params: List[AnyRef])(implicit ec: ExecutionContext, collector: InvocationCollectors.ServiceInvocationCollector, metaData: MetaData): Future[AnyRef]
+  def invokeService(params: List[AnyRef])(implicit ec: ExecutionContext, collector: InvocationCollectors.ServiceInvocationCollector, metaData: MetaData, contextId: ContextId): Future[AnyRef]
 
 }

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/DynamicService.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/DynamicService.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.management.sample.service
 import java.io.File
 
 import org.apache.commons.io.FileUtils
-import pl.touk.nussknacker.engine.api.MetaData
+import pl.touk.nussknacker.engine.api.{ContextId, MetaData}
 import pl.touk.nussknacker.engine.api.definition.{Parameter, ServiceWithExplicitMethod}
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors.ServiceInvocationCollector
 import pl.touk.nussknacker.engine.api.typed.typing
@@ -20,7 +20,7 @@ class DynamicService extends ServiceWithExplicitMethod {
   private val fileWithDefinition = new File(Properties.tmpDir, "nk-dynamic-params.lst")
 
   override def invokeService(params: List[AnyRef])
-                            (implicit ec: ExecutionContext, collector: ServiceInvocationCollector, metaData: MetaData): Future[AnyRef] = {
+                            (implicit ec: ExecutionContext, collector: ServiceInvocationCollector, metaData: MetaData, contextId: ContextId): Future[AnyRef] = {
     val toCollect = params.mkString(",")
     val res = ().asInstanceOf[AnyRef]
     collector.collect(toCollect, Some(res))(Future.successful(res))

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/UnionReturnObjectService.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/UnionReturnObjectService.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.management.sample.service
 
-import pl.touk.nussknacker.engine.api.MetaData
+import pl.touk.nussknacker.engine.api.{ContextId, MetaData}
 import pl.touk.nussknacker.engine.api.definition.{Parameter, ServiceWithExplicitMethod}
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors.ServiceInvocationCollector
 import pl.touk.nussknacker.engine.api.typed.typing
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case object UnionReturnObjectService extends ServiceWithExplicitMethod {
 
   override def invokeService(params: List[AnyRef])
-                            (implicit ec: ExecutionContext, collector: ServiceInvocationCollector, metaData: MetaData): Future[AnyRef] =
+                            (implicit ec: ExecutionContext, collector: ServiceInvocationCollector, metaData: MetaData, contextId: ContextId): Future[AnyRef] =
     Future.successful(Map("foo" -> 1))
 
   override def parameterDefinition: List[Parameter] = List.empty

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ServiceInvoker.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ServiceInvoker.scala
@@ -27,7 +27,7 @@ private[definition] class ServiceInvokerImpl(objectWithMethodDef: ObjectWithMeth
                      (implicit ec: ExecutionContext, metaData: MetaData): Future[Any] = {
     objectWithMethodDef.invokeMethod(params,
       outputVariableNameOpt = nodeContext.outputVariableNameOpt,
-      additional = Seq(ec, collector.getOrElse(TestServiceInvocationCollector(nodeContext)), metaData, NodeId(nodeContext.nodeId), new ContextId(nodeContext.contextId))
+      additional = Seq(ec, collector.getOrElse(TestServiceInvocationCollector(nodeContext)), metaData, NodeId(nodeContext.nodeId), ContextId(nodeContext.contextId))
     ).asInstanceOf[Future[Any]]
   }
 
@@ -41,7 +41,7 @@ private[definition] class JavaServiceInvokerImpl(objectWithMethodDef: ObjectWith
     val result = objectWithMethodDef.invokeMethod(
       params,
       outputVariableNameOpt = None,
-      additional = Seq(prepareExecutor(ec), collector.getOrElse(TestServiceInvocationCollector(nodeContext)), metaData, NodeId(nodeContext.nodeId), new ContextId(nodeContext.contextId)))
+      additional = Seq(prepareExecutor(ec), collector.getOrElse(TestServiceInvocationCollector(nodeContext)), metaData, NodeId(nodeContext.nodeId), ContextId(nodeContext.contextId)))
     FutureConverters.toScala(result.asInstanceOf[CompletionStage[_]])
   }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ServiceInvoker.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/ServiceInvoker.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors.{NodeContext, ServiceInvocationCollector, TestServiceInvocationCollector}
 import pl.touk.nussknacker.engine.api.typed.typing.SingleTypingResult
-import pl.touk.nussknacker.engine.api.{MetaData, Service}
+import pl.touk.nussknacker.engine.api.{MetaData, Service, ContextId}
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectWithMethodDef
 import pl.touk.nussknacker.engine.definition.MethodDefinitionExtractor.UnionDefinitionExtractor
 
@@ -27,7 +27,7 @@ private[definition] class ServiceInvokerImpl(objectWithMethodDef: ObjectWithMeth
                      (implicit ec: ExecutionContext, metaData: MetaData): Future[Any] = {
     objectWithMethodDef.invokeMethod(params,
       outputVariableNameOpt = nodeContext.outputVariableNameOpt,
-      additional = Seq(ec, collector.getOrElse(TestServiceInvocationCollector(nodeContext)), metaData, NodeId(nodeContext.nodeId))
+      additional = Seq(ec, collector.getOrElse(TestServiceInvocationCollector(nodeContext)), metaData, NodeId(nodeContext.nodeId), new ContextId(nodeContext.contextId))
     ).asInstanceOf[Future[Any]]
   }
 
@@ -41,7 +41,7 @@ private[definition] class JavaServiceInvokerImpl(objectWithMethodDef: ObjectWith
     val result = objectWithMethodDef.invokeMethod(
       params,
       outputVariableNameOpt = None,
-      additional = Seq(prepareExecutor(ec), collector.getOrElse(TestServiceInvocationCollector(nodeContext)), metaData, NodeId(nodeContext.nodeId)))
+      additional = Seq(prepareExecutor(ec), collector.getOrElse(TestServiceInvocationCollector(nodeContext)), metaData, NodeId(nodeContext.nodeId), new ContextId(nodeContext.contextId)))
     FutureConverters.toScala(result.asInstanceOf[CompletionStage[_]])
   }
 
@@ -78,7 +78,7 @@ object ServiceInvoker {
 
     override protected val expectedReturnType: Option[Class[_]] = Some(classOf[Future[_]])
     override protected val additionalDependencies = Set[Class[_]](classOf[ExecutionContext],
-      classOf[ServiceInvocationCollector], classOf[MetaData], classOf[NodeId])
+      classOf[ServiceInvocationCollector], classOf[MetaData], classOf[NodeId], classOf[ContextId])
 
   }
 
@@ -86,7 +86,7 @@ object ServiceInvoker {
 
     override protected val expectedReturnType: Option[Class[_]] = Some(classOf[java.util.concurrent.CompletionStage[_]])
     override protected val additionalDependencies = Set[Class[_]](classOf[Executor],
-      classOf[ServiceInvocationCollector], classOf[MetaData], classOf[NodeId])
+      classOf[ServiceInvocationCollector], classOf[MetaData], classOf[NodeId], classOf[ContextId])
 
   }
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
@@ -788,7 +788,7 @@ object InterpreterSpec {
 
     override def returnType: typing.TypingResult = Typed[String]
 
-    override def invokeService(params: List[AnyRef])(implicit ec: ExecutionContext, collector: InvocationCollectors.ServiceInvocationCollector, metaData: MetaData): Future[AnyRef] = {
+    override def invokeService(params: List[AnyRef])(implicit ec: ExecutionContext, collector: InvocationCollectors.ServiceInvocationCollector, metaData: MetaData, contextId: ContextId): Future[AnyRef] = {
       Future.successful(params.head.asInstanceOf[Long].toString)
     }
 

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessInterpreter.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessInterpreter.scala
@@ -177,12 +177,12 @@ case class StandaloneProcessInterpreter(source: StandaloneSource[Any],
 
   private val counter = new AtomicLong(0)
 
-  def invoke(input: Any)(implicit ec: ExecutionContext): Future[GenericListResultType[Any]] = {
-    invokeToResult(input).map(_.right.map(_.map(_.output)))
+  def invoke(input: Any, contextIdOpt: Option[String] = None)(implicit ec: ExecutionContext): Future[GenericListResultType[Any]] = {
+    invokeToResult(input, contextIdOpt).map(_.right.map(_.map(_.output)))
   }
 
-  def invokeToResult(input: Any)(implicit ec: ExecutionContext): InterpreterOutputType = modelData.withThisAsContextClassLoader {
-    val contextId = s"${context.processId}-${counter.getAndIncrement()}"
+  def invokeToResult(input: Any, contextIdOpt: Option[String] = None)(implicit ec: ExecutionContext): InterpreterOutputType = modelData.withThisAsContextClassLoader {
+    val contextId = contextIdOpt.getOrElse(s"${context.processId}-${counter.getAndIncrement()}")
     measureTime {
       val ctx = Context(contextId).withVariable(Interpreter.InputParamName, input)
       invoker(ctx, ec)

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -134,7 +134,7 @@ class StandaloneTestMain(testData: TestData, process: EspProcess, modelData: Mod
     try {
       val processVersion = ProcessVersion.empty.copy(processName = ProcessName("snapshot version")) // testing process may be unreleased, so it has no version
       standaloneInterpreter.open(JobData(process.metaData, processVersion))
-      val results = Await.result(Future.sequence(parsedTestData.map(standaloneInterpreter.invokeToResult)), timeout)
+      val results = Await.result(Future.sequence(parsedTestData.map(standaloneInterpreter.invokeToResult(_, None))), timeout)
       collectSinkResults(collectingListener.runId, results)
       collectExceptions(collectingListener, results)
       collectingListener.results

--- a/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessConfigCreator.scala
+++ b/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessConfigCreator.scala
@@ -80,7 +80,7 @@ case class Request3(field13: String, field23: String)
 class EnricherService extends Service {
   @MethodToInvoke
   def invoke()(implicit ex: ExecutionContext, collector: ServiceInvocationCollector, contextId: ContextId): Future[Response] = {
-    Future.successful(Response("alamakota-" + contextId.id))
+    Future.successful(Response("alamakota-" + contextId.value))
   }
 }
 

--- a/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessConfigCreator.scala
+++ b/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessConfigCreator.scala
@@ -79,8 +79,8 @@ case class Request3(field13: String, field23: String)
 
 class EnricherService extends Service {
   @MethodToInvoke
-  def invoke()(implicit ex: ExecutionContext, collector: ServiceInvocationCollector): Future[Response] = {
-    Future.successful(Response("alamakota"))
+  def invoke()(implicit ex: ExecutionContext, collector: ServiceInvocationCollector, contextId: ContextId): Future[Response] = {
+    Future.successful(Response("alamakota-" + contextId.id))
   }
 }
 

--- a/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/test/StandaloneTestMainSpec.scala
+++ b/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/test/StandaloneTestMainSpec.scala
@@ -34,6 +34,7 @@ class StandaloneTestMainSpec extends FunSuite with Matchers with BeforeAndAfterE
 
     val input = """{ "field1": "a", "field2": "b" }
       |{ "field1": "c", "field2": "d" }""".stripMargin
+    val defaultContextId = "proc1-0"
     val config = ConfigFactory.load()
 
     val results = StandaloneTestMain.run(
@@ -53,8 +54,8 @@ class StandaloneTestMainSpec extends FunSuite with Matchers with BeforeAndAfterE
 
     results.mockedResults("processor").toSet shouldBe Set(MockedResult("proc1-0", "processorService", "processor service invoked"))
     results.mockedResults("endNodeIID").toSet shouldBe Set(MockedResult("proc1-0",
-      "endNodeIID", """{
-                      |  "field1" : "alamakota"
+      "endNodeIID", s"""{
+                      |  "field1" : "alamakota-$defaultContextId"
                       |}""".stripMargin))
 
     StandaloneProcessConfigCreator.processorService.get().invocationsCount.get shouldBe 0


### PR DESCRIPTION
The idea is to pass some custom generated context id (correlation id) when invoking standalone process so that the same context id is available when executing services.
    
This way we are able to log inbound and outbound HTTP requests with the same correlation id (context id).