### PR TITLE
[FIX] Avoid duplicate # in suggestions for helpers

### DIFF
--- a/ui/client/components/graph/node-modal/editors/expression/ExpressionSuggest.js
+++ b/ui/client/components/graph/node-modal/editors/expression/ExpressionSuggest.js
@@ -20,8 +20,8 @@ import {reducer as nodeDetails} from "../../../../../reducers/nodeDetailsState"
 
 var inputExprIdCounter = 0
 
-const identifierRegexpsWithoutDot = [/[#a-z0-9-_]/]
-const identifierRegexpsIncludingDot = [/[#a-z0-9-_.]/]
+const identifierRegexpsWithoutDot = [/[#a-zA-Z0-9-_]/]
+const identifierRegexpsIncludingDot = [/[#a-zA-Z0-9-_.]/]
 
 const commandFindConfiguration = {
   name: "find",


### PR DESCRIPTION
"#" is duplicated when suggestion capital letters (e.g. in utils):
![Peek 2020-09-08 09-46](https://user-images.githubusercontent.com/147658/92448087-68a2d600-f1b8-11ea-9325-fe2a35e84424.gif)
