### PR TITLE
Fix template typing, drop intermediate results to get rid of "Merging same types..." warning

### DIFF
--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -39,8 +39,11 @@ private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: Commo
         typeExpression(e, ctx)
       case e:CompositeStringExpression =>
         val validatedParts = e.getExpressions.toList.map(typeExpression(_, ctx)).sequence
-
-        validatedParts.map(partResults => CollectedTypingResult(Monoid.combineAll(partResults.map(_.intermediateResults)), Typed[String]))
+        // We drop intermediate results here:
+        // * It's tricky to combine it as each of the subexpressions has it's own abstract tree with positions relative to the subexpression's starting position
+        // * CompositeStringExpression is dedicated to template SpEL expressions. It cannot be nested (as templates cannot be nested)
+        // * Currently we don't use intermediate typing results outside of Typer
+        validatedParts.map(_ => CollectedTypingResult.withEmptyIntermediateResults(Typed[String]))
       case e:LiteralExpression =>
         Valid(CollectedTypingResult.withEmptyIntermediateResults(Typed[String]))
       case e:NullExpression =>

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -556,11 +556,8 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
     parse[String]("alamakota #{444}", ctx, SpelExpressionParser.Template) shouldBe 'valid
     parse[String]("alamakota #{444 + #obj.value}", ctx, SpelExpressionParser.Template) shouldBe 'valid
     parse[String]("alamakota #{444 + #nothing}", ctx, SpelExpressionParser.Template) shouldBe 'invalid
-    // WARN - Merging same types: TypedClass(class java.lang.String,List()) for the same nodes. This shouldn't happen
     parse[String]("#{'raz'},#{'dwa'}", ctx, SpelExpressionParser.Template) shouldBe 'valid
-    the [AssertionError] thrownBy {
-      parse[String]("#{'raz'},#{12345}", ctx, SpelExpressionParser.Template)
-    } should have message("assertion failed: Types not matching during combination of types for spel nodes: TypedClass(class java.lang.String,List()) != TypedClass(class java.lang.Integer,List())")
+    parse[String]("#{'raz'},#{12345}", ctx, SpelExpressionParser.Template) shouldBe 'valid
   }
 
   test("evaluates expression with template context") {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -556,7 +556,11 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
     parse[String]("alamakota #{444}", ctx, SpelExpressionParser.Template) shouldBe 'valid
     parse[String]("alamakota #{444 + #obj.value}", ctx, SpelExpressionParser.Template) shouldBe 'valid
     parse[String]("alamakota #{444 + #nothing}", ctx, SpelExpressionParser.Template) shouldBe 'invalid
-
+    // WARN - Merging same types: TypedClass(class java.lang.String,List()) for the same nodes. This shouldn't happen
+    parse[String]("#{'raz'},#{'dwa'}", ctx, SpelExpressionParser.Template) shouldBe 'valid
+    the [AssertionError] thrownBy {
+      parse[String]("#{'raz'},#{12345}", ctx, SpelExpressionParser.Template)
+    } should have message("assertion failed: Types not matching during combination of types for spel nodes: TypedClass(class java.lang.String,List()) != TypedClass(class java.lang.Integer,List())")
   }
 
   test("evaluates expression with template context") {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/TyperSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/TyperSpec.scala
@@ -1,0 +1,49 @@
+package pl.touk.nussknacker.engine.spel
+
+import cats.data.Validated.Valid
+import cats.data.ValidatedNel
+import org.scalatest.{FunSuite, Matchers}
+import org.springframework.expression.common.TemplateParserContext
+import pl.touk.nussknacker.engine.api.context.ValidationContext
+import pl.touk.nussknacker.engine.api.expression.ExpressionParseError
+import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
+import pl.touk.nussknacker.engine.api.typed.supertype.{CommonSupertypeFinder, SupertypeClassResolutionStrategy}
+import pl.touk.nussknacker.engine.api.typed.typing.Typed
+import pl.touk.nussknacker.engine.dict.{KeysDictTyper, SimpleDictRegistry}
+import pl.touk.nussknacker.engine.expression.PositionRange
+import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
+
+class TyperSpec extends FunSuite with Matchers {
+
+  test("simple expression") {
+    typeExpression("#x + 2", "x" -> 2) shouldBe Valid(CollectedTypingResult(Map(
+      PositionRange(0, 2) -> Typed[Integer],
+      PositionRange(3, 4) -> Typed[Integer],
+      PositionRange(5, 6) -> Typed[Integer]
+    ), Typed[Integer]))
+  }
+
+  test("template") {
+    typeTemplate("result: #{#x + 2}", "x" -> 2) shouldBe Valid(CollectedTypingResult(Map.empty, Typed[String]))
+  }
+
+  private val strictTypeChecking = false
+  private val strictMethodsChecking = false
+  private val classResolutionStrategy = SupertypeClassResolutionStrategy.Union
+  private val commonSupertypeFinder = new CommonSupertypeFinder(classResolutionStrategy, strictTypeChecking)
+  private val dict = new SimpleDictRegistry(Map.empty)
+  private val typer = new Typer(this.getClass.getClassLoader, commonSupertypeFinder, new KeysDictTyper(dict), strictMethodsChecking)(ClassExtractionSettings.Default)
+  private val parser = new org.springframework.expression.spel.standard.SpelExpressionParser()
+
+  private def typeExpression(expr: String, variables: (String, Any)*): ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
+    val parsed = parser.parseExpression(expr)
+    val validationCtx = ValidationContext(variables.toMap.mapValuesNow(Typed.fromInstance))
+    typer.typeExpression(parsed, validationCtx)
+  }
+
+  private def typeTemplate(expr: String, variables: (String, Any)*): ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
+    val parsed = parser.parseExpression(expr, new TemplateParserContext())
+    val validationCtx = ValidationContext(variables.toMap.mapValuesNow(Typed.fromInstance))
+    typer.typeExpression(parsed, validationCtx)
+  }
+}


### PR DESCRIPTION
In case of template SpEL expressions, each of the subexpressions has it's own abstract tree with positions relative to the subexpressions starting position, e.g. 
  expression `"result: #{#x + 1}"`, will be parsed as:
  LiteralExpression: `"result: "`
  SpelExpression: `"#x + 1"`

Therefore:
* positions in `CollectedTypingResult` are not correct (not absolute)
* we can have "Merging same types" warnings in case of positions clash