### PR TITLE
Access job data from custom nodes

### DIFF
--- a/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkCustomNodeContext.scala
+++ b/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkCustomNodeContext.scala
@@ -1,19 +1,21 @@
 package pl.touk.nussknacker.engine.flink.api.process
 
-import pl.touk.nussknacker.engine.api.MetaData
+import pl.touk.nussknacker.engine.api.{JobData, MetaData}
 import pl.touk.nussknacker.engine.flink.api.NkGlobalParameters
 import pl.touk.nussknacker.engine.flink.api.signal.FlinkProcessSignalSender
 
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
-case class FlinkCustomNodeContext(metaData: MetaData,
+case class FlinkCustomNodeContext(jobData: JobData,
                                   // TODO: it can be used in state recovery - make sure that it won't change during renaming of nodes on gui
                                   nodeId: String,
                                   timeout: FiniteDuration,
                                   lazyParameterHelper: FlinkLazyParameterFunctionHelper,
                                   signalSenderProvider: FlinkProcessSignalSenderProvider,
-                                  globalParameters: Option[NkGlobalParameters])
+                                  globalParameters: Option[NkGlobalParameters]) {
+  def metaData: MetaData = jobData.metaData
+}
 
 case class SignalSenderKey(id: String, klass: Class[_])
 
@@ -26,5 +28,3 @@ class FlinkProcessSignalSenderProvider(signalSenders: Map[SignalSenderKey, Flink
       .getOrElse(throw new IllegalArgumentException(s"Unknown signal class: ${clazz.getName}, please check ProcessConfigCreator"))._2
   }
 }
-
-case class FlinkProcessConfig()

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
@@ -103,7 +103,7 @@ class FlinkProcessRegistrar(compileProcess: (EspProcess, ProcessVersion) => Clas
 
     val globalParameters = NkGlobalParameters.readFromContext(env.getConfig)
     def nodeContext(nodeId: String): FlinkCustomNodeContext = {
-      FlinkCustomNodeContext(metaData, nodeId, processWithDeps.processTimeout,
+      FlinkCustomNodeContext(processWithDeps.jobData, nodeId, processWithDeps.processTimeout,
         new FlinkLazyParameterFunctionHelper(createInterpreter(compiledProcessWithDeps)),
         processWithDeps.signalSenders, globalParameters)
     }


### PR DESCRIPTION
Job data is already available from services via RuntimeInjectedJobData trait.