### PR TITLE
Fix for: node validation after source without returnType

### DIFF
--- a/ui/client/common/ProcessUtils.ts
+++ b/ui/client/common/ProcessUtils.ts
@@ -113,7 +113,7 @@ class ProcessUtils {
     const clazzName = _.get(nodeObjectTypeDefinition, "returnType")
     switch (node.type) {
       case "Source": {
-        return [{input: clazzName}]
+        return _.isEmpty(clazzName) ? [] : [{input: clazzName}]
       }
       case "SubprocessInputDefinition": {
         return node.parameters.map(param => ({[param.name]: param.typ}))


### PR DESCRIPTION
... with broken graph structure caused: failed cursor: DownField(type),DownField(input),DownField(variableTypes)