### PR TITLE
Add custom actions

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -17,6 +17,7 @@ Nussknacker versions
     * [#1360](https://github.com/TouK/nussknacker/pull/1360) Service query can use global variables
 * [#1361](https://github.com/TouK/nussknacker/pull/1361) Lazy vars removal
 * [#1363](https://github.com/TouK/nussknacker/pull/1363) Open/close only services that are actually used in process
+* [#1367](https://github.com/TouK/nussknacker/pull/1367) Custom actions - experimental/wip version
 
 0.3.1 (not released yet) 
 ------------------------

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -17,7 +17,7 @@ Nussknacker versions
     * [#1360](https://github.com/TouK/nussknacker/pull/1360) Service query can use global variables
 * [#1361](https://github.com/TouK/nussknacker/pull/1361) Lazy vars removal
 * [#1363](https://github.com/TouK/nussknacker/pull/1363) Open/close only services that are actually used in process
-* [#1367](https://github.com/TouK/nussknacker/pull/1367) Custom actions - experimental/wip version
+* [#1367](https://github.com/TouK/nussknacker/pull/1367) Custom actions - first, experimental version
 
 0.3.1 (not released yet) 
 ------------------------

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
@@ -4,6 +4,20 @@ import pl.touk.nussknacker.engine.api.process.ProcessName
 
 import java.net.URI
 
+/*
+This is a work in progress version.
+FIXME:
+1. Currently custom actions definition is split between ProcessManager and ProcessStateDefinitionManager,
+   the latter specifying which custom actions are available and the former defining how custom action should be handled.
+2. There is no validation on BE to check if given action can be processed,
+   eg if an action is some sort of custom process deployment we should validate it against current process status.
+   For now we only disable custom action buttons on FE when action's allowed process states doesn't include current process state.
+
+Things to consider in future changes:
+1. Allowing for attaching comments to custom actions, similarly to stop/deploy comments.
+2. Storing custom actions taken in DB.
+ */
+
 case class CustomAction(name: String,
                         allowedProcessStates: List[StateStatus],
                         icon: Option[URI] = None)

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
@@ -24,6 +24,30 @@ case class CustomActionRequest(name: String,
                                processName: ProcessName,
                                params: Map[String, String])
 
-case class CustomActionResult(msg: String)
+case class CustomActionResult(req: CustomActionRequest, msg: String)
 
-case class CustomActionError(msg: String)
+sealed trait CustomActionError extends Exception {
+  def request: CustomActionRequest
+
+  def msg: String
+
+  override def getMessage: String = msg
+}
+
+case class CustomActionFailure(request: CustomActionRequest, msg: String) extends CustomActionError
+
+case class CustomActionInvalidStatus(request: CustomActionRequest, stateStatus: StateStatus) extends CustomActionError {
+  override val msg: String = s"Process status: $stateStatus is not allowed for action ${request.name}"
+}
+
+case class CustomActionNotImplemented(request: CustomActionRequest) extends CustomActionError {
+  override val msg: String = s"${request.name} is not implemented"
+}
+
+case class CustomActionNonExisting(request: CustomActionRequest) extends CustomActionError {
+  override val msg: String = s"${request.name} is not existing"
+}
+
+case class CustomActionInvalidProcessStatus(request: CustomActionRequest) extends CustomActionError {
+  override val msg: String = s"Invalid process status for action: ${request.name}"
+}

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
@@ -37,7 +37,7 @@ sealed trait CustomActionError extends Exception {
 case class CustomActionFailure(request: CustomActionRequest, msg: String) extends CustomActionError
 
 case class CustomActionInvalidStatus(request: CustomActionRequest, stateStatus: StateStatus) extends CustomActionError {
-  override val msg: String = s"Process status: $stateStatus is not allowed for action ${request.name}"
+  override val msg: String = s"Process status: ${stateStatus.name} is not allowed for action ${request.name}"
 }
 
 case class CustomActionNotImplemented(request: CustomActionRequest) extends CustomActionError {
@@ -46,8 +46,4 @@ case class CustomActionNotImplemented(request: CustomActionRequest) extends Cust
 
 case class CustomActionNonExisting(request: CustomActionRequest) extends CustomActionError {
   override val msg: String = s"${request.name} is not existing"
-}
-
-case class CustomActionInvalidProcessStatus(request: CustomActionRequest) extends CustomActionError {
-  override val msg: String = s"Invalid process status for action: ${request.name}"
 }

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
@@ -5,11 +5,9 @@ import pl.touk.nussknacker.engine.api.process.ProcessName
 import java.net.URI
 
 /*
-This is a work in progress version.
+This is an experimental/wip version.
 FIXME:
-1. Currently custom actions definition is split between ProcessManager and ProcessStateDefinitionManager,
-   the latter specifying which custom actions are available and the former defining how custom action should be handled.
-2. There is no validation on BE to check if given action can be processed,
+1. There is no validation on BE to check if given action can be processed,
    eg if an action is some sort of custom process deployment we should validate it against current process status.
    For now we only disable custom action buttons on FE when action's allowed process states doesn't include current process state.
 

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
@@ -1,0 +1,17 @@
+package pl.touk.nussknacker.engine.api.deployment
+
+import pl.touk.nussknacker.engine.api.process.ProcessName
+
+import java.net.URI
+
+case class CustomAction(name: String,
+                        allowedProcessStates: List[StateStatus],
+                        icon: Option[URI] = None)
+
+case class CustomActionRequest(name: String,
+                               processName: ProcessName,
+                               params: Map[String, String])
+
+case class CustomActionResult(msg: String)
+
+case class CustomActionError(msg: String)

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
@@ -5,7 +5,7 @@ import pl.touk.nussknacker.engine.api.ProcessVersion
 import java.net.URI
 
 /*
-This is an experimental/wip version.
+This is an experimental version, API will change in the future.
 CustomActions purpose is to allow non standard process management actions (like deploy, cancel, etc.)
 
 FIXME:

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.api.deployment
 
-import pl.touk.nussknacker.engine.api.process.ProcessName
+import pl.touk.nussknacker.engine.api.ProcessVersion
 
 import java.net.URI
 
@@ -22,7 +22,8 @@ case class CustomAction(name: String,
                         icon: Option[URI] = None)
 
 case class CustomActionRequest(name: String,
-                               processName: ProcessName,
+                               processVersion: ProcessVersion,
+                               user: User,
                                params: Map[String, String])
 
 case class CustomActionResult(req: CustomActionRequest, msg: String)

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
@@ -6,10 +6,11 @@ import java.net.URI
 
 /*
 This is an experimental/wip version.
+CustomActions purpose is to allow non standard process management actions (like deploy, cancel, etc.)
+
 FIXME:
-1. There is no validation on BE to check if given action can be processed,
-   eg if an action is some sort of custom process deployment we should validate it against current process status.
-   For now we only disable custom action buttons on FE when action's allowed process states doesn't include current process state.
+1. Additional validations on action invoke, like checking if process definition is valid
+2. Handle CustomActionRequest#params
 
 Things to consider in future changes:
 1. Allowing for attaching comments to custom actions, similarly to stop/deploy comments.

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
@@ -24,5 +24,7 @@ trait ProcessManager extends AutoCloseable {
 
   def processStateDefinitionManager: ProcessStateDefinitionManager
 
+  def customActions: List[CustomAction]
+
   def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]]
 }

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
@@ -26,5 +26,6 @@ trait ProcessManager extends AutoCloseable {
 
   def customActions: List[CustomAction]
 
-  def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]]
+  def invokeCustomAction(actionRequest: CustomActionRequest,
+                         processDeploymentData: ProcessDeploymentData): Future[Either[CustomActionError, CustomActionResult]]
 }

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessManager.scala
@@ -24,4 +24,5 @@ trait ProcessManager extends AutoCloseable {
 
   def processStateDefinitionManager: ProcessStateDefinitionManager
 
+  def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]]
 }

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
@@ -10,7 +10,6 @@ import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessAction
 //@TODO: In future clean up it.
 trait ProcessStateDefinitionManager {
   def statusActions(stateStatus: StateStatus): List[ProcessActionType]
-  def customActions: List[CustomAction]
   def statusTooltip(stateStatus: StateStatus): Option[String]
   def statusDescription(stateStatus: StateStatus): Option[String]
   def statusIcon(stateStatus: StateStatus): Option[URI]

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
@@ -10,6 +10,7 @@ import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessAction
 //@TODO: In future clean up it.
 trait ProcessStateDefinitionManager {
   def statusActions(stateStatus: StateStatus): List[ProcessActionType]
+  def customActions: List[CustomAction]
   def statusTooltip(stateStatus: StateStatus): Option[String]
   def statusDescription(stateStatus: StateStatus): Option[String]
   def statusIcon(stateStatus: StateStatus): Option[URI]

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleProcessStateDefinitionManager.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleProcessStateDefinitionManager.scala
@@ -77,8 +77,6 @@ object SimpleProcessStateDefinitionManager extends ProcessStateDefinitionManager
   override def statusActions(stateStatus: StateStatus): List[ProcessActionType] =
     statusActionsMap.getOrElse(stateStatus, defaultActions)
 
-  override val customActions: List[CustomAction] = List.empty
-
   override def mapActionToStatus(stateAction: Option[ProcessActionType]): StateStatus =
     stateAction
       .map(sa => actionStatusMap.getOrElse(sa, SimpleStateStatus.Unknown))

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleProcessStateDefinitionManager.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleProcessStateDefinitionManager.scala
@@ -1,9 +1,8 @@
 package pl.touk.nussknacker.engine.api.deployment.simple
 
 import java.net.URI
-
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
-import pl.touk.nussknacker.engine.api.deployment.{ProcessActionType, ProcessStateDefinitionManager, StateStatus}
+import pl.touk.nussknacker.engine.api.deployment.{CustomAction, ProcessActionType, ProcessStateDefinitionManager, StateStatus}
 
 object SimpleProcessStateDefinitionManager extends ProcessStateDefinitionManager {
   val defaultActions = List()
@@ -77,6 +76,8 @@ object SimpleProcessStateDefinitionManager extends ProcessStateDefinitionManager
 
   override def statusActions(stateStatus: StateStatus): List[ProcessActionType] =
     statusActionsMap.getOrElse(stateStatus, defaultActions)
+
+  override val customActions: List[CustomAction] = List.empty
 
   override def mapActionToStatus(stateAction: Option[ProcessActionType]): StateStatus =
     stateAction

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessManager.scala
@@ -81,7 +81,8 @@ abstract class FlinkProcessManager(modelData: ModelData, shouldVerifyBeforeDeplo
 
   override def customActions: List[CustomAction] = List.empty
 
-  override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] =
+  override def invokeCustomAction(actionRequest: CustomActionRequest,
+                                  processDeploymentData: ProcessDeploymentData): Future[Either[CustomActionError, CustomActionResult]] =
     Future.successful(Left(CustomActionNotImplemented(actionRequest)))
 
   private def requireRunningProcess[T](processName: ProcessName)(action: ProcessState => Future[T]): Future[T] = {

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessManager.scala
@@ -82,7 +82,7 @@ abstract class FlinkProcessManager(modelData: ModelData, shouldVerifyBeforeDeplo
   override def customActions: List[CustomAction] = List.empty
 
   override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] =
-    Future.successful(Left(CustomActionError("Not implemented")))
+    Future.successful(Left(CustomActionNotImplemented(actionRequest)))
 
   private def requireRunningProcess[T](processName: ProcessName)(action: ProcessState => Future[T]): Future[T] = {
     val name = processName.value

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessManager.scala
@@ -79,6 +79,8 @@ abstract class FlinkProcessManager(modelData: ModelData, shouldVerifyBeforeDeplo
     }
   }
 
+  override def customActions: List[CustomAction] = List.empty
+
   override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] =
     Future.successful(Left(CustomActionError("Not implemented")))
 

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessManager.scala
@@ -79,6 +79,9 @@ abstract class FlinkProcessManager(modelData: ModelData, shouldVerifyBeforeDeplo
     }
   }
 
+  override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] =
+    Future.successful(Left(CustomActionError("Not implemented")))
+
   private def requireRunningProcess[T](processName: ProcessName)(action: ProcessState => Future[T]): Future[T] = {
     val name = processName.value
     findJobStatus(processName).flatMap {

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessStateDefinitionManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessStateDefinitionManager.scala
@@ -1,10 +1,9 @@
 package pl.touk.nussknacker.engine.management
 
 import java.net.URI
-
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleProcessStateDefinitionManager
-import pl.touk.nussknacker.engine.api.deployment.{ProcessStateDefinitionManager, ProcessActionType, StateStatus}
+import pl.touk.nussknacker.engine.api.deployment.{CustomAction, ProcessActionType, ProcessStateDefinitionManager, StateStatus}
 
 object FlinkProcessStateDefinitionManager extends ProcessStateDefinitionManager  {
   val statusActionsMap: Map[StateStatus, List[ProcessActionType]] = Map(
@@ -31,6 +30,8 @@ object FlinkProcessStateDefinitionManager extends ProcessStateDefinitionManager 
 
   override def statusActions(stateStatus: StateStatus): List[ProcessActionType] =
     statusActionsMap.getOrElse(stateStatus, SimpleProcessStateDefinitionManager.statusActions(stateStatus))
+
+  override val customActions: List[CustomAction] = List.empty
 
   override def mapActionToStatus(stateAction: Option[ProcessActionType]): StateStatus =
     SimpleProcessStateDefinitionManager.mapActionToStatus(stateAction)

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessStateDefinitionManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessStateDefinitionManager.scala
@@ -31,8 +31,6 @@ object FlinkProcessStateDefinitionManager extends ProcessStateDefinitionManager 
   override def statusActions(stateStatus: StateStatus): List[ProcessActionType] =
     statusActionsMap.getOrElse(stateStatus, SimpleProcessStateDefinitionManager.statusActions(stateStatus))
 
-  override val customActions: List[CustomAction] = List.empty
-
   override def mapActionToStatus(stateAction: Option[ProcessActionType]): StateStatus =
     SimpleProcessStateDefinitionManager.mapActionToStatus(stateAction)
 

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -92,7 +92,7 @@ class StandaloneProcessManager(modelData: ModelData, client: StandaloneProcessCl
 
   override def customActions: List[CustomAction] = List.empty
 
-  override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionNotImplemented, CustomActionResult]] = Future.successful {
+  override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
     Left(CustomActionNotImplemented(actionRequest))
   }
 }

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -90,6 +90,8 @@ class StandaloneProcessManager(modelData: ModelData, client: StandaloneProcessCl
 
   }
 
+  override def customActions: List[CustomAction] = List.empty
+
   override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
     Left(CustomActionError("Not implemented"))
   }

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -92,9 +92,9 @@ class StandaloneProcessManager(modelData: ModelData, client: StandaloneProcessCl
 
   override def customActions: List[CustomAction] = List.empty
 
-  override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
-    Left(CustomActionNotImplemented(actionRequest))
-  }
+  override def invokeCustomAction(actionRequest: CustomActionRequest,
+                                  processDeploymentData: ProcessDeploymentData): Future[Either[CustomActionError, CustomActionResult]] =
+    Future.successful(Left(CustomActionNotImplemented(actionRequest)))
 }
 
 object StandaloneTestMain {

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -87,7 +87,11 @@ class StandaloneProcessManager(modelData: ModelData, client: StandaloneProcessCl
   override def processStateDefinitionManager: ProcessStateDefinitionManager = SimpleProcessStateDefinitionManager
 
   override def close(): Unit = {
-    
+
+  }
+
+  override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
+    Left(CustomActionError("Not implemented"))
   }
 }
 

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/management/StandaloneProcessManager.scala
@@ -92,8 +92,8 @@ class StandaloneProcessManager(modelData: ModelData, client: StandaloneProcessCl
 
   override def customActions: List[CustomAction] = List.empty
 
-  override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
-    Left(CustomActionError("Not implemented"))
+  override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionNotImplemented, CustomActionResult]] = Future.successful {
+    Left(CustomActionNotImplemented(actionRequest))
   }
 }
 

--- a/ui/client/actions/actionTypes.ts
+++ b/ui/client/actions/actionTypes.ts
@@ -63,3 +63,4 @@ export type ActionTypes =
   | "REDO"
   | "CLEAR"
   | "PROCESS_STATE_LOADED"
+  | "CUSTOM_ACTION"

--- a/ui/client/actions/actionTypes.ts
+++ b/ui/client/actions/actionTypes.ts
@@ -63,4 +63,3 @@ export type ActionTypes =
   | "REDO"
   | "CLEAR"
   | "PROCESS_STATE_LOADED"
-  | "CUSTOM_ACTION"

--- a/ui/client/assets/img/toolbarButtons/custom_action.svg
+++ b/ui/client/assets/img/toolbarButtons/custom_action.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#ccc" class="bi bi-box-arrow-up-right" viewBox="0 0 16 16">
+    <path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"/>
+    <path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"/>
+</svg>

--- a/ui/client/components/Process/ProcessStateUtils.ts
+++ b/ui/client/components/Process/ProcessStateUtils.ts
@@ -1,4 +1,4 @@
-import {ActionType, ProcessStateType, StatusType} from "./types"
+import {ActionType, ProcessStateType, StatusTypeType} from "./types"
 
 class ProcessStateUtils {
 
@@ -6,7 +6,7 @@ class ProcessStateUtils {
 
   public canCancel = (state: ProcessStateType): boolean => state?.allowedActions.includes(ActionType.Cancel)
 
-  public isRunning = (state: ProcessStateType): boolean => state?.status.type === StatusType.Running.toString()
+  public isRunning = (state: ProcessStateType): boolean => state?.status.type === StatusTypeType.Running.toString()
 
 }
 

--- a/ui/client/components/Process/types.ts
+++ b/ui/client/components/Process/types.ts
@@ -60,7 +60,6 @@ export type ProcessStateType = {
   status: StatusType,
   deploymentId?: string,
   allowedActions: Array<ActionType>,
-  customActions: Array<CustomAction>,
   icon?: string,
   tooltip?: string,
   description?: string,
@@ -72,10 +71,4 @@ export type ProcessStateType = {
 export type StatusType = {
   name: StatusName,
   type: StatusTypeType,
-}
-
-export type CustomAction = {
-  name: string,
-  allowedProcessStates: Array<StatusType>,
-  icon: string | null
 }

--- a/ui/client/components/Process/types.ts
+++ b/ui/client/components/Process/types.ts
@@ -7,7 +7,7 @@ export enum ActionType {
   Pause = "PAUSE",
 }
 
-export enum StatusType {
+export enum StatusTypeType {
   Running = "RunningStateStatus",
   NotDeployed= "AllowDeployStateStatus"
 }
@@ -57,16 +57,25 @@ export interface ProcessType {
 }
 
 export type ProcessStateType = {
-  status: {
-    name: StatusName,
-    type: StatusType,
-  },
+  status: StatusType,
   deploymentId?: string,
   allowedActions: Array<ActionType>,
+  customActions: Array<CustomAction>,
   icon?: string,
   tooltip?: string,
   description?: string,
   startTime?: Date,
   attributes?: UnknownRecord,
   errors?: Array<string>,
+}
+
+export type StatusType = {
+  name: StatusName,
+  type: StatusTypeType,
+}
+
+export type CustomAction = {
+  name: string,
+  allowedProcessStates: Array<StatusType>,
+  icon: string | null
 }

--- a/ui/client/components/toolbars/status/ProcessInfo.tsx
+++ b/ui/client/components/toolbars/status/ProcessInfo.tsx
@@ -103,6 +103,7 @@ class ProcessInfo extends React.Component<OwnProps & StateProps, State> {
     const icon = this.getIcon(process, processState, isStateLoaded, iconHeight, iconWidth, description)
     const transitionKey = this.getTransitionKey(process, processState)
     const customActions = processDefinitionData.customActions || []
+    // TODO: better styling of process info toolbar in case of many custom actions
     const customButtons = customActions.map((a, ix) => <CustomActionButton
         action={a} processId={process.id} processStatus={process.state.status} key={ix + this.buttons.length}
     />)

--- a/ui/client/components/toolbars/status/ProcessInfo.tsx
+++ b/ui/client/components/toolbars/status/ProcessInfo.tsx
@@ -18,6 +18,7 @@ import SaveButton from "../process/buttons/SaveButton"
 import {ToolbarButtons} from "../../toolbarComponents/ToolbarButtons"
 import {CollapsibleToolbar} from "../../toolbarComponents/CollapsibleToolbar"
 import i18next from "i18next"
+import CustomActionButton from "./buttons/CustomActionButton";
 
 type State = UnknownRecord
 
@@ -88,11 +89,20 @@ class ProcessInfo extends React.Component<OwnProps & StateProps, State> {
     `${process.id}` :
     `${process.id}-${processState?.icon || process?.state?.icon || unknownIcon}`
 
+  private buttons = [
+    <SaveButton/>,
+    <Deploy/>,
+    <Cancel/>,
+    <Metrics/>
+  ]
+
   render() {
     const {process, processState, isStateLoaded, iconHeight, iconWidth, capabilities} = this.props
     const description = this.getDescription(process, processState, isStateLoaded)
     const icon = this.getIcon(process, processState, isStateLoaded, iconHeight, iconWidth, description)
     const transitionKey = this.getTransitionKey(process, processState)
+    const customActions = process.state.customActions || []
+    const customButtons = customActions.map(a => <CustomActionButton action={a} processId={process.id} processStatus={process.state.status} />)
 
     return (
       <CollapsibleToolbar title={i18next.t("panels.status.title", "Status")} id="PROCESS-INFO">
@@ -111,10 +121,7 @@ class ProcessInfo extends React.Component<OwnProps & StateProps, State> {
             </CssFade>
           </SwitchTransition>
           <ToolbarButtons>
-            <SaveButton/>
-            <Deploy/>
-            <Cancel/>
-            <Metrics/>
+            {[...this.buttons, ...customButtons]}
           </ToolbarButtons>
         </DragHandle>
       </CollapsibleToolbar>

--- a/ui/client/components/toolbars/status/ProcessInfo.tsx
+++ b/ui/client/components/toolbars/status/ProcessInfo.tsx
@@ -19,6 +19,7 @@ import {ToolbarButtons} from "../../toolbarComponents/ToolbarButtons"
 import {CollapsibleToolbar} from "../../toolbarComponents/CollapsibleToolbar"
 import i18next from "i18next"
 import CustomActionButton from "./buttons/CustomActionButton";
+import {getProcessDefinitionData} from "../../../reducers/selectors/settings";
 
 type State = UnknownRecord
 
@@ -97,11 +98,11 @@ class ProcessInfo extends React.Component<OwnProps & StateProps, State> {
   ]
 
   render() {
-    const {process, processState, isStateLoaded, iconHeight, iconWidth, capabilities} = this.props
+    const {process, processState, isStateLoaded, iconHeight, iconWidth, processDefinitionData} = this.props
     const description = this.getDescription(process, processState, isStateLoaded)
     const icon = this.getIcon(process, processState, isStateLoaded, iconHeight, iconWidth, description)
     const transitionKey = this.getTransitionKey(process, processState)
-    const customActions = process.state.customActions || []
+    const customActions = processDefinitionData.customActions || []
     const customButtons = customActions.map((a, ix) => <CustomActionButton
         action={a} processId={process.id} processStatus={process.state.status} key={ix + this.buttons.length}
     />)
@@ -136,6 +137,7 @@ const mapState = (state: RootState) => ({
   process: getFetchedProcessDetails(state),
   capabilities: getCapabilities(state),
   processState: getProcessState(state),
+  processDefinitionData: getProcessDefinitionData(state),
 })
 
 type StateProps = ReturnType<typeof mapState>

--- a/ui/client/components/toolbars/status/ProcessInfo.tsx
+++ b/ui/client/components/toolbars/status/ProcessInfo.tsx
@@ -90,10 +90,10 @@ class ProcessInfo extends React.Component<OwnProps & StateProps, State> {
     `${process.id}-${processState?.icon || process?.state?.icon || unknownIcon}`
 
   private buttons = [
-    <SaveButton/>,
-    <Deploy/>,
-    <Cancel/>,
-    <Metrics/>
+    <SaveButton key={0}/>,
+    <Deploy key={1}/>,
+    <Cancel key={2}/>,
+    <Metrics key={3}/>
   ]
 
   render() {
@@ -102,7 +102,9 @@ class ProcessInfo extends React.Component<OwnProps & StateProps, State> {
     const icon = this.getIcon(process, processState, isStateLoaded, iconHeight, iconWidth, description)
     const transitionKey = this.getTransitionKey(process, processState)
     const customActions = process.state.customActions || []
-    const customButtons = customActions.map(a => <CustomActionButton action={a} processId={process.id} processStatus={process.state.status} />)
+    const customButtons = customActions.map((a, ix) => <CustomActionButton
+        action={a} processId={process.id} processStatus={process.state.status} key={ix + this.buttons.length}
+    />)
 
     return (
       <CollapsibleToolbar title={i18next.t("panels.status.title", "Status")} id="PROCESS-INFO">

--- a/ui/client/components/toolbars/status/buttons/CustomActionButton.tsx
+++ b/ui/client/components/toolbars/status/buttons/CustomActionButton.tsx
@@ -4,8 +4,9 @@ import {ReactComponent as DefaultIcon} from "../../../../assets/img/toolbarButto
 import {loadProcessState} from "../../../../actions/nk";
 import HttpService from "../../../../http/HttpService";
 import {useDispatch} from "react-redux";
-import {CustomAction, StatusType} from "../../../Process/types";
+import {StatusType} from "../../../Process/types";
 import {useTranslation} from "react-i18next";
+import {CustomAction} from "../../../../types";
 
 type Props = {
   action: CustomAction,

--- a/ui/client/components/toolbars/status/buttons/CustomActionButton.tsx
+++ b/ui/client/components/toolbars/status/buttons/CustomActionButton.tsx
@@ -32,10 +32,11 @@ export default function CustomActionButton(props: Props) {
       ? t("panels.actions.custom-action.tooltips.disabled", "Disabled for {{statusName}} status.", {statusName})
       : null
 
+  // TODO: handle additional params
   const onClick = () => {
     confirm(`Do you want to run ${action.name}`)
       && dispatch(HttpService
-          .customAction(processId, action.name)
+          .customAction(processId, action.name, {})
           .finally(() => dispatch(loadProcessState(processId))))
   }
 

--- a/ui/client/components/toolbars/status/buttons/CustomActionButton.tsx
+++ b/ui/client/components/toolbars/status/buttons/CustomActionButton.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 export default function CustomActionButton(props: Props) {
 
-  const { action, processId, processStatus } = props
+  const {action, processId, processStatus} = props
 
   const dispatch = useDispatch()
   const {t} = useTranslation()

--- a/ui/client/components/toolbars/status/buttons/CustomActionButton.tsx
+++ b/ui/client/components/toolbars/status/buttons/CustomActionButton.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import ToolbarButton from "../../../toolbarComponents/ToolbarButton";
+import {ReactComponent as DefaultIcon} from "../../../../assets/img/toolbarButtons/custom_action.svg";
+import {loadProcessState} from "../../../../actions/nk";
+import HttpService from "../../../../http/HttpService";
+import {useDispatch} from "react-redux";
+import {CustomAction, StatusType} from "../../../Process/types";
+import {useTranslation} from "react-i18next";
+
+type Props = {
+  action: CustomAction,
+  processId: string,
+  processStatus: StatusType
+}
+
+export default function CustomActionButton(props: Props) {
+
+  const { action, processId, processStatus } = props
+
+  const dispatch = useDispatch()
+  const {t} = useTranslation()
+
+  const icon = action.icon
+      ? <img alt={`custom-action-${action.name}`} src={action.icon} />
+      : <DefaultIcon/>
+
+  const statusName = processStatus.name
+  const isDisabled = !action.allowedProcessStates.map(s => s.name).includes(statusName)
+
+  const toolTip = isDisabled
+      ? t("panels.actions.custom-action.tooltips.disabled", "Disabled for {{statusName}} status.", {statusName})
+      : null
+
+  const onClick = () => {
+    confirm(`Do you want to run ${action.name}`)
+      && dispatch(HttpService
+          .customAction(processId, action.name)
+          .finally(() => dispatch(loadProcessState(processId))))
+  }
+
+  return <ToolbarButton
+    name={action.name}
+    title={toolTip}
+    disabled={isDisabled}
+    icon={icon}
+    onClick={onClick}
+  />
+}

--- a/ui/client/http/HttpService.ts
+++ b/ui/client/http/HttpService.ts
@@ -170,7 +170,7 @@ class HttpService {
   }
 
   customAction(processId, actionName) {
-    const data = { actionName: actionName, params: {} }
+    const data = {actionName: actionName, params: {}}
     return api.post(`/processManagement/customAction/${processId}`, data).then(res => {
       this.addInfo(res.data.msg)
       return {isSuccess: res.data.isSuccess}

--- a/ui/client/http/HttpService.ts
+++ b/ui/client/http/HttpService.ts
@@ -175,7 +175,8 @@ class HttpService {
       this.addInfo(res.data.msg)
       return {isSuccess: res.data.isSuccess}
     }).catch(error => {
-      return this.addError(error.response.data.msg, error, false).then(() => {
+      const msg = error.response.data.msg || error.response.data
+      return this.addError(msg, error, false).then(() => {
         return {isSuccess: false}
       })
     })

--- a/ui/client/http/HttpService.ts
+++ b/ui/client/http/HttpService.ts
@@ -169,8 +169,8 @@ class HttpService {
     })
   }
 
-  customAction(processId, actionName) {
-    const data = {actionName: actionName, params: {}}
+  customAction(processId: string, actionName: string, params: object) {
+    const data = {actionName: actionName, params: params}
     return api.post(`/processManagement/customAction/${processId}`, data).then(res => {
       this.addInfo(res.data.msg)
       return {isSuccess: res.data.isSuccess}

--- a/ui/client/http/HttpService.ts
+++ b/ui/client/http/HttpService.ts
@@ -175,7 +175,7 @@ class HttpService {
       this.addInfo(res.data.msg)
       return {isSuccess: res.data.isSuccess}
     }).catch(error => {
-      return this.addError(`Action ${actionName} failed`, error, true).then(() => {
+      return this.addError(error.response.data.msg, error, false).then(() => {
         return {isSuccess: false}
       })
     })

--- a/ui/client/http/HttpService.ts
+++ b/ui/client/http/HttpService.ts
@@ -169,7 +169,7 @@ class HttpService {
     })
   }
 
-  customAction(processId: string, actionName: string, params: object) {
+  customAction(processId: string, actionName: string, params: Record<string, unknown>) {
     const data = {actionName: actionName, params: params}
     return api.post(`/processManagement/customAction/${processId}`, data).then(res => {
       this.addInfo(res.data.msg)

--- a/ui/client/http/HttpService.ts
+++ b/ui/client/http/HttpService.ts
@@ -175,7 +175,7 @@ class HttpService {
       this.addInfo(res.data.msg)
       return {isSuccess: res.data.isSuccess}
     }).catch(error => {
-      return this.addError(`Failed to submit action for ${processId}`, error, true).then(() => {
+      return this.addError(`Action ${actionName} failed`, error, true).then(() => {
         return {isSuccess: false}
       })
     })

--- a/ui/client/http/HttpService.ts
+++ b/ui/client/http/HttpService.ts
@@ -169,6 +169,18 @@ class HttpService {
     })
   }
 
+  customAction(processId, actionName) {
+    const data = { actionName: actionName, params: {} }
+    return api.post(`/processManagement/customAction/${processId}`, data).then(res => {
+      this.addInfo(res.data.msg)
+      return {isSuccess: res.data.isSuccess}
+    }).catch(error => {
+      return this.addError(`Failed to submit action for ${processId}`, error, true).then(() => {
+        return {isSuccess: false}
+      })
+    })
+  }
+
   invokeService(processingType, serviceName, parameters) {
     return api.post(`/service/${processingType}/${serviceName}`, parameters)
   }

--- a/ui/client/types/process.ts
+++ b/ui/client/types/process.ts
@@ -1,6 +1,7 @@
 import {Edge} from "./edge"
 import {NodeType} from "./node"
 import {ValidationResult} from "./validation"
+import {StatusType} from "../components/Process/types";
 
 export type Process = {
   nodes: NodeType[],
@@ -25,9 +26,16 @@ export type NodesGroup = {
   name: string,
 }
 
+export type CustomAction = {
+  name: string,
+  allowedProcessStates: Array<StatusType>,
+  icon: string | null
+}
+
 export type ProcessDefinitionData = {
   nodesConfig?: $TodoType,
   nodesToAdd?: NodesGroup[],
   processDefinition?: $TodoType,
+  customActions?: Array<CustomAction>,
   defaultAsyncInterpretation?: boolean,
 }

--- a/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/codecs/URICodecs.scala
+++ b/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/codecs/URICodecs.scala
@@ -1,0 +1,11 @@
+package pl.touk.nussknacker.restmodel.codecs
+
+import io.circe.{Decoder, Encoder}
+
+import java.net.URI
+
+object URICodecs {
+
+  implicit val uriEncoder: Encoder[URI] = Encoder.encodeString.contramap(_.toString)
+  implicit val uriDecoder: Decoder[URI] = Decoder.decodeString.map(URI.create)
+}

--- a/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
+++ b/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
@@ -4,12 +4,15 @@ import io.circe.Decoder
 import io.circe.generic.JsonCodec
 import io.circe.generic.semiauto.deriveDecoder
 import pl.touk.nussknacker.engine.api.definition.{MandatoryParameterValidator, ParameterEditor, ParameterValidator}
+import pl.touk.nussknacker.engine.api.deployment.{CustomAction, StateStatus}
 import pl.touk.nussknacker.engine.api.process.SingleNodeConfig
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.definition.TypeInfos.MethodInfo
 import pl.touk.nussknacker.engine.graph.evaluatedparam
 import pl.touk.nussknacker.engine.graph.node.NodeData
 import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.EdgeType
+
+import java.net.URI
 
 package object definition {
 
@@ -18,6 +21,7 @@ package object definition {
                                                             nodesConfig: Map[String, SingleNodeConfig],
                                                             additionalPropertiesConfig: Map[String, UiAdditionalPropertyConfig],
                                                             edgesForNodes: List[NodeEdges],
+                                                            customActions: List[UICustomAction],
                                                             defaultAsyncInterpretation: Boolean)
 
   @JsonCodec(encodeOnly = true) case class UIProcessDefinition(services: Map[String, UIObjectDefinition],
@@ -76,5 +80,15 @@ package object definition {
     implicit def decoder(implicit typing: Decoder[TypingResult]): Decoder[UIParameter] = deriveDecoder[UIParameter]
 
   }
+
+  object UICustomAction {
+    import pl.touk.nussknacker.restmodel.codecs.URICodecs.{uriDecoder, uriEncoder}
+
+    def apply(action: CustomAction): UICustomAction = UICustomAction(
+      name = action.name, allowedProcessStates = action.allowedProcessStates, icon = action.icon
+    )
+  }
+  @JsonCodec
+  case class UICustomAction(name: String, allowedProcessStates: List[StateStatus], icon: Option[URI])
 
 }

--- a/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/displayedgraph/ProcessStatus.scala
+++ b/ui/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/displayedgraph/ProcessStatus.scala
@@ -6,25 +6,32 @@ import io.circe.generic.JsonCodec
 import io.circe.{Decoder, Encoder, Json}
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessStateDefinitionManager, SimpleStateStatus}
-import pl.touk.nussknacker.engine.api.deployment.{ProcessState, ProcessStateDefinitionManager, StateStatus}
+import pl.touk.nussknacker.engine.api.deployment.{CustomAction, ProcessState, ProcessStateDefinitionManager, StateStatus}
 
 //TODO: Do we really  we need ProcessStatus and ProcessState - Do these DTO's do the same things?
 @JsonCodec case class ProcessStatus(status: StateStatus,
                                     deploymentId: Option[String],
                                     allowedActions: List[ProcessActionType],
+                                    customActions: List[ProcessStatus.CustomActionDTO],
                                     icon: Option[URI],
                                     tooltip: Option[String],
                                     description: Option[String],
                                     startTime: Option[Long],
                                     attributes: Option[Json],
-                                    errors: List[String])
+                                    errors: List[String]) {
+}
 
 object ProcessStatus {
   implicit val uriEncoder: Encoder[URI] = Encoder.encodeString.contramap(_.toString)
   implicit val uriDecoder: Decoder[URI] = Decoder.decodeString.map(URI.create)
 
-  def simple(status: StateStatus, deploymentId: Option[String], errors: List[String]): ProcessStatus =
-    ProcessStatus(status, SimpleProcessStateDefinitionManager, deploymentId, Option.empty, Option.empty, errors)
+  object CustomActionDTO {
+    def apply(action: CustomAction, status: StateStatus): CustomActionDTO = CustomActionDTO(
+       name = action.name, allowedProcessStates = action.allowedProcessStates, icon = action.icon
+    )
+  }
+  @JsonCodec
+  case class CustomActionDTO(name: String, allowedProcessStates: List[StateStatus], icon: Option[URI])
 
   def simple(status: StateStatus): ProcessStatus =
     ProcessStatus(status, SimpleProcessStateDefinitionManager)
@@ -34,6 +41,7 @@ object ProcessStatus {
       status = status,
       previousState.map(_.deploymentId.value),
       allowedActions = SimpleProcessStateDefinitionManager.statusActions(status),
+      customActions = List.empty,
       icon = if (icon.isDefined) icon else SimpleProcessStateDefinitionManager.statusIcon(status),
       tooltip = if (tooltip.isDefined) tooltip else SimpleProcessStateDefinitionManager.statusTooltip(status),
       description = if (description.isDefined) description else SimpleProcessStateDefinitionManager.statusDescription(status),
@@ -55,6 +63,7 @@ object ProcessStatus {
       status,
       deploymentId,
       allowedActions = processStateDefinitionManager.statusActions(status),
+      customActions = processStateDefinitionManager.customActions.map(CustomActionDTO(_, status)),
       icon = processStateDefinitionManager.statusIcon(status),
       tooltip = processStateDefinitionManager.statusTooltip(status),
       description = processStateDefinitionManager.statusDescription(status),
@@ -68,6 +77,7 @@ object ProcessStatus {
       deploymentId = Some(processState.deploymentId.value),
       status = processState.status,
       allowedActions = processState.allowedActions,
+      customActions = List.empty,
       icon = processState.icon,
       tooltip = processState.tooltip,
       description = processState.description,

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -124,7 +124,7 @@ object NusskanckerDefaultAppRouter extends NusskanckerAppRouter {
         ManagementResources(counter, managementActor, testResultsMaxSizeInBytes,
           processAuthorizer, processRepository, featureTogglesConfig, processResolving),
         new ValidationResources(processResolving),
-        new DefinitionResources(modelData, subprocessRepository, typesForCategories),
+        new DefinitionResources(modelData, typeToConfig, subprocessRepository, typesForCategories),
         new SignalsResources(modelData, processRepository, processAuthorizer),
         new UserResources(typesForCategories),
         new NotificationResources(managementActor, processRepository),

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/DefinitionResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/DefinitionResources.scala
@@ -3,8 +3,7 @@ package pl.touk.nussknacker.ui.api
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.{Directives, Route}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
-import pl.touk.nussknacker.engine.ModelData
-import pl.touk.nussknacker.ui.definition
+import pl.touk.nussknacker.engine.{ModelData, ProcessingTypeData}
 import pl.touk.nussknacker.ui.definition.UIProcessObjectsFactory
 import pl.touk.nussknacker.ui.process.processingtypedata.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.process.{ProcessObjectsFinder, ProcessTypesForCategories}
@@ -14,7 +13,8 @@ import pl.touk.nussknacker.ui.util.EspPathMatchers
 
 import scala.concurrent.ExecutionContext
 
-class DefinitionResources(modelData: ProcessingTypeDataProvider[ModelData],
+class DefinitionResources(modelDataProvider: ProcessingTypeDataProvider[ModelData],
+                          processingTypeDataProvider: ProcessingTypeDataProvider[ProcessingTypeData],
                           subprocessRepository: SubprocessRepository,
                           typesForCategories: ProcessTypesForCategories)
                          (implicit ec: ExecutionContext)
@@ -27,19 +27,18 @@ class DefinitionResources(modelData: ProcessingTypeDataProvider[ModelData],
       get {
         complete {
           val subprocessIds = subprocessRepository.loadSubprocesses().map(_.canonical.metaData.id).toList
-          ProcessObjectsFinder.componentIds(modelData.all.values.map(_.processDefinition).toList, subprocessIds)
+          ProcessObjectsFinder.componentIds(modelDataProvider.all.values.map(_.processDefinition).toList, subprocessIds)
         }
       }
     } ~ path("processDefinitionData" / "services") {
       get {
         complete {
-          val pd = modelData.mapValues(_.processDefinition).forType("streaming")
-          modelData.mapValues(_.processDefinition.services.mapValues(UIProcessObjectsFactory.createUIObjectDefinition)).all
+          modelDataProvider.mapValues(_.processDefinition.services.mapValues(UIProcessObjectsFactory.createUIObjectDefinition)).all
         }
       }
     // TODO: Now we can't have processingType = componentIds or services - we should redesign our API (probably fetch componentIds and services only for given processingType)
     } ~ pathPrefix("processDefinitionData" / Segment) { processingType =>
-      modelData.forType(processingType).map { modelDataForType =>
+      processingTypeDataProvider.forType(processingType).map { processingTypeData =>
         //TODO maybe always return data for all subprocesses versions instead of fetching just one-by-one?
         pathEndOrSingleSlash {
           post { // POST - because there is sending complex subprocessVersions parameter
@@ -47,11 +46,18 @@ class DefinitionResources(modelData: ProcessingTypeDataProvider[ModelData],
               parameter('isSubprocess.as[Boolean]) { (isSubprocess) =>
                 val subprocesses = subprocessRepository.loadSubprocesses(subprocessVersions)
                 complete(
-                  UIProcessObjectsFactory.prepareUIProcessObjects(modelDataForType, user, subprocesses, isSubprocess, typesForCategories))
+                  UIProcessObjectsFactory.prepareUIProcessObjects(
+                    processingTypeData.modelData,
+                    processingTypeData.processManager,
+                    user,
+                    subprocesses,
+                    isSubprocess,
+                    typesForCategories)
+                )
               }
             }
           }
-        } ~ dictResources.route(modelDataForType)
+        } ~ dictResources.route(processingTypeData.modelData)
       }.getOrElse {
         complete(HttpResponse(status = StatusCodes.NotFound, entity = s"Processing type: $processingType not found"))
       }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -15,16 +15,15 @@ import io.circe.generic.JsonCodec
 import io.circe.parser.parse
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
-import pl.touk.nussknacker.engine.api
 import pl.touk.nussknacker.engine.api.deployment.TestProcess.{ExceptionResult, ExpressionInvocationResult, MockedResult, NodeResult, ResultContext, TestData, TestResults}
 import pl.touk.nussknacker.engine.api.DisplayJson
+import pl.touk.nussknacker.ui.process.{deployment => uideployment}
 import pl.touk.nussknacker.engine.api.deployment.{CustomActionError, CustomActionResult, SavepointResult}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
 import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
 import pl.touk.nussknacker.restmodel.process.ProcessIdWithName
-import pl.touk.nussknacker.restmodel.processdetails.ProcessShapeFetchStrategy
 import pl.touk.nussknacker.ui.api.ProcessesResources.UnmarshallError
 import pl.touk.nussknacker.ui.api.deployment.{CustomActionRequest, CustomActionResponse}
 import pl.touk.nussknacker.ui.config.FeatureTogglesConfig
@@ -210,7 +209,7 @@ class ManagementResources(processCounter: ProcessCounter,
       path("processManagement" / "customAction" / Segment) { processName =>
         (post & processId(processName) & entity(as[CustomActionRequest])) { (process, req) =>
           complete {
-            (managementActor ? (req.toEngineRequest(process.name), process.id, user))
+            (managementActor ? uideployment.CustomAction(req.toEngineRequest(process.name), process, user))
               .mapTo[Either[CustomActionError, CustomActionResult]]
               .map(CustomActionResponse(_))
               .flatMap(Marshal(_).to[MessageEntity])

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -34,8 +34,7 @@ import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.ui.uiresolving.UIProcessResolving
 
 import scala.concurrent.duration._
-import java.util.concurrent.TimeUnit
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 
 object ManagementResources {
@@ -108,10 +107,8 @@ class ManagementResources(processCounter: ProcessCounter,
     with ProcessDirectives {
 
   //TODO: in the future we could use https://github.com/akka/akka-http/pull/1828 when we can bump version to 10.1.x
-  private val requestTimeoutDuration = FiniteDuration(
-    length = system.settings.config.getDuration("akka.http.server.request-timeout").toNanos,
-    unit = TimeUnit.NANOSECONDS)
-  private implicit val timeout: Timeout = Timeout(requestTimeoutDuration)
+  private val durationFromConfig = system.settings.config.getDuration("akka.http.server.request-timeout")
+  private implicit val timeout: Timeout = Timeout(durationFromConfig.toMillis millis)
   private implicit final val plainBytes: FromEntityUnmarshaller[Array[Byte]] = Unmarshaller.byteArrayUnmarshaller
   private implicit final val plainString: FromEntityUnmarshaller[String] = Unmarshaller.stringUnmarshaller
 
@@ -209,26 +206,23 @@ class ManagementResources(processCounter: ProcessCounter,
           }
         }
       } ~
-    // TODO: Support concurrent calls.
-   //  Currently invoking custom action is synchronous. We're blocking/awaiting the response from ManagementActor
       path("processManagement" / "customAction" / Segment) { processName =>
         (post & processId(processName) & entity(as[CustomActionRequest])) { (process, req) =>
-          val responseF = (managementActor ? uideployment.CustomAction(req.toEngineRequest(process.name), process, user))
-            .mapTo[Either[CustomActionError, CustomActionResult]]
-            .flatMap {
-              case res@Right(_) =>
-                toHttpResponse(CustomActionResponse(res))(StatusCodes.OK)
-              case res@Left(err) =>
-                val response = toHttpResponse(CustomActionResponse(res)) _
-                err match {
-                  case _: CustomActionFailure => response(StatusCodes.InternalServerError)
-                  case _: CustomActionInvalidStatus => response(StatusCodes.Forbidden)
-                  case _: CustomActionNotImplemented => response(StatusCodes.NotImplemented)
-                  case _: CustomActionNonExisting => response(StatusCodes.NotFound)
-                }
-            }
           complete {
-            Await.result(responseF, requestTimeoutDuration)
+            (managementActor ? uideployment.CustomAction(req.toEngineRequest(process.name), process, user))
+              .mapTo[Either[CustomActionError, CustomActionResult]]
+              .flatMap {
+                case res@Right(_) =>
+                  toHttpResponse(CustomActionResponse(res))(StatusCodes.OK)
+                case res@Left(err) =>
+                  val response = toHttpResponse(CustomActionResponse(res)) _
+                  err match {
+                    case _: CustomActionFailure => response(StatusCodes.InternalServerError)
+                    case _: CustomActionInvalidStatus => response(StatusCodes.Forbidden)
+                    case _: CustomActionNotImplemented => response(StatusCodes.NotImplemented)
+                    case _: CustomActionNonExisting => response(StatusCodes.NotFound)
+                  }
+              }
           }
         }
       }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -208,8 +208,10 @@ class ManagementResources(processCounter: ProcessCounter,
       } ~
       path("processManagement" / "customAction" / Segment) { processName =>
         (post & processId(processName) & entity(as[CustomActionRequest])) { (process, req) =>
+          val params = req.params.getOrElse(Map.empty)
+          val customAction = uideployment.CustomAction(req.actionName, process, user, params)
           complete {
-            (managementActor ? uideployment.CustomAction(req.toEngineRequest(process.name), process, user))
+            (managementActor ? customAction)
               .mapTo[Either[CustomActionError, CustomActionResult]]
               .flatMap {
                 case res@Right(_) =>

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.ui.api
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.{HttpResponse, MessageEntity, StatusCodes}
+import akka.http.scaladsl.model.{HttpResponse, MessageEntity, StatusCode, StatusCodes}
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
 import akka.pattern.ask
@@ -18,7 +18,7 @@ import io.circe.{Decoder, Encoder, Json}
 import pl.touk.nussknacker.engine.api.deployment.TestProcess.{ExceptionResult, ExpressionInvocationResult, MockedResult, NodeResult, ResultContext, TestData, TestResults}
 import pl.touk.nussknacker.engine.api.DisplayJson
 import pl.touk.nussknacker.ui.process.{deployment => uideployment}
-import pl.touk.nussknacker.engine.api.deployment.{CustomActionError, CustomActionResult, SavepointResult}
+import pl.touk.nussknacker.engine.api.deployment.{CustomActionError, CustomActionFailure, CustomActionInvalidStatus, CustomActionNonExisting, CustomActionNotImplemented, CustomActionResult, SavepointResult}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
 import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
@@ -211,13 +211,25 @@ class ManagementResources(processCounter: ProcessCounter,
           complete {
             (managementActor ? uideployment.CustomAction(req.toEngineRequest(process.name), process, user))
               .mapTo[Either[CustomActionError, CustomActionResult]]
-              .map(CustomActionResponse(_))
-              .flatMap(Marshal(_).to[MessageEntity])
-              .map(en => HttpResponse(entity = en))
+              .flatMap {
+                case res@Right(_) =>
+                  toHttpResponse(CustomActionResponse(res))(StatusCodes.OK)
+                case res@Left(err) =>
+                  val response = toHttpResponse(CustomActionResponse(res)) _
+                  err match {
+                    case _: CustomActionFailure => response(StatusCodes.InternalServerError)
+                    case _: CustomActionInvalidStatus => response(StatusCodes.Forbidden)
+                    case _: CustomActionNotImplemented => response(StatusCodes.NotImplemented)
+                    case _: CustomActionNonExisting => response(StatusCodes.NotFound)
+                  }
+              }
           }
         }
       }
   }
+
+  private def toHttpResponse[A:Encoder](a: A)(code: StatusCode): Future[HttpResponse] =
+    Marshal(a).to[MessageEntity].map(en => HttpResponse(entity = en, status = code))
 
   private def performTest(id: ProcessIdWithName, testData: Array[Byte], displayableProcessJson: String)(implicit user: LoggedUser): Future[ResultsWithCounts] = {
     parse(displayableProcessJson).right.flatMap(Decoder[DisplayableProcess].decodeJson) match {

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/deployment/CustomActionRequest.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/deployment/CustomActionRequest.scala
@@ -1,0 +1,16 @@
+package pl.touk.nussknacker.ui.api.deployment
+
+import io.circe.generic.JsonCodec
+import pl.touk.nussknacker.engine
+import pl.touk.nussknacker.engine.api.process.ProcessName
+
+@JsonCodec
+case class CustomActionRequest(actionName: String,
+                               params: Option[Map[String, String]] = None) {
+
+  def toEngineRequest(processName: ProcessName): engine.api.deployment.CustomActionRequest =
+    engine.api.deployment.CustomActionRequest(
+      actionName,
+      processName,
+      params.getOrElse(Map.empty))
+}

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/deployment/CustomActionRequest.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/deployment/CustomActionRequest.scala
@@ -1,16 +1,7 @@
 package pl.touk.nussknacker.ui.api.deployment
 
 import io.circe.generic.JsonCodec
-import pl.touk.nussknacker.engine
-import pl.touk.nussknacker.engine.api.process.ProcessName
 
 @JsonCodec
 case class CustomActionRequest(actionName: String,
-                               params: Option[Map[String, String]] = None) {
-
-  def toEngineRequest(processName: ProcessName): engine.api.deployment.CustomActionRequest =
-    engine.api.deployment.CustomActionRequest(
-      actionName,
-      processName,
-      params.getOrElse(Map.empty))
-}
+                               params: Option[Map[String, String]] = None)

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/deployment/CustomActionResponse.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/deployment/CustomActionResponse.scala
@@ -1,0 +1,16 @@
+package pl.touk.nussknacker.ui.api.deployment
+
+import io.circe.generic.JsonCodec
+import pl.touk.nussknacker.engine.api.deployment.{CustomActionError, CustomActionResult}
+
+object CustomActionResponse {
+  def apply(actionResultE: Either[CustomActionError, CustomActionResult]): CustomActionResponse = {
+    actionResultE match {
+      case Right(result) => CustomActionResponse(isSuccess = true, msg = result.msg)
+      case Left(err) => CustomActionResponse(isSuccess = false, msg = err.msg)
+    }
+  }
+}
+
+@JsonCodec
+case class CustomActionResponse(isSuccess: Boolean, msg: String)

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactory.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactory.scala
@@ -4,6 +4,7 @@ import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.api.MetaData
 import pl.touk.nussknacker.engine.api.async.{DefaultAsyncInterpretationValue, DefaultAsyncInterpretationValueDeterminer}
 import pl.touk.nussknacker.engine.api.definition.{Parameter, RawParameterEditor}
+import pl.touk.nussknacker.engine.api.deployment.ProcessManager
 import pl.touk.nussknacker.engine.api.process.{AdditionalPropertyConfig, ParameterConfig, SingleNodeConfig}
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, Unknown}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -30,6 +31,7 @@ object UIProcessObjectsFactory {
   import pl.touk.nussknacker.engine.util.config.FicusReaders._
 
   def prepareUIProcessObjects(modelDataForType: ModelData,
+                              processManager: ProcessManager,
                               user: LoggedUser,
                               subprocessesDetails: Set[SubprocessDetails],
                               isSubprocess: Boolean,
@@ -83,6 +85,7 @@ object UIProcessObjectsFactory {
         processDefinition = chosenProcessDefinition,
         isSubprocess = isSubprocess,
         subprocessesDetails = subprocessesDetails),
+      customActions = processManager.customActions.map(UICustomAction(_)),
       defaultAsyncInterpretation = defaultAsyncInterpretation.value)
   }
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
@@ -115,6 +115,12 @@ class ManagementActor(managers: ProcessingTypeDataProvider[ProcessManager],
       }
     case DeploymentStatus =>
       reply(Future.successful(DeploymentStatusResponse(beingDeployed)))
+
+    case (action: CustomActionRequest, id: ProcessId, user: LoggedUser) =>
+      reply(for {
+        manager <- processManager(id)(ec, user)
+        response <- manager.invokeCustomAction(action)
+      } yield response)
   }
 
   //This method handles some corner cases like retention for keeping old states - some engine can cleanup canceled states. It's more Flink hermetic.

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/AppResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/AppResourcesSpec.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.ui.api
 
 import java.util.Collections
-
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.testkit.TestProbe
@@ -11,7 +10,7 @@ import io.circe.Json
 import io.circe.syntax.EncoderOps
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuite, Matchers, OptionValues}
 import pl.touk.nussknacker.engine.api.deployment.StateStatus
-import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
+import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessStateDefinitionManager, SimpleStateStatus}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.util.process.EmptyProcessConfigCreator
@@ -31,7 +30,7 @@ class AppResourcesSpec extends FunSuite with ScalatestRouteTest with Matchers wi
   }
 
   private def processStatus(deploymentId: Option[String], status: StateStatus): ProcessStatus =
-    ProcessStatus.simple(status, deploymentId, List.empty)
+    ProcessStatus(status, SimpleProcessStateDefinitionManager, deploymentId, Option.empty, Option.empty, Nil)
 
   private def prepareBasicAppResources(statusCheck: TestProbe) = {
     new AppResources(ConfigFactory.empty(), emptyReload, emptyProcessingTypeDataProvider, processRepository, TestFactory.processValidation,

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -238,7 +238,7 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
   test("execute invalid custom action") {
     saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
     customAction(SampleProcess.process.id, CustomActionRequest("invalid-action")) ~> check {
-      status shouldBe StatusCodes.InternalServerError
+      status shouldBe StatusCodes.OK
       responseAs[CustomActionResponse] shouldBe CustomActionResponse(isSuccess = false, msg = "Invalid action")
     }
   }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.ui.api
 
 import java.time.LocalDateTime
-
 import akka.http.scaladsl.model.{ContentTypeRange, StatusCodes}
 import akka.http.scaladsl.server
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -13,7 +12,7 @@ import io.circe.Json
 import io.circe.syntax._
 import org.scalatest._
 import org.scalatest.matchers.BeMatcher
-import pl.touk.nussknacker.engine.api.deployment.{CustomProcess, ProcessActionType}
+import pl.touk.nussknacker.engine.api.deployment.{CustomActionError, CustomActionResult, CustomProcess, ProcessActionType}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.EspProcessBuilder
 import pl.touk.nussknacker.engine.canonize.ProcessCanonizer
@@ -239,7 +238,7 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
     saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
     customAction(SampleProcess.process.id, CustomActionRequest("invalid-action")) ~> check {
       status shouldBe StatusCodes.OK
-      responseAs[CustomActionResponse] shouldBe CustomActionResponse(isSuccess = false, msg = "Invalid action")
+      responseAs[CustomActionResponse] shouldBe CustomActionResponse(isSuccess = false, msg = "invalid-action is not existing")
     }
   }
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -234,11 +234,27 @@ class ManagementResourcesSpec extends FunSuite with ScalatestRouteTest with Fail
     }
   }
 
-  test("execute invalid custom action") {
+  test("execute non existing custom action") {
     saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
-    customAction(SampleProcess.process.id, CustomActionRequest("invalid-action")) ~> check {
-      status shouldBe StatusCodes.OK
-      responseAs[CustomActionResponse] shouldBe CustomActionResponse(isSuccess = false, msg = "invalid-action is not existing")
+    customAction(SampleProcess.process.id, CustomActionRequest("non-existing")) ~> check {
+      status shouldBe StatusCodes.NotFound
+      responseAs[CustomActionResponse] shouldBe CustomActionResponse(isSuccess = false, msg = "non-existing is not existing")
+    }
+  }
+
+  test("execute not implemented custom action") {
+    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
+    customAction(SampleProcess.process.id, CustomActionRequest("not-implemented")) ~> check {
+      status shouldBe StatusCodes.NotImplemented
+      responseAs[CustomActionResponse] shouldBe CustomActionResponse(isSuccess = false, msg = "not-implemented is not implemented")
+    }
+  }
+
+  test("execute custom action with not allowed process status") {
+    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
+    customAction(SampleProcess.process.id, CustomActionRequest("invalid-status")) ~> check {
+      status shouldBe StatusCodes.Forbidden
+      responseAs[CustomActionResponse] shouldBe CustomActionResponse(isSuccess = false, msg = s"Process status: WARNING is not allowed for action invalid-status")
     }
   }
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.ui.api.helpers
 
 import java.net.URI
-
 import akka.actor.ActorRef
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -22,6 +21,7 @@ import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
 import pl.touk.nussknacker.restmodel.process
 import pl.touk.nussknacker.ui.api._
+import pl.touk.nussknacker.ui.api.deployment.CustomActionRequest
 import pl.touk.nussknacker.ui.api.helpers.TestFactory._
 import pl.touk.nussknacker.ui.config.{AnalyticsConfig, FeatureTogglesConfig}
 import pl.touk.nussknacker.ui.db.entity.ProcessActionEntityData
@@ -197,6 +197,11 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
 
   def stop(processName: String): RouteTestResult = {
     Post(s"/adminProcessManagement/stop/$processName") ~> withPermissions(deployRoute(), testPermissionDeploy |+| testPermissionRead)
+  }
+
+  def customAction(processName: String, reqPayload: CustomActionRequest): RouteTestResult = {
+    Post(s"/processManagement/customAction/$processName", TestFactory.posting.toRequest(reqPayload)) ~>
+      withPermissions(deployRoute(), testPermissionDeploy |+| testPermissionRead)
   }
 
   def getSampleProcess: RouteTestResult = {

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessPosting.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessPosting.scala
@@ -13,7 +13,7 @@ class ProcessPosting {
 
   private implicit val ptsEncoder: Encoder[ProcessToSave] = io.circe.generic.semiauto.deriveEncoder
 
-  private def toRequest[T:Encoder](value: T): RequestEntity = HttpEntity(ContentTypes.`application/json`, value.asJson.spaces2)
+  def toRequest[T:Encoder](value: T): RequestEntity = HttpEntity(ContentTypes.`application/json`, value.asJson.spaces2)
 
   def toEntity(process: EspProcess): RequestEntity = {
     toRequest(ProcessConverter.toDisplayable(ProcessCanonizer.canonize(process), TestProcessingTypes.Streaming))

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.ProcessingTypeConfig
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
 import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessState, SimpleStateStatus}
-import pl.touk.nussknacker.engine.api.deployment.{DeploymentId, ProcessDeploymentData, ProcessState, SavepointResult, StateStatus, User}
+import pl.touk.nussknacker.engine.api.deployment.{CustomActionError, CustomActionRequest, CustomActionResult, DeploymentId, ProcessDeploymentData, ProcessState, SavepointResult, StateStatus, User}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.{ProcessAdditionalFields, ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -191,8 +191,14 @@ object TestFactory extends TestPermissions{
 
     override protected def runProgram(processName: ProcessName, mainClass: String, args: List[String], savepointPath: Option[String]): Future[Unit] = ???
 
-    override def close(): Unit = {}
+    override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
+      actionRequest.name match {
+        case "hello" => Right(CustomActionResult("Hi"))
+        case _ => Left(CustomActionError("Invalid action"))
+      }
+    }
 
+    override def close(): Unit = {}
   }
 
   class SampleSubprocessRepository(subprocesses: Set[CanonicalProcess]) extends SubprocessRepository {

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -190,11 +190,15 @@ object TestFactory extends TestPermissions{
 
     override protected def runProgram(processName: ProcessName, mainClass: String, args: List[String], savepointPath: Option[String]): Future[Unit] = ???
 
-    override def customActions: List[CustomAction] = List(CustomAction(name = "hello", allowedProcessStates = List(SimpleStateStatus.Warning, SimpleStateStatus.NotDeployed)))
+    override def customActions: List[CustomAction] = List(
+      CustomAction(name = "hello", allowedProcessStates = List(SimpleStateStatus.Warning, SimpleStateStatus.NotDeployed)),
+      CustomAction(name = "not-implemented", allowedProcessStates = List(SimpleStateStatus.Warning, SimpleStateStatus.NotDeployed)),
+      CustomAction(name = "invalid-status", allowedProcessStates = Nil),
+    )
 
     override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionNotImplemented, CustomActionResult]] = Future.successful {
       actionRequest.name match {
-        case "hello" => Right(CustomActionResult(actionRequest, "Hi"))
+        case "hello" | "invalid-status" => Right(CustomActionResult(actionRequest, "Hi"))
         case _ => Left(CustomActionNotImplemented(actionRequest))
       }
     }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.ProcessingTypeConfig
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
 import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessState, SimpleStateStatus}
-import pl.touk.nussknacker.engine.api.deployment.{CustomAction, CustomActionError, CustomActionRequest, CustomActionResult, DeploymentId, ProcessDeploymentData, ProcessState, SavepointResult, StateStatus, User}
+import pl.touk.nussknacker.engine.api.deployment.{CustomAction, CustomActionNotImplemented, CustomActionRequest, CustomActionResult, DeploymentId, ProcessDeploymentData, ProcessState, SavepointResult, StateStatus, User}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.{ProcessAdditionalFields, ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -190,12 +190,12 @@ object TestFactory extends TestPermissions{
 
     override protected def runProgram(processName: ProcessName, mainClass: String, args: List[String], savepointPath: Option[String]): Future[Unit] = ???
 
-    override def customActions: List[CustomAction] = List(CustomAction(name = "Hi", allowedProcessStates = List.empty))
+    override def customActions: List[CustomAction] = List(CustomAction(name = "hello", allowedProcessStates = List(SimpleStateStatus.Warning, SimpleStateStatus.NotDeployed)))
 
-    override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
+    override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionNotImplemented, CustomActionResult]] = Future.successful {
       actionRequest.name match {
-        case "hello" => Right(CustomActionResult("Hi"))
-        case _ => Left(CustomActionError("Invalid action"))
+        case "hello" => Right(CustomActionResult(actionRequest, "Hi"))
+        case _ => Left(CustomActionNotImplemented(actionRequest))
       }
     }
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -1,14 +1,13 @@
 package pl.touk.nussknacker.ui.api.helpers
 
 import java.util.concurrent.atomic.AtomicReference
-
 import akka.http.scaladsl.server.Route
 import cats.instances.future._
 import pl.touk.nussknacker.engine.ProcessingTypeConfig
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
 import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessState, SimpleStateStatus}
-import pl.touk.nussknacker.engine.api.deployment.{CustomActionError, CustomActionRequest, CustomActionResult, DeploymentId, ProcessDeploymentData, ProcessState, SavepointResult, StateStatus, User}
+import pl.touk.nussknacker.engine.api.deployment.{CustomAction, CustomActionError, CustomActionRequest, CustomActionResult, DeploymentId, ProcessDeploymentData, ProcessState, SavepointResult, StateStatus, User}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.{ProcessAdditionalFields, ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -190,6 +189,8 @@ object TestFactory extends TestPermissions{
     override protected def stop(job: ProcessState, savepointDir: Option[String]): Future[SavepointResult] = Future.successful(SavepointResult(path = stopSavepointPath))
 
     override protected def runProgram(processName: ProcessName, mainClass: String, args: List[String], savepointPath: Option[String]): Future[Unit] = ???
+
+    override def customActions: List[CustomAction] = List(CustomAction(name = "Hi", allowedProcessStates = List.empty))
 
     override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
       actionRequest.name match {

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.ProcessingTypeConfig
 import pl.touk.nussknacker.engine.ProcessingTypeData.ProcessingType
 import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessState, SimpleStateStatus}
-import pl.touk.nussknacker.engine.api.deployment.{CustomAction, CustomActionNotImplemented, CustomActionRequest, CustomActionResult, DeploymentId, ProcessDeploymentData, ProcessState, SavepointResult, StateStatus, User}
+import pl.touk.nussknacker.engine.api.deployment.{CustomAction, CustomActionError, CustomActionNotImplemented, CustomActionRequest, CustomActionResult, DeploymentId, ProcessDeploymentData, ProcessState, SavepointResult, StateStatus, User}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.{ProcessAdditionalFields, ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -196,7 +196,7 @@ object TestFactory extends TestPermissions{
       CustomAction(name = "invalid-status", allowedProcessStates = Nil)
     )
 
-    override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionNotImplemented, CustomActionResult]] = Future.successful {
+    override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
       actionRequest.name match {
         case "hello" | "invalid-status" => Right(CustomActionResult(actionRequest, "Hi"))
         case _ => Left(CustomActionNotImplemented(actionRequest))

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -193,7 +193,7 @@ object TestFactory extends TestPermissions{
     override def customActions: List[CustomAction] = List(
       CustomAction(name = "hello", allowedProcessStates = List(SimpleStateStatus.Warning, SimpleStateStatus.NotDeployed)),
       CustomAction(name = "not-implemented", allowedProcessStates = List(SimpleStateStatus.Warning, SimpleStateStatus.NotDeployed)),
-      CustomAction(name = "invalid-status", allowedProcessStates = Nil),
+      CustomAction(name = "invalid-status", allowedProcessStates = Nil)
     )
 
     override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionNotImplemented, CustomActionResult]] = Future.successful {

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/TestFactory.scala
@@ -196,11 +196,13 @@ object TestFactory extends TestPermissions{
       CustomAction(name = "invalid-status", allowedProcessStates = Nil)
     )
 
-    override def invokeCustomAction(actionRequest: CustomActionRequest): Future[Either[CustomActionError, CustomActionResult]] = Future.successful {
-      actionRequest.name match {
-        case "hello" | "invalid-status" => Right(CustomActionResult(actionRequest, "Hi"))
-        case _ => Left(CustomActionNotImplemented(actionRequest))
-      }
+    override def invokeCustomAction(actionRequest: CustomActionRequest,
+                                    processDeploymentData: ProcessDeploymentData): Future[Either[CustomActionError, CustomActionResult]] =
+      Future.successful {
+        actionRequest.name match {
+          case "hello" | "invalid-status" => Right(CustomActionResult(actionRequest, "Hi"))
+          case _ => Left(CustomActionNotImplemented(actionRequest))
+        }
     }
 
     override def close(): Unit = {}

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactorySpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactorySpec.scala
@@ -12,6 +12,7 @@ import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.util.process.EmptyProcessConfigCreator
 import pl.touk.nussknacker.engine.{ModelData, ProcessingTypeConfig}
 import pl.touk.nussknacker.ui.api.helpers.TestFactory
+import pl.touk.nussknacker.ui.api.helpers.TestFactory.MockProcessManager
 import pl.touk.nussknacker.ui.process.ProcessTypesForCategories
 import pl.touk.nussknacker.ui.util.ConfigWithScalaVersion
 
@@ -61,6 +62,8 @@ class UIProcessObjectsFactorySpec extends FunSuite with Matchers {
 
   }
 
+  private val mockProcessManager = new MockProcessManager
+
   test("should read editor from annotations") {
     val model: ModelData = LocalModelData(ConfigWithScalaVersion.streamingProcessTypeConfig, new EmptyProcessConfigCreator() {
       override def services(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[Service]] =
@@ -69,6 +72,7 @@ class UIProcessObjectsFactorySpec extends FunSuite with Matchers {
 
     val processObjects = UIProcessObjectsFactory.prepareUIProcessObjects(
       model,
+      mockProcessManager,
       TestFactory.user("userId"),
       Set(),
       false,
@@ -97,7 +101,7 @@ class UIProcessObjectsFactorySpec extends FunSuite with Matchers {
     })
 
     val processObjects =
-      UIProcessObjectsFactory.prepareUIProcessObjects(model, TestFactory.user("userId"), Set(), false,
+      UIProcessObjectsFactory.prepareUIProcessObjects(model, mockProcessManager, TestFactory.user("userId"), Set(), false,
         new ProcessTypesForCategories(ConfigWithScalaVersion.config))
 
     processObjects.nodesToAdd.filter(_.name == "hiddenCategory") shouldBe empty
@@ -113,7 +117,7 @@ class UIProcessObjectsFactorySpec extends FunSuite with Matchers {
     })
 
     val processObjects =
-      UIProcessObjectsFactory.prepareUIProcessObjects(model, TestFactory.user("userId"), Set(), false,
+      UIProcessObjectsFactory.prepareUIProcessObjects(model, mockProcessManager, TestFactory.user("userId"), Set(), false,
         new ProcessTypesForCategories(ConfigWithScalaVersion.config))
 
     val nodeGroups = processObjects.nodesToAdd.filter(_.name == "someCategory")


### PR DESCRIPTION
1. Custom process actions like custom deploy can be defined via ProcessManager.
2. New post endpoint: api/processManagement/cusotmAciton/:processId
3. On process edit page, in right side panel, in status toolbar custom action button is displayed
4. ~~!Currently there is no validation on BE to check if given action can be processed, eg if an action is some sorf of custom process deployment we should validate it against current process status. For now we only disable custom action buttons on FE when custom action allowed process states differ from current process state.~~

Things to consider  in future changes:
1. Allowing for attaching comments to custom actions, similarly to stop/deploy comments.
2. Storing taken custom action on db side.