### PR TITLE
[Build] Publish via githubactions - first version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,9 +1,15 @@
-name: PR Build
+name: "Build and Test"
 on:
   pull_request:
     branches:
       - master
       - staging
+  push:
+    branches:
+      - master
+      - staging
+env:
+  CROSS_BUILD: ${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/master' || startsWith(github.head_ref, 'preview') }}
 
 jobs:
   build:
@@ -105,7 +111,7 @@ jobs:
       - name: Integration tests
         shell: bash
         run: ./ciRunSbt.sh flinkProcessManager/it:test engineStandalone/it:test
-  slowTest:
+  slowTests:
     name: Slow tests
     runs-on: ubuntu-latest
     needs: [ build ]
@@ -177,12 +183,61 @@ jobs:
       - name: Untar artifacts
         shell: bash
         run:  tar xfz target.tgz
-      - name: setup node
-        shell: bash
-        run: (cd ui/client; npm ci)
       - name: Prepare docker
         shell: bash
         run: echo "version in ThisBuild := \"$GITHUB_SHA\"" > version.sbt && ./ciRunSbt.sh dist/docker:publishLocal
       - name: Test docker
         shell: bash
-        run: cd ./demo/docker && echo "NUSSKNACKER_VERSION=$GITHUB_SHA" > .env && ./testQuickstart.sh
+        env:
+          NUSSKNACKER_VERSION: ghactionstest-$GITHUB_SHA
+        run: cd ./demo/docker && ./testQuickstart.sh
+
+#TODO: extract to different workflow?
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build, tests, crossCompile, integrationTests, slowTests, frontendTests, dockerTest]
+    if: ${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/master' || startsWith(github.head_ref, 'preview') ||  github.head_ref == 'publish_githubactions' }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Cache npm
+        uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.11.0
+      - name: Setup npm
+        run: (cd ui/client; npm ci)
+      - name: Cache ivy packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-ivy2-${{ hashFiles('**/*.sbt') }}
+          restore-keys: ${{ runner.os }}-sbt
+      - uses: olafurpg/setup-scala@v10
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-target
+      - name: Untar artifacts
+        shell: bash
+        run:  tar xfz target.tgz
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build
+        shell: bash
+        env:
+          #TODO: shouldn't be needed...
+          nexusUrl: https://oss.sonatype.org/content/repositories/snapshots
+          nexusUser: ${{ secrets.SONATYPE_USER }}
+          nexusPassword: ${{ secrets.SONATYPE_PASSWORD }}
+        #TODO: handle version better
+        run: sbt -J-Xms1000M -J-Xmx1000M "set version in ThisBuild := (version in ThisBuild).value.replace(\"-SNAPSHOT\", \"-$(date -I)-$GITHUB_RUN_NUMBER-$GITHUB_SHA-ghactionstest-SNAPSHOT\")" publish dist/docker:publish
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,7 @@ on:
       - master
       - staging
 env:
+  #we use this variable in ciRunSbt.sh
   CROSS_BUILD: ${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/master' || startsWith(github.head_ref, 'preview') }}
 
 jobs:
@@ -189,14 +190,14 @@ jobs:
       - name: Test docker
         shell: bash
         env:
-          NUSSKNACKER_VERSION: ghactionstest-$GITHUB_SHA
+          NUSSKNACKER_VERSION: ghactionstest-${{ github.sha }}
         run: cd ./demo/docker && ./testQuickstart.sh
 
 #TODO: extract to different workflow?
   publish:
     runs-on: ubuntu-latest
     needs: [build, tests, crossCompile, integrationTests, slowTests, frontendTests, dockerTest]
-    if: ${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/master' || startsWith(github.head_ref, 'preview') ||  github.head_ref == 'publish_githubactions' }}
+    if: ${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/master' || startsWith(github.head_ref, 'preview') }}
     steps:
       - uses: actions/checkout@v1
       - name: Cache npm

--- a/build.sbt
+++ b/build.sbt
@@ -281,7 +281,7 @@ lazy val dockerSettings = {
       val latestBranch = Some(git.gitCurrentBranch.value + "-latest")
 
       List(dockerVersion, updateLatest, latestBranch, dockerTagName)
-        //FIXME: remove githubactions
+        //FIXME: remove ghactionstest when all publishing will be done with githbub actions
         .map(_.map("ghactionstest-" + _).map(sanitize))
         .map(alias.withTag).distinct
     },

--- a/build.sbt
+++ b/build.sbt
@@ -18,27 +18,35 @@ lazy val supportedScalaVersions = List(scala212, scala211)
 val silencerV_2_12 = "1.6.0"
 val silencerV = "1.7.0"
 
+//TODO: replace configuration by system properties with configuration via environment after removing travis scripts
+//then we can change names to snake case, for "normal" env variables
+def propOrEnv(name: String, default: String): String = propOrEnv(name).getOrElse(default)
+def propOrEnv(name: String): Option[String] = Option(System.getProperty(name)).orElse(sys.env.get(name))
+
+
 //by default we include flink and scala, we want to be able to disable this behaviour for performance reasons
-val includeFlinkAndScala = Option(System.getProperty("includeFlinkAndScala", "true")).exists(_.toBoolean)
+val includeFlinkAndScala = propOrEnv("includeFlinkAndScala", "true").toBoolean
 
 val flinkScope = if (includeFlinkAndScala) "compile" else "provided"
-val nexusUrlFromProps = Option(System.getProperty("nexusUrl"))
+val nexusUrlFromProps = propOrEnv("nexusUrl")
 //TODO: this is pretty clunky, but works so far for our case...
 val nexusHostFromProps = nexusUrlFromProps.map(_.replaceAll("http[s]?://", "").replaceAll("[:/].*", ""))
 
 //Docker release configuration
-val dockerTagName = Option(System.getProperty("dockerTagName"))
-val dockerPort = System.getProperty("dockerPort", "8080").toInt
-val dockerUserName = Some(System.getProperty("dockerUserName", "touk"))
-val dockerPackageName = System.getProperty("dockerPackageName", "nussknacker")
-val dockerUpLatestFromProp = Option(System.getProperty("dockerUpLatest")).flatMap(p => Try(p.toBoolean).toOption)
-val addDevModel = System.getProperty("addDevModel", "false").toBoolean
+val dockerTagName = propOrEnv("dockerTagName")
+val dockerPort = propOrEnv("dockerPort", "8080").toInt
+val dockerUserName = Option(propOrEnv("dockerUserName", "touk"))
+val dockerPackageName = propOrEnv("dockerPackageName", "nussknacker")
+val dockerUpLatestFromProp = propOrEnv("dockerUpLatest").flatMap(p => Try(p.toBoolean).toOption)
+val addDevModel = propOrEnv("addDevModel", "false").toBoolean
 
 // `publishArtifact := false` should be enough to keep sbt from publishing root module,
 // unfortunately it does not work, so we resort to hack by publishing root module to Resolver.defaultLocal
 //publishArtifact := false
 publishTo := Some(Resolver.defaultLocal)
 crossScalaVersions := Nil
+
+ThisBuild / isSnapshot := version(_ contains "-SNAPSHOT").value
 
 lazy val publishSettings = Seq(
   publishMavenStyle := true,
@@ -69,7 +77,7 @@ lazy val publishSettings = Seq(
   organization := "pl.touk.nussknacker",
   homepage := Some(url(s"https://github.com/touk/nussknacker")),
   credentials := nexusHostFromProps.map(host => Credentials("Sonatype Nexus Repository Manager",
-    host, System.getProperty("nexusUser", "touk"), System.getProperty("nexusPassword"))
+    host, propOrEnv("nexusUser", "touk"), propOrEnv("nexusPassword", null))
     // otherwise ~/.sbt/1.0/sonatype.sbt will be used
   ).toSeq
 )
@@ -251,7 +259,6 @@ lazy val dockerSettings = {
     packageName := dockerPackageName,
     dockerUpdateLatest := dockerUpLatestFromProp.getOrElse(!isSnapshot.value),
     dockerLabels := Map(
-      "tag" -> dockerTagName.getOrElse(version.value),
       "version" -> version.value,
       "scala" -> scalaVersion.value,
       "flink" -> flinkV
@@ -264,7 +271,20 @@ lazy val dockerSettings = {
       "OAUTH2_GRANT_TYPE" -> "authorization_code",
       "OAUTH2_SCOPE" -> "read:user",
     ),
-    version in Docker := dockerTagName.getOrElse(version.value)
+    dockerAliases := {
+      //https://docs.docker.com/engine/reference/commandline/tag/#extended-description
+      def sanitize(str: String) = str.replaceAll("[^a-zA-Z0-9.\\-_]", "_")
+      val alias = dockerAlias.value
+
+      val updateLatest = if (dockerUpdateLatest.value) Some("latest") else None
+      val dockerVersion = Some(version.value)
+      val latestBranch = Some(git.gitCurrentBranch.value + "-latest")
+
+      List(dockerVersion, updateLatest, latestBranch, dockerTagName)
+        //FIXME: remove githubactions
+        .map(_.map("ghactionstest-" + _).map(sanitize))
+        .map(alias.withTag).distinct
+    },
   )
 }
 


### PR DESCRIPTION
Things that are left for future PRs:
- computing coverage
- adding devModel for staging
- cross publishing
- building FE only once and caching artifacts

Refactor of workflows:
- GithubActions do not handle composite actions or other form of reusing parts of workflow definition (e.g. no support for YAML anchors...). There is composite run step: https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action, but one can only use "run" as steps and not other actions 