### PR TITLE
Typed QueryableState

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -702,7 +702,7 @@ lazy val flinkModelUtil = (project in engine("flink/model-util")).
         "org.apache.flink" %% "flink-streaming-scala" % flinkV % "provided"
       )
     }
-  ).dependsOn(flinkUtil, flinkTestUtil % "test", process % "test")
+  ).dependsOn(flinkUtil, flinkTestUtil % "test", process)
 
 lazy val flinkTestUtil = (project in engine("flink/test-util")).
   settings(commonSettings).
@@ -844,7 +844,7 @@ lazy val queryableState = (project in engine("queryableState")).
         "com.typesafe" % "config" % configV
       )
     }
-  ).dependsOn(api)
+  ).dependsOn(api, flinkApi, util)
 
 
 

--- a/demo/docker/flink/flink-conf.yaml
+++ b/demo/docker/flink/flink-conf.yaml
@@ -29,8 +29,10 @@ taskmanager.hostname: taskmanager
 
 taskmanager.data.port: 6126
 
-taskmanager.memory.task.heap.size: 256m
-taskmanager.memory.managed.size: 204m
+taskmanager.memory.task.heap.size: 512m
+taskmanager.memory.managed.size: 1512m
+#queryable state...
+taskmanager.memory.framework.off-heap.size: 256m
 
 env.java.opts.taskmanager: "-Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=localhost -Dcom.sun.management.jmxremote.port=9009 -Dcom.sun.management.jmxremote.rmi.port=9008 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 
@@ -90,5 +92,6 @@ metrics.scope.operator: demo.<host>.taskmanagerTask.<tm_id>.<job_name>.<operator
 classloader.resolve-order: parent-first
 akka.framesize: 209715200b
 
+queryable-state.enable: true
 query.server.port: 6125
 blob.server.port: 6124

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/queryablestate/QueryableClient.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/queryablestate/QueryableClient.scala
@@ -1,11 +1,24 @@
 package pl.touk.nussknacker.engine.api.queryablestate
 
+import io.circe.Json
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
+import pl.touk.nussknacker.engine.api.deployment.DeploymentId
+
 import scala.concurrent.{ExecutionContext, Future}
 
 trait QueryableClient extends AutoCloseable {
 
-  def fetchJsonState(taskId: String, queryName: String, key: String)(implicit ec: ExecutionContext): Future[String]
+  def fetchJsonState(taskId: DeploymentId, queryName: String, key: String)(implicit ec: ExecutionContext): Future[String]
 
-  def fetchJsonState(taskId: String, queryName: String)(implicit ec: ExecutionContext): Future[String]
+  def fetchJsonState(taskId: DeploymentId, queryName: String)(implicit ec: ExecutionContext): Future[String]
+
+  def fetchState(taskId: DeploymentId,
+                 nodeId: NodeId,
+                 queryName: String,
+                 transformationObject: Any,
+                 keyId: String
+                )(implicit ec: ExecutionContext): Future[AnyRef] = {
+    Future.successful(null)
+  }
 
 }

--- a/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkCustomStreamTransformation.scala
+++ b/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkCustomStreamTransformation.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.engine.flink.api.process
 
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala.DataStream
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.api.typed.{ReturningType, typing}
@@ -13,6 +14,13 @@ object FlinkCustomStreamTransformation {
   : FlinkCustomStreamTransformation = new FlinkCustomStreamTransformation {
     override def transform(start: DataStream[Context], context: FlinkCustomNodeContext)
     : DataStream[ValueWithContext[AnyRef]] = fun(start, context)
+  }
+
+  def apply(fun: (DataStream[Context], FlinkCustomNodeContext) => DataStream[ValueWithContext[AnyRef]], states: Map[String, TypeInformation[_]])
+  : FlinkCustomStreamTransformation = new FlinkCustomStreamTransformation {
+    override def transform(start: DataStream[Context], context: FlinkCustomNodeContext)
+    : DataStream[ValueWithContext[AnyRef]] = fun(start, context)
+    override def queryableStateTypes(): Map[String, TypeInformation[_]] = states
   }
 
   def apply(fun: (DataStream[Context], FlinkCustomNodeContext) => DataStream[ValueWithContext[AnyRef]],
@@ -29,6 +37,9 @@ trait FlinkCustomStreamTransformation {
 
   // TODO: To be consistent with ContextTransformation should return Context
   def transform(start: DataStream[Context], context: FlinkCustomNodeContext): DataStream[ValueWithContext[AnyRef]]
+
+  //this will be used by FlinkQueryableClient
+  def queryableStateTypes(): Map[String, TypeInformation[_]] = Map.empty
 
 }
 

--- a/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/QueryableStateTest.scala
+++ b/engine/flink/management/sample/src/test/scala/pl/touk/nussknacker/engine/process/QueryableStateTest.scala
@@ -10,6 +10,7 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.scalatest.{FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.deployment.DeploymentId
 import pl.touk.nussknacker.engine.api.process.ProcessObjectDependencies
 import pl.touk.nussknacker.engine.build.EspProcessBuilder
 import pl.touk.nussknacker.engine.flink.queryablestate.FlinkQueryableClient
@@ -75,7 +76,7 @@ class QueryableStateTest extends FlatSpec with FlinkSpec with Matchers with Kafk
       val client = FlinkQueryableClient(s"localhost:$strangePort, localhost:$queryStateProxyPortLow, localhost:${queryStateProxyPortLow + 1}")
 
       def queryState(jobId: String): Future[Boolean] = client.fetchState[java.lang.Boolean](
-        jobId = jobId,
+        jobId = DeploymentId(jobId),
         queryName = "single-lock-state",
         key = DevProcessConfigCreator.oneElementValue).map(Boolean.box(_))
 

--- a/engine/flink/model-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
+++ b/engine/flink/model-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
@@ -7,6 +7,7 @@ import pl.touk.nussknacker.engine.api.context.ContextTransformation
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
 import pl.touk.nussknacker.engine.api.editor._
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
+import pl.touk.nussknacker.engine.flink.util.transformer.aggregate.transformers.aggregatorQueryable
 
 import scala.concurrent.duration.Duration
 
@@ -115,6 +116,7 @@ object sampleTransformers {
   object SlidingAggregateTransformerV2 extends CustomStreamTransformer with ExplicitUidInOperatorsSupport {
 
     @MethodToInvoke(returnType = classOf[AnyRef])
+    @QueryableStateNames(values = Array("aggregate"))
     def execute(@ParamName("keyBy") keyBy: LazyParameter[CharSequence],
                 @ParamName("aggregator")
                 @DualEditor(simpleEditor = new SimpleEditor(
@@ -136,6 +138,7 @@ object sampleTransformers {
       val windowDuration = Duration(length.toMillis, TimeUnit.MILLISECONDS)
       transformers.slidingTransformer(keyBy, aggregateBy, aggregator, windowDuration, variableName, emitWhenEventLeft, explicitUidInStatefulOperators)
     }
+
   }
 
   object TumblingAggregateTransformer extends CustomStreamTransformer with ExplicitUidInOperatorsSupport {

--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/json/BestEffortJsonEncoder.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/json/BestEffortJsonEncoder.scala
@@ -44,8 +44,8 @@ case class BestEffortJsonEncoder(failOnUnkown: Boolean, highPriority: PartialFun
       case a: Instant => Encoder[Instant].apply(a)
       case a: OffsetDateTime => Encoder[OffsetDateTime].apply(a)
       case a: DisplayJson => a.asJson
-      case a: scala.collection.Map[String@unchecked, _] => encodeMap(a.toMap)
-      case a: java.util.Map[String@unchecked, _] => encodeMap(a.asScala.toMap)
+      case a: scala.collection.Map[String@unchecked, _] if a.forall(_._1.isInstanceOf[String]) => encodeMap(a.toMap)
+      case a: java.util.Map[String@unchecked, _] if a.asScala.forall(_._1.isInstanceOf[String]) => encodeMap(a.asScala.toMap)
       case a: Traversable[_] => fromValues(a.map(encode).toList)
       case a: java.util.Collection[_] => fromValues(a.asScala.map(encode).toList)
       case _ if !failOnUnkown => safeString(any.toString)

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/QueryableStateResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/QueryableStateResources.scala
@@ -5,12 +5,22 @@ import cats.data.EitherT
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.Json
 import io.circe.parser.parse
-import pl.touk.nussknacker.engine.ProcessingTypeData
+import pl.touk.nussknacker.engine.{ModelData, ProcessingTypeData}
+import pl.touk.nussknacker.engine.api.context.ContextTransformation
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
+import pl.touk.nussknacker.engine.api.deployment.DeploymentId
+import pl.touk.nussknacker.engine.compile.ExpressionCompiler
+import pl.touk.nussknacker.engine.compile.nodecompilation.NodeCompiler
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.QueryableStateName
+import pl.touk.nussknacker.engine.graph.node.CustomNodeData
+import pl.touk.nussknacker.engine.spel.SpelExpressionParser
+import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
 import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository
 import pl.touk.nussknacker.ui.process.{JobStatusService, ProcessObjectsFinder}
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
 import pl.touk.nussknacker.restmodel.process.ProcessIdWithName
+import pl.touk.nussknacker.restmodel.processdetails.BaseProcessDetails
+import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
 import pl.touk.nussknacker.ui.process.processingtypedata.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
@@ -47,12 +57,71 @@ class QueryableStateResources(typeToConfig: ProcessingTypeDataProvider[Processin
           }
         }
       }
+    /*
+      The flow is:
+      - we checkout process, compile it (probably we should take version that is deployed?) and get custom transformer implementation.
+        We do it this way, so that transformer can have logic for determining type of state
+      - queryableClient (i.e. Flink one...) retrieves state type from transformer and can invoke state using this information
+      - We assume that this works *only* if model in NK UI is compatible with the one in deployed process (add check for that in the future)...
+     */
+    } ~ path("typedQueryableState" / "fetch") {
+      parameters('processId, 'queryName, 'nodeId, 'key ?) { (processName, queryName, nodeId, key) =>
+        (get & processId(processName)) { processId =>
+          canDeploy(processId) {
+            complete {
+
+              import QueryStateErrors._
+              import cats.instances.future._
+              import cats.syntax.either._
+
+              def fetchTypedState(deploymentId: DeploymentId, displayableProcess: BaseProcessDetails[DisplayableProcess]) = {
+                val data = typeToConfig.forTypeUnsafe(displayableProcess.processingType)
+                val modelData = data.modelData
+                modelData.withThisAsContextClassLoader {
+                  val transformer: Any = prepareTransformer(modelData, displayableProcess, nodeId)
+                  data.queryableClient.get.fetchState(deploymentId, NodeId(nodeId), queryName, transformer, key.get)
+                }
+              }
+              val encoder = BestEffortJsonEncoder(failOnUnkown = false)
+
+              val fetchedJsonState = for {
+                details <- EitherT.fromOptionF(processRepository.fetchLatestProcessDetailsForProcessId[DisplayableProcess](processId.id), noJob(processName))
+                state <- EitherT.fromOptionF(jobStatusService.retrieveJobStatus(processId), noJob(processName))
+                value <- EitherT.right[String](fetchTypedState(state.deploymentId.get, details))
+              } yield value
+              fetchedJsonState.value.map {
+                case Left(msg) => throw new RuntimeException(msg)
+                case Right(value) => encoder.encode(value)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  //we compile process to get context transformation object, it's QueryableClient resposibility to handle details (e.g. type)
+  private def prepareTransformer(modelData: ModelData, displayableProcess: BaseProcessDetails[DisplayableProcess], nodeId: String) = {
+    val expressionCompiler = ExpressionCompiler.withoutOptimization(modelData).withExpressionParsers {
+      case spel: SpelExpressionParser => spel.typingDictLabels
+    }
+    val compiler = new NodeCompiler(modelData.processWithObjectsDefinition,
+      expressionCompiler, modelData.modelClassLoader.classLoader)
+    val process = displayableProcess.json.get
+    val ctx = modelData
+      .validator
+      .validate(ProcessConverter.fromDisplayable(process)).typing(nodeId)
+    val node = process.nodes.find(_.id == nodeId).get.asInstanceOf[CustomNodeData]
+    compiler.compileCustomNodeObject(node, Left(ctx.inputValidationContext), false)(process.metaData, NodeId(nodeId))
+      .compiledObject.toOption.get match {
+      case a: ContextTransformation => a.implementation
+      case b => b
     }
   }
 
   private def prepareQueryableStates()(implicit user: LoggedUser): Future[Map[String, List[QueryableStateName]]] = {
     processRepository.fetchAllProcessesDetails[DisplayableProcess]().map { processList =>
-      ProcessObjectsFinder.findQueries(processList, typeToConfig.all.values.map(_.modelData.processDefinition))
+      ProcessObjectsFinder.findQueries(processList, typeToConfig.all.filterKeys(_ == "streaming-generic").values.map(_.modelData.processDefinition))
     }
   }
 
@@ -65,7 +134,7 @@ class QueryableStateResources(typeToConfig: ProcessingTypeDataProvider[Processin
       processingType <- EitherT.liftF(processRepository.fetchProcessingType(processId.id))
       state <- EitherT(jobStatusService.retrieveJobStatus(processId).map(Either.fromOption(_, noJob(processId.name.value))))
       jobId <- EitherT.fromEither(Either.fromOption(state.deploymentId, if (state.status.isDuringDeploy) deployInProgress(processId.name.value) else noJobRunning(processId.name.value)))
-      jsonString <- EitherT.right(fetchState(processingType, jobId.value, queryName, key))
+      jsonString <- EitherT.right(fetchState(processingType, jobId, queryName, key))
       json <- EitherT.fromEither(parse(jsonString).leftMap(msg => wrongJson(msg.message, jsonString)))
     } yield json
     fetchedJsonState.value.map {
@@ -74,7 +143,7 @@ class QueryableStateResources(typeToConfig: ProcessingTypeDataProvider[Processin
     }
   }
 
-  private def fetchState(processingType: String, jobId: String, queryName: String, key: Option[String]): Future[String] = {
+  private def fetchState(processingType: String, jobId: DeploymentId, queryName: String, key: Option[String]): Future[String] = {
     typeToConfig.forTypeUnsafe(processingType).queryableClient match {
       case None => Future.failed(new Exception(s"Queryable client not found for processing type $processingType"))
       case Some(queryableClient) =>


### PR DESCRIPTION
This is prototype of being able to acces generic state via queryable state in Flink. 
We have to be able to compute TypeInformation for given node for this to work.
Unfortunately, we need https://issues.apache.org/jira/browse/FLINK-21138 to be merged before we can really use it, as we still use Kryo serialization in many cases...