### PR TITLE
Improvements: Process state

### DIFF
--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/QueryableStateResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/QueryableStateResources.scala
@@ -63,7 +63,7 @@ class QueryableStateResources(typeToConfig: ProcessingTypeDataProvider[Processin
 
     val fetchedJsonState = for {
       processingType <- EitherT.liftF(processRepository.fetchProcessingType(processId.id))
-      state <- EitherT(jobStatusService.retrieveJobStatus(processId).map(Either.fromOption(_, noJob(processId.name.value))))
+      state <- EitherT.liftF(jobStatusService.retrieveJobStatus(processId))
       jobId <- EitherT.fromEither(Either.fromOption(state.deploymentId, if (state.status.isDuringDeploy) deployInProgress(processId.name.value) else noJobRunning(processId.name.value)))
       jsonString <- EitherT.right(fetchState(processingType, jobId.value, queryName, key))
       json <- EitherT.fromEither(parse(jsonString).leftMap(msg => wrongJson(msg.message, jsonString)))

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/JobStatusService.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/JobStatusService.scala
@@ -3,19 +3,23 @@ package pl.touk.nussknacker.ui.process
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
+import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.deployment.ProcessState
-import pl.touk.nussknacker.restmodel.displayedgraph.ProcessStatus
 import pl.touk.nussknacker.restmodel.process.ProcessIdWithName
 import pl.touk.nussknacker.ui.process.deployment.CheckStatus
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class JobStatusService(managerActor: ActorRef) {
+class JobStatusService(managerActor: ActorRef) extends LazyLogging {
   import scala.concurrent.duration._
 
-  def retrieveJobStatus(processId: ProcessIdWithName)(implicit user: LoggedUser): Future[Option[ProcessState]] = {
+  /**
+    * Handling error at retrieving status from manager is created at ManagementActor
+    */
+  def retrieveJobStatus(processId: ProcessIdWithName)(implicit ec: ExecutionContext, user: LoggedUser): Future[ProcessState] = {
     implicit val timeout: Timeout = Timeout(1 minute)
-    (managerActor ? CheckStatus(processId, user)).mapTo[Option[ProcessState]]
+    (managerActor ? CheckStatus(processId, user)).mapTo[ProcessState]
   }
+
 }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/AppResourcesSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/AppResourcesSpec.scala
@@ -42,20 +42,20 @@ class AppResourcesSpec extends FunSuite with ScalatestRouteTest with Matchers wi
     val statusCheck = TestProbe()
     val resources = prepareBasicAppResources(statusCheck)
 
-    createDeployedProcess("id1")
-    createDeployedProcess("id2")
-    createDeployedProcess("id3")
+    createDeployedProcess(ProcessName("id1"))
+    createDeployedProcess(ProcessName("id2"))
+    createDeployedProcess(ProcessName("id3"))
 
     val result = Get("/app/healthCheck/process/deployment") ~> withPermissions(resources, testPermissionRead)
 
     val first = statusCheck.expectMsgClass(classOf[CheckStatus])
-    statusCheck.reply(akka.actor.Status.Failure(new Exception("Failed to check status")))
+    statusCheck.reply(processStatus(SimpleStateStatus.FailedToGet))
 
     statusCheck.expectMsgClass(classOf[CheckStatus])
-    statusCheck.reply(Some(processStatus(SimpleStateStatus.Running)))
+    statusCheck.reply(processStatus(SimpleStateStatus.Running))
 
     val third = statusCheck.expectMsgClass(classOf[CheckStatus])
-    statusCheck.reply(None)
+    statusCheck.reply(processStatus(SimpleStateStatus.NotFound))
 
     result ~> check {
       status shouldBe StatusCodes.InternalServerError
@@ -74,7 +74,7 @@ class AppResourcesSpec extends FunSuite with ScalatestRouteTest with Matchers wi
     val result = Get("/app/healthCheck/process/deployment") ~> withPermissions(resources, testPermissionRead)
 
     val second = statusCheck.expectMsgClass(classOf[CheckStatus])
-    statusCheck.reply(None)
+    statusCheck.reply(processStatus(SimpleStateStatus.NotFound))
 
     result ~> check {
       status shouldBe StatusCodes.InternalServerError
@@ -87,15 +87,15 @@ class AppResourcesSpec extends FunSuite with ScalatestRouteTest with Matchers wi
     val statusCheck = TestProbe()
     val resources = prepareBasicAppResources(statusCheck)
 
-    createDeployedProcess("id1")
-    createDeployedProcess("id2")
+    createDeployedProcess(ProcessName("id1"))
+    createDeployedProcess(ProcessName("id2"))
 
     val result = Get("/app/healthCheck/process/deployment") ~> withPermissions(resources, testPermissionRead)
 
     statusCheck.expectMsgClass(classOf[CheckStatus])
-    statusCheck.reply(Some(processStatus(SimpleStateStatus.Running)))
+    statusCheck.reply(processStatus(SimpleStateStatus.Running))
     statusCheck.expectMsgClass(classOf[CheckStatus])
-    statusCheck.reply(Some(processStatus(SimpleStateStatus.Running)))
+    statusCheck.reply(processStatus(SimpleStateStatus.Running))
 
     result ~> check {
       status shouldBe StatusCodes.OK
@@ -106,12 +106,12 @@ class AppResourcesSpec extends FunSuite with ScalatestRouteTest with Matchers wi
     val statusCheck = TestProbe()
     val resources = prepareBasicAppResources(statusCheck)
 
-    createDeployedProcess("id1")
+    createDeployedProcess(ProcessName("id1"))
 
     val result = Get("/app/healthCheck/process/deployment") ~> withPermissions(resources, testPermissionRead)
 
     statusCheck.expectMsgClass(classOf[CheckStatus])
-    statusCheck.reply(Some(processStatus(SimpleStateStatus.Running)))
+    statusCheck.reply(processStatus(SimpleStateStatus.Running))
 
     result ~> check {
       status shouldBe StatusCodes.OK

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -267,6 +267,9 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
   def prepareCancel(id: process.ProcessId): Future[ProcessActionEntityData] =
     deploymentProcessRepository.markProcessAsCancelled(id, 1, Some("Cancel comment"))
 
+  def createProcess(processName: ProcessName): process.ProcessId =
+    createProcess(processName, testCategoryName, false)
+
   def createProcess(processName: ProcessName, category: String, isSubprocess: Boolean): process.ProcessId =
     prepareProcess(processName, category, isSubprocess).futureValue
 
@@ -281,8 +284,8 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
     createDeployedProcess(processName, testCategoryName, isSubprocess)
 
   //TODO replace all processName: String to processName: ProcessName
-  def createDeployedProcess(processName: String): process.ProcessId =
-    createDeployedProcess(ProcessName(processName), testCategoryName, false)
+  def createDeployedProcess(processName: ProcessName): process.ProcessId =
+    createDeployedProcess(processName, testCategoryName, false)
 
   def createDeployedCanceledProcess(processName: ProcessName, category: String, isSubprocess: Boolean) : process.ProcessId = {
     (for {


### PR DESCRIPTION
Right now we always return state => process, because at ManagementActor we handle corner cases like missing state, mismatches etc.. 

* Refactor 
* JobStatusService now returns ProcessState instead of Option[ProcessState]