### PR TITLE
[Improvement] Compile process only once on Flink

### DIFF
--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/ProcessPartFunction.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/ProcessPartFunction.scala
@@ -4,7 +4,7 @@ import org.apache.flink.api.common.functions.RichFunction
 import org.apache.flink.configuration.Configuration
 import pl.touk.nussknacker.engine.flink.api.exception.FlinkEspExceptionHandler
 import pl.touk.nussknacker.engine.graph.node.NodeData
-import pl.touk.nussknacker.engine.process.compiler.CompiledProcessWithDeps
+import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
 import pl.touk.nussknacker.engine.splittedgraph.SplittedNodesCollector
 import pl.touk.nussknacker.engine.splittedgraph.splittednode.SplittedNode
 
@@ -32,11 +32,11 @@ trait ProcessPartFunction extends ExceptionHandlerFunction {
 //Helper trait dealing with ExceptionHandler lifecycle
 trait ExceptionHandlerFunction extends RichFunction {
 
-  def compiledProcessWithDepsProvider: ClassLoader => CompiledProcessWithDeps
+  def compiledProcessWithDepsProvider: ClassLoader => FlinkProcessCompilerData
 
   protected var exceptionHandler: FlinkEspExceptionHandler = _
 
-  protected lazy val compiledProcessWithDeps : CompiledProcessWithDeps = compiledProcessWithDepsProvider(getRuntimeContext.getUserCodeClassLoader)
+  protected lazy val compiledProcessWithDeps : FlinkProcessCompilerData = compiledProcessWithDepsProvider(getRuntimeContext.getUserCodeClassLoader)
 
   override def close(): Unit = {
     if (exceptionHandler != null) {

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
@@ -11,7 +11,7 @@ import pl.touk.nussknacker.engine.api.process.AsyncExecutionContextPreparer
 import pl.touk.nussknacker.engine.api.{Context, InterpretationResult}
 import pl.touk.nussknacker.engine.graph.node.NodeData
 import pl.touk.nussknacker.engine.process.ProcessPartFunction
-import pl.touk.nussknacker.engine.process.compiler.CompiledProcessWithDeps
+import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
 import pl.touk.nussknacker.engine.splittedgraph.SplittedNodesCollector
 import pl.touk.nussknacker.engine.splittedgraph.splittednode.SplittedNode
 
@@ -20,7 +20,7 @@ import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-private[registrar] class AsyncInterpretationFunction(val compiledProcessWithDepsProvider: ClassLoader => CompiledProcessWithDeps,
+private[registrar] class AsyncInterpretationFunction(val compiledProcessWithDepsProvider: ClassLoader => FlinkProcessCompilerData,
                                                      val node: SplittedNode[_<:NodeData], validationContext: ValidationContext,
                                                      asyncExecutionContextPreparer: AsyncExecutionContextPreparer)
   extends RichAsyncFunction[Context, InterpretationResult] with LazyLogging with ProcessPartFunction {

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/CollectingSinkFunction.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/CollectingSinkFunction.scala
@@ -6,9 +6,9 @@ import pl.touk.nussknacker.engine.api.test.InvocationCollectors.SinkInvocationCo
 import pl.touk.nussknacker.engine.compiledgraph.part.SinkPart
 import pl.touk.nussknacker.engine.graph.node
 import pl.touk.nussknacker.engine.process.{ExceptionHandlerFunction, ProcessPartFunction}
-import pl.touk.nussknacker.engine.process.compiler.CompiledProcessWithDeps
+import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
 
-private[registrar] class CollectingSinkFunction(val compiledProcessWithDepsProvider: ClassLoader => CompiledProcessWithDeps,
+private[registrar] class CollectingSinkFunction(val compiledProcessWithDepsProvider: ClassLoader => FlinkProcessCompilerData,
                                                 collectingSink: SinkInvocationCollector, sinkId: String)
   extends RichSinkFunction[InterpretationResult] with ExceptionHandlerFunction {
 

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkCompilerLazyInterpreterCreator.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkCompilerLazyInterpreterCreator.scala
@@ -3,9 +3,9 @@ package pl.touk.nussknacker.engine.process.registrar
 import org.apache.flink.api.common.functions.RuntimeContext
 import pl.touk.nussknacker.engine.api.MetaData
 import pl.touk.nussknacker.engine.definition.{CompilerLazyParameterInterpreter, LazyInterpreterDependencies}
-import pl.touk.nussknacker.engine.process.compiler.CompiledProcessWithDeps
+import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
 
-class FlinkCompilerLazyInterpreterCreator(runtimeContext: RuntimeContext, withDeps: CompiledProcessWithDeps)
+class FlinkCompilerLazyInterpreterCreator(runtimeContext: RuntimeContext, withDeps: FlinkProcessCompilerData)
   extends CompilerLazyParameterInterpreter {
 
   //TODO: is this good place?

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/StreamExecutionEnvPreparer.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/StreamExecutionEnvPreparer.scala
@@ -11,7 +11,7 @@ import org.apache.flink.streaming.api.operators.StreamOperatorFactory
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.runtime.operators.windowing.WindowOperator
 import pl.touk.nussknacker.engine.api.StreamMetaData
-import pl.touk.nussknacker.engine.process.compiler.CompiledProcessWithDeps
+import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
 import pl.touk.nussknacker.engine.process.util.StateConfiguration.RocksDBStateBackendConfig
 import pl.touk.nussknacker.engine.process.util.{MetaDataExtractor, StateConfiguration}
 import pl.touk.nussknacker.engine.process.{CheckpointConfig, ExecutionConfigPreparer}
@@ -25,9 +25,9 @@ import scala.collection.JavaConverters._
  */
 trait StreamExecutionEnvPreparer {
 
-  def preRegistration(env: StreamExecutionEnvironment, compiledProcessWithDeps: CompiledProcessWithDeps): Unit
+  def preRegistration(env: StreamExecutionEnvironment, compiledProcessWithDeps: FlinkProcessCompilerData): Unit
 
-  def postRegistration(env: StreamExecutionEnvironment, compiledProcessWithDeps: CompiledProcessWithDeps): Unit
+  def postRegistration(env: StreamExecutionEnvironment, compiledProcessWithDeps: FlinkProcessCompilerData): Unit
 
   def flinkClassLoaderSimulation: ClassLoader
 }
@@ -36,7 +36,7 @@ class DefaultStreamExecutionEnvPreparer(checkpointConfig: Option[CheckpointConfi
                                         rocksDBStateBackendConfig: Option[RocksDBStateBackendConfig],
                                        executionConfigPreparer: ExecutionConfigPreparer) extends StreamExecutionEnvPreparer with LazyLogging {
 
-  override def preRegistration(env: StreamExecutionEnvironment, processWithDeps: CompiledProcessWithDeps): Unit = {
+  override def preRegistration(env: StreamExecutionEnvironment, processWithDeps: FlinkProcessCompilerData): Unit = {
 
     executionConfigPreparer.prepareExecutionConfig(env.getConfig)(processWithDeps.metaData, processWithDeps.jobData.processVersion)
 
@@ -58,7 +58,7 @@ class DefaultStreamExecutionEnvPreparer(checkpointConfig: Option[CheckpointConfi
     env.setStateBackend(StateConfiguration.prepareRocksDBStateBackend(config).asInstanceOf[StateBackend])
   }
 
-  override def postRegistration(env: StreamExecutionEnvironment, compiledProcessWithDeps: CompiledProcessWithDeps): Unit = {
+  override def postRegistration(env: StreamExecutionEnvironment, compiledProcessWithDeps: FlinkProcessCompilerData): Unit = {
     initializeStateDescriptors(env)
   }
 

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.api.exception.EspExceptionInfo
 import pl.touk.nussknacker.engine.api.{Context, InterpretationResult}
 import pl.touk.nussknacker.engine.graph.node.NodeData
 import pl.touk.nussknacker.engine.process.ProcessPartFunction
-import pl.touk.nussknacker.engine.process.compiler.CompiledProcessWithDeps
+import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
 import pl.touk.nussknacker.engine.splittedgraph.SplittedNodesCollector
 import pl.touk.nussknacker.engine.splittedgraph.splittednode.SplittedNode
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
@@ -15,7 +15,7 @@ import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
 import scala.concurrent.{Await, ExecutionContext}
 import scala.util.control.NonFatal
 
-private[registrar] class SyncInterpretationFunction(val compiledProcessWithDepsProvider: ClassLoader => CompiledProcessWithDeps,
+private[registrar] class SyncInterpretationFunction(val compiledProcessWithDepsProvider: ClassLoader => FlinkProcessCompilerData,
                                                     val node: SplittedNode[_<:NodeData], validationContext: ValidationContext)
   extends RichFlatMapFunction[Context, InterpretationResult] with ProcessPartFunction {
 


### PR DESCRIPTION
Due to complex structure of invocations/serialization we compiled whole process in each Flink operator (in (A)SyncFunction). 
For diagrams with complex structure it slows initialization process significantly