### PR TITLE
[Improvement] Correct tests handling for EagerService

### DIFF
--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/test/InvocationCollectors.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/test/InvocationCollectors.scala
@@ -84,7 +84,7 @@ object InvocationCollectors {
       }
     }
 
-    private def withRunIdDefined[T](f: (TestRunId) => T): T = {
+    private def withRunIdDefined[T](f: TestRunId => T): T = {
       runIdOpt match {
         case Some(runId) => f(runId)
         case None => throw new IllegalStateException("RunId is not defined")
@@ -94,8 +94,9 @@ object InvocationCollectors {
   }
 
   case class TestServiceInvocationCollector(runIdOpt: Option[TestRunId],
-                                                    contextId: ContextId,
-                                                    nodeId: NodeId, serviceRef: String) extends ServiceInvocationCollector {
+                                            contextId: ContextId,
+                                            nodeId: NodeId,
+                                            serviceRef: String) extends ServiceInvocationCollector {
 
     override protected def collectorMode: CollectorMode = CollectorMode.Test
 

--- a/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/test/InvocationCollectors.scala
+++ b/engine/api/src/main/scala/pl/touk/nussknacker/engine/api/test/InvocationCollectors.scala
@@ -29,7 +29,6 @@ object InvocationCollectors {
 
   trait ServiceInvocationCollector {
 
-    def enable(runId: TestRunId): ServiceInvocationCollector
     protected def runIdOpt: Option[TestRunId]
     protected def collectorMode: CollectorMode
     protected def updateResult(runId: TestRunId, testInvocation: Any, name: String): Unit
@@ -64,8 +63,8 @@ object InvocationCollectors {
     }
   }
 
-  case class QueryServiceInvocationCollector private(runIdOpt: Option[TestRunId], serviceName: String) extends ServiceInvocationCollector {
-    def enable(runId: TestRunId) = this.copy(runIdOpt = Some(runId))
+  case class QueryServiceInvocationCollector(runIdOpt: Option[TestRunId], serviceName: String) extends ServiceInvocationCollector {
+
     override protected def collectorMode: CollectorMode = CollectorMode.Query
 
     override protected def updateResult(runId: TestRunId, testInvocation: Any, name: String): Unit = {
@@ -94,28 +93,16 @@ object InvocationCollectors {
 
   }
 
-  case class TestServiceInvocationCollector private(runIdOpt: Option[TestRunId],
+  case class TestServiceInvocationCollector(runIdOpt: Option[TestRunId],
                                                     contextId: ContextId,
                                                     nodeId: NodeId, serviceRef: String) extends ServiceInvocationCollector {
-    def enable(runId: TestRunId) = this.copy(runIdOpt = Some(runId))
+
     override protected def collectorMode: CollectorMode = CollectorMode.Test
 
     override protected def updateResult(runId: TestRunId, testInvocation: Any, name: String): Unit = {
       ResultsCollectingListenerHolder.updateResults(
         runId, _.updateMockedResult(nodeId.id, contextId, serviceRef, testInvocation)
       )
-    }
-  }
-
-  object TestServiceInvocationCollector {
-    def apply(contextId: ContextId, nodeId: NodeId, serviceRef: String): TestServiceInvocationCollector = {
-      TestServiceInvocationCollector(runIdOpt = None, contextId, nodeId, serviceRef)
-    }
-  }
-
-  object QueryServiceInvocationCollector {
-    def apply(serviceName: String): QueryServiceInvocationCollector = {
-      QueryServiceInvocationCollector(runIdOpt = None, serviceName = serviceName)
     }
   }
 

--- a/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/InterpreterSetup.scala
+++ b/engine/benchmarks/src/main/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/InterpreterSetup.scala
@@ -58,7 +58,7 @@ class InterpreterSetup[T:ClassTag] {
     val definitions = ProcessDefinitionExtractor.extractObjectWithMethods(configCreator,
       api.process.ProcessObjectDependencies(ConfigFactory.empty(), ObjectNamingProvider(getClass.getClassLoader)))
 
-    ProcessCompilerData.prepare(process, definitions, listeners, getClass.getClassLoader)(DefaultAsyncInterpretationValueDeterminer.DefaultValue)
+    ProcessCompilerData.prepare(process, definitions, listeners, getClass.getClassLoader, None)(DefaultAsyncInterpretationValueDeterminer.DefaultValue)
   }
 
   private def failOnErrors[Y](obj: ValidatedNel[ProcessCompilationError, Y]): Y = obj match {

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkProcessCompiler.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkProcessCompiler.scala
@@ -21,6 +21,7 @@ import pl.touk.nussknacker.engine.flink.util.listener.NodeCountMetricListener
 import pl.touk.nussknacker.engine.graph.EspProcess
 import pl.touk.nussknacker.engine.util.LoggingListener
 import pl.touk.nussknacker.engine.ModelData
+import pl.touk.nussknacker.engine.api.test.TestRunId
 import pl.touk.nussknacker.engine.modelconfig.{InputConfigDuringExecution, ModelConfigLoader}
 
 import scala.concurrent.duration.FiniteDuration
@@ -43,7 +44,7 @@ class FlinkProcessCompiler(creator: ProcessConfigCreator,
 
   def this(modelData: ModelData) = this(modelData.configCreator, modelData.inputConfigDuringExecution, modelData.modelConfigLoader, diskStateBackendSupport = true, modelData.objectNaming)
 
-  def compileProcess(process: EspProcess, processVersion: ProcessVersion)(userCodeClassLoader: ClassLoader): FlinkProcessCompilerData = {
+  def compileProcess(process: EspProcess, processVersion: ProcessVersion, testRunId: Option[TestRunId])(userCodeClassLoader: ClassLoader): FlinkProcessCompilerData = {
     val config = loadConfig(userCodeClassLoader)
     val processObjectDependencies = ProcessObjectDependencies(config, objectNaming)
 
@@ -59,7 +60,7 @@ class FlinkProcessCompiler(creator: ProcessConfigCreator,
     val listenersToUse = listeners(processObjectDependencies)
 
     val compiledProcess =
-      ProcessCompilerData.prepare(process, definitions(processObjectDependencies), listenersToUse, userCodeClassLoader)
+      ProcessCompilerData.prepare(process, definitions(processObjectDependencies), listenersToUse, userCodeClassLoader, testRunId)
 
     val compiledExceptionHandler = validateOrFailProcessCompilation(compiledProcess.compileExceptionHandler())
     val listeningExceptionHandler = new ListeningExceptionHandler(listenersToUse,

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/compiler/TestFlinkProcessCompiler.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/compiler/TestFlinkProcessCompiler.scala
@@ -43,16 +43,6 @@ class TestFlinkProcessCompiler(creator: ProcessConfigCreator,
     })
   }
 
-  override protected def prepareService(service: ObjectWithMethodDef): ObjectWithMethodDef = {
-    overrideObjectWithMethod(service, (parameterCreator: Map[String, Any], outputVariableNameOpt, additional: Seq[AnyRef], _) => {
-      val newAdditional = additional.map {
-        case c: ServiceInvocationCollector => c.enable(collectingListener.runId)
-        case a => a
-      }
-      service.invokeMethod(parameterCreator, outputVariableNameOpt, newAdditional)
-    })
-  }
-
   //exceptions are recorded any way, by listeners
   override protected def prepareExceptionHandler(exceptionHandler: ObjectWithMethodDef): ObjectWithMethodDef = {
     overrideObjectWithMethod(exceptionHandler, (_, _, _, _) =>
@@ -66,6 +56,8 @@ class TestFlinkProcessCompiler(creator: ProcessConfigCreator,
     )
   }
 
+  override protected def prepareService(service: ObjectWithMethodDef): ObjectWithMethodDef = service
 }
+
 
 

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
@@ -39,7 +39,7 @@ import scala.language.implicitConversions
   NOTE: We should try to use *ONLY* core Flink API here, to avoid version compatibility problems.
   Various NK-dependent Flink hacks should be, if possible, placed in StreamExecutionEnvPreparer.
  */
-class FlinkProcessRegistrar(compileProcess: (EspProcess, ProcessVersion) => ClassLoader => FlinkProcessCompilerData,
+class FlinkProcessRegistrar(compileProcess: (EspProcess, ProcessVersion, Option[TestRunId]) => ClassLoader => FlinkProcessCompilerData,
                             streamExecutionEnvPreparer: StreamExecutionEnvPreparer,
                             eventTimeMetricDuration: FiniteDuration) extends LazyLogging {
 
@@ -47,7 +47,7 @@ class FlinkProcessRegistrar(compileProcess: (EspProcess, ProcessVersion) => Clas
 
   def register(env: StreamExecutionEnvironment, process: EspProcess, processVersion: ProcessVersion, testRunId: Option[TestRunId] = None): Unit = {
     usingRightClassloader(env) {
-      val processCompilation = compileProcess(process, processVersion)
+      val processCompilation = compileProcess(process, processVersion, testRunId)
       val userClassLoader = UserClassLoader.get("root")
       //here we are sure the classloader is ok
       val processWithDeps = processCompilation(userClassLoader)

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -194,8 +194,7 @@ object SampleNodes {
   object CollectingEagerService extends EagerService {
 
     @MethodToInvoke
-    def invoke(@ParamName("static") static: String,
-               @ParamName("dynamic") dynamic: LazyParameter[String]): ServiceInvoker = new ServiceInvoker {
+    def invoke(@ParamName("static") static: String, @ParamName("dynamic") dynamic: LazyParameter[String]): ServiceInvoker = new ServiceInvoker {
       override def invokeService(params: Map[String, Any])(implicit ec: ExecutionContext,
                                                            collector: ServiceInvocationCollector,
                                                            contextId: ContextId): Future[Any] = {

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -191,6 +191,23 @@ object SampleNodes {
 
   }
 
+  object CollectingEagerService extends EagerService {
+
+    @MethodToInvoke
+    def invoke(@ParamName("static") static: String,
+               @ParamName("dynamic") dynamic: LazyParameter[String]): ServiceInvoker = new ServiceInvoker {
+      override def invokeService(params: Map[String, Any])(implicit ec: ExecutionContext,
+                                                           collector: ServiceInvocationCollector,
+                                                           contextId: ContextId): Future[Any] = {
+        collector.collect(s"static-$static-dynamic-${params("dynamic")}", Option(())) {
+          Future.successful(())
+        }
+      }
+
+      override def returnType: TypingResult = Typed[Void]
+    }
+
+  }
 
   object ServiceAcceptingScalaOption extends Service {
     @MethodToInvoke

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkStreamingProcessMainSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkStreamingProcessMainSpec.scala
@@ -45,8 +45,8 @@ class SimpleProcessConfigCreator extends EmptyProcessConfigCreator {
     "logService" -> WithCategories(LogService, "c1"),
     "throwingService" -> WithCategories(new ThrowingService(new RuntimeException("Thrown as expected")), "c1"),
     "throwingTransientService" -> WithCategories(new ThrowingService(new ConnectException()), "c1"),
-    "returningDependentTypeService" -> WithCategories(ReturningDependentTypeService, "c1")
-
+    "returningDependentTypeService" -> WithCategories(ReturningDependentTypeService, "c1"),
+    "collectingEager" -> WithCategories(CollectingEagerService, "c1")
   )
 
   override def sinkFactories(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[SinkFactory]] = Map(

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
@@ -46,6 +46,7 @@ class FlinkTestMainSpec extends FunSuite with Matchers with Inside with BeforeAn
         .source("id", "input")
         .filter("filter1", "#input.value1 > 1")
         .buildSimpleVariable("v1", "variable1", "'ala'")
+        .processor("eager1", "collectingEager", "static" -> "'s'", "dynamic" -> "#input.id")
         .processor("proc2", "logService", "all" -> "#input.id")
         .sink("out", "#input.value1", "monitor")
 
@@ -71,6 +72,8 @@ class FlinkTestMainSpec extends FunSuite with Matchers with Inside with BeforeAn
 
     results.mockedResults("proc2") shouldBe List(MockedResult("proc1-id-0-1", "logService", "0-collectedDuringServiceInvocation"))
     results.mockedResults("out") shouldBe List(MockedResult("proc1-id-0-1", "monitor", "11"))
+    results.mockedResults("eager1") shouldBe List(MockedResult("proc1-id-0-1", "collectingEager", "static-s-dynamic-0"))
+
     MonitorEmptySink.invocationsCount.get() shouldBe 0
     LogService.invocationsCount.get() shouldBe 0
   }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
@@ -249,7 +249,7 @@ object ProcessCompiler {
             dictRegistry: DictRegistry,
             expressionCompilerCreate: (ClassLoader, DictRegistry, ExpressionDefinition[ObjectWithMethodDef], ClassExtractionSettings) => ExpressionCompiler): ProcessCompiler = {
     val expressionCompiler = expressionCompilerCreate(classLoader, dictRegistry, definitions.expressionConfig, definitions.settings)
-    val nodeCompiler = new NodeCompiler(definitions, expressionCompiler, classLoader)
+    val nodeCompiler = new NodeCompiler(definitions, expressionCompiler, classLoader, None)
     val sub = new PartSubGraphCompiler(expressionCompiler, nodeCompiler)
     new ProcessCompiler(classLoader, sub, GlobalVariablesPreparer(definitions.expressionConfig), nodeCompiler)
   }

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilerData.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilerData.scala
@@ -7,6 +7,7 @@ import pl.touk.nussknacker.engine.Interpreter
 import pl.touk.nussknacker.engine.api.async.DefaultAsyncInterpretationValue
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.exception.EspExceptionHandler
+import pl.touk.nussknacker.engine.api.test.TestRunId
 import pl.touk.nussknacker.engine.api.{Lifecycle, MetaData, ProcessListener}
 import pl.touk.nussknacker.engine.compile.nodecompilation.NodeCompiler
 import pl.touk.nussknacker.engine.compiledgraph.CompiledProcessParts
@@ -30,7 +31,8 @@ object ProcessCompilerData {
   def prepare(process: EspProcess,
               definitions: ProcessDefinition[ObjectWithMethodDef],
               listeners: Seq[ProcessListener],
-              userCodeClassLoader: ClassLoader
+              userCodeClassLoader: ClassLoader,
+              testRunId: Option[TestRunId]
              )(implicit defaultAsyncValue: DefaultAsyncInterpretationValue): ProcessCompilerData = {
     val servicesDefs = definitions.services
 
@@ -39,7 +41,7 @@ object ProcessCompilerData {
 
     val expressionCompiler = ExpressionCompiler.withOptimization(userCodeClassLoader, dictRegistry, definitions.expressionConfig, definitions.settings)
     //for testing environment it's important to take classloader from user jar
-    val nodeCompiler = new NodeCompiler(definitions, expressionCompiler, userCodeClassLoader)
+    val nodeCompiler = new NodeCompiler(definitions, expressionCompiler, userCodeClassLoader, testRunId)
     val subCompiler = new PartSubGraphCompiler(expressionCompiler, nodeCompiler)
     val processCompiler = new ProcessCompiler(userCodeClassLoader, subCompiler, GlobalVariablesPreparer(definitions.expressionConfig), nodeCompiler)
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeDataValidator.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeDataValidator.scala
@@ -35,7 +35,7 @@ object NodeDataValidator {
         case spel: SpelExpressionParser => spel.typingDictLabels
       }
       val compiler = new NodeCompiler(modelData.processWithObjectsDefinition,
-        expressionCompiler, modelData.modelClassLoader.classLoader)
+        expressionCompiler, modelData.modelClassLoader.classLoader, None)
       implicit val nodeId: NodeId = NodeId(nodeData.id)
 
       nodeData match {

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/TestInfoProvider.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/TestInfoProvider.scala
@@ -32,7 +32,7 @@ class ModelDataTestInfoProvider(modelData: ModelData) extends TestInfoProvider w
     case spel: SpelExpressionParser => spel.typingDictLabels
   }
 
-  private lazy val nodeCompiler = new NodeCompiler(modelData.processWithObjectsDefinition, expressionCompiler, modelData.modelClassLoader.classLoader)
+  private lazy val nodeCompiler = new NodeCompiler(modelData.processWithObjectsDefinition, expressionCompiler, modelData.modelClassLoader.classLoader, None)
 
   override def getTestingCapabilities(metaData: MetaData, source: Source): TestingCapabilities = {
     val sourceObj = prepareSourceObj(source)(metaData)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQuery.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQuery.scala
@@ -46,13 +46,12 @@ class ServiceQuery(modelData: ModelData) {
     val definitions = modelData.withThisAsContextClassLoader {
       ProcessDefinitionExtractor.extractObjectWithMethods(modelData.configCreator, ProcessObjectDependencies(modelData.processConfig, modelData.objectNaming))
     }
-    val compiler = new NodeCompiler(definitions, ExpressionCompiler.withoutOptimization(modelData), modelData.modelClassLoader.classLoader)
+    val compiler = new NodeCompiler(definitions, ExpressionCompiler.withoutOptimization(modelData), modelData.modelClassLoader.classLoader, None)
 
 
     withOpenedService(serviceName, definitions) { 
 
-      val collector = QueryServiceInvocationCollector(serviceName)
-        .enable(TestRunId(UUID.randomUUID().toString))
+      val collector = QueryServiceInvocationCollector(Some(TestRunId(UUID.randomUUID().toString)), serviceName)
 
       val variablesPreparer = GlobalVariablesPreparer(definitions.expressionConfig)
       val validationContext = variablesPreparer.emptyValidationContext(metaData)

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
@@ -141,7 +141,7 @@ class InterpreterSpec extends FunSuite with Matchers {
 
     val definitions = ProcessDefinitionExtractor.extractObjectWithMethods(configCreator, api.process.ProcessObjectDependencies(ConfigFactory.empty(), ObjectNamingProvider(getClass.getClassLoader)))
 
-    ProcessCompilerData.prepare(process, definitions, listeners, getClass.getClassLoader)(DefaultAsyncInterpretationValueDeterminer.DefaultValue)
+    ProcessCompilerData.prepare(process, definitions, listeners, getClass.getClassLoader, None)(DefaultAsyncInterpretationValueDeterminer.DefaultValue)
   }
 
   private def failOnErrors[T](obj: ValidatedNel[ProcessCompilationError, T]): T = obj match {

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ServiceInvokerTest.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ServiceInvokerTest.scala
@@ -19,7 +19,7 @@ class ServiceInvokerTest extends FlatSpec with PatientScalaFutures with OptionVa
   private val nodeId = NodeId("id")
   private val jobData: JobData = JobData(metadata, ProcessVersion.empty)
   private implicit val ctxId: ContextId = ContextId("")
-  private implicit val collector: TestServiceInvocationCollector = TestServiceInvocationCollector(ctxId, nodeId, "")
+  private implicit val collector: TestServiceInvocationCollector = TestServiceInvocationCollector(None, ctxId, nodeId, "")
 
   it should "invoke service method with declared parameters as scala params" in {
     val mock = new MockService(jobData)

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQuerySpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQuerySpec.scala
@@ -1,24 +1,32 @@
 package pl.touk.nussknacker.engine.util.service.query
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{FlatSpec, Matchers}
-import pl.touk.nussknacker.engine.api.{MethodToInvoke, ParamName, Service}
+import org.scalatest.{FlatSpec, Matchers, stats}
+import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
+import pl.touk.nussknacker.engine.api.context.transformation.{NodeDependencyValue, SingleInputGenericNodeTransformation}
+import pl.touk.nussknacker.engine.api.definition.{NodeDependency, Parameter, ParameterWithExtractor}
+import pl.touk.nussknacker.engine.api.{ContextId, EagerService, LazyParameter, MethodToInvoke, ParamName, Service, ServiceInvoker}
 import pl.touk.nussknacker.engine.api.process.{ExpressionConfig, ProcessObjectDependencies, WithCategories}
+import pl.touk.nussknacker.engine.api.test.ServiceInvocationCollector
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
 import pl.touk.nussknacker.engine.util.process.EmptyProcessConfigCreator
+import pl.touk.nussknacker.engine.util.service.query.QueryServiceTesting.CollectingDynamicEagerService.static
 import pl.touk.nussknacker.engine.util.service.query.ServiceQuery.{QueryResult, ServiceNotFoundException}
-import pl.touk.nussknacker.engine.util.service.query.QueryServiceTesting.{ConcatService, CreateQuery}
+import pl.touk.nussknacker.engine.util.service.query.QueryServiceTesting.{CollectingDynamicEagerService, CollectingEagerService, ConcatService, CreateQuery}
 import pl.touk.nussknacker.test.PatientScalaFutures
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
 class ServiceQuerySpec extends FlatSpec with Matchers with PatientScalaFutures {
+
   import pl.touk.nussknacker.engine.spel.Implicits._
 
   override def spanScaleFactor: Double = 2
+
   private implicit val ec: ExecutionContext = SynchronousExecutionContext.ctx
 
   it should "evaluate spel expressions" in {
@@ -41,6 +49,12 @@ class ServiceQuerySpec extends FlatSpec with Matchers with PatientScalaFutures {
     assertThrows[ServiceNotFoundException](Await.result(CreateQuery("srv", new ConcatService).invoke("dummy"), 1 second))
   }
 
+  it should "invoke eager service" in {
+    List(CollectingDynamicEagerService, CollectingEagerService).foreach { service =>
+      invokeService(service, "static" -> "'s'", "dynamic" -> "'d'").futureValue.result shouldBe "static-s-dynamic-d"
+    }
+  }
+
   private def invokeConcatService(s1: String, s2: String) =
     invokeService(new ConcatService, "s1" -> s1, "s2" -> s2)
 
@@ -52,6 +66,32 @@ class ServiceQuerySpec extends FlatSpec with Matchers with PatientScalaFutures {
 
 
 object QueryServiceTesting {
+
+  class ConcatService extends Service {
+    @MethodToInvoke
+    def concat(@ParamName("s1") s1: String, @ParamName("s2") s2: String)
+              (implicit executionContext: ExecutionContext): Future[String] = {
+      if (s1 == "fail") {
+        Future.failed(new IllegalArgumentException("Fail"))
+      } else {
+        Future(s1 + s2)
+      }
+    }
+  }
+
+  class CollectingEagerInvoker(static: String) extends ServiceInvoker {
+    override def invokeService(params: Map[String, Any])(implicit ec: ExecutionContext,
+                                                         collector: ServiceInvocationCollector,
+                                                         contextId: ContextId): Future[Any] = {
+      val returnValue = s"static-$static-dynamic-${params("dynamic")}"
+      collector.collect("mocked" + returnValue, Option("")) {
+        Future.successful(returnValue)
+      }
+    }
+
+    override def returnType: TypingResult = Typed[String]
+
+  }
 
   object InvokeService {
     def apply(service: Service, args: (String, Expression)*)
@@ -75,16 +115,34 @@ object QueryServiceTesting {
     }
   }
 
-  class ConcatService extends Service {
+  object CollectingEagerService extends EagerService {
+
     @MethodToInvoke
-    def concat(@ParamName("s1") s1: String, @ParamName("s2") s2: String)
-              (implicit executionContext: ExecutionContext): Future[String] = {
-      if (s1 == "fail") {
-        Future.failed(new IllegalArgumentException("Fail"))
-      } else {
-        Future(s1 + s2)
-      }
+    def invoke(@ParamName("static") static: String,
+               @ParamName("dynamic") dynamic: LazyParameter[String]): ServiceInvoker = new CollectingEagerInvoker(static)
+
+  }
+
+  object CollectingDynamicEagerService extends EagerService with SingleInputGenericNodeTransformation[ServiceInvoker] {
+
+    override type State = Nothing
+    private val static = ParameterWithExtractor.mandatory[String]("static")
+    private val dynamic = ParameterWithExtractor.lazyMandatory[String]("dynamic")
+
+    override def contextTransformation(context: ValidationContext,
+                                       dependencies: List[NodeDependencyValue])
+                                      (implicit nodeId: ProcessCompilationError.NodeId): CollectingDynamicEagerService.NodeTransformationDefinition = {
+      case TransformationStep(Nil, _) => NextParameters(initialParameters)
+      case TransformationStep(_, _) => FinalResults(context)
     }
+
+    override def initialParameters: List[Parameter] = List(static.parameter, dynamic.parameter)
+
+    override def implementation(params: Map[String, Any],
+                                dependencies: List[NodeDependencyValue],
+                                finalState: Option[State]): ServiceInvoker = new CollectingEagerInvoker(static.extractValue(params))
+
+    override def nodeDependencies: List[NodeDependency] = Nil
   }
 
 }

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQuerySpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/util/service/query/ServiceQuerySpec.scala
@@ -1,19 +1,18 @@
 package pl.touk.nussknacker.engine.util.service.query
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{FlatSpec, Matchers, stats}
+import org.scalatest.{FlatSpec, Matchers}
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.context.transformation.{NodeDependencyValue, SingleInputGenericNodeTransformation}
 import pl.touk.nussknacker.engine.api.definition.{NodeDependency, Parameter, ParameterWithExtractor}
 import pl.touk.nussknacker.engine.api.{ContextId, EagerService, LazyParameter, MethodToInvoke, ParamName, Service, ServiceInvoker}
 import pl.touk.nussknacker.engine.api.process.{ExpressionConfig, ProcessObjectDependencies, WithCategories}
-import pl.touk.nussknacker.engine.api.test.ServiceInvocationCollector
+import pl.touk.nussknacker.engine.api.test.InvocationCollectors.ServiceInvocationCollector
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
 import pl.touk.nussknacker.engine.util.process.EmptyProcessConfigCreator
-import pl.touk.nussknacker.engine.util.service.query.QueryServiceTesting.CollectingDynamicEagerService.static
 import pl.touk.nussknacker.engine.util.service.query.ServiceQuery.{QueryResult, ServiceNotFoundException}
 import pl.touk.nussknacker.engine.util.service.query.QueryServiceTesting.{CollectingDynamicEagerService, CollectingEagerService, ConcatService, CreateQuery}
 import pl.touk.nussknacker.test.PatientScalaFutures

--- a/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/test/StandaloneTestMainSpec.scala
+++ b/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/test/StandaloneTestMainSpec.scala
@@ -30,6 +30,7 @@ class StandaloneTestMainSpec extends FunSuite with Matchers with BeforeAndAfterE
       .filter("filter1", "#input.field1() == 'a'")
       .enricher("enricher", "var1", "enricherService")
       .processor("processor", "processorService")
+      .processor("eagerProcessor", "collectingEager", "static" -> "'s'", "dynamic" -> "#input.field1()")
       .sink("endNodeIID", "#var1", "response-sink")
 
     val input = """{ "field1": "a", "field2": "b" }
@@ -53,6 +54,8 @@ class StandaloneTestMainSpec extends FunSuite with Matchers with BeforeAndAfterE
     )
 
     results.mockedResults("processor").toSet shouldBe Set(MockedResult("proc1-0", "processorService", "processor service invoked"))
+    results.mockedResults("eagerProcessor").toSet shouldBe Set(MockedResult("proc1-0", "collectingEager", "static-s-dynamic-a"))
+
     results.mockedResults("endNodeIID").toSet shouldBe Set(MockedResult("proc1-0",
       "endNodeIID", s"""{
                       |  "field1" : "alamakota-$defaultContextId"


### PR DESCRIPTION
The main change is passing TestRunId to compiler explicitly, without hacks in e.g. TestFlinkProcessCompiler. 
This is first PR with test handling refactor. Some more will follow :)