### PR TITLE
Global ExecutionContext and local Sttp backend removed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -250,6 +250,7 @@ val jbcryptV = "0.4"
 val cronParserV = "9.1.3"
 val javaxValidationApiV = "2.0.1.Final"
 val caffeineCacheV = "2.8.2"
+val sttpV = "2.2.3"
 
 lazy val dockerSettings = {
   val workingDir = "/opt/nussknacker"
@@ -826,7 +827,6 @@ lazy val httpUtils = (project in engine("httpUtils")).
   settings(
     name := "nussknacker-http-utils",
     libraryDependencies ++= {
-      val sttpV = "2.2.3"
       Seq(
         "io.circe" %% "circe-core" % circeV,
         "io.circe" %% "circe-parser" % circeV,
@@ -925,6 +925,7 @@ lazy val ui = (project in file("ui/server"))
         "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % "test",
         "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
         "de.heikoseeberger" %% "akka-http-circe" % akkaHttpCirceV,
+        "com.softwaremill.sttp.client" %% "akka-http-backend" % sttpV,
 
         "ch.qos.logback" % "logback-core" % logbackV,
         "ch.qos.logback" % "logback-classic" % logbackV,
@@ -945,7 +946,7 @@ lazy val ui = (project in file("ui/server"))
 
         "com.typesafe.slick" %% "slick-testkit" % slickV % "test",
         "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % "test",
-        "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % "test"
+        "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % "test",
       )
     }
   )

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticatorProvider.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticatorProvider.scala
@@ -6,9 +6,12 @@ import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
 import pl.touk.nussknacker.ui.security.api.AuthenticatorFactory.AuthenticatorData
 import pl.touk.nussknacker.ui.security.basicauth.BasicAuthenticatorFactory
 import pl.touk.nussknacker.ui.security.api.oauth2.OAuth2AuthenticatorFactory
+import sttp.client.{NothingT, SttpBackend}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 object AuthenticatorProvider extends LazyLogging {
-  def apply(config: Config, classLoader: ClassLoader, allCategories: List[String]): AuthenticatorData = {
+  def apply(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticatorData = {
     val loaded = ScalaServiceLoader.loadClass[AuthenticatorFactory](classLoader) {
       AuthenticationConfiguration.parseMethod(config) match {
         case AuthenticationMethod.OAuth2 => OAuth2AuthenticatorFactory()

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticator.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticator.scala
@@ -7,8 +7,7 @@ import pl.touk.nussknacker.engine.util.cache.DefaultCache
 import pl.touk.nussknacker.ui.security.api.{DefaultAuthenticationConfiguration, LoggedUser, RulesSet}
 import pl.touk.nussknacker.ui.security.basicauth.BasicHttpAuthenticator.{EncryptedPassword, PlainPassword, UserWithPassword}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class BasicHttpAuthenticator(configuration: DefaultAuthenticationConfiguration, allCategories: List[String]) extends SecurityDirectives.AsyncAuthenticator[LoggedUser] {
   //If we want use always reloaded config then we need just prepareUsers()
@@ -17,7 +16,7 @@ class BasicHttpAuthenticator(configuration: DefaultAuthenticationConfiguration, 
   private val hashesCache =
     configuration.cachingHashesOrDefault.toCacheConfig.map(DefaultCache[(String, String), String])
 
-  def apply(credentials: Credentials): Future[Option[LoggedUser]] = Future {
+  def apply(credentials: Credentials): Future[Option[LoggedUser]] = Future.successful {
     credentials match {
       case d@Provided(id) => authenticate(d)
       case _ => None

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2Authenticator.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2Authenticator.scala
@@ -5,11 +5,13 @@ import akka.http.scaladsl.server.directives.{Credentials, SecurityDirectives}
 import cats.data.NonEmptyList
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.ui.security.api.LoggedUser
+import sttp.client.{NothingT, SttpBackend}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class OAuth2Authenticator(configuration: OAuth2Configuration, service: OAuth2Service) extends SecurityDirectives.AsyncAuthenticator[LoggedUser] with LazyLogging {
+class OAuth2Authenticator(configuration: OAuth2Configuration, service: OAuth2Service)
+                         (implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT])
+  extends SecurityDirectives.AsyncAuthenticator[LoggedUser] with LazyLogging {
   def apply(credentials: Credentials): Future[Option[LoggedUser]] =
     authenticate(credentials)
 
@@ -27,7 +29,7 @@ class OAuth2Authenticator(configuration: OAuth2Configuration, service: OAuth2Ser
 }
 
 object OAuth2Authenticator extends LazyLogging {
-  def apply(configuration: OAuth2Configuration, service: OAuth2Service): OAuth2Authenticator =
+  def apply(configuration: OAuth2Configuration, service: OAuth2Service)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2Authenticator =
     new OAuth2Authenticator(configuration, service)
 }
 

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticatorFactory.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticatorFactory.scala
@@ -7,10 +7,12 @@ import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.ui.security.api.AuthenticatorFactory
 import pl.touk.nussknacker.ui.security.api.AuthenticatorFactory.{AuthenticatorData, LoggedUserAuth}
 import pl.touk.nussknacker.ui.security.oauth2.{AuthenticationOAuth2Resources, OAuth2Authenticator, OAuth2Configuration, OAuth2Service, OAuth2ServiceProvider}
+import sttp.client.{NothingT, SttpBackend}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 
-class OAuth2AuthenticatorFactory extends AuthenticatorFactory with LazyLogging {
-  import scala.concurrent.ExecutionContext.Implicits.global
+class OAuth2AuthenticatorFactory(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]) extends AuthenticatorFactory with LazyLogging {
 
   override def createAuthenticator(config: Config, classLoader: ClassLoader, allCategories: List[String]): AuthenticatorData = {
     val configuration = OAuth2Configuration.create(config)
@@ -34,5 +36,5 @@ class OAuth2AuthenticatorFactory extends AuthenticatorFactory with LazyLogging {
 }
 
 object OAuth2AuthenticatorFactory {
-  def apply(): OAuth2AuthenticatorFactory = new OAuth2AuthenticatorFactory()
+  def apply()(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2AuthenticatorFactory = new OAuth2AuthenticatorFactory()
 }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ClientApi.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ClientApi.scala
@@ -16,8 +16,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class OAuth2ClientApi[ProfileResponse: Decoder, AccessTokenResponse: Decoder]
 (configuration: OAuth2Configuration)
-(implicit backend: SttpBackend[Future, Nothing, NothingT]) extends LazyLogging {
-  private implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+(implicit ec: ExecutionContext, backend: SttpBackend[Future, Nothing, NothingT]) extends LazyLogging {
   import io.circe.syntax._
 
   def accessTokenRequest(authorizeToken: String): Future[AccessTokenResponse] = {
@@ -74,8 +73,8 @@ class OAuth2ClientApi[ProfileResponse: Decoder, AccessTokenResponse: Decoder]
 }
 
 object OAuth2ClientApi {
-  implicit val backend: SttpBackend[Future, Nothing, NothingT] = AsyncHttpClientFutureBackend.usingConfig(new DefaultAsyncHttpClientConfig.Builder().build())
-  def apply[ProfileResponse: Decoder, AccessTokenResponse: Decoder](configuration: OAuth2Configuration): OAuth2ClientApi[ProfileResponse, AccessTokenResponse]
+  def apply[ProfileResponse: Decoder, AccessTokenResponse: Decoder](configuration: OAuth2Configuration)
+                                                                   (implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2ClientApi[ProfileResponse, AccessTokenResponse]
     = new OAuth2ClientApi[ProfileResponse, AccessTokenResponse](configuration)
 
   @JsonCodec case class DefaultAccessTokenResponse(access_token: String, token_type: String, refresh_token: Option[String])

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceFactory.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceFactory.scala
@@ -1,8 +1,11 @@
 package pl.touk.nussknacker.ui.security.oauth2
 
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
 import pl.touk.nussknacker.ui.security.api.LoggedUser
+import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
+import sttp.client.{NothingT, SttpBackend}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait OAuth2Service {
   def authenticate(code: String): Future[OAuth2AuthenticateData]
@@ -10,7 +13,7 @@ trait OAuth2Service {
 }
 
 trait OAuth2ServiceFactory {
-  def create(configuration: OAuth2Configuration, allCategories: List[String]): OAuth2Service
+  def create(configuration: OAuth2Configuration, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2Service
 }
 
 case class OAuth2AuthenticateData(access_token: String, token_type: String, refresh_token: Option[String])

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceProvider.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceProvider.scala
@@ -2,9 +2,12 @@ package pl.touk.nussknacker.ui.security.oauth2
 
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
+import sttp.client.{NothingT, SttpBackend}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 object OAuth2ServiceProvider extends LazyLogging {
-  def apply(configuration: OAuth2Configuration, classLoader: ClassLoader, allCategories: List[String] = Nil): OAuth2Service = {
+  def apply(configuration: OAuth2Configuration, classLoader: ClassLoader, allCategories: List[String] = Nil)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2Service = {
     val service = ScalaServiceLoader.loadClass[OAuth2ServiceFactory](classLoader) {
       DefaultOAuth2ServiceFactory()
     }

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticatorDataSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticatorDataSpec.scala
@@ -6,6 +6,8 @@ import pl.touk.nussknacker.ui.security.api.AuthenticationConfiguration.{ConfigRu
 import pl.touk.nussknacker.ui.security.api.AuthenticationMethod.AuthenticationMethod
 import pl.touk.nussknacker.ui.security.api.{AuthenticationMethod, CachingHashesConfig, DefaultAuthenticationConfiguration}
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 
 class BasicHttpAuthenticatorDataSpec extends FunSpec with Matchers {
   class DummyConfiguration(usersList: List[ConfigUser], rulesList: List[ConfigRule] = List.empty, method: AuthenticationMethod = AuthenticationMethod.BasicAuth,

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ClientApiSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ClientApiSpec.scala
@@ -9,6 +9,8 @@ import sttp.client.StringBody
 import sttp.client.testing.SttpBackendStub
 import sttp.model.{Header, HeaderNames, MediaType, Uri}
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class OAuth2ClientApiSpec extends FlatSpec with Matchers with BeforeAndAfter with PatientScalaFutures with Suite  {
   import io.circe.syntax._
 

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceProviderSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceProviderSpec.scala
@@ -1,8 +1,15 @@
 package pl.touk.nussknacker.ui.security.oauth2
 
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
 import org.scalatest.{FlatSpec, Matchers}
+import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
+import sttp.client.{NothingT, SttpBackend}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class OAuth2ServiceProviderSpec extends FlatSpec with Matchers {
+  implicit val backend: SttpBackend[Future, Nothing, NothingT] = AsyncHttpClientFutureBackend.usingConfig(new DefaultAsyncHttpClientConfig.Builder().build())
   it should "return default OAuth2 service" in {
     OAuth2ServiceProvider(ExampleOAuth2ServiceFactory.testConfig, this.getClass.getClassLoader, List.empty) shouldBe a[OAuth2Service]
   }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.ui
 
 import java.lang.Thread.UncaughtExceptionHandler
+
 import _root_.cors.CorsSupport
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.{Directives, Route}
@@ -35,6 +36,8 @@ import pl.touk.nussknacker.ui.security.ssl._
 import pl.touk.nussknacker.ui.uiresolving.UIProcessResolving
 import pl.touk.nussknacker.ui.validation.ProcessValidation
 import slick.jdbc.{HsqldbProfile, JdbcBackend, JdbcProfile, PostgresProfile}
+import sttp.client.{NothingT, SttpBackend}
+import sttp.client.akkahttp.AkkaHttpBackend
 
 import scala.concurrent.Future
 
@@ -51,6 +54,8 @@ object NusskanckerDefaultAppRouter extends NusskanckerAppRouter {
 
   override def create(config: Config, dbConfig: DbConfig)(implicit system: ActorSystem, materializer: Materializer): (Route, Iterable[AutoCloseable]) = {
     import system.dispatcher
+
+    implicit val sttpBackend: SttpBackend[Future, Nothing, NothingT] = AkkaHttpBackend()
 
     val testResultsMaxSizeInBytes = config.getOrElse[Int]("testResultsMaxSizeInBytes", 500 * 1024 * 1000)
     val environment = config.getString("environment")


### PR DESCRIPTION
I have found `ExecutionContext.Implicits.global` in a few places in the security package and changed it to implicit parameters so that we could use the main (from Akka) NK execution context.

I have also removed a locally created Sttp backend in favour of one created from Akka.