### PR TITLE
[Improvement] RecordFormatter simplifications, correct json handling

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -27,6 +27,7 @@ Nussknacker versions
 * [#1373](https://github.com/TouK/nussknacker/pull/1373) Ability to load custom model config programmatically
 * [#1406](https://github.com/TouK/nussknacker/pull/1406) Eager services - ability to create service object using static parameters
 * [#1428](https://gihub.com/TouK/nussknacker/pull/1428) Kafka SchemaRegistry source/sink can use JSON payloads. In this PR we assume one schema registry contains either json or avro payloads but not both.                                         
+* [#1445](https://gihub.com/TouK/nussknacker/pull/1445) Small refactor of RecordFormatter, correct handling different formatting in kafka-json in test data generation
 
 0.3.1 (not released yet) 
 ------------------------

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -23,6 +23,7 @@ To see biggest differences please consult the [changelog](Changelog.md).
 * [#1373](https://github.com/TouK/nussknacker/pull/1373) Creating `ClassLoaderModelData` directly is not allowed, use
   `ModelData.apply` with plain config, wrapping with ModelConfigToLoad by yourself is not needed.
 * [#1406](https://github.com/TouK/nussknacker/pull/1406) `ServiceReturningType` is deprecated in favour of `EagerService` 
+* [#1445](https://gihub.com/TouK/nussknacker/pull/1445) `RecordFormatter` now handles `TestDataSplit` for Kafka sources. It is required in `KafkaSource` creation, instead of `TestDataSplit` 
 
 ## In version 0.3.0
 

--- a/engine/demo/src/main/java/pl/touk/nussknacker/engine/javademo/DemoProcessConfigCreator.java
+++ b/engine/demo/src/main/java/pl/touk/nussknacker/engine/javademo/DemoProcessConfigCreator.java
@@ -28,6 +28,7 @@ import pl.touk.nussknacker.engine.flink.api.timestampwatermark.StandardTimestamp
 import pl.touk.nussknacker.engine.flink.api.timestampwatermark.TimestampWatermarkHandler;
 import pl.touk.nussknacker.engine.javaapi.process.ExpressionConfig;
 import pl.touk.nussknacker.engine.javaapi.process.ProcessConfigCreator;
+import pl.touk.nussknacker.engine.kafka.generic.sources;
 import pl.touk.nussknacker.engine.kafka.serialization.KafkaSerializationSchemaFactory;
 import pl.touk.nussknacker.engine.kafka.serialization.schemas;
 import pl.touk.nussknacker.engine.kafka.sink.KafkaSinkFactory;
@@ -87,7 +88,7 @@ public class DemoProcessConfigCreator implements ProcessConfigCreator {
         return new KafkaSourceFactory<>(
                 schema,
                 Option.apply(extractor),
-                TestParsingUtils.newLineSplit(),
+                sources.JsonRecordFormatter$.MODULE$,
                 processObjectDependencies,
                 ClassTag$.MODULE$.apply(Transaction.class)
         );

--- a/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/SchemaRegistryProvider.scala
+++ b/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/SchemaRegistryProvider.scala
@@ -13,7 +13,7 @@ trait SchemaRegistryProvider extends Serializable {
 
   def serializationSchemaFactory: KafkaAvroSerializationSchemaFactory
 
-  def recordFormatter(topic: String): Option[RecordFormatter]
+  def recordFormatter: RecordFormatter
 
   def validateSchema(schema: Schema): ValidatedNel[SchemaRegistryError, Schema]
 }

--- a/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/ConfluentSchemaRegistryProvider.scala
+++ b/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/ConfluentSchemaRegistryProvider.scala
@@ -18,8 +18,8 @@ class ConfluentSchemaRegistryProvider(schemaRegistryClientFactory: ConfluentSche
                                       kafkaConfig: KafkaConfig,
                                       formatKey: Boolean) extends SchemaRegistryProvider {
 
-  override def recordFormatter(topic: String): Option[RecordFormatter] =
-    Some(ConfluentAvroToJsonFormatter(schemaRegistryClientFactory, kafkaConfig, topic, formatKey))
+  override def recordFormatter: RecordFormatter =
+    ConfluentAvroToJsonFormatter(schemaRegistryClientFactory, kafkaConfig, formatKey)
 
   override def createSchemaRegistryClient: ConfluentSchemaRegistryClient =
     schemaRegistryClientFactory.createSchemaRegistryClient(kafkaConfig)

--- a/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/formatter/ConfluentAvroMessageFormatter.scala
+++ b/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/formatter/ConfluentAvroMessageFormatter.scala
@@ -28,7 +28,8 @@ private[confluent] class ConfluentAvroMessageFormatter(schemaRegistryClient: Sch
     val schema = AvroSchemaUtils.getSchema(obj)
 
     try {
-      val encoder = encoderFactory.jsonEncoder(schema, output)
+      //pretty = false is important, as we rely on the fact that there are no new lines in message parsing
+      val encoder = encoderFactory.jsonEncoder(schema, output, false)
       val writer = new GenericDatumWriter[AnyRef](schema)
       obj match {
         case bytes: Array[Byte] =>

--- a/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/source/BaseKafkaAvroSourceFactory.scala
+++ b/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/source/BaseKafkaAvroSourceFactory.scala
@@ -23,7 +23,7 @@ abstract class BaseKafkaAvroSourceFactory[T: ClassTag](timestampAssigner: Option
   def createSource(preparedTopic: PreparedKafkaTopic,
                    kafkaConfig: KafkaConfig,
                    deserializationSchemaFactory: KafkaAvroDeserializationSchemaFactory,
-                   createRecordFormatter: String => Option[RecordFormatter],
+                   createRecordFormatter: RecordFormatter,
                    schemaDeterminer: AvroSchemaDeterminer,
                    returnGenericAvroType: Boolean)
                   (implicit processMetaData: MetaData,
@@ -38,8 +38,7 @@ abstract class BaseKafkaAvroSourceFactory[T: ClassTag](timestampAssigner: Option
         kafkaConfig,
         deserializationSchemaFactory.create[T](schemaUsedInRuntime, kafkaConfig),
         assignerToUse(kafkaConfig),
-        createRecordFormatter(preparedTopic.prepared),
-        TestParsingUtils.newLineSplit
+        createRecordFormatter
       ) with ReturningType {
         override def returnType: typing.TypingResult = AvroSchemaTypeDefinitionExtractor.typeDefinition(schemaData.schema)
       }
@@ -49,8 +48,7 @@ abstract class BaseKafkaAvroSourceFactory[T: ClassTag](timestampAssigner: Option
         kafkaConfig,
         deserializationSchemaFactory.create[T](schemaUsedInRuntime, kafkaConfig),
         assignerToUse(kafkaConfig),
-        createRecordFormatter(preparedTopic.prepared),
-        TestParsingUtils.newLineSplit
+        createRecordFormatter
       )
     }
   }

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/RecordFormatter.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/RecordFormatter.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.kafka
 
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
+import pl.touk.nussknacker.engine.api.test.{TestDataSplit, TestParsingUtils}
 
 /**
   * It is interface for bi-directional conversion between Kafka record and bytes. It is used when data
@@ -10,8 +11,32 @@ import org.apache.kafka.clients.producer.ProducerRecord
   */
 trait RecordFormatter {
 
-  def formatRecord(record: ConsumerRecord[Array[Byte], Array[Byte]]): Array[Byte]
+  protected def formatRecord(record: ConsumerRecord[Array[Byte], Array[Byte]]): Array[Byte]
 
-  def parseRecord(bytes: Array[Byte]): ProducerRecord[Array[Byte], Array[Byte]]
+  protected def parseRecord(topic: String, bytes: Array[Byte]): ProducerRecord[Array[Byte], Array[Byte]]
 
+  protected def testDataSplit: TestDataSplit
+
+  def prepareGeneratedTestData(records: List[ConsumerRecord[Array[Byte], Array[Byte]]]): Array[Byte] = {
+    testDataSplit.joinData(records.map(formatRecord))
+  }
+
+  def parseDataForTest(topic: String, mergedData: Array[Byte]): List[ProducerRecord[Array[Byte], Array[Byte]]] = {
+    testDataSplit.splitData(mergedData).map { formatted =>
+      parseRecord(topic, formatted)
+    }
+  }
+
+}
+
+object BasicFormatter extends BasicFormatter
+
+trait BasicFormatter extends RecordFormatter {
+
+  override def formatRecord(record: ConsumerRecord[Array[Byte], Array[Byte]]): Array[Byte] = record.value()
+
+  override def parseRecord(topic: String, bytes: Array[Byte]): ProducerRecord[Array[Byte], Array[Byte]] =
+    new ProducerRecord[Array[Byte], Array[Byte]](topic, bytes)
+
+  override def testDataSplit: TestDataSplit = TestParsingUtils.newLineSplit
 }

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/source/KafkaSourceFactory.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/source/KafkaSourceFactory.scala
@@ -1,18 +1,17 @@
 package pl.touk.nussknacker.engine.kafka.source
 
-import javax.validation.constraints.NotBlank
 import org.apache.flink.api.common.serialization.DeserializationSchema
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.NodeId
 import pl.touk.nussknacker.engine.api.editor.{DualEditor, DualEditorMode, SimpleEditor, SimpleEditorType}
 import pl.touk.nussknacker.engine.api.process.{ProcessObjectDependencies, Source, TestDataGenerator}
-import pl.touk.nussknacker.engine.api.test.TestDataSplit
 import pl.touk.nussknacker.engine.api.{MetaData, MethodToInvoke, ParamName}
 import pl.touk.nussknacker.engine.flink.api.process.FlinkSourceFactory
 import pl.touk.nussknacker.engine.flink.api.timestampwatermark.TimestampWatermarkHandler
 import pl.touk.nussknacker.engine.kafka.KafkaFactory._
 import pl.touk.nussknacker.engine.kafka.serialization.{FixedKafkaDeserializationSchemaFactory, KafkaDeserializationSchemaFactory}
-import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaUtils}
+import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaUtils, RecordFormatter}
 
+import javax.validation.constraints.NotBlank
 import scala.reflect.ClassTag
 
 /** <pre>
@@ -31,18 +30,18 @@ import scala.reflect.ClassTag
   * */
 class KafkaSourceFactory[T: ClassTag](deserializationSchemaFactory: KafkaDeserializationSchemaFactory[T],
                                       timestampAssigner: Option[TimestampWatermarkHandler[T]],
-                                      testPrepareInfo: TestDataSplit,
+                                      formatter: RecordFormatter,
                                       processObjectDependencies: ProcessObjectDependencies)
-  extends BaseKafkaSourceFactory(deserializationSchemaFactory, timestampAssigner, testPrepareInfo, processObjectDependencies) {
+  extends BaseKafkaSourceFactory(deserializationSchemaFactory, timestampAssigner, formatter, processObjectDependencies) {
 
   def this(deserializationSchema: DeserializationSchema[T],
            timestampAssigner: Option[TimestampWatermarkHandler[T]],
-           testPrepareInfo: TestDataSplit,
+           formatter: RecordFormatter,
            processObjectDependencies: ProcessObjectDependencies) =
     this(
       FixedKafkaDeserializationSchemaFactory(deserializationSchema),
       timestampAssigner,
-      testPrepareInfo,
+      formatter,
       processObjectDependencies
     )
 
@@ -62,20 +61,20 @@ class KafkaSourceFactory[T: ClassTag](deserializationSchemaFactory: KafkaDeseria
 class SingleTopicKafkaSourceFactory[T: ClassTag](topic: String,
                                                  deserializationSchemaFactory: KafkaDeserializationSchemaFactory[T],
                                                  timestampAssigner: Option[TimestampWatermarkHandler[T]],
-                                                 testPrepareInfo: TestDataSplit,
+                                                 formatter: RecordFormatter,
                                                  processObjectDependencies: ProcessObjectDependencies)
-  extends BaseKafkaSourceFactory(deserializationSchemaFactory, timestampAssigner, testPrepareInfo, processObjectDependencies) {
+  extends BaseKafkaSourceFactory(deserializationSchemaFactory, timestampAssigner, formatter, processObjectDependencies) {
 
   def this(topic: String,
            deserializationSchema: DeserializationSchema[T],
            timestampAssigner: Option[TimestampWatermarkHandler[T]],
-           testPrepareInfo: TestDataSplit,
+           formatter: RecordFormatter,
            processObjectDependencies: ProcessObjectDependencies) =
     this(
       topic,
       FixedKafkaDeserializationSchemaFactory(deserializationSchema),
       timestampAssigner,
-      testPrepareInfo,
+      formatter,
       processObjectDependencies
     )
 
@@ -88,7 +87,7 @@ class SingleTopicKafkaSourceFactory[T: ClassTag](topic: String,
 
 abstract class BaseKafkaSourceFactory[T: ClassTag](deserializationSchemaFactory: KafkaDeserializationSchemaFactory[T],
                                                    timestampAssigner: Option[TimestampWatermarkHandler[T]],
-                                                   testPrepareInfo: TestDataSplit,
+                                                   formatter: RecordFormatter,
                                                    processObjectDependencies: ProcessObjectDependencies)
   extends FlinkSourceFactory[T] with Serializable {
 
@@ -101,6 +100,6 @@ abstract class BaseKafkaSourceFactory[T: ClassTag](deserializationSchemaFactory:
     val preparedTopics = topics.map(KafkaUtils.prepareKafkaTopic(_, processObjectDependencies))
     val serializationSchema = deserializationSchemaFactory.create(topics, kafkaConfig)
     serializationSchema.getProducedType
-    new KafkaSource(preparedTopics, kafkaConfig, serializationSchema, timestampAssigner, None, testPrepareInfo)
+    new KafkaSource(preparedTopics, kafkaConfig, serializationSchema, timestampAssigner, formatter)
   }
 }

--- a/engine/flink/kafka-util/src/test/scala/pl/touk/nussknacker/engine/kafka/KafkaSourceFactorySpec.scala
+++ b/engine/flink/kafka-util/src/test/scala/pl/touk/nussknacker/engine/kafka/KafkaSourceFactorySpec.scala
@@ -48,8 +48,7 @@ class KafkaSourceFactorySpec extends FlatSpec with KafkaSpec with Matchers {
 
 
   private def createSource(topic: String): KafkaSource[String] = {
-    val sourceFactory = new KafkaSourceFactory[String](new SimpleStringSchema, None,
-      TestParsingUtils.newLineSplit, ProcessObjectDependencies(config, ObjectNamingProvider(getClass.getClassLoader)))
+    val sourceFactory = new KafkaSourceFactory[String](new SimpleStringSchema, None, BasicFormatter, ProcessObjectDependencies(config, ObjectNamingProvider(getClass.getClassLoader)))
     sourceFactory.create(MetaData("", StreamMetaData()), topic)(NodeId(""))
   }
 

--- a/engine/flink/kafka-util/src/test/scala/pl/touk/nussknacker/engine/kafka/generic/JsonRecordFormatterSpec.scala
+++ b/engine/flink/kafka-util/src/test/scala/pl/touk/nussknacker/engine/kafka/generic/JsonRecordFormatterSpec.scala
@@ -1,0 +1,48 @@
+package pl.touk.nussknacker.engine.kafka.generic
+
+import io.circe.Json
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.scalatest.{FunSuite, Matchers}
+import pl.touk.nussknacker.engine.api.CirceUtil.decodeJsonUnsafe
+import pl.touk.nussknacker.engine.kafka.generic.sources.JsonRecordFormatter
+
+import java.nio.charset.StandardCharsets
+
+class JsonRecordFormatterSpec extends FunSuite with Matchers {
+
+  private val topic = "testTopic"
+
+  test("handles generate -> parse for any json formatting") {
+
+    testGenerateThenParse("{}")
+    testGenerateThenParse("""{"st": {"a": "b"}}""")
+    testGenerateThenParse(
+      """{
+        |"st": {
+        |"a":
+        |"bb"} }
+        |""".stripMargin)
+    testGenerateThenParse(
+      """{
+        |"st": 
+        |{ "a": "bb\n\n", "list": [
+        |]}
+        |
+        |}""".stripMargin)
+  }
+
+  private def testGenerateThenParse(json: String): Unit = {
+    val recordBytes = json.getBytes(StandardCharsets.UTF_8)
+    val size = 3
+
+    val record = new ConsumerRecord[Array[Byte], Array[Byte]](topic, 0, 0, null, recordBytes)
+    val formatted = JsonRecordFormatter.prepareGeneratedTestData((1 to size).map(_ => record).toList)
+    val parsed = JsonRecordFormatter.parseDataForTest(topic, formatted)
+    parsed should have length size
+    parsed.foreach { producer =>
+      decodeJsonUnsafe[Json](producer.value()) shouldBe decodeJsonUnsafe[Json](recordBytes)
+    }
+  }
+
+
+}

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/DevProcessConfigCreator.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/DevProcessConfigCreator.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.engine.management.sample
 
 import java.time.LocalDateTime
-
 import com.typesafe.config.Config
 import io.circe.Encoder
 import org.apache.flink.api.common.serialization.SimpleStringSchema
@@ -21,7 +20,7 @@ import pl.touk.nussknacker.engine.flink.util.transformer.aggregate.AggregateHelp
 import pl.touk.nussknacker.engine.flink.util.transformer.aggregate.sampleTransformers.SlidingAggregateTransformerV2
 import pl.touk.nussknacker.engine.flink.util.transformer.outer.OuterJoinTransformer
 import pl.touk.nussknacker.engine.flink.util.transformer.{TransformStateTransformer, UnionTransformer, UnionWithMemoTransformer}
-import pl.touk.nussknacker.engine.kafka.KafkaConfig
+import pl.touk.nussknacker.engine.kafka.{BasicFormatter, KafkaConfig}
 import pl.touk.nussknacker.engine.kafka.serialization.schemas.SimpleSerializationSchema
 import pl.touk.nussknacker.engine.kafka.sink.KafkaSinkFactory
 import pl.touk.nussknacker.engine.kafka.source.KafkaSourceFactory
@@ -78,7 +77,7 @@ class DevProcessConfigCreator extends ProcessConfigCreator {
   override def sourceFactories(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[SourceFactory[_]]] = Map(
     "real-kafka" -> all(new KafkaSourceFactory[String](new SimpleStringSchema,
                                                         None,
-                                                        TestParsingUtils.newLineSplit,
+                                                        BasicFormatter,
                                                         processObjectDependencies)),
     "kafka-transaction" -> all(FlinkSourceFactory.noParam(new NoEndingSource)),
     "boundedSource" -> categories(BoundedSource),

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -4,10 +4,10 @@ import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Date, Optional, UUID}
-
 import cats.data.Validated.Valid
 import com.github.ghik.silencer.silent
 import io.circe.generic.JsonCodec
+
 import javax.annotation.Nullable
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
@@ -37,7 +37,7 @@ import pl.touk.nussknacker.engine.flink.util.service.TimeMeasuringService
 import pl.touk.nussknacker.engine.flink.util.signal.KafkaSignalStreamConnector
 import pl.touk.nussknacker.engine.flink.util.source.{CollectionSource, EspDeserializationSchema}
 import pl.touk.nussknacker.engine.kafka.source.KafkaSourceFactory
-import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaUtils}
+import pl.touk.nussknacker.engine.kafka.{BasicFormatter, KafkaConfig, KafkaUtils}
 import pl.touk.nussknacker.engine.process.SimpleJavaEnum
 import pl.touk.nussknacker.engine.util.Implicits._
 import pl.touk.nussknacker.engine.util.typing.TypingUtils
@@ -759,7 +759,7 @@ object SampleNodes {
   class KeyValueKafkaSourceFactory(processObjectDependencies: ProcessObjectDependencies) extends KafkaSourceFactory[KeyValue](
               new EspDeserializationSchema[KeyValue](e => CirceUtil.decodeJsonUnsafe[KeyValue](e)),
               Some(outOfOrdernessTimestampExtractor[KeyValue](_.date)),
-              TestParsingUtils.newLineSplit,
+              BasicFormatter,
               processObjectDependencies)
 
 }

--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/functions/conversion.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/functions/conversion.scala
@@ -1,8 +1,8 @@
 package pl.touk.nussknacker.engine.util.functions
 
-import pl.touk.nussknacker.engine.api.{Documentation, ParamName}
+import pl.touk.nussknacker.engine.api.{Documentation, HideToString, ParamName}
 
-object conversion {
+object conversion extends HideToString {
 
   @Documentation(description = "Wrap param in 'Unknown' type to make it usable in places where type checking is too much restrictive")
   def toAny(@ParamName("value") value: Any): Any = {


### PR DESCRIPTION
`RecordFormatter` and `TestDataSplit` should have matching behaviour, as formatting has impact on test data split. This changes embeds `TestDataSplit` into `RecordFormatter`.
We also introduce `JsonRecordFormatter` to better handle different json formattings for kafka-json in tests (e.g. many new lines etc.)