### PR TITLE
Upgrade project dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ lazy val supportedScalaVersions = List(scala212, scala211)
 
 // Silencer must be compatible with exact scala version - see compatibility matrix: https://search.maven.org/search?q=silencer-plugin
 // Silencer 1.7.x require Scala 2.12.11 (see warning above)
+// Silencer (and all '@silent' annotations) can be removed after we drop support for Scala 2.11
+// https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html
 val silencerV_2_12 = "1.6.0"
 val silencerV = "1.7.0"
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ import scala.util.Try
 
 val scala211 = "2.11.12"
 // Warning: Flink doesn't work correctly with 2.12.11
+// Warning: 2.12.13 + crossVersion break sbt-scoverage: https://github.com/scoverage/sbt-scoverage/issues/319
 val scala212 = "2.12.10"
 lazy val supportedScalaVersions = List(scala212, scala211)
 
@@ -222,37 +223,38 @@ val scalaTestV = "3.0.8"
 val scalaCheckV = "1.14.0"
 val logbackV = "1.1.3"
 val argonautV = "6.2.1"
-val circeV = "0.11.1"
+val circeV = "0.11.2"
+val circeJava8V = "0.11.1"
 val jwtCirceV = "4.0.0"
 val jacksonV = "2.9.2"
 val catsV = "1.5.0"
 val scalaParsersV = "1.0.4"
 val dispatchV = "1.0.1"
-val slf4jV = "1.7.21"
-val scalaLoggingV = "3.9.0"
-val scalaCompatV = "0.9.0"
+val slf4jV = "1.7.30"
+val scalaLoggingV = "3.9.2"
+val scalaCompatV = "0.9.1"
 val ficusV = "1.4.7"
-val configV = "1.4.0"
+val configV = "1.4.1"
 val commonsLangV = "3.3.2"
 val commonsTextV = "1.8"
 val commonsIOV = "2.4"
 //we want to use 5.x for standalone metrics to have tags, however dropwizard development kind of freezed. Maybe we should consider micrometer?
 //In Flink metrics we use bundled dropwizard metrics v. 3.x
 val dropWizardV = "5.0.0-rc3"
-val scalaCollectionsCompatV = "2.1.6"
+val scalaCollectionsCompatV = "2.3.2"
 
 val akkaHttpV = "10.1.8"
 val akkaHttpCirceV = "1.27.0"
-val slickV = "3.3.2"
-val hsqldbV = "2.5.0"
-val postgresV = "42.2.12"
+val slickV = "3.3.3"
+val hsqldbV = "2.5.1"
+val postgresV = "42.2.19"
 val flywayV = "6.3.3"
 val confluentV = "5.5.0"
 val jbcryptV = "0.4"
 val cronParserV = "9.1.3"
 val javaxValidationApiV = "2.0.1.Final"
 val caffeineCacheV = "2.8.8"
-val sttpV = "2.2.3"
+val sttpV = "2.2.9"
 
 lazy val dockerSettings = {
   val workingDir = "/opt/nussknacker"
@@ -661,7 +663,7 @@ lazy val util = (project in engine("util")).
         "com.github.ben-manes.caffeine" % "caffeine" % caffeineCacheV,
         "org.scala-lang.modules" %% "scala-java8-compat" % scalaCompatV,
         "com.iheart" %% "ficus" % ficusV,
-        "io.circe" %% "circe-java8" % circeV,
+        "io.circe" %% "circe-java8" % circeJava8V,
         "org.apache.avro" % "avro" % avroV % Optional
       )
     }
@@ -768,7 +770,7 @@ lazy val api = (project in engine("api")).
         "io.circe" %% "circe-parser" % circeV,
         "io.circe" %% "circe-generic" % circeV,
         "io.circe" %% "circe-generic-extras" % circeV,
-        "io.circe" %% "circe-java8" % circeV,
+        "io.circe" %% "circe-java8" % circeJava8V,
         "com.iheart" %% "ficus" % ficusV,
         "org.apache.commons" % "commons-lang3" % commonsLangV,
         "org.apache.commons" % "commons-text" % commonsTextV,
@@ -877,7 +879,7 @@ lazy val restmodel = (project in file("ui/restmodel"))
   .settings(
     name := "nussknacker-restmodel",
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-java8" % circeV
+      "io.circe" %% "circe-java8" % circeJava8V
     )
   )
   //interpreter needed for evaluatedparam etc

--- a/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/timestampwatermark/TimestampWatermarkHandler.scala
+++ b/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/timestampwatermark/TimestampWatermarkHandler.scala
@@ -35,7 +35,7 @@ object StandardTimestampWatermarkHandler {
 }
 
 @silent("deprecated")
-@nowarn("deprecated")
+@nowarn("cat=deprecation")
 class LegacyTimestampWatermarkHandler[T](timestampAssigner: TimestampAssigner[T]) extends TimestampWatermarkHandler[T] {
   override def assignTimestampAndWatermarks(dataStream: DataStream[T]): DataStream[T] = {
     timestampAssigner match {

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/signal/KafkaSignalStreamConnector.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/signal/KafkaSignalStreamConnector.scala
@@ -28,7 +28,7 @@ trait KafkaSignalStreamConnector {
   //Please note that *in general* it's not OK to assign standard event-based watermark, as signal streams usually
   //can be idle for long time. This prevent advancement of watermark on connected stream, which can lean to unexpected behaviour e.g. in aggregates
   @silent("deprecated")
-  @nowarn("deprecated")
+  @nowarn("cat=deprecation")
   protected def assignTimestampsAndWatermarks[B](dataStream: DataStream[B]): DataStream[B] = {
     dataStream.assignTimestampsAndWatermarks(new IngestionTimeExtractor[B])
   }

--- a/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/CustomValidatedService.scala
+++ b/engine/flink/management/sample/src/main/scala/pl/touk/nussknacker/engine/management/sample/service/CustomValidatedService.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 
 // Remove @silent after upgrade to silencer 1.7
 @silent("deprecated")
-@nowarn("deprecated")
+@nowarn("cat=deprecation")
 class CustomValidatedService extends Service with ServiceReturningType {
 
   @MethodToInvoke

--- a/engine/flink/model-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PeriodicSourceFactory.scala
+++ b/engine/flink/model-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PeriodicSourceFactory.scala
@@ -79,7 +79,7 @@ class PeriodicFunction(duration: Duration) extends SourceFunction[Unit] {
 }
 
 @silent("deprecated")
-@nowarn("deprecated")
+@nowarn("cat=deprecation")
 class MapAscendingTimestampExtractor(timestampField: String) extends AscendingTimestampExtractor[AnyRef] {
   override def extractAscendingTimestamp(element: AnyRef): Long = {
     element match {

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -324,7 +324,7 @@ object SampleNodes {
 
   // Remove @silent after upgrade to silencer 1.7
   @silent("deprecated")
-  @nowarn("deprecated")
+  @nowarn("cat=deprecation")
   object ReturningDependentTypeService extends Service with ServiceReturningType {
 
     @MethodToInvoke

--- a/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/BlockingQueueSource.scala
+++ b/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/BlockingQueueSource.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
  * This source allow to add elements after creation or decide when input stream is finished. It also emit watermark after each added element.
  */
 @silent("deprecated")
-@nowarn("deprecated")
+@nowarn("cat=deprecation")
 class BlockingQueueSource[T: TypeInformation](timestampAssigner: AssignerWithPunctuatedWatermarks[T]) extends FlinkSource[T] with Serializable {
 
   private val id = UUID.randomUUID().toString

--- a/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/EmitWatermarkAfterEachElementCollectionSource.scala
+++ b/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/EmitWatermarkAfterEachElementCollectionSource.scala
@@ -18,7 +18,7 @@ import scala.annotation.nowarn
  * This source in contrary to `CollectionSource` emit watermark after each element. It is important feature during tests if you want to make them deterministic.
  */
 @silent("deprecated")
-@nowarn("deprecated")
+@nowarn("cat=deprecation")
 class EmitWatermarkAfterEachElementCollectionSource[T: TypeInformation](list: Seq[T],
                                                                         timestampAssigner: AssignerWithPunctuatedWatermarks[T]) extends FlinkSource[T] {
 

--- a/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/timestamp/BoundedOutOfOrderPreviousElementAssigner.scala
+++ b/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/timestamp/BoundedOutOfOrderPreviousElementAssigner.scala
@@ -12,7 +12,7 @@ import scala.annotation.nowarn
  * See https://ci.apache.org/projects/flink/flink-docs-stable/dev/connectors/kafka.html#using-kafka-timestamps-and-flink-event-time-in-kafka-010
  */
 @silent("deprecated")
-@nowarn("deprecated")
+@nowarn("cat=deprecation")
 class BoundedOutOfOrderPreviousElementAssigner[T](maxOutOfOrdernessMillis: Long)
   extends AssignerWithPeriodicWatermarks[T] with Serializable {
 

--- a/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/timestamp/BoundedOutOfOrdernessPunctuatedExtractor.scala
+++ b/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/timestamp/BoundedOutOfOrdernessPunctuatedExtractor.scala
@@ -7,7 +7,7 @@ import org.apache.flink.streaming.api.watermark.Watermark
 import scala.annotation.nowarn
 
 @silent("deprecated")
-@nowarn("deprecated")
+@nowarn("cat=deprecation")
 abstract class BoundedOutOfOrdernessPunctuatedExtractor[T](maxOutOfOrdernessMillis: Long)
   extends AssignerWithPunctuatedWatermarks[T] {
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -1191,7 +1191,7 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
 
   // Remove @silent after upgrade to silencer 1.7
   @silent("deprecated")
-  @nowarn("deprecated")
+  @nowarn("cat=deprecation")
   object ServiceReturningTypeSample extends Service with ServiceReturningType {
 
     @MethodToInvoke
@@ -1210,7 +1210,7 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
 
   // Remove @silent after upgrade to silencer 1.7
   @silent("deprecated")
-  @nowarn("deprecated")
+  @nowarn("cat=deprecation")
   object ServiceReturningTypeWithExplicitMethodSample extends Service with ServiceReturningType with ServiceWithExplicitMethod {
 
     override def returnType(parameters: Map[String, (TypingResult, Option[Any])]): typing.TypingResult = {
@@ -1250,7 +1250,7 @@ class ProcessValidatorSpec extends FunSuite with Matchers with Inside {
 
   // Remove @silent after upgrade to silencer 1.7
   @silent("deprecated")
-  @nowarn("deprecated")
+  @nowarn("cat=deprecation")
   object ServiceWithCustomValidation extends Service with ServiceReturningType {
 
     @MethodToInvoke


### PR DESCRIPTION
Some dependency upgrades. Scala 2.11 holds us from upgrading circe and cats. Flink with its frozen Akka version makes it impossible to use a newer Akka HTTP.

NK extensions use nussknacker-ui assembly as their runtime so we should try keeping packaged dependencies up to date.