### PR TITLE
optional outputVariable for StandaloneCustomTransformer

### DIFF
--- a/engine/standalone/api/src/main/scala/pl/touk/nussknacker/engine/standalone/api/StandaloneCustomTransformer.scala
+++ b/engine/standalone/api/src/main/scala/pl/touk/nussknacker/engine/standalone/api/StandaloneCustomTransformer.scala
@@ -7,9 +7,6 @@ trait StandaloneCustomTransformer {
 
   type StandaloneCustomTransformation = (InterpreterType, LazyParameterInterpreter) => InterpreterType
 
-  //TODO: also without variable...
-  def createTransformation(outputVariable: String) : StandaloneCustomTransformation
+  def createTransformation(outputVariable: Option[String]) : StandaloneCustomTransformation
   
 }
-
-

--- a/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessInterpreter.scala
+++ b/engine/standalone/engine/src/main/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessInterpreter.scala
@@ -109,7 +109,7 @@ object StandaloneProcessInterpreter {
         }
         validatedTransformer.andThen { transformer =>
           val result = compileWithCompilationErrors(node, validationContext).andThen(partInvoker(_, parts))
-          result.map(rs => rs.map(transformer.createTransformation(node.data.outputVar.get)(_, lazyParameterInterpreter)))
+          result.map(rs => rs.map(transformer.createTransformation(node.data.outputVar)(_, lazyParameterInterpreter)))
         }
     }
 

--- a/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessConfigCreator.scala
+++ b/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessConfigCreator.scala
@@ -208,7 +208,7 @@ object StandaloneCustomExtractor extends CustomStreamTransformer {
 
 class StandaloneCustomExtractor(outputVariableName: String, expression: LazyParameter[AnyRef]) extends StandaloneCustomTransformer {
 
-  override def createTransformation(outputVariable: String): StandaloneCustomTransformation =
+  override def createTransformation(outputVariable: Option[String]): StandaloneCustomTransformation =
     (continuation: InterpreterType, lpi: LazyParameterInterpreter) => {
       val exprInterpreter: (ExecutionContext, engine.api.Context) => Future[Any] = lpi.createInterpreter(expression)
       (ctx: engine.api.Context, ec: ExecutionContext) => {

--- a/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessConfigCreator.scala
+++ b/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessConfigCreator.scala
@@ -40,7 +40,8 @@ class StandaloneProcessConfigCreator extends ProcessConfigCreator with LazyLoggi
 
   override def customStreamTransformers(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[CustomStreamTransformer]] = Map(
     "splitter" -> WithCategories(ProcessSplitter),
-    "extractor" -> WithCategories(StandaloneCustomExtractor)
+    "extractor" -> WithCategories(StandaloneCustomExtractor),
+    "filterWithLog" -> WithCategories(StandaloneFilterWithLog)
   )
 
   override def services(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[Service]] = Map(
@@ -221,6 +222,36 @@ class StandaloneCustomExtractor(outputVariableName: String, expression: LazyPara
     }
 
 }
+
+case class StandaloneLogInformation(filterExpression: Boolean)
+
+object StandaloneFilterWithLog extends CustomStreamTransformer {
+
+  @MethodToInvoke(returnType = classOf[Unit])
+  def invoke(@ParamName("filterExpression") filterExpression: LazyParameter[java.lang.Boolean])
+            (implicit nodeId: NodeId): StandaloneCustomTransformer = {
+    new StandaloneFilterWithLog(filterExpression, nodeId)
+  }
+
+}
+
+class StandaloneFilterWithLog(filterExpression: LazyParameter[java.lang.Boolean], nodeId: NodeId) extends StandaloneCustomTransformer {
+
+  override def createTransformation(outputVariable: Option[String]): StandaloneCustomTransformation =
+    (continuation: InterpreterType, lpi: LazyParameterInterpreter) => {
+      implicit val implicitLpi: LazyParameterInterpreter = lpi
+      val lazyLogInformation = filterExpression.map(StandaloneLogInformation(_))
+      val exprInterpreter: (ExecutionContext, engine.api.Context) => Future[StandaloneLogInformation] = lpi.createInterpreter(lazyLogInformation)
+      (ctx: engine.api.Context, ec: ExecutionContext) => {
+        implicit val ecc: ExecutionContext = ec
+        exprInterpreter(ec, ctx).flatMap(exprResult => {
+          if(exprResult.filterExpression) continuation(ctx, ec)
+          else Future(Right(List(InterpretationResult(DeadEndReference(nodeId.id), exprResult, ctx))))
+        })
+      }
+    }
+}
+
 
 object ParameterResponseSinkFactory extends SinkFactory {
   @MethodToInvoke

--- a/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessInterpreterSpec.scala
+++ b/engine/standalone/engine/src/test/scala/pl/touk/nussknacker/engine/standalone/StandaloneProcessInterpreterSpec.scala
@@ -239,6 +239,31 @@ class StandaloneProcessInterpreterSpec extends FunSuite with Matchers with VeryP
     ))
   }
 
+  test("ignore filter and continue process execution") {
+    val process = EspProcessBuilder
+      .id("proc1")
+      .exceptionHandler()
+      .source("start", "request1-post-source")
+      .customNodeNoOutput("filter", "filterWithLog", "filterExpression" -> "true")
+      .emptySink("endNodeIID", "parameterResponse-sink", "computed" -> "#input.field1 + 'd'")
+
+    val result = runProcess(process, Request1("abc", "b"))
+
+    result shouldBe Right(List("abcd withRandomString"))
+  }
+
+  test("stop process on filter and return StandaloneLogInformation") {
+    val process = EspProcessBuilder
+      .id("proc1")
+      .exceptionHandler()
+      .source("start", "request1-post-source")
+      .customNodeNoOutput("filter", "filterWithLog", "filterExpression" -> "false")
+      .emptySink("endNodeIID", "parameterResponse-sink", "computed" -> "#input.field1 + 'd'")
+
+    val result = runProcess(process, Request1("abc", "b"))
+    result shouldBe Right(List(StandaloneLogInformation(false)))
+  }
+
   def runProcess(process: EspProcess,
                  input: Any,
                  creator: StandaloneProcessConfigCreator = new StandaloneProcessConfigCreator,

--- a/engine/standalone/util/src/main/scala/pl/touk/nussknacker/engine/standalone/utils/customtransformers/ProcessSplitter.scala
+++ b/engine/standalone/util/src/main/scala/pl/touk/nussknacker/engine/standalone/utils/customtransformers/ProcessSplitter.scala
@@ -26,12 +26,12 @@ object ProcessSplitter extends CustomStreamTransformer {
 class ProcessSplitter(parts: LazyParameter[java.util.Collection[Any]])
   extends StandaloneCustomTransformer with ReturningType {
 
-  override def createTransformation(outputVariable: String): StandaloneCustomTransformation =
+  override def createTransformation(outputVariable: Option[String]): StandaloneCustomTransformation =
     (continuation: InterpreterType, lpi: LazyParameterInterpreter) => (ctx, ec) => {
       implicit val ecc: ExecutionContext = ec
       lpi.createInterpreter(parts)(ec, ctx).flatMap { partsToInterpret =>
         Future.sequence(partsToInterpret.asScala.toList.map { partToInterpret =>
-          val newCtx = ctx.withVariable(outputVariable, partToInterpret)
+          val newCtx = ctx.withVariable(outputVariable.get, partToInterpret)
           continuation(newCtx, ec)
         })
       }.map { results: List[Either[NonEmptyList[EspExceptionInfo[_ <: Throwable]], List[InterpretationResult]]] =>


### PR DESCRIPTION
Changing `createTransformation(outputVariable: String)` to `createTransformation(outputVariable: Option[String])` makes it possible to move extracting of `outputVariable` (or not extracting it) from `StandaloneProcessInterpreter` to `createTransformation`. 
That allows to create `StandaloneCustomTransformer` with no return value. 