### PR TITLE
[Improvement] Correct HLL typed serialization, serialization improvements

### DIFF
--- a/engine/flink/model-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/CardinalityAggregator.scala
+++ b/engine/flink/model-util/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/CardinalityAggregator.scala
@@ -5,16 +5,19 @@ import cats.data.Validated.Valid
 import com.clearspring.analytics.stream.cardinality.{HyperLogLogPlus, ICardinality}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+import org.apache.flink.types.Value
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
+
+import scala.reflect.ClassTag
 
 //Approximate unique count (using https://en.wikipedia.org/wiki/HyperLogLog). Result is number
 //The parameters should be adjusted for use case, see HyperLogLogPlusAggregatorSpec for some experiments
 case class HyperLogLogPlusAggregator(p: Int = 10, sp: Int = 15)
-  extends CardinalityAggregator(() => new HyperLogLogPlus(p, sp), ic => new CardinalityWrapper(ic) {
-    override def readFromBytes(bytes: Array[Byte]): ICardinality = HyperLogLogPlus.Builder.build(bytes)
-  })
+  extends CardinalityAggregator(() => new HyperLogLogPlus(p, sp), ic => new HyperLogLogPlusWrapper(ic))
 
-class CardinalityAggregator(zeroCardinality: () => ICardinality, wrapper: ICardinality => CardinalityWrapper) extends Aggregator with Serializable {
+class CardinalityAggregator[Wrapper<:CardinalityWrapper:ClassTag](zeroCardinality: () => ICardinality,
+                                                                  wrapper: ICardinality => Wrapper) extends Aggregator with Serializable {
 
   override type Aggregate = CardinalityWrapper
 
@@ -36,20 +39,27 @@ class CardinalityAggregator(zeroCardinality: () => ICardinality, wrapper: ICardi
 
   override def computeOutputType(input: TypingResult): Validated[String, TypingResult] = Valid(Typed[Long])
 
-  override def computeStoredType(input: TypingResult): Validated[String, TypingResult] = Valid(Typed[CardinalityWrapper])
+  override def computeStoredType(input: TypingResult): Validated[String, TypingResult] = Valid(Typed[Wrapper])
 
 }
 
-private[aggregate] abstract class CardinalityWrapper extends KryoSerializable with Serializable {
-
-  def readFromBytes(bytes: Array[Byte]): ICardinality
-
-  var wrapped: ICardinality = _
+class HyperLogLogPlusWrapper extends CardinalityWrapper {
 
   def this(cardinality: ICardinality) = {
     this()
     this.wrapped = cardinality
   }
+
+  override def readFromBytes(bytes: Array[Byte]): ICardinality = HyperLogLogPlus.Builder.build(bytes)
+
+}
+
+//We extend both Flink and Kryo serialization mechanisms, to serialize both when using generic types and types based on TypingResult
+private[aggregate] abstract class CardinalityWrapper extends Value with KryoSerializable with Serializable {
+
+  def readFromBytes(bytes: Array[Byte]): ICardinality
+
+  var wrapped: ICardinality = _
 
   override def write(kryo: Kryo, output: Output): Unit = {
     val bytes = wrapped.getBytes
@@ -60,6 +70,19 @@ private[aggregate] abstract class CardinalityWrapper extends KryoSerializable wi
   override def read(kryo: Kryo, input: Input): Unit = {
     val size = input.readInt()
     wrapped = readFromBytes(input.readBytes(size))
+  }
+
+  override def write(out: DataOutputView): Unit = {
+    val bytes = wrapped.getBytes
+    out.writeInt(bytes.length)
+    out.write(bytes)
+  }
+
+  override def read(in: DataInputView): Unit = {
+    val size = in.readInt()
+    val bytes = new Array[Byte](size)
+    in.read(bytes)
+    wrapped = readFromBytes(bytes)
   }
 }
 

--- a/engine/flink/model-util/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/AggregatesSpec.scala
+++ b/engine/flink/model-util/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/AggregatesSpec.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.flink.util.transformer.aggregate
 
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FunSuite, Matchers}
-import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypedObjectTypingResult, TypedUnion, TypingResult, Unknown}
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypedObjectTypingResult, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.flink.util.transformer.aggregate.aggregates.{FirstAggregator, LastAggregator, ListAggregator, MapAggregator, MaxAggregator, MinAggregator, SetAggregator, SumAggregator}
 import java.lang.{Integer => JInt, Long => JLong}
 import java.util.{List => JList, Map => JMap, Set => JSet}
@@ -14,7 +14,7 @@ class AggregatesSpec extends FunSuite with TableDrivenPropertyChecks with Matche
   private val justAnyObject = new JustAnyClass
   private val aggregators = Table(
     ("aggregate", "input", "obj", "stored", "output"),
-    (HyperLogLogPlusAggregator(), Typed[String], "", Typed[CardinalityWrapper], Typed[Long]),
+    (HyperLogLogPlusAggregator(), Typed[String], "", Typed[HyperLogLogPlusWrapper], Typed[Long]),
     (SumAggregator, Typed[Int], 1, Typed[JLong], Typed[JLong]),
 
     (MinAggregator, Typed[Int], 1, Typed[JInt], Typed[JInt]),

--- a/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
+++ b/engine/flink/process/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
@@ -71,7 +71,7 @@ class TypingResultAwareTypeInformationDetection(customisation:
       case a:TypedTaggedValue => forType(a.underlying)
       case a:TypedDict => forType(a.objType)
       case a:TypedClass if a.params.isEmpty =>
-        //TODO: scala case classes are not handled nicely here...
+        //TODO: scala case classes are not handled nicely here... CaseClassTypeInfo is created only via macro, here Kryo is used
         registeredTypeInfos.find(_.getTypeClass == a.klass).getOrElse(TypeInformation.of(a.klass))
 
       case a:TypedClass if a.klass == classOf[java.util.List[_]] => new ListTypeInfo[Any](forType(a.params.head))


### PR DESCRIPTION
- HyperLogLogPlus is serialized much more efficiently for TypingResult based serialization
- isCompatibleWithReconfiguredSerializer is handled correctly for TypedObjectBasedTypeInformation