### PR TITLE
Fix: Update process with same json

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -37,6 +37,7 @@ Nussknacker versions
 * [#1510](https://github.com/TouK/nussknacker/pull/1510) `FlinkSource` API allows to create stream of `Context` (FlinkSource API and test support API refactoring).
 * [#1497](https://github.com/TouK/nussknacker/pull/1497) Initial support for multiple (named) schedules in `PeriodicProcessManager`
 * [#1499](https://github.com/TouK/nussknacker/pull/1499) ClassTag is provided in params in avro key-value deserialization schema factory: `KafkaAvroKeyValueDeserializationSchemaFactory`
+* [#1533](https://github.com/TouK/nussknacker/pull/1533) Fix: Update process with same json
 
 0.3.1 (not released yet) 
 ------------------------

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessDBQueryRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessDBQueryRepository.scala
@@ -125,4 +125,8 @@ object ProcessDBQueryRepository {
   case class InvalidProcessTypeError(id: String) extends BadRequestError {
     def getMessage = s"Process $id is not GraphProcess"
   }
+
+  case class InvalidProcessJson(rawJson: String) extends BadRequestError {
+    def getMessage = s"Invalid raw json string: $rawJson"
+  }
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
@@ -55,6 +55,7 @@ trait ProcessRepository[F[_]] {
 class DBProcessRepository(val dbConfig: DbConfig, val modelVersion: ProcessingTypeDataProvider[Int])
   extends ProcessRepository[DB] with EspTables with LazyLogging with CommentActions with ProcessDBQueryRepository[DB] {
 
+  import io.circe.parser._
   import profile.api._
 
   // FIXME: It's temporary way.. After merge and refactor process repositories we can remove it.
@@ -98,17 +99,31 @@ class DBProcessRepository(val dbConfig: DbConfig, val modelVersion: ProcessingTy
       case CustomProcess(mainClass) => (None, Some(mainClass))
     }
 
-    def normalizeJsonString(jsonString: String) = jsonString.filterNot(_.isWhitespace)
+    //TODO: Move this normalization to DTO - GraphProcess
+    def normalizeJsonString(jsonString: String): Either[InvalidProcessJson, String] = parse(jsonString) match {
+      case Left(_) => Left(InvalidProcessJson(s"Invalid raw json string: $jsonString."))
+      case Right(json) => Right(json.noSpaces)
+    }
 
-    //FIXME: In some reasons in lastVersion.json is string with whitespaces..
+    def createProcessVersionEntityData(id: Int, processingType: ProcessingType, json: Option[String], maybeMainClass: Option[String]) = ProcessVersionEntityData(
+      id = id + 1, processId = processId.value, json =json, mainClass = maybeMainClass, createDate = DateUtils.toTimestamp(now),
+      user = loggedUser.username, modelVersion = modelVersion.forType(processingType)
+    )
+
+    //We compare Json representation to ignore formatting differences
     def isLastVersionContainsSameJson(lastVersion: ProcessVersionEntityData, maybeJson: Option[String]) =
       lastVersion.json.map(normalizeJsonString) == maybeJson.map(normalizeJsonString)
 
-    def versionToInsert(latestProcessVersion: Option[ProcessVersionEntityData], processesVersionCount: Int, processingType: ProcessingType): Option[ProcessVersionEntityData] = latestProcessVersion match {
-        case Some(version) if isLastVersionContainsSameJson(version, maybeJson) && version.mainClass == maybeMainClass => None
-        case _ => Option(ProcessVersionEntityData(id = processesVersionCount + 1, processId = processId.value,
-          json = maybeJson.map(normalizeJsonString), mainClass = maybeMainClass, createDate = DateUtils.toTimestamp(now),
-          user = loggedUser.username, modelVersion = modelVersion.forType(processingType)))
+    //TODO: after we move Json type to GraphProcess we should clean up this pattern matching
+    def versionToInsert(latestProcessVersion: Option[ProcessVersionEntityData], processesVersionCount: Int, processingType: ProcessingType) =
+      (latestProcessVersion, maybeJson) match {
+        case (Some(version), _) if isLastVersionContainsSameJson(version, maybeJson) && version.mainClass == maybeMainClass =>
+          Right(None)
+        case (_, Some(json)) =>
+          normalizeJsonString(json)
+            .map(j => Option(createProcessVersionEntityData(processesVersionCount, processingType, Some(j), None)))
+        case (_, None) =>
+          Right(Option(createProcessVersionEntityData(processesVersionCount, processingType, None, maybeMainClass)))
       }
 
     //TODO: why EitherT.right doesn't infere properly here?
@@ -121,7 +136,7 @@ class DBProcessRepository(val dbConfig: DbConfig, val modelVersion: ProcessingTy
       _ <- EitherT.fromEither(Either.cond(process.processType == ProcessType.fromDeploymentData(processDeploymentData), (), InvalidProcessTypeError(processId.value.toString))) //FIXME: Move this condition to service..
       processesVersionCount <- rightT(processVersionsTableNoJson.filter(p => p.processId === processId.value).length.result)
       latestProcessVersion <- rightT(fetchProcessLatestVersionsQuery(processId)(ProcessShapeFetchStrategy.FetchDisplayable).result.headOption)
-      newProcessVersion <- EitherT.fromEither(Right(versionToInsert(latestProcessVersion, processesVersionCount, process.processingType)))
+      newProcessVersion <- EitherT.fromEither(versionToInsert(latestProcessVersion, processesVersionCount, process.processingType))
       _ <- EitherT.right[EspError](newProcessVersion.map(processVersionsTable += _).getOrElse(dbMonad.pure(0)))
     } yield newProcessVersion
     insertAction.value

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -419,15 +419,6 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
     ProcessJson(parser.decode[Json](response).right.get)
 }
 
-class ProcessVersionJson(ver: Long, user: String)
-
-object ProcessVersionJson {
-  def apply(version: Json): ProcessVersionJson = new ProcessVersionJson(
-    version.hcursor.downField("processVersionId").as[Long].right.get,
-    version.hcursor.downField("user").as[String].right.get
-  )
-}
-
 object ProcessJson{
   def apply(process: Json): ProcessJson = {
     val lastAction = process.hcursor.downField("lastAction").as[Option[Json]].right.get
@@ -443,8 +434,7 @@ object ProcessJson{
       process.hcursor.downField("state").downField("tooltip").as[Option[String]].right.get,
       process.hcursor.downField("state").downField("description").as[Option[String]].right.get,
       process.hcursor.downField("processCategory").as[String].right.get,
-      process.hcursor.downField("isArchived").as[Boolean].right.get,
-      process.hcursor.downField("history").as[List[Json]].right.get.map(ProcessVersionJson(_))
+      process.hcursor.downField("isArchived").as[Boolean].right.get
     )
   }
 }
@@ -459,8 +449,7 @@ final case class ProcessJson(id: String,
                              stateTooltip: Option[String],
                              stateDescription: Option[String],
                              processCategory: String,
-                             isArchived: Boolean,
-                             history: List[ProcessVersionJson]) {
+                             isArchived: Boolean) {
 
   def isDeployed: Boolean = lastActionType.contains(ProcessActionType.Deploy.toString)
 


### PR DESCRIPTION
After moved rename to process properties we can observe that when we change name then system create new version.. In fact we always send rename request and update process request.. If we change 2-3 times name then we can observe that system creates new version of process - but in json we don't see differences.. I debug mode I saw that lastProcessVersion json contains white spaces like `\n` but in BE tests I couldn't reproduce it.. 

This MR fix this situation. 