### PR TITLE
Some of the akhq routes were incorrectly resolved as  default (nk) route

### DIFF
--- a/demo/docker/nginx/nginx.conf
+++ b/demo/docker/nginx/nginx.conf
@@ -14,6 +14,9 @@ http {
       proxy_pass http://akhq:8080/akhq/;
     }
 
+    location /ui/ {
+      proxy_pass http://akhq:8080/akhq/ui/;
+    }
     # this is the internal Docker DNS, cache only for 30s
     # This setting + substitution pattern used below is because we want ot have separated compose for app and environment.
     # More details you can find here: https://sandro-keil.de/blog/let-nginx-start-if-upstream-host-is-unavailable-or-down/


### PR DESCRIPTION
Some of the akhq routes were incorrectly resolved as  default (nk) route, just a little nuisance. 