### PR TITLE
Upgraded akhq to 0.17, 

### DIFF
--- a/demo/docker/docker-compose-env.yml
+++ b/demo/docker/docker-compose-env.yml
@@ -50,7 +50,7 @@ services:
 
   akhq:
     container_name: nussknacker_akhq
-    image: tchiotludo/akhq:${AKHQ_VERSION-0.16.0}
+    image: tchiotludo/akhq:${AKHQ_VERSION-0.17.0}
     environment:
       AKHQ_CONFIGURATION: |
         micronaut:


### PR DESCRIPTION
this solved the bug of some of the akhq ui links not working, 
In case you ask ... yes, I checked whether it works before asking for PR.

Additionally, some new akhq features arrived. The most exciting one is support for references in avro schemas