### PR TITLE
Fix for visibility of cancelJob/submitJob methods in FlinkMiniCluster…

### DIFF
--- a/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/flink/test/FlinkMiniClusterHolder.scala
+++ b/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/flink/test/FlinkMiniClusterHolder.scala
@@ -31,9 +31,9 @@ trait FlinkMiniClusterHolder {
 
   def stop(): Unit
 
-  private[test] def cancelJob(jobID: JobID): Unit
+  def cancelJob(jobID: JobID): Unit
 
-  private[test] def submitJob(jobGraph: JobGraph): JobID
+  def submitJob(jobGraph: JobGraph): JobID
 
   def runningJobs(): Iterable[JobID]
 
@@ -65,10 +65,10 @@ class FlinkMiniClusterHolderImpl(flinkMiniCluster: MiniClusterWithClientResource
     flinkMiniCluster.after()
   }
 
-  override private[test] def cancelJob(jobID: JobID): Unit =
+  override def cancelJob(jobID: JobID): Unit =
     flinkMiniCluster.getClusterClient.cancel(jobID)
 
-  override private[test] def submitJob(jobGraph: JobGraph): JobID =
+  override def submitJob(jobGraph: JobGraph): JobID =
     flinkMiniCluster.getClusterClient.submitJob(jobGraph).get()
 
   override def listJobs(): List[JobStatusMessage] =


### PR DESCRIPTION
…Holder to make it usable in nk-compat