### PR TITLE
Fixed SPI for AuthenticationProvider

### DIFF
--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticatorFactory.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticatorFactory.scala
@@ -3,6 +3,9 @@ package pl.touk.nussknacker.ui.security.api
 import akka.http.scaladsl.server.directives.AuthenticationDirective
 import akka.http.scaladsl.server.Route
 import com.typesafe.config.Config
+import sttp.client.{NothingT, SttpBackend}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 trait AuthenticatorFactory {
   import AuthenticatorFactory._
@@ -11,7 +14,7 @@ trait AuthenticatorFactory {
 
   //TODO: Extract putting allCategories in up level. Authenticator should return only Authenticated User(id, roles)
   // mapping Authenticated User with all Categories should be do only at one place
-  def createAuthenticator(config: Config, classLoader: ClassLoader, allCategories: List[String]): AuthenticatorData
+  def createAuthenticator(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticatorData
 }
 
 object AuthenticatorFactory {

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticatorFactory.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticatorFactory.scala
@@ -5,10 +5,13 @@ import akka.http.scaladsl.server.directives.SecurityDirectives
 import com.typesafe.config.Config
 import pl.touk.nussknacker.ui.security.api.AuthenticatorFactory.{AuthenticatorData, LoggedUserAuth}
 import pl.touk.nussknacker.ui.security.api.{AuthenticatorFactory, DefaultAuthenticationConfiguration}
+import sttp.client.{NothingT, SttpBackend}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class BasicAuthenticatorFactory extends AuthenticatorFactory with Directives {
 
-  override def createAuthenticator(config: Config, classLoader: ClassLoader, allCategories: List[String]): AuthenticatorData = {
+  override def createAuthenticator(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticatorData = {
     val configuration = DefaultAuthenticationConfiguration.create(config)
     AuthenticatorData(createDirective(configuration, allCategories), configuration)
   }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticatorFactory.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticatorFactory.scala
@@ -1,39 +1,31 @@
 package pl.touk.nussknacker.ui.security.oauth2
 
-import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.SecurityDirectives
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
-import pl.touk.nussknacker.ui.security.api.{AuthenticatorFactory, LoggedUser}
-import pl.touk.nussknacker.ui.security.api.AuthenticatorFactory.{AuthenticatorData, LoggedUserAuth}
+import pl.touk.nussknacker.ui.security.api.{AuthenticatorFactory}
+import pl.touk.nussknacker.ui.security.api.AuthenticatorFactory.AuthenticatorData
 import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.{ExecutionContext, Future}
 
+class OAuth2AuthenticatorFactory extends AuthenticatorFactory with LazyLogging {
 
-class OAuth2AuthenticatorFactory(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]) extends AuthenticatorFactory with LazyLogging {
-
-  override def createAuthenticator(config: Config, classLoader: ClassLoader, allCategories: List[String]): AuthenticatorData = {
+  override def createAuthenticator(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticatorData = {
     val configuration = OAuth2Configuration.create(config)
     val service = OAuth2ServiceProvider(configuration, classLoader, allCategories)
 
     AuthenticatorData(
-      createDirective(configuration, service),
+      directive = SecurityDirectives.authenticateOAuth2Async(
+        authenticator = OAuth2Authenticator(configuration, service),
+        realm = realm
+      ),
       configuration,
-      createRoutes(service)
+      routes = List(new AuthenticationOAuth2Resources(service).route())
     )
   }
-
-  def createDirective(config: OAuth2Configuration, service: OAuth2Service[LoggedUser, _]): LoggedUserAuth = {
-    SecurityDirectives.authenticateOAuth2Async(
-      authenticator = OAuth2Authenticator(config, service),
-      realm = realm
-    )
-  }
-
-  def createRoutes(service: OAuth2Service[_, OAuth2AuthorizationData]): List[Route] = List(new AuthenticationOAuth2Resources(service).route())
 }
 
 object OAuth2AuthenticatorFactory {
-  def apply()(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2AuthenticatorFactory = new OAuth2AuthenticatorFactory()
+  def apply(): OAuth2AuthenticatorFactory = new OAuth2AuthenticatorFactory()
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -69,7 +69,7 @@ trait NusskanckerDefaultAppRouter extends NusskanckerAppRouter {
   override def create(config: Config, dbConfig: DbConfig)(implicit system: ActorSystem, materializer: Materializer): (Route, Iterable[AutoCloseable]) = {
     import system.dispatcher
 
-    implicit val sttpBackend: SttpBackend[Future, Nothing, NothingT] = AkkaHttpBackend()
+    implicit val sttpBackend: SttpBackend[Future, Nothing, NothingT] = AkkaHttpBackend.usingActorSystem(system)
 
     val testResultsMaxSizeInBytes = config.getOrElse[Int]("testResultsMaxSizeInBytes", 500 * 1024 * 1000)
     val environment = config.getString("environment")


### PR DESCRIPTION
With my previous PR to the security module, I added implicit arguments to the constructor of `OAuth2AuthenticatorFactory`. This makes it impossible to load its subclasses with SPI.
I moved the `ec` argument to the `createAuthenticator` and pulled down STTP backend creation into the authenticator factory class.