### PR TITLE
Grafana dashboard corrections

### DIFF
--- a/demo/docker/grafana/dashboards/Flink-ESP.json
+++ b/demo/docker/grafana/dashboards/Flink-ESP.json
@@ -1429,7 +1429,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "influx",
-      "description": "IMPORTANT. \nThis metrics does NOT show the overall lag on Kafka source; a largest lag among all the source partitions is shown. ",
+      "description": "IMPORTANT. \nThis metric does NOT show the overall lag on Kafka source; a largest lag among all the source partitions is shown.",
       "editable": true,
       "error": false,
       "fill": 1,
@@ -2200,22 +2200,27 @@
         "auto_min": "10s",
         "current": {
           "selected": false,
-          "text": "10s",
-          "value": "10s"
+          "text": "1m",
+          "value": "1m"
         },
         "hide": 0,
         "label": null,
         "name": "interval",
         "options": [
           {
-            "selected": true,
-            "text": "10s",
-            "value": "10s"
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
           },
           {
             "selected": false,
             "text": "1m",
             "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "3m",
+            "value": "3m"
           },
           {
             "selected": false,
@@ -2263,7 +2268,7 @@
             "value": "30d"
           }
         ],
-        "query": "10s,1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "query": "30s,1m,3m, 10m,30m,1h,6h,12h,1d,7d,14d,30d",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
@@ -2277,7 +2282,6 @@
   "timepicker": {
     "now": true,
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",

--- a/demo/docker/grafana/dashboards/Flink-ESP.json
+++ b/demo/docker/grafana/dashboards/Flink-ESP.json
@@ -2200,8 +2200,8 @@
         "auto_min": "10s",
         "current": {
           "selected": false,
-          "text": "1m",
-          "value": "1m"
+          "text": "30s",
+          "value": "30s"
         },
         "hide": 0,
         "label": null,
@@ -2209,6 +2209,11 @@
         "options": [
           {
             "selected": false,
+            "text": "10s",
+            "value": "10s"
+          },
+          {
+            "selected": true,
             "text": "30s",
             "value": "30s"
           },
@@ -2268,7 +2273,7 @@
             "value": "30d"
           }
         ],
-        "query": "30s,1m,3m, 10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "query": "10s,30s,1m,3m, 10m,30m,1h,6h,12h,1d,7d,14d,30d",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"

--- a/demo/docker/grafana/dashboards/Flink-ESP.json
+++ b/demo/docker/grafana/dashboards/Flink-ESP.json
@@ -1466,7 +1466,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -1484,12 +1484,6 @@
                 "process"
               ],
               "type": "tag"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
             }
           ],
           "measurement": "records-lag-max",

--- a/demo/docker/grafana/dashboards/Flink-ESP.json
+++ b/demo/docker/grafana/dashboards/Flink-ESP.json
@@ -51,7 +51,7 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -197,7 +197,7 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -350,7 +350,7 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -501,7 +501,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -627,7 +627,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -753,7 +753,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -904,7 +904,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -1030,7 +1030,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -1156,7 +1156,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -1311,7 +1311,7 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -1429,6 +1429,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "influx",
+      "description": "IMPORTANT. \nThis metrics does NOT show the overall lag on Kafka source; a largest lag among all the source partitions is shown. ",
       "editable": true,
       "error": false,
       "fill": 1,
@@ -1455,7 +1456,7 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -1469,7 +1470,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "$tag_process [$tag_slot]",
+          "alias": "$tag_process",
           "dsType": "influxdb",
           "groupBy": [
             {
@@ -1481,12 +1482,6 @@
             {
               "params": [
                 "process"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "slot"
               ],
               "type": "tag"
             },
@@ -1536,7 +1531,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Lag on Kafka source (events)",
+      "title": "Max lag among Kafka source partitions (events)",
       "tooltip": {
         "msResolution": false,
         "shared": true,
@@ -1604,7 +1599,7 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -1747,7 +1742,7 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -1890,7 +1885,7 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
@@ -2033,7 +2028,7 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },

--- a/demo/docker/telegraf/telegraf.conf
+++ b/demo/docker/telegraf/telegraf.conf
@@ -46,5 +46,5 @@
 [agent]
   metric_batch_size = 10000
   metric_buffer_limit = 100000
-  interval = "9s"
+  interval = "10s"
   flush_interval = "10s"

--- a/demo/docker/telegraf/telegraf.conf
+++ b/demo/docker/telegraf/telegraf.conf
@@ -42,3 +42,9 @@
   urls = ["http://influxdb:8086"]
   skip_database_creation = true
   database = "esp"
+
+[agent]
+  metric_batch_size = 10000
+  metric_buffer_limit = 100000
+  interval = "9s"
+  flush_interval = "10s"


### PR DESCRIPTION
Changed treatment of null metric values on the graph. Instead of extrapolating values  with a straight  line ("connect"), simply do not show anything in the time period when there were no metrics reported. The result is hopefully on the attached pic.
![image](https://user-images.githubusercontent.com/50945192/120154341-12673e80-c1f0-11eb-8647-1fb6631f7710.png)

Additionally modified  the "max lag" graph , we were showing stacked sum of max lags as reported by each Flink parallelized task. This is roughly the same value shown and stacked as many times as the Flink task parallelism level. Decided to show only one value, commented the graph accordingly. 

![image](https://user-images.githubusercontent.com/50945192/120152852-4c374580-c1ee-11eb-8494-9df5a5c2cc56.png).


An interesting new effect is visible - every 4 minutes reporting (hopefully only reporting) stops for ca 20s, I get this effect on both my local machine and client (N..a) deployment.