### PR TITLE
jobmanager and taskmanager should share volume where state data are stored

### DIFF
--- a/demo/docker/docker-compose-env.yml
+++ b/demo/docker/docker-compose-env.yml
@@ -97,7 +97,7 @@ services:
     volumes:
       - ./flink/flink-conf.yaml:/tmp/flink-conf.yaml
       - ./flink/flink-entrypoint.sh:/flink-entrypoint.sh
-      - nussknacker_storage_jobmanager:/opt/flink/data
+      - nussknacker_storage_flink:/opt/flink/data
 
   taskmanager:
     container_name: nussknacker_taskmanager
@@ -116,7 +116,7 @@ services:
     volumes:
       - ./flink/flink-conf.yaml:/tmp/flink-conf.yaml
       - ./flink/flink-entrypoint.sh:/flink-entrypoint.sh
-      - nussknacker_storage_taskmanager:/opt/flink/data
+      - nussknacker_storage_flink:/opt/flink/data
     ulimits:
       nproc: 70000
       nofile:
@@ -157,6 +157,5 @@ volumes:
   nussknacker_storage_zookeeper_datalog:
   nussknacker_storage_zookeeper_data:
   nussknacker_storage_kafka_data:
-  nussknacker_storage_taskmanager:
-  nussknacker_storage_jobmanager:
+  nussknacker_storage_flink:
   nussknacker_storage_influxdb:


### PR DESCRIPTION
Currently in the demo version jobmanager and taskmanager use their own (separate) docker volumes. As the result jobmanager is not deleting old checkpoint files created by taskmanager. 

Jobmanager and taskmanager should share volume where statedata are stored