### PR TITLE
Fix for Spel validation: Use not existing method reference

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -48,6 +48,7 @@ Nussknacker versions
 * [#1728](https://github.com/TouK/nussknacker/pull/1728) Replace schemaRegistryClient and recordFormatter in `SchemaRegistryProvider` with their factories.
 * [#1651](https://github.com/TouK/nussknacker/pull/1651) `KafkaAvroSourceFactory` provides additional #inputMeta variable with event's metadata.
 * [#1756](https://github.com/TouK/nussknacker/pull/1756) `TypingResultAwareTypeInformationDetection` can be used to serialize aggregates more efficiently
+* [#1772](https://github.com/TouK/nussknacker/pull/1772) Fix for Spel validation when we try use not existing method reference
 
 0.3.1 (not released yet) 
 ------------------------

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -12,6 +12,7 @@ import org.springframework.expression.Expression
 import org.springframework.expression.common.{CompositeStringExpression, LiteralExpression}
 import org.springframework.expression.spel.ast._
 import org.springframework.expression.spel.{SpelNode, standard}
+import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.expression.{ExpressionParseError, ExpressionTypingInfo}
 import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
@@ -27,11 +28,15 @@ import pl.touk.nussknacker.engine.types.EspTypeUtils
 
 import scala.annotation.tailrec
 import scala.reflect.runtime._
+import scala.util.{Success, Failure, Try}
+import scala.util.control.NonFatal
 
 private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: CommonSupertypeFinder,
                           dictTyper: SpelDictTyper, strictMethodsChecking: Boolean)(implicit settings: ClassExtractionSettings) extends LazyLogging {
 
   import ast.SpelAst._
+
+  type NodeTypingResult = ValidatedNel[ExpressionParseError, CollectedTypingResult]
 
   def typeExpression(expr: Expression, ctx: ValidationContext): ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
     expr match {
@@ -66,8 +71,7 @@ private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: Commo
     result
   }
 
-  private def typeNode(validationContext: ValidationContext, node: SpelNode, current: TypingContext)
-  : ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
+  private def typeNode(validationContext: ValidationContext, node: SpelNode, current: TypingContext): NodeTypingResult = {
 
     def toResult(typ: TypingResult) = current.toResult(TypedNode(node, typ))
 
@@ -84,7 +88,14 @@ private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: Commo
       case _ => invalid("Wrong part types")
     }
 
-    node match {
+    def catchUnexpectedErrors(block: => NodeTypingResult): NodeTypingResult = Try(block) match {
+      case Success(value) =>
+        value
+      case Failure(e) =>
+        throw new SpelCompilationException(node, e)
+    }
+
+    catchUnexpectedErrors(node match {
 
       case e: Assign => invalid("Value modifications are not supported")
       case e: BeanReference => invalid("Bean reference is not supported")
@@ -246,7 +257,7 @@ private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: Commo
           case Some(result) => valid(result)
           case None => invalid(s"Unresolved reference '$name'")
         }
-    }
+    })
   }
 
   private def checkEqualityLikeOperation(validationContext: ValidationContext, node: Operator, current: TypingContext): ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
@@ -399,6 +410,8 @@ object Typer {
 
   }
 
+  class SpelCompilationException(node: SpelNode, cause: Throwable)
+    extends RuntimeException(s"Can't compile SpEL expression: `${node.toStringAST}`, message: `${cause.getMessage}`.", cause)
 }
 
 private[spel] case class TypedNode(nodeId: SpelNodeId, typ: TypingResult)

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -155,12 +155,8 @@ private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: Commo
           }
         }
 
-      case e: MethodReference => typeChildren(validationContext, node, current.popStack) { typedParams =>
-        TypeMethodReference(e.getName, current.stack, typedParams) match {
-          case Right(typingResult) => Valid(typingResult)
-          case Left(errorMsg) => if(strictMethodsChecking) invalid(errorMsg) else Valid(Unknown)
-        }
-      }
+      case e: MethodReference =>
+        extractMethodReference(e, validationContext, node, current)
 
       case e: OpEQ => checkEqualityLikeOperation(validationContext, e, current)
       case e: OpNE => checkEqualityLikeOperation(validationContext, e, current)
@@ -290,6 +286,20 @@ private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: Commo
         Valid(Typed(l.toSet))
   }
 
+  private def extractMethodReference(reference: MethodReference, validationContext: ValidationContext, node: SpelNode, context: TypingContext) = {
+    context.stack match {
+      case _ :: tail =>
+        typeChildren(validationContext, node, context.copy(stack = tail)) { typedParams =>
+          TypeMethodReference(reference.getName, context.stack, typedParams) match {
+            case Right(typingResult) => Valid(typingResult)
+            case Left(errorMsg) => if(strictMethodsChecking) invalid(errorMsg) else Valid(Unknown)
+          }
+        }
+      case Nil =>
+        invalid(s"Invalid method reference: ${reference.toStringAST}.")
+    }
+  }
+
   @tailrec
   private def extractSingleProperty(e: PropertyOrFieldReference)
                                    (t: SingleTypingResult): ValidatedNel[ExpressionParseError, TypingResult]  = {
@@ -380,11 +390,7 @@ object Typer {
     def pushOnStack(typingResult: CollectedTypingResult): TypingContext =
       TypingContext(typingResult.finalResult :: stack, intermediateResults ++ typingResult.intermediateResults)
 
-    def popStack: TypingContext = copy(stack = stack.tail)
-
     def stackHead: Option[TypingResult] = stack.headOption
-
-    def stackTail: List[TypingResult] = stack.tail
 
     def withoutIntermediateResults: TypingContext = copy(intermediateResults = Map.empty)
 

--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -117,6 +117,10 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
     parse[Any]("'' - 1") shouldEqual Invalid(NonEmptyList.of(ExpressionParseError("Operator '-' used with mismatch types: String and Integer")))
   }
 
+  test("use not existing method reference") {
+    parse[Any]("notExistingMethod(1)", ctxWithGlobal) shouldBe Invalid(NonEmptyList.of(ExpressionParseError("Invalid method reference: notExistingMethod(1).")))
+  }
+
   test("null properly") {
     parse[String]("null") shouldBe 'valid
     parse[Long]("null") shouldBe 'valid


### PR DESCRIPTION
TODO:
- Add tests
- Rethrow exception with content of expression for easier further diagnostics
- Add entry in changelog