### PR TITLE
Fix: Load config app

### DIFF
--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/config/ConfigFactoryExt.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/config/ConfigFactoryExt.scala
@@ -30,8 +30,10 @@ object ConfigFactoryExt {
 
   def loadEmptyConfigWithOverrides(classLoader: ClassLoader): Config = ConfigFactory.load(classLoader, ConfigFactory.empty())
 
-  def load(resources: List[URI], classLoader: ClassLoader): Config = {
-    resources.map(ConfigFactoryExt.parseUri).reverse.foldLeft(loadEmptyConfigWithOverrides(classLoader))(_.withFallback(_))
-  }
-
+  def load(resources: List[URI], classLoader: ClassLoader): Config =
+    resources
+      .map(ConfigFactoryExt.parseUri)
+      .reverse
+      .foldLeft(ConfigFactory.empty())(_.withFallback(_))
+      .withFallback(loadEmptyConfigWithOverrides(classLoader))
 }

--- a/engine/util/src/test/resources/reference.conf
+++ b/engine/util/src/test/resources/reference.conf
@@ -1,0 +1,5 @@
+akka {
+    http {
+        server.request-timeout: 20s
+    }
+}

--- a/engine/util/src/test/scala/pl/touk/nussknacker/engine/util/config/ConfigFactoryExtSpec.scala
+++ b/engine/util/src/test/scala/pl/touk/nussknacker/engine/util/config/ConfigFactoryExtSpec.scala
@@ -11,7 +11,7 @@ class ConfigFactoryExtSpec extends FunSuite with Matchers {
 
   test("loads in correct order") {
 
-    val conf1 = writeToTemp(Map("f1" -> "default", "f2" ->"not so default"))
+    val conf1 = writeToTemp(Map("f1" -> "default", "f2" ->"not so default", "akka.http.server.request-timeout" -> "300s"))
     val conf2 = writeToTemp(Map("f1" -> "I win!"))
 
     val result = ConfigFactoryExt.load(List(conf1, conf2, "classpath:someConfig.conf").mkString(", "), getClass.getClassLoader)
@@ -20,7 +20,7 @@ class ConfigFactoryExtSpec extends FunSuite with Matchers {
     result.getString("f2") shouldBe "not so default"
     result.getString("f4") shouldBe "fromClasspath"
     result.hasPath("f5") shouldBe false
-
+    result.getString("akka.http.server.request-timeout") shouldBe "300s"
   }
 
   def writeToTemp(map: Map[String, Any]): URI = {


### PR DESCRIPTION
Loaded empty config (`ConfigFactoryExt.loadEmptyConfigWithOverrides`) contains settings from reference.conf. This should be used as last fallback configuration. 