### PR TITLE
More flexible authenticator customization by using named SPI services.

### DIFF
--- a/engine/security/src/it/scala/pl/touk/nussknacker/ui/security/oauth2/OpenIdConnectServiceSpec.scala
+++ b/engine/security/src/it/scala/pl/touk/nussknacker/ui/security/oauth2/OpenIdConnectServiceSpec.scala
@@ -6,7 +6,6 @@ import org.apache.commons.lang3.StringEscapeUtils
 import org.scalatest.{FunSuite, Matchers}
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext._
 import pl.touk.nussknacker.test.VeryPatientScalaFutures
-import pl.touk.nussknacker.ui.security.api.AuthenticationMethod
 import sttp.client.asynchttpclient.WebSocketHandler
 import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
 import sttp.client.{SttpBackend, _}
@@ -69,7 +68,6 @@ class OpenIdConnectServiceSpec extends FunSuite with ForAllTestContainer with Ma
   private def oauth2Conf: OAuth2Configuration = {
 
     OAuth2Configuration(
-      method = AuthenticationMethod.OAuth2,
       usersFile = new URI("classpath://users.conf"),
       authorizeUri = uri"$baseUrl/auth".toJavaUri,
       clientSecret = realmClientSecret,

--- a/engine/security/src/main/resources/META-INF/services/pl.touk.nussknacker.ui.security.api.AuthenticationProvider
+++ b/engine/security/src/main/resources/META-INF/services/pl.touk.nussknacker.ui.security.api.AuthenticationProvider
@@ -1,0 +1,2 @@
+pl.touk.nussknacker.ui.security.basicauth.BasicAuthenticationProvider
+pl.touk.nussknacker.ui.security.oauth2.OAuth2AuthenticationProvider

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationConfiguration.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationConfiguration.scala
@@ -1,21 +1,15 @@
 package pl.touk.nussknacker.ui.security.api
 
-import java.io.File
-import java.net.{URI, URL}
-import java.security.PublicKey
+import java.net.URI
 
-import com.typesafe.config.{Config, ConfigFactory}
-import pl.touk.nussknacker.engine.util.cache.CacheConfig
+import com.typesafe.config.Config
 import pl.touk.nussknacker.engine.util.config.ConfigFactoryExt
 import pl.touk.nussknacker.ui.security.api.AuthenticationConfiguration.{ConfigRule, ConfigUser}
-import pl.touk.nussknacker.ui.security.api.AuthenticationMethod.AuthenticationMethod
 import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
 import pl.touk.nussknacker.ui.security.api.Permission.Permission
 
-import scala.concurrent.duration._
-
 trait AuthenticationConfiguration {
-  def method: AuthenticationMethod
+  def name: String
   def usersFile: URI
 
   val userConfig: Config = ConfigFactoryExt.parseUri(usersFile)
@@ -23,14 +17,6 @@ trait AuthenticationConfiguration {
   lazy val users: List[ConfigUser] = AuthenticationConfiguration.getUsers(userConfig)
 
   lazy val rules: List[ConfigRule] = AuthenticationConfiguration.getRules(userConfig)
-}
-
-object AuthenticationMethod extends Enumeration {
-  type AuthenticationMethod = Value
-
-  val BasicAuth = Value("BasicAuth")
-  val OAuth2 = Value("OAuth2")
-  val Other = Value("Other")
 }
 
 object AuthenticationConfiguration {
@@ -42,8 +28,6 @@ object AuthenticationConfiguration {
   val methodConfigPath = s"$authenticationConfigPath.method"
   val usersConfigurationPath = "users"
   val rulesConfigurationPath = "rules"
-
-  def parseMethod(config: Config): AuthenticationMethod = config.as[AuthenticationMethod](methodConfigPath)
 
   def getUsers(config: Config): List[ConfigUser] = config.as[List[ConfigUser]](usersConfigurationPath)
 
@@ -59,53 +43,4 @@ object AuthenticationConfiguration {
                         categories: List[String] = List.empty,
                         permissions: List[Permission] = List.empty,
                         globalPermissions: List[GlobalPermission] = List.empty)
-}
-
-case class DefaultAuthenticationConfiguration(method: AuthenticationMethod = AuthenticationMethod.Other, usersFile: URI,
-                                              cachingHashes: Option[CachingHashesConfig]) extends AuthenticationConfiguration {
-
-  def cachingHashesOrDefault: CachingHashesConfig = cachingHashes.getOrElse(CachingHashesConfig.defaultConfig)
-
-  def implicitGrantEnabled: Boolean = false
-
-  def idTokenNonceVerificationRequired: Boolean = false
-}
-
-object DefaultAuthenticationConfiguration {
-  import AuthenticationConfiguration._
-  import pl.touk.nussknacker.engine.util.config.CustomFicusInstances._
-  import net.ceedubs.ficus.readers.ArbitraryTypeReader._
-  import net.ceedubs.ficus.readers.EnumerationReader._
-
-  def create(config: Config): DefaultAuthenticationConfiguration =
-    config.as[DefaultAuthenticationConfiguration](authenticationConfigPath)
-}
-
-case class CachingHashesConfig(enabled: Option[Boolean],
-                               maximumSize: Option[Long],
-                               expireAfterAccess: Option[FiniteDuration],
-                               expireAfterWrite: Option[FiniteDuration]) {
-
-  def isEnabled: Boolean = enabled.getOrElse(CachingHashesConfig.defaultEnabledValue)
-
-  def toCacheConfig: Option[CacheConfig[(String, String), String]] =
-    if (isEnabled) {
-      Some(CacheConfig(
-        maximumSize.getOrElse(CacheConfig.defaultMaximumSize),
-        expireAfterAccess.orElse(CachingHashesConfig.defaultExpireAfterAccess),
-        expireAfterWrite.orElse(CachingHashesConfig.defaultExpireAfterWrite)
-      ))
-    } else {
-      None
-    }
-
-}
-
-object CachingHashesConfig {
-
-  val defaultEnabledValue: Boolean = false
-  val defaultExpireAfterAccess: Option[FiniteDuration] = Some(1.hour)
-  val defaultExpireAfterWrite: Option[FiniteDuration] = None
-  val defaultConfig: CachingHashesConfig = CachingHashesConfig(Some(defaultEnabledValue), None, None, None)
-
 }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationProvider.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationProvider.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.ui.security.api
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.api.NamedServiceProvider
 import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
 import pl.touk.nussknacker.ui.security.basicauth.BasicAuthenticationProvider
 import pl.touk.nussknacker.ui.security.oauth2.OAuth2AuthenticationProvider
@@ -9,7 +10,7 @@ import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait AuthenticationProvider {
+trait AuthenticationProvider extends NamedServiceProvider {
   val realm = "nussknacker"
 
   //TODO: Extract putting allCategories in up level. Authenticator should return only Authenticated User(id, roles)
@@ -19,12 +20,10 @@ trait AuthenticationProvider {
 
 object AuthenticationProvider extends LazyLogging {
   def apply(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationProvider = {
-    val loaded = ScalaServiceLoader.loadClass[AuthenticationProvider](classLoader) {
-      AuthenticationConfiguration.parseMethod(config) match {
-        case AuthenticationMethod.OAuth2 => OAuth2AuthenticationProvider()
-        case _ => BasicAuthenticationProvider()
-      }
-    }
+    val loaded = ScalaServiceLoader.loadNamed[AuthenticationProvider](
+      config.getString(AuthenticationConfiguration.methodConfigPath),
+      classLoader
+    )
     logger.info(s"Loaded authenticator method: $loaded.")
     loaded
   }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationConfiguration.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationConfiguration.scala
@@ -1,0 +1,61 @@
+package pl.touk.nussknacker.ui.security.basicauth
+
+import com.typesafe.config.Config
+import pl.touk.nussknacker.engine.util.cache.CacheConfig
+import pl.touk.nussknacker.ui.security.api.AuthenticationConfiguration
+
+import java.net.URI
+import scala.concurrent.duration._
+
+case class BasicAuthenticationConfiguration(usersFile: URI,
+                                            cachingHashes: Option[CachingHashesConfig]) extends AuthenticationConfiguration {
+
+  override def name: String = BasicAuthenticationConfiguration.name
+
+  def cachingHashesOrDefault: CachingHashesConfig = cachingHashes.getOrElse(CachingHashesConfig.defaultConfig)
+
+  def implicitGrantEnabled: Boolean = false
+
+  def idTokenNonceVerificationRequired: Boolean = false
+}
+
+object BasicAuthenticationConfiguration {
+
+  import AuthenticationConfiguration._
+  import pl.touk.nussknacker.engine.util.config.CustomFicusInstances._
+  import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+
+  val name: String = "BasicAuth"
+
+  def create(config: Config): BasicAuthenticationConfiguration =
+    config.as[BasicAuthenticationConfiguration](authenticationConfigPath)
+}
+
+case class CachingHashesConfig(enabled: Option[Boolean],
+                               maximumSize: Option[Long],
+                               expireAfterAccess: Option[FiniteDuration],
+                               expireAfterWrite: Option[FiniteDuration]) {
+
+  def isEnabled: Boolean = enabled.getOrElse(CachingHashesConfig.defaultEnabledValue)
+
+  def toCacheConfig: Option[CacheConfig[(String, String), String]] =
+    if (isEnabled) {
+      Some(CacheConfig(
+        maximumSize.getOrElse(CacheConfig.defaultMaximumSize),
+        expireAfterAccess.orElse(CachingHashesConfig.defaultExpireAfterAccess),
+        expireAfterWrite.orElse(CachingHashesConfig.defaultExpireAfterWrite)
+      ))
+    } else {
+      None
+    }
+
+}
+
+object CachingHashesConfig {
+
+  val defaultEnabledValue: Boolean = false
+  val defaultExpireAfterAccess: Option[FiniteDuration] = Some(1.hour)
+  val defaultExpireAfterWrite: Option[FiniteDuration] = None
+  val defaultConfig: CachingHashesConfig = CachingHashesConfig(Some(defaultEnabledValue), None, None, None)
+
+}

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationProvider.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationProvider.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.ui.security.basicauth
 
 import akka.http.scaladsl.server.Directives
 import com.typesafe.config.Config
-import pl.touk.nussknacker.ui.security.api.{AuthenticationProvider, AuthenticationResources, DefaultAuthenticationConfiguration}
+import pl.touk.nussknacker.ui.security.api.{AuthenticationProvider, AuthenticationResources}
 import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,9 +10,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class BasicAuthenticationProvider extends AuthenticationProvider with Directives {
 
   override def createAuthenticationResources(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationResources = {
-    val configuration = DefaultAuthenticationConfiguration.create(config)
+    val configuration = BasicAuthenticationConfiguration.create(config)
     new BasicAuthenticationResources(realm, configuration, allCategories)
   }
+
+  def name: String = BasicAuthenticationConfiguration.name
 }
 
 object BasicAuthenticationProvider {

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationResources.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationResources.scala
@@ -2,10 +2,10 @@ package pl.touk.nussknacker.ui.security.basicauth
 
 import akka.http.scaladsl.server.directives.SecurityDirectives
 import pl.touk.nussknacker.ui.security.api.AuthenticationResources.LoggedUserAuth
-import pl.touk.nussknacker.ui.security.api.{AuthenticationResources, DefaultAuthenticationConfiguration}
+import pl.touk.nussknacker.ui.security.api.{AuthenticationResources}
 
-class BasicAuthenticationResources(realm: String, configuration: DefaultAuthenticationConfiguration, allCategories: List[String]) extends AuthenticationResources {
-  val name: String = configuration.method.toString
+class BasicAuthenticationResources(realm: String, configuration: BasicAuthenticationConfiguration, allCategories: List[String]) extends AuthenticationResources {
+  val name: String = configuration.name
 
   def authenticate(): LoggedUserAuth =
     SecurityDirectives.authenticateBasicAsync(

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticator.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticator.scala
@@ -4,12 +4,12 @@ import akka.http.scaladsl.server.directives.Credentials.Provided
 import akka.http.scaladsl.server.directives.{Credentials, SecurityDirectives}
 import org.mindrot.jbcrypt.BCrypt
 import pl.touk.nussknacker.engine.util.cache.DefaultCache
-import pl.touk.nussknacker.ui.security.api.{DefaultAuthenticationConfiguration, LoggedUser, RulesSet}
+import pl.touk.nussknacker.ui.security.api.{LoggedUser, RulesSet}
 import pl.touk.nussknacker.ui.security.basicauth.BasicHttpAuthenticator.{EncryptedPassword, PlainPassword, UserWithPassword}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class BasicHttpAuthenticator(configuration: DefaultAuthenticationConfiguration, allCategories: List[String]) extends SecurityDirectives.AsyncAuthenticator[LoggedUser] {
+class BasicHttpAuthenticator(configuration: BasicAuthenticationConfiguration, allCategories: List[String]) extends SecurityDirectives.AsyncAuthenticator[LoggedUser] {
   //If we want use always reloaded config then we need just prepareUsers()
   private val users = prepareUsers()
 
@@ -65,7 +65,7 @@ class BasicHttpAuthenticator(configuration: DefaultAuthenticationConfiguration, 
 }
 
 object BasicHttpAuthenticator {
-  def apply(config: DefaultAuthenticationConfiguration, allCategories: List[String]): BasicHttpAuthenticator = new BasicHttpAuthenticator(config, allCategories)
+  def apply(config: BasicAuthenticationConfiguration, allCategories: List[String]): BasicHttpAuthenticator = new BasicHttpAuthenticator(config, allCategories)
 
   private sealed trait Password {
     def value: String

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationProvider.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationProvider.scala
@@ -14,6 +14,8 @@ class OAuth2AuthenticationProvider extends AuthenticationProvider with LazyLoggi
     val service = OAuth2ServiceProvider(configuration, classLoader, allCategories)
     new OAuth2AuthenticationResources(realm, service, configuration)
   }
+
+  def name: String = OAuth2Configuration.name
 }
 
 object OAuth2AuthenticationProvider {

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationResources.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationResources.scala
@@ -18,7 +18,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class OAuth2AuthenticationResources(realm: String, service: OAuth2Service[LoggedUser, OAuth2AuthorizationData], configuration: OAuth2Configuration)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT])
   extends AuthenticationResources with Directives with LazyLogging with FailFastCirceSupport {
 
-  override val name: String = configuration.method.toString
+  override val name: String = configuration.name
 
   override val frontendSettings: ToResponseMarshallable = OAuth2AuthenticationSettings(
     configuration.authorizeUrl.map(_.toString),

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2Configuration.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2Configuration.scala
@@ -7,7 +7,6 @@ import com.typesafe.config.Config
 import pl.touk.nussknacker.engine.util.Implicits.SourceIsReleasable
 import pl.touk.nussknacker.ui.security.CertificatesAndKeys
 import pl.touk.nussknacker.ui.security.api.AuthenticationConfiguration
-import pl.touk.nussknacker.ui.security.api.AuthenticationMethod.AuthenticationMethod
 import pl.touk.nussknacker.ui.security.oauth2.ProfileFormat.ProfileFormat
 import sttp.model.{HeaderNames, MediaType, Uri}
 
@@ -15,8 +14,7 @@ import scala.concurrent.duration.{FiniteDuration, HOURS}
 import scala.io.Source
 import scala.util.Using
 
-case class OAuth2Configuration(method: AuthenticationMethod,
-                               usersFile: URI,
+case class OAuth2Configuration(usersFile: URI,
                                authorizeUri: URI,
                                clientSecret: String,
                                clientId: String,
@@ -33,6 +31,7 @@ case class OAuth2Configuration(method: AuthenticationMethod,
                                accessTokenRequestContentType: String = MediaType.ApplicationJson.toString(),
                                defaultTokenExpirationTime: FiniteDuration = FiniteDuration(1, HOURS)
                               ) extends AuthenticationConfiguration {
+  override def name: String = OAuth2Configuration.name
 
   def authorizeUrl: Option[URI] = Option(Uri(authorizeUri).params(Map(
     "client_id" -> clientId,
@@ -54,6 +53,7 @@ object OAuth2Configuration {
   import net.ceedubs.ficus.readers.ArbitraryTypeReader._
   import net.ceedubs.ficus.readers.EnumerationReader._
 
+  val name = "OAuth2"
   def create(config: Config): OAuth2Configuration = config.as[OAuth2Configuration](authenticationConfigPath)
 }
 

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/api/AuthenticationConfigurationSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/api/AuthenticationConfigurationSpec.scala
@@ -4,6 +4,8 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 import pl.touk.nussknacker.engine.util.cache.CacheConfig
+import pl.touk.nussknacker.ui.security.basicauth.BasicAuthenticationConfiguration
+
 import scala.concurrent.duration._
 
 class AuthenticationConfigurationSpec extends FlatSpec with Matchers with ScalatestRouteTest with OptionValues {
@@ -16,9 +18,9 @@ class AuthenticationConfigurationSpec extends FlatSpec with Matchers with Scalat
         }
       """.stripMargin)
 
-    val authConfig = DefaultAuthenticationConfiguration.create(config)
-    authConfig shouldBe a[DefaultAuthenticationConfiguration]
-    authConfig.method shouldBe AuthenticationMethod.Other
+    val authConfig = BasicAuthenticationConfiguration.create(config)
+    authConfig shouldBe a[BasicAuthenticationConfiguration]
+    authConfig.name shouldBe BasicAuthenticationConfiguration.name
     authConfig.cachingHashesOrDefault.isEnabled shouldBe false
   }
 
@@ -34,7 +36,7 @@ class AuthenticationConfigurationSpec extends FlatSpec with Matchers with Scalat
         }
       """.stripMargin)
 
-    val authConfig = DefaultAuthenticationConfiguration.create(config)
+    val authConfig = BasicAuthenticationConfiguration.create(config)
     authConfig.cachingHashesOrDefault.isEnabled shouldBe true
     authConfig.cachingHashesOrDefault.toCacheConfig.value shouldEqual CacheConfig(expireAfterAccess = Some(10.minutes))
   }

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticationResourcesSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticationResourcesSpec.scala
@@ -3,17 +3,14 @@ package pl.touk.nussknacker.ui.security.basicauth
 import akka.http.scaladsl.server.directives.Credentials
 import org.scalatest.{FunSpec, Matchers}
 import pl.touk.nussknacker.ui.security.api.AuthenticationConfiguration.{ConfigRule, ConfigUser}
-import pl.touk.nussknacker.ui.security.api.AuthenticationMethod.AuthenticationMethod
-import pl.touk.nussknacker.ui.security.api.{AuthenticationMethod, CachingHashesConfig, DefaultAuthenticationConfiguration}
 
 import java.net.URI
-import scala.concurrent.ExecutionContext.Implicits.global
 
 
 class BasicHttpAuthenticationResourcesSpec extends FunSpec with Matchers {
-  class DummyConfiguration(usersList: List[ConfigUser], rulesList: List[ConfigRule] = List.empty, method: AuthenticationMethod = AuthenticationMethod.BasicAuth,
+  class DummyConfiguration(usersList: List[ConfigUser], rulesList: List[ConfigRule] = List.empty,
                            usersFile: URI = URI.create("classpath:basicauth-user.conf"), cachingHashes: Option[CachingHashesConfig] = None)
-    extends DefaultAuthenticationConfiguration(method: AuthenticationMethod, usersFile: URI, cachingHashes) {
+    extends BasicAuthenticationConfiguration(usersFile: URI, cachingHashes) {
     override lazy val users: List[ConfigUser] = usersList
     override lazy val rules: List[ConfigRule] = rulesList
   }

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactory.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactory.scala
@@ -6,7 +6,7 @@ import io.circe.generic.JsonCodec
 import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec, JsonKey}
 import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
 import pl.touk.nussknacker.ui.security.api.Permission.Permission
-import pl.touk.nussknacker.ui.security.api.{AuthenticationMethod, GlobalPermission, LoggedUser, Permission}
+import pl.touk.nussknacker.ui.security.api.{GlobalPermission, LoggedUser, Permission}
 import pl.touk.nussknacker.ui.security.oauth2.ExampleOAuth2ServiceFactory.{TestAccessTokenResponse, TestProfileResponse}
 import sttp.client.{NothingT, SttpBackend}
 
@@ -76,7 +76,6 @@ object ExampleOAuth2ServiceFactory {
 
   def testConfig: OAuth2Configuration =
     OAuth2Configuration(
-      AuthenticationMethod.OAuth2,
       new File("ui/server/src/test/resources/oauth2-users.conf").toURI,
       URI.create("https://github.com/login/oauth/authorize"),
       "clientSecret",

--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/loader/ScalaServiceLoader.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/loader/ScalaServiceLoader.scala
@@ -1,10 +1,9 @@
 package pl.touk.nussknacker.engine.util.loader
 
 import pl.touk.nussknacker.engine.api.NamedServiceProvider
-
-import java.util.ServiceLoader
 import pl.touk.nussknacker.engine.util.multiplicity.{Empty, Many, Multiplicity, One}
 
+import java.util.ServiceLoader
 import scala.reflect.ClassTag
 
 object ScalaServiceLoader {
@@ -14,7 +13,6 @@ object ScalaServiceLoader {
     val claz: Class[T] = toClass(classTag)
     ServiceLoader
       .load(claz, classLoader)
-      .iterator()
       .asScala
       .toList
   }
@@ -39,7 +37,7 @@ object ScalaServiceLoader {
     val className = implicitly[ClassTag[T]].runtimeClass.getName
     Multiplicity(available.filter(_.name == name)) match {
       case Empty() =>
-        throw new IllegalArgumentException(s"Failed to find $className with name '$name', available names: ${available.map(_.name).mkString(", ")}")
+        throw new IllegalArgumentException(s"Failed to find $className with name '$name', available names: ${available.map(_.name).distinct.mkString(", ")}")
       case One(instance) => instance
       case Many(more) =>
         throw new IllegalArgumentException(s"More than one $className with name '$name' found: ${more.map(_.getClass).mkString(", ")}")

--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/multiplicity.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/multiplicity.scala
@@ -2,9 +2,13 @@ package pl.touk.nussknacker.engine.util
 
 object multiplicity {
 
-  sealed trait Multiplicity[A]
+  sealed trait Multiplicity[A] {
+    def orElse(alternative: Multiplicity[A]): Multiplicity[A] = this
+  }
 
-  case class Empty[T]() extends Multiplicity[T]
+  case class Empty[T]() extends Multiplicity[T] {
+    override def orElse(alternative: Multiplicity[T]): Multiplicity[T] = alternative
+  }
 
   case class One[T](value: T) extends Multiplicity[T]
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -36,7 +36,8 @@ import pl.touk.nussknacker.ui.process.processingtypedata.{ProcessingTypeDataProv
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.CreateProcessAction
 import pl.touk.nussknacker.ui.process.repository.RepositoryManager
 import pl.touk.nussknacker.ui.processreport.ProcessCounter
-import pl.touk.nussknacker.ui.security.api.{DefaultAuthenticationConfiguration, LoggedUser}
+import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.security.basicauth.BasicAuthenticationConfiguration
 import pl.touk.nussknacker.ui.service.ConfigProcessToolbarService
 import pl.touk.nussknacker.ui.util.ConfigWithScalaVersion
 
@@ -109,11 +110,11 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
     typeToConfig = typeToConfig
   )
 
-  val authenticationConfig = DefaultAuthenticationConfiguration.create(testConfig)
+  val authenticationConfig = BasicAuthenticationConfiguration.create(testConfig)
   val analyticsConfig = AnalyticsConfig(testConfig)
 
   val usersRoute = new UserResources(processCategoryService)
-  val settingsRoute = new SettingsResources(featureTogglesConfig, typeToConfig, authenticationConfig.method.toString, analyticsConfig)
+  val settingsRoute = new SettingsResources(featureTogglesConfig, typeToConfig, authenticationConfig.name, analyticsConfig)
 
   val processesExportResources = new ProcessesExportResources(fetchingProcessRepository, processActivityRepository, processResolving)
 


### PR DESCRIPTION
I have found out that the extension engine for authenticators is hardly useful.
You can override an authenticator, but you cannot add a new method name since they are defined in an enumeration. So in the case of a totally new authenticator, it is not possible to pass to FE a method name other than `Other`.

The PR drops the enumeration in favor of the NamedServiceProvider interface.
I have also renamed `DefaultAuthenticationConfiguration` to `Basic...` since it seems the only usage case and the class is not extendable.