### PR TITLE
Add missing volume declaration

### DIFF
--- a/demo/docker/docker-compose.yml
+++ b/demo/docker/docker-compose.yml
@@ -19,3 +19,4 @@ services:
 
 volumes:
   nussknacker_storage_app:
+  nussknacker_storage_flink:


### PR DESCRIPTION
Fixes ERROR: Named volume "nussknacker_storage_flink:/opt/flink/data:rw" is used in service "app" but no declaration was found in the volumes section.