### PR TITLE
Category-permission mapping extracted from AuthenticationProvider

### DIFF
--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticatedUser.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticatedUser.scala
@@ -1,0 +1,3 @@
+package pl.touk.nussknacker.ui.security.api
+
+case class AuthenticatedUser(id: String, username: String, roles: List[String])

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationConfiguration.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationConfiguration.scala
@@ -4,7 +4,7 @@ import java.net.URI
 
 import com.typesafe.config.Config
 import pl.touk.nussknacker.engine.util.config.ConfigFactoryExt
-import pl.touk.nussknacker.ui.security.api.AuthenticationConfiguration.{ConfigRule, ConfigUser}
+import pl.touk.nussknacker.ui.security.api.AuthenticationConfiguration.ConfigUser
 import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
 import pl.touk.nussknacker.ui.security.api.Permission.Permission
 
@@ -15,23 +15,23 @@ trait AuthenticationConfiguration {
   val userConfig: Config = ConfigFactoryExt.parseUri(usersFile)
 
   lazy val users: List[ConfigUser] = AuthenticationConfiguration.getUsers(userConfig)
-
-  lazy val rules: List[ConfigRule] = AuthenticationConfiguration.getRules(userConfig)
 }
 
 object AuthenticationConfiguration {
-  import net.ceedubs.ficus.Ficus._
   import net.ceedubs.ficus.readers.EnumerationReader._
   import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+  import pl.touk.nussknacker.engine.util.config.CustomFicusInstances._
 
   val authenticationConfigPath = "authentication"
   val methodConfigPath = s"$authenticationConfigPath.method"
+  val usersConfigPath = s"$authenticationConfigPath.usersFile"
   val usersConfigurationPath = "users"
   val rulesConfigurationPath = "rules"
 
   def getUsers(config: Config): List[ConfigUser] = config.as[List[ConfigUser]](usersConfigurationPath)
 
-  def getRules(config: Config): List[ConfigRule] = config.as[List[ConfigRule]](rulesConfigurationPath)
+  def getRules(usersFile: URI): List[ConfigRule] = ConfigFactoryExt.parseUri(usersFile).as[List[ConfigRule]](rulesConfigurationPath)
+  def getRules(config: Config): List[ConfigRule] = getRules(config.as[URI](usersConfigPath))
 
   case class ConfigUser(identity: String,
                         password: Option[String],

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationProvider.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationProvider.scala
@@ -13,13 +13,11 @@ import scala.concurrent.{ExecutionContext, Future}
 trait AuthenticationProvider extends NamedServiceProvider {
   val realm = "nussknacker"
 
-  //TODO: Extract putting allCategories in up level. Authenticator should return only Authenticated User(id, roles)
-  // mapping Authenticated User with all Categories should be do only at one place
-  def createAuthenticationResources(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationResources
+  def createAuthenticationResources(config: Config, classLoader: ClassLoader)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationResources
 }
 
 object AuthenticationProvider extends LazyLogging {
-  def apply(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationProvider = {
+  def apply(config: Config, classLoader: ClassLoader)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationProvider = {
     val loaded = ScalaServiceLoader.loadNamed[AuthenticationProvider](
       config.getString(AuthenticationConfiguration.methodConfigPath),
       classLoader

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationResources.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationResources.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.directives.AuthenticationDirective
 import akka.http.scaladsl.server.{Directives, Route}
 import com.typesafe.config.Config
-import pl.touk.nussknacker.ui.security.api.AuthenticationResources.LoggedUserAuth
 import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -14,7 +13,7 @@ trait AuthenticationResources extends Directives {
   val name: String
   val frontendSettings: ToResponseMarshallable = StatusCodes.NoContent
 
-  def authenticate(): LoggedUserAuth
+  def authenticate(): AuthenticationDirective[AuthenticatedUser]
 
   final lazy val routeWithPathPrefix: Route =
     pathPrefix("authentication" / name.toLowerCase() ) {
@@ -26,9 +25,7 @@ trait AuthenticationResources extends Directives {
 }
 
 object AuthenticationResources {
-  type LoggedUserAuth = AuthenticationDirective[LoggedUser]
-
-  def apply(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationResources = {
-    AuthenticationProvider(config, classLoader, allCategories).createAuthenticationResources(config, classLoader, allCategories)
+  def apply(config: Config, classLoader: ClassLoader)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationResources = {
+    AuthenticationProvider(config, classLoader).createAuthenticationResources(config, classLoader)
   }
 }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/LoggedUser.scala
@@ -15,10 +15,6 @@ sealed trait LoggedUser {
 }
 
 object LoggedUser {
-  def apply(authenticatedUser: AuthenticatedUser, config: Config, processCategories: List[String]): LoggedUser = {
-    apply(authenticatedUser, AuthenticationConfiguration.getRules(config), processCategories)
-  }
-
   def apply(authenticatedUser: AuthenticatedUser, rules: List[ConfigRule], processCategories: List[String]): LoggedUser = {
     val rulesSet = RulesSet.getOnlyMatchingRules(authenticatedUser.roles, rules, processCategories)
     apply(id = authenticatedUser.id, username = authenticatedUser.username, rulesSet = rulesSet)

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationProvider.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationProvider.scala
@@ -9,9 +9,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class BasicAuthenticationProvider extends AuthenticationProvider with Directives {
 
-  override def createAuthenticationResources(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationResources = {
+  override def createAuthenticationResources(config: Config, classLoader: ClassLoader)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationResources = {
     val configuration = BasicAuthenticationConfiguration.create(config)
-    new BasicAuthenticationResources(realm, configuration, allCategories)
+    new BasicAuthenticationResources(realm, configuration)
   }
 
   def name: String = BasicAuthenticationConfiguration.name

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationResources.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationResources.scala
@@ -1,15 +1,14 @@
 package pl.touk.nussknacker.ui.security.basicauth
 
-import akka.http.scaladsl.server.directives.SecurityDirectives
-import pl.touk.nussknacker.ui.security.api.AuthenticationResources.LoggedUserAuth
-import pl.touk.nussknacker.ui.security.api.{AuthenticationResources}
+import akka.http.scaladsl.server.directives.{AuthenticationDirective, SecurityDirectives}
+import pl.touk.nussknacker.ui.security.api.{AuthenticatedUser, AuthenticationResources}
 
-class BasicAuthenticationResources(realm: String, configuration: BasicAuthenticationConfiguration, allCategories: List[String]) extends AuthenticationResources {
+class BasicAuthenticationResources(realm: String, configuration: BasicAuthenticationConfiguration) extends AuthenticationResources {
   val name: String = configuration.name
 
-  def authenticate(): LoggedUserAuth =
+  def authenticate(): AuthenticationDirective[AuthenticatedUser] =
     SecurityDirectives.authenticateBasicAsync(
-      authenticator = BasicHttpAuthenticator(configuration, allCategories),
+      authenticator = BasicHttpAuthenticator(configuration),
       realm = realm
     )
 }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/GitHubProfile.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/GitHubProfile.scala
@@ -1,16 +1,15 @@
 package pl.touk.nussknacker.ui.security.oauth2
 
 import io.circe.generic.JsonCodec
-import pl.touk.nussknacker.ui.security.api.{LoggedUser, RulesSet}
+import pl.touk.nussknacker.ui.security.api.{AuthenticatedUser, LoggedUser, RulesSet}
 import pl.touk.nussknacker.ui.security.oauth2.OAuth2Profile.getUserRoles
 
 @JsonCodec case class GitHubProfileResponse(id: Long, email: Option[String], login: Option[String])
 
 object GitHubProfile extends OAuth2Profile[GitHubProfileResponse] {
-  def getLoggedUser(profile: GitHubProfileResponse, configuration: OAuth2Configuration, allCategories: List[String]): LoggedUser = {
+  def getAuthenticatedUser(profile: GitHubProfileResponse, configuration: OAuth2Configuration): AuthenticatedUser = {
     val userRoles = getUserRoles(profile.email, configuration)
-    val rulesSet = RulesSet.getOnlyMatchingRules(userRoles, configuration.rules, allCategories)
     val username = profile.login.getOrElse(profile.id.toString)
-    LoggedUser(id = profile.id.toString, username = username, rulesSet = rulesSet)
+    AuthenticatedUser(id = profile.id.toString, username = username, userRoles)
   }
 }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationProvider.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationProvider.scala
@@ -9,9 +9,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class OAuth2AuthenticationProvider extends AuthenticationProvider with LazyLogging {
 
-  override def createAuthenticationResources(config: Config, classLoader: ClassLoader, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationResources = {
+  override def createAuthenticationResources(config: Config, classLoader: ClassLoader)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): AuthenticationResources = {
     val configuration = OAuth2Configuration.create(config)
-    val service = OAuth2ServiceProvider(configuration, classLoader, allCategories)
+    val service = OAuth2ServiceProvider(configuration, classLoader)
     new OAuth2AuthenticationResources(realm, service, configuration)
   }
 

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2Profile.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2Profile.scala
@@ -1,9 +1,9 @@
 package pl.touk.nussknacker.ui.security.oauth2
 
-import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.security.api.AuthenticatedUser
 
 trait OAuth2Profile[ProfileResponse] {
-  def getLoggedUser(profile: ProfileResponse, configuration: OAuth2Configuration, allCategories: List[String]): LoggedUser
+  def getAuthenticatedUser(profile: ProfileResponse, configuration: OAuth2Configuration): AuthenticatedUser
 }
 
 object OAuth2Profile {

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceFactory.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceFactory.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.ui.security.oauth2
 
-import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.security.api.AuthenticatedUser
 import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.duration.{Deadline, FiniteDuration}
@@ -20,6 +20,6 @@ trait OAuth2Service[+UserInfoData, +AuthorizationData <: OAuth2AuthorizationData
 
 
 trait OAuth2ServiceFactory {
-  def create(configuration: OAuth2Configuration, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2Service[LoggedUser, OAuth2AuthorizationData] =
+  def create(configuration: OAuth2Configuration)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2Service[AuthenticatedUser, OAuth2AuthorizationData] =
     throw new NotImplementedError("Trying to use the new version of the interface, which is not implemented yet")
 }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceProvider.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceProvider.scala
@@ -2,19 +2,19 @@ package pl.touk.nussknacker.ui.security.oauth2
 
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
-import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.security.api.{AuthenticatedUser, LoggedUser}
 import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object OAuth2ServiceProvider extends LazyLogging {
-  def apply(configuration: OAuth2Configuration, classLoader: ClassLoader, allCategories: List[String] = Nil)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2Service[LoggedUser, OAuth2AuthorizationData] = {
+  def apply(configuration: OAuth2Configuration, classLoader: ClassLoader)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): OAuth2Service[AuthenticatedUser, OAuth2AuthorizationData] = {
     val service = ScalaServiceLoader.loadClass[OAuth2ServiceFactory](classLoader) {
       DefaultOAuth2ServiceFactory()
     }
 
     logger.info(s"Loaded OAuth2Service: $service.")
 
-    service.create(configuration, allCategories)
+    service.create(configuration)
   }
 }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OpenIdConnectProfile.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OpenIdConnectProfile.scala
@@ -1,10 +1,9 @@
 package pl.touk.nussknacker.ui.security.oauth2
 
 import java.time.LocalDate
-
 import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec, JsonKey}
 import io.circe.java8.time.{JavaTimeDecoders, JavaTimeEncoders}
-import pl.touk.nussknacker.ui.security.api.{LoggedUser, RulesSet}
+import pl.touk.nussknacker.ui.security.api.{AuthenticatedUser, LoggedUser, RulesSet}
 import pl.touk.nussknacker.ui.security.oauth2.OAuth2Profile.getUserRoles
 
 import scala.concurrent.duration.Deadline
@@ -52,10 +51,9 @@ object OpenIdConnectUserInfo extends EpochSecondsCodecs with JavaTimeDecoders wi
 }
 
 object OpenIdConnectProfile extends OAuth2Profile[OpenIdConnectUserInfo] {
-  def getLoggedUser(profile: OpenIdConnectUserInfo, configuration: OAuth2Configuration, allCategories: List[String]): LoggedUser = {
+  def getAuthenticatedUser(profile: OpenIdConnectUserInfo, configuration: OAuth2Configuration): AuthenticatedUser = {
     val userRoles = getUserRoles(profile.email, configuration)
-    val rulesSet = RulesSet.getOnlyMatchingRules(userRoles, configuration.rules, allCategories)
     val username = profile.preferredUsername.orElse(profile.nickname).orElse(profile.subject).get
-    LoggedUser(id = profile.subject.get, username = username, rulesSet = rulesSet)
+    AuthenticatedUser(id = profile.subject.get, username = username, userRoles)
   }
 }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/UserMappingOAuth2Service.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/UserMappingOAuth2Service.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.ui.security.oauth2
 
 import io.circe.Decoder
-import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.security.api.AuthenticatedUser
 import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.duration.Deadline
@@ -10,17 +10,17 @@ import scala.concurrent.{ExecutionContext, Future}
 class UserMappingOAuth2Service[UserInfoData: Decoder, AuthorizationData <: OAuth2AuthorizationData : Decoder]
 (
   delegate: OAuth2Service[UserInfoData, AuthorizationData],
-  loggedUserFunction: UserInfoData => LoggedUser
+  loggedUserFunction: UserInfoData => AuthenticatedUser
 )
 (implicit ec: ExecutionContext, backend: SttpBackend[Future, Nothing, NothingT])
-  extends OAuth2Service[LoggedUser, AuthorizationData] {
+  extends OAuth2Service[AuthenticatedUser, AuthorizationData] {
 
-  def obtainAuthorizationAndUserInfo(authorizationCode: String): Future[(AuthorizationData, Option[LoggedUser])] =
+  def obtainAuthorizationAndUserInfo(authorizationCode: String): Future[(AuthorizationData, Option[AuthenticatedUser])] =
     delegate.obtainAuthorizationAndUserInfo(authorizationCode).map { case (authorization, userInfo) =>
       (authorization, userInfo.map(loggedUserFunction))
     }
 
-  def checkAuthorizationAndObtainUserinfo(accessToken: String): Future[(LoggedUser, Option[Deadline])] =
+  def checkAuthorizationAndObtainUserinfo(accessToken: String): Future[(AuthenticatedUser, Option[Deadline])] =
     delegate.checkAuthorizationAndObtainUserinfo(accessToken).map { case (userInfo, expiration) =>
       (loggedUserFunction(userInfo), expiration)
     }

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/api/LoggedUserTest.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/api/LoggedUserTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import Permission._
 import org.scalatest.prop.{TableFor3, TableFor4}
+import pl.touk.nussknacker.ui.security.api.AuthenticationConfiguration.ConfigRule
 
 class LoggedUserTest extends FunSuite with Matchers {
 
@@ -37,5 +38,24 @@ class LoggedUserTest extends FunSuite with Matchers {
       u.can(c,p) shouldEqual r
       u.username shouldBe "user"
     }
+  }
+
+  test("should map an AuthenticatedUser to a LoggedUser with permissions matching roles") {
+    val processCategories = List("First", "Second")
+    val rules = List(
+      ConfigRule("FirstDeployer", categories = List("First"), permissions = List(Read, Deploy)),
+      ConfigRule("FirstEditor", categories = List("First"), permissions = List(Read, Write)),
+      ConfigRule("SecondDeployer", categories = List("Second"), permissions = List(Read, Deploy)),
+      ConfigRule("SecondEditor", categories = List("Second"), permissions = List(Read, Write))
+    )
+
+    val authorizedUser = LoggedUser.apply(AuthenticatedUser("userId", "userName", List("FirstDeployer", "SecondEditor")), rules, processCategories)
+
+    authorizedUser.can("First", Read) shouldBe true
+    authorizedUser.can("First", Deploy) shouldBe true
+    authorizedUser.can("First", Write) shouldBe false
+    authorizedUser.can("Second", Read) shouldBe true
+    authorizedUser.can("Second", Deploy) shouldBe false
+    authorizedUser.can("Second", Write) shouldBe true
   }
 }

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticationResourcesSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/basicauth/BasicHttpAuthenticationResourcesSpec.scala
@@ -12,7 +12,6 @@ class BasicHttpAuthenticationResourcesSpec extends FunSpec with Matchers {
                            usersFile: URI = URI.create("classpath:basicauth-user.conf"), cachingHashes: Option[CachingHashesConfig] = None)
     extends BasicAuthenticationConfiguration(usersFile: URI, cachingHashes) {
     override lazy val users: List[ConfigUser] = usersList
-    override lazy val rules: List[ConfigRule] = rulesList
   }
 
   // result of python -c 'import bcrypt; print(bcrypt.hashpw("password".encode("utf8"), bcrypt.gensalt(rounds=12, prefix="2a")))'
@@ -22,20 +21,20 @@ class BasicHttpAuthenticationResourcesSpec extends FunSpec with Matchers {
   private val userWithEncryptedPassword = ConfigUser("foo", None, Some(encryptedPassword), List.empty)
 
   it("should authenticate using plain password") {
-    val authenticator = new BasicHttpAuthenticator(new DummyConfiguration(List(ConfigUser("foo", Some("password"), None, List.empty))), List.empty)
+    val authenticator = new BasicHttpAuthenticator(new DummyConfiguration(List(ConfigUser("foo", Some("password"), None, List.empty))))
     authenticator.authenticate(new SampleProvidedCredentials("foo","password")) shouldBe 'defined
     authenticator.authenticate(new SampleProvidedCredentials("foo","password2")) shouldBe 'empty
   }
 
   it("should authenticate using bcrypt password") {
-    val authenticator = new BasicHttpAuthenticator(new DummyConfiguration(List(userWithEncryptedPassword)), List.empty)
+    val authenticator = new BasicHttpAuthenticator(new DummyConfiguration(List(userWithEncryptedPassword)))
     authenticator.authenticate(new SampleProvidedCredentials("foo",matchingSecret)) shouldBe 'defined
     authenticator.authenticate(new SampleProvidedCredentials("foo",notMatchingSecret)) shouldBe 'empty
   }
 
   it("should cache hashes") {
     var hashComputationCount = 0
-    val authenticator = new BasicHttpAuthenticator(new DummyConfiguration(List(userWithEncryptedPassword), cachingHashes = Some(CachingHashesConfig(enabled = Some(true), None, None, None))), List.empty) {
+    val authenticator = new BasicHttpAuthenticator(new DummyConfiguration(List(userWithEncryptedPassword), cachingHashes = Some(CachingHashesConfig(enabled = Some(true), None, None, None)))) {
       override protected def computeBCryptHash(receivedSecret: String, encryptedPassword: String): String = {
         hashComputationCount += 1
         super.computeBCryptHash(receivedSecret, encryptedPassword)

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactory.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactory.scala
@@ -4,9 +4,10 @@ import java.net.URI
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.JsonCodec
 import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec, JsonKey}
+import pl.touk.nussknacker.ui.security.api.AuthenticationConfiguration.ConfigRule
 import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
 import pl.touk.nussknacker.ui.security.api.Permission.Permission
-import pl.touk.nussknacker.ui.security.api.{GlobalPermission, LoggedUser, Permission}
+import pl.touk.nussknacker.ui.security.api.{AuthenticatedUser, AuthenticationConfiguration, GlobalPermission, LoggedUser, Permission}
 import pl.touk.nussknacker.ui.security.oauth2.ExampleOAuth2ServiceFactory.{TestAccessTokenResponse, TestProfileResponse}
 import sttp.client.{NothingT, SttpBackend}
 
@@ -15,26 +16,30 @@ import scala.concurrent.duration.{Deadline, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
 
-class ExampleOAuth2Service(clientApi: OAuth2ClientApi[TestProfileResponse, TestAccessTokenResponse], configuration: OAuth2Configuration)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]) extends OAuth2Service[LoggedUser, OAuth2AuthorizationData] with LazyLogging {
+class ExampleOAuth2Service(clientApi: OAuth2ClientApi[TestProfileResponse, TestAccessTokenResponse], configuration: OAuth2Configuration)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]) extends OAuth2Service[AuthenticatedUser, OAuth2AuthorizationData] with LazyLogging {
 
 
-  def obtainAuthorizationAndUserInfo(authorizationCode: String): Future[(OAuth2AuthorizationData, Option[LoggedUser])] =
+  def obtainAuthorizationAndUserInfo(authorizationCode: String): Future[(OAuth2AuthorizationData, Option[AuthenticatedUser])] =
     clientApi.accessTokenRequest(authorizationCode).map((_, None))
 
-  def checkAuthorizationAndObtainUserinfo(accessToken: String): Future[(LoggedUser, Option[Deadline])] =
-    clientApi.profileRequest(accessToken).map{ prf =>
+  def checkAuthorizationAndObtainUserinfo(accessToken: String): Future[(AuthenticatedUser, Option[Deadline])] =
+    clientApi.profileRequest(accessToken).map{ prf: TestProfileResponse =>
       LoggedUser(
         id = prf.uid,
         username = prf.email,
         isAdmin = ExampleOAuth2ServiceFactory.isAdmin(prf.clearance.roles),
-        categoryPermissions = ExampleOAuth2ServiceFactory.getPermissions(prf.clearance.roles, prf.clearance.portals),
         globalPermissions = ExampleOAuth2ServiceFactory.getGlobalPermissions(prf.clearance.roles)
+      )
+      AuthenticatedUser(
+        prf.uid,
+        username = prf.email,
+        prf.clearance.roles
       )
     }.map((_, None))
 }
 
 class ExampleOAuth2ServiceFactory extends OAuth2ServiceFactory {
-  override def create(configuration: OAuth2Configuration, allCategories: List[String])(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): ExampleOAuth2Service =
+  override def create(configuration: OAuth2Configuration)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]): ExampleOAuth2Service =
     ExampleOAuth2ServiceFactory.service(configuration)
 }
 
@@ -88,6 +93,8 @@ object ExampleOAuth2ServiceFactory {
       None
     )
 
+  val testRules: List[AuthenticationConfiguration.ConfigRule] = AuthenticationConfiguration.getRules(testConfig.usersFile)
+
   object TestPermissionResponse extends Enumeration {
     type PermissionTest = Value
     val Reader = Value("Reader")
@@ -117,5 +124,5 @@ object ExampleOAuth2ServiceFactory {
 
   @JsonCodec case class TestProfileResponse(email: String, uid: String, clearance: TestProfileClearanceResponse)
   @JsonCodec case class TestTokenIntrospectionResponse(exp: Option[Long])
-  @JsonCodec case class TestProfileClearanceResponse(roles: List[String], portals: List[String])
+  @JsonCodec case class TestProfileClearanceResponse(roles: List[String])
 }

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactorySpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactorySpec.scala
@@ -1,11 +1,10 @@
 package pl.touk.nussknacker.ui.security.oauth2
 
 import java.net.URI
-
 import io.circe.Json
 import org.scalatest.{FlatSpec, Matchers, Suite}
 import pl.touk.nussknacker.test.PatientScalaFutures
-import pl.touk.nussknacker.ui.security.api.{LoggedUser, Permission}
+import pl.touk.nussknacker.ui.security.api.{AuthenticationConfiguration, LoggedUser, Permission}
 import pl.touk.nussknacker.ui.security.oauth2.ExampleOAuth2ServiceFactory.{TestAccessTokenResponse, TestPermissionResponse, TestProfileClearanceResponse, TestProfileResponse}
 import pl.touk.nussknacker.ui.security.oauth2.OAuth2ErrorHandler.{OAuth2CompoundException, OAuth2ServerError}
 import sttp.client.Response
@@ -20,6 +19,7 @@ class ExampleOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
   import ExecutionContext.Implicits.global
 
   val config = ExampleOAuth2ServiceFactory.testConfig
+  val rules = ExampleOAuth2ServiceFactory.testRules
 
   def createErrorOAuth2Service(uri: URI, code: StatusCode) = {
     implicit val testingBackend = SttpBackendStub
@@ -63,78 +63,6 @@ class ExampleOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
         case _: OAuth2ServerError => succeed
       }.getOrElse(throw ex)
     }.futureValue
-  }
-
-  it should ("properly parse data from profile for profile Reader role") in {
-    val response = TestProfileResponse(
-      email = "some@email.com",
-      uid = "3123123",
-      clearance = TestProfileClearanceResponse(
-        roles = List(TestPermissionResponse.Reader.toString),
-        portals = List("somePortal1", "somePortal2")
-      )
-    )
-
-    val service = createDefaultServiceMock(response.asJson, config.profileUri)
-    val (user, _) = service.checkAuthorizationAndObtainUserinfo("6V1reBXblpmfjRJP").futureValue
-
-    user shouldBe a[LoggedUser]
-    user.isAdmin shouldBe false
-    user.id shouldBe response.uid
-
-    user.can("somePortal1", Permission.Read) shouldBe true
-    user.can("somePortal2", Permission.Read) shouldBe true
-  }
-
-  it should ("properly parse data from profile for profile Deploy, Writer role with access to AdminTab") in {
-    val response = TestProfileResponse(
-      email = "some@email.com",
-      uid = "3123123",
-      clearance = TestProfileClearanceResponse(
-        roles = List(
-          TestPermissionResponse.Deployer.toString,
-          TestPermissionResponse.Writer.toString,
-          TestPermissionResponse.AdminTab.toString
-        ),
-        portals = List("somePortal1", "somePortal2")
-      )
-    )
-
-    val service = createDefaultServiceMock(response.asJson, config.profileUri)
-    val (user, _) = service.checkAuthorizationAndObtainUserinfo("6V1reBXblpmfjRJP").futureValue
-
-    user shouldBe a[LoggedUser]
-    user.isAdmin shouldBe false
-    user.id shouldBe response.uid
-
-    user.can("somePortal1", Permission.Read) shouldBe false
-    user.can("somePortal1", Permission.Deploy) shouldBe true
-    user.can("somePortal2", Permission.Read) shouldBe false
-    user.can("somePortal2", Permission.Deploy) shouldBe true
-  }
-
-  it should ("properly parse data from profile for profile role Admin") in {
-    val response = TestProfileResponse(
-      email = "some@email.com",
-      uid = "3123123",
-      clearance = TestProfileClearanceResponse(
-        roles = List(
-          TestPermissionResponse.Admin.toString
-        ),
-        portals = List("somePortal1")
-      )
-    )
-
-    val service = createDefaultServiceMock(response.asJson, config.profileUri)
-    val (user, _) = service.checkAuthorizationAndObtainUserinfo("6V1reBXblpmfjRJP").futureValue
-
-    user shouldBe a[LoggedUser]
-    user.isAdmin shouldBe true
-    user.id shouldBe response.uid
-
-    user.can("somePortal1", Permission.Read) shouldBe true
-    user.can("somePortal1", Permission.Write) shouldBe true
-    user.can("somePortal1", Permission.Deploy) shouldBe true
   }
 
   it should ("handling BadRequest response from profile request") in {

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationResourcesSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationResourcesSpec.scala
@@ -28,7 +28,7 @@ class OAuth2AuthenticationResourcesSpec extends FunSpec with Matchers with Scala
       .thenRespondWrapped(Future(Response(Option.empty, StatusCode.InternalServerError, "Bad Request")))
     )
 
-    new OAuth2AuthenticationResources(realm, DefaultOAuth2ServiceFactory.service(config, List.empty), config)
+    new OAuth2AuthenticationResources(realm, DefaultOAuth2ServiceFactory.service(config), config)
   }
 
   protected lazy val badAuthenticationResources = {
@@ -37,7 +37,7 @@ class OAuth2AuthenticationResourcesSpec extends FunSpec with Matchers with Scala
       .whenRequestMatches(_.uri.equals(Uri(config.accessTokenUri)))
       .thenRespondWrapped(Future(Response(Option.empty, StatusCode.BadRequest, "Bad Request")))
 
-    new OAuth2AuthenticationResources(realm, DefaultOAuth2ServiceFactory.service(config, List.empty), config)
+    new OAuth2AuthenticationResources(realm, DefaultOAuth2ServiceFactory.service(config), config)
   }
 
   protected lazy val authenticationResources = {
@@ -49,7 +49,7 @@ class OAuth2AuthenticationResourcesSpec extends FunSpec with Matchers with Scala
       .thenRespond(""" { "id": "1", "email": "some@email.com" } """)
 
 
-    new OAuth2AuthenticationResources(realm, DefaultOAuth2ServiceFactory.service(config, List.empty), config)
+    new OAuth2AuthenticationResources(realm, DefaultOAuth2ServiceFactory.service(config), config)
   }
 
   def authenticationOauth2(resource: OAuth2AuthenticationResources, authorizationCode: String) = {

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceProviderSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceProviderSpec.scala
@@ -12,6 +12,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class OAuth2ServiceProviderSpec extends FlatSpec with Matchers {
   implicit val backend: SttpBackend[Future, Nothing, NothingT] = AsyncHttpClientFutureBackend.usingConfig(new DefaultAsyncHttpClientConfig.Builder().build())
   it should "return default OAuth2 service" in {
-    OAuth2ServiceProvider(ExampleOAuth2ServiceFactory.testConfig, this.getClass.getClassLoader, List.empty) shouldBe a[OAuth2Service[_, _]]
+    OAuth2ServiceProvider(ExampleOAuth2ServiceFactory.testConfig, this.getClass.getClassLoader) shouldBe a[OAuth2Service[_, _]]
   }
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -100,6 +100,7 @@ trait NusskanckerDefaultAppRouter extends NusskanckerAppRouter {
     val processActivityRepository = new ProcessActivityRepository(dbConfig)
 
     val authenticationResources = AuthenticationResources(config, getClass.getClassLoader)
+    val authorizationRules = AuthenticationConfiguration.getRules(config)
 
     val counter = new ProcessCounter(subprocessRepository)
 
@@ -184,7 +185,7 @@ trait NusskanckerDefaultAppRouter extends NusskanckerAppRouter {
         apiResourcesWithoutAuthentication.reduce(_ ~ _)
       } ~ authenticationResources.authenticate() { authenticatedUser =>
         pathPrefix("api") {
-          val loggedUser = LoggedUser(authenticatedUser, config, processCategoryService.getAllCategories)
+          val loggedUser = LoggedUser(authenticatedUser, authorizationRules, processCategoryService.getAllCategories)
           apiResourcesWithAuthentication.map(_.securedRoute(loggedUser)).reduce(_ ~ _)
         }
       }


### PR DESCRIPTION
Solves https://github.com/TouK/nussknacker/blob/staging/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationProvider.scala#L15
AuthenticationProvider no longer delivers a LoggedUser but an AuthenticatedUser instance with a roles collection. Permission mapping is moved to an additional LoggedUser apply method.