### PR TITLE
Fix 'counts' functionality for custom nodes. Only incoming events should be counted

### DIFF
--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
@@ -219,7 +219,7 @@ class CustomNodeProcessSpec extends FunSuite with Matchers with ProcessTestHelpe
       .exceptionHandler()
       .source("id", "input")
       .buildSimpleVariable("testVar", "beforeNode", "'testBeforeNode'")
-      .customNodeNoOutput("custom", "customFilter", "groupBy" -> "#input.id", "stringVal" -> "'terefere'")
+      .customNodeNoOutput("custom", "customFilter", "input" -> "#input.id", "stringVal" -> "'terefere'")
       .processorEnd("proc2", "logService", "all" -> "#input.id")
 
     val data = List(SimpleRecord("terefere", 3, "a", new Date(0)), SimpleRecord("kuku", 3, "b", new Date(0)))
@@ -235,7 +235,7 @@ class CustomNodeProcessSpec extends FunSuite with Matchers with ProcessTestHelpe
       .exceptionHandler()
       .source("id", "input")
       .buildSimpleVariable("testVar", "beforeNode", "'testBeforeNode'")
-      .customNodeNoOutput("custom", "customFilterContextTransformation", "groupBy" -> "#input.id", "stringVal" -> "'terefere'")
+      .customNodeNoOutput("custom", "customFilterContextTransformation", "input" -> "#input.id", "stringVal" -> "'terefere'")
       .processorEnd("proc2", "logService", "all" -> "#input.id")
 
     val data = List(SimpleRecord("terefere", 3, "a", new Date(0)), SimpleRecord("kuku", 3, "b", new Date(0)))
@@ -304,5 +304,18 @@ class CustomNodeProcessSpec extends FunSuite with Matchers with ProcessTestHelpe
     MockService.data shouldBe List("1")
   }
 
+  test("listeners should count only incoming events to nodes") {
+    CountingNodesListener.reset
+    val process = EspProcessBuilder.id("proc1")
+      .exceptionHandler()
+      .source("id", "input")
+      .buildSimpleVariable("testVar", "beforeNode", "'testBeforeNode'")
+      .customNodeNoOutput("custom", "customFilter", "input" -> "#input.id", "stringVal" -> "'terefere'")
+      .processorEnd("proc2", "logService", "all" -> "#input.id")
+    val data = List(SimpleRecord("terefere", 3, "a", new Date(0)), SimpleRecord("kuku", 3, "b", new Date(0)))
+    processInvoker.invokeWithSampleData(process, data)
+
+    CountingNodesListener.nodesEntered shouldBe List("id", "testVar", "custom", "proc2", "id", "testVar", "custom")
+  }
 
 }

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
@@ -305,7 +305,6 @@ class CustomNodeProcessSpec extends FunSuite with Matchers with ProcessTestHelpe
   }
 
   test("listeners should count only incoming events to nodes") {
-    CountingNodesListener.reset
     val process = EspProcessBuilder.id("proc1")
       .exceptionHandler()
       .source("id", "input")
@@ -313,9 +312,10 @@ class CustomNodeProcessSpec extends FunSuite with Matchers with ProcessTestHelpe
       .customNodeNoOutput("custom", "customFilter", "input" -> "#input.id", "stringVal" -> "'terefere'")
       .processorEnd("proc2", "logService", "all" -> "#input.id")
     val data = List(SimpleRecord("terefere", 3, "a", new Date(0)), SimpleRecord("kuku", 3, "b", new Date(0)))
-    processInvoker.invokeWithSampleData(process, data)
 
-    CountingNodesListener.nodesEntered shouldBe List("id", "testVar", "custom", "proc2", "id", "testVar", "custom")
+    CountingNodesListener.listen {
+      processInvoker.invokeWithSampleData(process, data)
+    } shouldBe List("id", "testVar", "custom", "proc2", "id", "testVar", "custom")
   }
 
 }

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
@@ -310,12 +310,15 @@ class CustomNodeProcessSpec extends FunSuite with Matchers with ProcessTestHelpe
       .source("id", "input")
       .buildSimpleVariable("testVar", "beforeNode", "'testBeforeNode'")
       .customNodeNoOutput("custom", "customFilter", "input" -> "#input.id", "stringVal" -> "'terefere'")
-      .processorEnd("proc2", "logService", "all" -> "#input.id")
+      .split("split",
+        GraphBuilder.emptySink("out", "monitor"),
+        GraphBuilder.endingCustomNode("custom-ending", None, "optionalEndingCustom", "param" -> "'param'")
+      )
     val data = List(SimpleRecord("terefere", 3, "a", new Date(0)), SimpleRecord("kuku", 3, "b", new Date(0)))
 
     CountingNodesListener.listen {
       processInvoker.invokeWithSampleData(process, data)
-    } shouldBe List("id", "testVar", "custom", "proc2", "id", "testVar", "custom")
+    } shouldBe List("id", "testVar", "custom", "split", "out", "custom-ending", "id", "testVar", "custom")
   }
 
 }

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/ProcessSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/functional/ProcessSpec.scala
@@ -225,7 +225,7 @@ class ProcessSpec extends FunSuite with Matchers with ProcessTestHelpers {
         .source("id", "input")
         .processor("processor1", "eagerLifecycleService", "name" -> "'1'")
         //just to test we open also in different process parts
-        .customNodeNoOutput("custom", "customFilter", "groupBy" -> "''", "stringVal" -> "''")
+        .customNodeNoOutput("custom", "customFilter", "input" -> "''", "stringVal" -> "''")
         .processor("processor2", "eagerLifecycleService", "name" -> "'2'")
         .processorEnd("enricher", "lifecycleService")
 

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/ProcessTestHelpers.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/helpers/ProcessTestHelpers.scala
@@ -102,7 +102,7 @@ object ProcessTestHelpers {
       "nodePassingStateToImplementation" -> WithCategories(NodePassingStateToImplementation)
     )
 
-    override def listeners(processObjectDependencies: ProcessObjectDependencies) = List()
+    override def listeners(processObjectDependencies: ProcessObjectDependencies) = List(CountingNodesListener)
 
     override def exceptionHandlerFactory(processObjectDependencies: ProcessObjectDependencies): ExceptionHandlerFactory =
       ExceptionHandlerFactory.noParams(_ => RecordingExceptionHandler)

--- a/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
+++ b/engine/flink/process/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
@@ -122,13 +122,10 @@ class FlinkTestMainSpec extends FunSuite with Matchers with Inside with BeforeAn
     val nodeResults = results.nodeResults
 
     nodeResults("id") shouldBe List(nodeResult(0, "input" -> input), nodeResult(1, "input" -> input2))
-
-    val resultsAfterCid = List(
+    nodeResults("cid") shouldBe List(nodeResult(0, "input" -> input), nodeResult(1, "input" -> input2))
+    nodeResults("out") shouldBe List(
       nodeResult(0, "input" -> input, "out" -> aggregate),
       nodeResult(1, "input" -> input2, "out" -> aggregate2))
-
-    nodeResults("cid") shouldBe resultsAfterCid
-    nodeResults("out") shouldBe resultsAfterCid
 
     val invocationResults = results.invocationResults
 

--- a/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -237,11 +237,11 @@ object SampleNodes {
   object CustomFilter extends CustomStreamTransformer {
 
     @MethodToInvoke(returnType = classOf[Void])
-    def execute(@ParamName("groupBy") groupBy: LazyParameter[String],
+    def execute(@ParamName("input") input: LazyParameter[String],
                 @ParamName("stringVal") stringVal: String) = FlinkCustomStreamTransformation((start: DataStream[Context], context: FlinkCustomNodeContext) => {
 
       start
-        .filter(new AbstractOneParamLazyParameterFunction(groupBy, context.lazyParameterHelper) with FilterFunction[Context] {
+        .filter(new AbstractOneParamLazyParameterFunction(input, context.lazyParameterHelper) with FilterFunction[Context] {
           override def filter(value: Context): Boolean = evaluateParameter(value) == stringVal
         })
         .map(ValueWithContext[AnyRef](null, _))
@@ -251,13 +251,13 @@ object SampleNodes {
   object CustomFilterContextTransformation extends CustomStreamTransformer {
 
     @MethodToInvoke(returnType = classOf[Void])
-    def execute(@ParamName("groupBy") groupBy: LazyParameter[String], @ParamName("stringVal") stringVal: String): ContextTransformation =
+    def execute(@ParamName("input") input: LazyParameter[String], @ParamName("stringVal") stringVal: String): ContextTransformation =
       ContextTransformation
         .definedBy(Valid(_))
         .implementedBy(
           FlinkCustomStreamTransformation { (start: DataStream[Context], context: FlinkCustomNodeContext) =>
             start
-              .filter(new AbstractOneParamLazyParameterFunction(groupBy, context.lazyParameterHelper) with FilterFunction[Context] {
+              .filter(new AbstractOneParamLazyParameterFunction(input, context.lazyParameterHelper) with FilterFunction[Context] {
                 override def filter(value: Context): Boolean = evaluateParameter(value) == stringVal
               })
               .map(ValueWithContext[AnyRef](null, _))
@@ -822,6 +822,18 @@ object SampleNodes {
       Future.successful(runMode)
     }
 
+  }
+
+  object CountingNodesListener extends EmptyProcessListener {
+    var nodesEntered: List[String] = Nil
+
+    def reset: Unit = {
+      nodesEntered = Nil
+    }
+
+    override def nodeEntered(nodeId: String, context: Context, processMetaData: MetaData): Unit = {
+      nodesEntered = nodesEntered ::: nodeId :: Nil
+    }
   }
 
 }

--- a/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -825,14 +825,19 @@ object SampleNodes {
   }
 
   object CountingNodesListener extends EmptyProcessListener {
-    var nodesEntered: List[String] = Nil
+    @volatile private var nodesEntered: List[String] = Nil
+    @volatile private var listening = false
 
-    def reset: Unit = {
+    def listen(body: => Unit): List[String] = {
       nodesEntered = Nil
+      listening = true
+      body
+      listening = false
+      nodesEntered
     }
 
     override def nodeEntered(nodeId: String, context: Context, processMetaData: MetaData): Unit = {
-      nodesEntered = nodesEntered ::: nodeId :: Nil
+      if(listening) nodesEntered = nodesEntered ::: nodeId :: Nil
     }
   }
 

--- a/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
+++ b/engine/interpreter/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
@@ -57,9 +57,9 @@ private class InterpreterInternal[F[_]](listeners: Seq[ProcessListener],
 
   private def interpretNode(node: Node, ctx: Context): F[List[InterpretationResult]] = {
     implicit val nodeImplicit: Node = node
-    listeners.foreach(_.nodeEntered(node.id, ctx, metaData))
     node match {
       case Source(_, next) =>
+        listeners.foreach(_.nodeEntered(node.id, ctx, metaData))
         interpretNext(next, ctx)
       case VariableBuilder(_, varName, Right(fields), next) =>
         val variable = createOrUpdateVariable(ctx, varName, fields)
@@ -154,11 +154,13 @@ private class InterpreterInternal[F[_]](listeners: Seq[ProcessListener],
     }
   }
 
-  private def interpretNext(next: Next, ctx: Context): F[List[InterpretationResult]] =
+  private def interpretNext(next: Next, ctx: Context): F[List[InterpretationResult]] = {
+    listeners.foreach(_.nodeEntered(next.id, ctx, metaData))
     next match {
       case NextNode(node) => tryToInterpretNode(node, ctx)
       case PartRef(ref) => monad.pure(List(InterpretationResult(NextPartReference(ref), outputValue(ctx), ctx)))
     }
+  }
 
   //hmm... is this OK?
   private def outputValue(ctx: Context): Any =


### PR DESCRIPTION
This PR also coherents presenting results of 'tests from file'. New variables in context are preseneted in the following node in graph. Before this was true for all kind of nodes besides custom nodes.