### PR TITLE
fixed test failure after class-validation changes

### DIFF
--- a/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/engine/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -106,10 +106,11 @@ class SpelExpressionSpec extends FunSuite with Matchers with EitherValues {
     def createTestClazzDefinitionFromClassNames(className: String) =
       TypeInfos.ClazzDefinition(TypedClass(ClassUtils.primitiveToWrapper(ClassUtils.getClass(className)), Nil), Map.empty)
 
-    val stringClazzDefinition = createTestClazzDefinitionFromClassNames("java.lang.String")
-    val longClazzDefinition = createTestClazzDefinitionFromClassNames("java.lang.Long")
-
-    TypeDefinitionSet(Set(stringClazzDefinition, longClazzDefinition))
+    TypeDefinitionSet(Set(
+      createTestClazzDefinitionFromClassNames("java.lang.String"),
+      createTestClazzDefinitionFromClassNames("java.lang.Long"),
+      createTestClazzDefinitionFromClassNames("pl.touk.nussknacker.engine.spel.SampleGlobalObject")
+    ))
   }
 
   test("evaluate static method call on validated class String") {


### PR DESCRIPTION
fixed class-validation changes derailing one of existing tests("not allow unknown variables in methods") in SpelExpressionSpec 