### PR TITLE
Fix/migration comments

### DIFF
--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/initialization/Initialization.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/initialization/Initialization.scala
@@ -124,7 +124,9 @@ class TechnicalProcessUpdate(customProcesses: Map[String, String], repository: D
           case Some(processId) =>
             fetchingProcessRepository.fetchLatestProcessVersion[Unit](processId).flatMap {
               case Some(version) if version.user == Initialization.nussknackerUser.username =>
-                repository.updateProcess(UpdateProcessAction(processId, deploymentData, "External update", false)).map(_.right.map(_ => ()))
+                repository
+                  .updateProcess(UpdateProcessAction(processId, deploymentData, "External update", increaseVersionWhenJsonNotChanged = false))
+                  .map(_.right.map(_ => ()))
               case latestVersion => logger.info(s"Scenario $processId not updated. DB version is: \n${latestVersion.flatMap(_.json).getOrElse("")}\n " +
                 s" and version from file is: \n$deploymentData")
                 DBIOAction.successful(Right(()))

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/initialization/Initialization.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/initialization/Initialization.scala
@@ -124,7 +124,7 @@ class TechnicalProcessUpdate(customProcesses: Map[String, String], repository: D
           case Some(processId) =>
             fetchingProcessRepository.fetchLatestProcessVersion[Unit](processId).flatMap {
               case Some(version) if version.user == Initialization.nussknackerUser.username =>
-                repository.updateProcess(UpdateProcessAction(processId, deploymentData, "External update")).map(_.right.map(_ => ()))
+                repository.updateProcess(UpdateProcessAction(processId, deploymentData, "External update", false)).map(_.right.map(_ => ()))
               case latestVersion => logger.info(s"Scenario $processId not updated. DB version is: \n${latestVersion.flatMap(_.json).getOrElse("")}\n " +
                 s" and version from file is: \n$deploymentData")
                 DBIOAction.successful(Right(()))

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
@@ -215,7 +215,10 @@ class DBProcessService(managerActor: ActorRef,
             val json = ProcessMarshaller.toJson(substituted).noSpaces
             GraphProcess(json)
           }
-          processUpdated <- EitherT(repositoryManager.runInTransaction(processRepository.updateProcess(UpdateProcessAction(processIdWithName.id, deploymentData, action.comment, false))))
+          processUpdated <- EitherT(repositoryManager
+            .runInTransaction(processRepository
+              .updateProcess(UpdateProcessAction(processIdWithName.id, deploymentData, action.comment, increaseVersionWhenJsonNotChanged = false))
+            ))
         } yield UpdateProcessResponse(
           processUpdated.newVersion.map(toProcessResponse(processIdWithName.name, _)),
           validation

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
@@ -215,7 +215,7 @@ class DBProcessService(managerActor: ActorRef,
             val json = ProcessMarshaller.toJson(substituted).noSpaces
             GraphProcess(json)
           }
-          processUpdated <- EitherT(repositoryManager.runInTransaction(processRepository.updateProcess(UpdateProcessAction(processIdWithName.id, deploymentData, action.comment))))
+          processUpdated <- EitherT(repositoryManager.runInTransaction(processRepository.updateProcess(UpdateProcessAction(processIdWithName.id, deploymentData, action.comment, false))))
         } yield UpdateProcessResponse(
           processUpdated.newVersion.map(toProcessResponse(processIdWithName.name, _)),
           validation

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigrator.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigrator.scala
@@ -14,10 +14,11 @@ case class MigrationResult(process: CanonicalProcess, migrationsApplied: List[Pr
 
   def id : String = process.metaData.id
 
-  def toUpdateAction(processId: ProcessId): UpdateProcessAction = UpdateProcessAction(processId,
-    GraphProcess(ProcessMarshaller.toJson(process).noSpaces),
-    s"Migrations applied: ${migrationsApplied.map(_.description).mkString(", ")}",
-    true
+  def toUpdateAction(processId: ProcessId): UpdateProcessAction = UpdateProcessAction(
+    id = processId,
+    deploymentData = GraphProcess(ProcessMarshaller.toJson(process).noSpaces),
+    comment = s"Migrations applied: ${migrationsApplied.map(_.description).mkString(", ")}",
+    increaseVersionWhenJsonNotChanged = true
   )
 
 }

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
@@ -33,7 +33,7 @@ object ProcessRepository {
   def create(dbConfig: DbConfig, modelData: ProcessingTypeDataProvider[ModelData]): DBProcessRepository =
     new DBProcessRepository(dbConfig, modelData.mapValues(_.migrations.version))
 
-  case class UpdateProcessAction(id: ProcessId, deploymentData: ProcessDeploymentData, comment: String, migration: Boolean)
+  case class UpdateProcessAction(id: ProcessId, deploymentData: ProcessDeploymentData, comment: String, forceIncreaseVersion: Boolean)
 
   case class CreateProcessAction(processName: ProcessName, category: String, processDeploymentData: ProcessDeploymentData, processingType: ProcessingType, isSubprocess: Boolean)
 
@@ -96,7 +96,7 @@ class DBProcessRepository(val dbConfig: DbConfig, val modelVersion: ProcessingTy
       newCommentAction(ProcessId(version.processId), version.id, updateProcessAction.comment)
     }
 
-    updateProcessInternal(updateProcessAction.id, updateProcessAction.deploymentData, updateProcessAction.migration).flatMap {
+    updateProcessInternal(updateProcessAction.id, updateProcessAction.deploymentData, updateProcessAction.forceIncreaseVersion).flatMap {
       // Comment should be added via ProcessService not to mix this repository responsibility.
       case updateProcessRes@Right(ProcessUpdated(_, Some(newVersion))) =>
         addNewCommentToVersion(newVersion).map(_ => updateProcessRes)

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
@@ -33,7 +33,7 @@ object ProcessRepository {
   def create(dbConfig: DbConfig, modelData: ProcessingTypeDataProvider[ModelData]): DBProcessRepository =
     new DBProcessRepository(dbConfig, modelData.mapValues(_.migrations.version))
 
-  case class UpdateProcessAction(id: ProcessId, deploymentData: ProcessDeploymentData, comment: String)
+  case class UpdateProcessAction(id: ProcessId, deploymentData: ProcessDeploymentData, comment: String, migration: Boolean)
 
   case class CreateProcessAction(processName: ProcessName, category: String, processDeploymentData: ProcessDeploymentData, processingType: ProcessingType, isSubprocess: Boolean)
 
@@ -82,7 +82,7 @@ class DBProcessRepository(val dbConfig: DbConfig, val modelVersion: ProcessingTy
         case None => processesTable.filter(_.name === action.processName.value).result.headOption.flatMap {
           case Some(_) => DBIOAction.successful(ProcessAlreadyExists(action.processName.value).asLeft)
           case None => (insertNew += processToSave)
-            .flatMap(entity => updateProcessInternal(ProcessId(entity.id), action.processDeploymentData))
+            .flatMap(entity => updateProcessInternal(ProcessId(entity.id), action.processDeploymentData, false))
             .map(_.right.map(_.newVersion))
         }
       }
@@ -96,7 +96,7 @@ class DBProcessRepository(val dbConfig: DbConfig, val modelVersion: ProcessingTy
       newCommentAction(ProcessId(version.processId), version.id, updateProcessAction.comment)
     }
 
-    updateProcessInternal(updateProcessAction.id, updateProcessAction.deploymentData).flatMap {
+    updateProcessInternal(updateProcessAction.id, updateProcessAction.deploymentData, updateProcessAction.migration).flatMap {
       // Comment should be added via ProcessService not to mix this repository responsibility.
       case updateProcessRes@Right(ProcessUpdated(_, Some(newVersion))) =>
         addNewCommentToVersion(newVersion).map(_ => updateProcessRes)
@@ -106,7 +106,7 @@ class DBProcessRepository(val dbConfig: DbConfig, val modelVersion: ProcessingTy
     }
   }
 
-  private def updateProcessInternal(processId: ProcessId, processDeploymentData: ProcessDeploymentData)(implicit loggedUser: LoggedUser): DB[XError[ProcessUpdated]] = {
+  private def updateProcessInternal(processId: ProcessId, processDeploymentData: ProcessDeploymentData, forceIncreaseVersion: Boolean)(implicit loggedUser: LoggedUser): DB[XError[ProcessUpdated]] = {
     val (maybeJson, maybeMainClass) = processDeploymentData match {
       case GraphProcess(json) => (Some(json), None)
       case CustomProcess(mainClass) => (None, Some(mainClass))
@@ -130,7 +130,7 @@ class DBProcessRepository(val dbConfig: DbConfig, val modelVersion: ProcessingTy
     //TODO: after we move Json type to GraphProcess we should clean up this pattern matching
     def versionToInsert(latestProcessVersion: Option[ProcessVersionEntityData], processingType: ProcessingType) =
       (latestProcessVersion, maybeJson) match {
-        case (Some(version), _) if isLastVersionContainsSameJson(version, maybeJson) && version.mainClass == maybeMainClass =>
+        case (Some(version), _) if isLastVersionContainsSameJson(version, maybeJson) && version.mainClass == maybeMainClass && !forceIncreaseVersion =>
           Right(None)
         case (versionOpt, Some(json)) =>
           normalizeJsonString(json)

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigratorSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigratorSpec.scala
@@ -38,9 +38,7 @@ class ProcessModelMigratorSpec extends FlatSpec with BeforeAndAfterEach with Pat
 
     val migrationResultOpt: Option[MigrationResult] = migrateByVersionsOpt(Some(1), 1)
 
-    migrationResultOpt.map(o => println(o.toUpdateAction(ProcessId(1L))))
-
-    migrationResultOpt shouldNot be('defined)
+    migrationResultOpt shouldBe empty
 
   }
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigratorSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigratorSpec.scala
@@ -34,6 +34,16 @@ class ProcessModelMigratorSpec extends FlatSpec with BeforeAndAfterEach with Pat
     processor shouldBe ServiceRef(ProcessTestData.otherExistingServiceId, List())
   }
 
+  it should "migration should not return empty migration result" in {
+
+    val migrationResultOpt: Option[MigrationResult] = migrateByVersionsOpt(Some(1), 1)
+
+    migrationResultOpt.map(o => println(o.toUpdateAction(ProcessId(1L))))
+
+    migrationResultOpt shouldNot be('defined)
+
+  }
+
   it should "migrate processes to new versions only if migrations not applied" in {
 
     val migrationResult: MigrationResult = migrateByVersions(Some(1), 1, 2)
@@ -46,9 +56,11 @@ class ProcessModelMigratorSpec extends FlatSpec with BeforeAndAfterEach with Pat
   }
 
   private def migrateByVersions(startFrom: Option[Int], migrations: Int*) : MigrationResult =
-    migrator(migrations: _*).migrateProcess(
-      ProcessTestData.toDetails(ProcessTestData.validDisplayableProcess.toDisplayable).copy(modelVersion = startFrom)).get
+    migrateByVersionsOpt(startFrom, migrations: _*).get
 
+  private def migrateByVersionsOpt(startFrom: Option[Int], migrations: Int*) : Option[MigrationResult] =
+    migrator(migrations: _*).migrateProcess(
+      ProcessTestData.toDetails(ProcessTestData.validDisplayableProcess.toDisplayable).copy(modelVersion = startFrom))
 
   private def extractProcessor(migrationResult: MigrationResult) = {
     val service = for {

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
@@ -197,7 +197,7 @@ class DBFetchingProcessRepositorySpec
 
   }
 
-  test("should generate new process version id on forceIncreaseVersion action param") {
+  test("should generate new process version id on increaseVersionWhenJsonNotChanged action param") {
 
     val processName = ProcessName("processName")
     val now = LocalDateTime.now()
@@ -213,7 +213,7 @@ class DBFetchingProcessRepositorySpec
     latestProcessVersion.id shouldBe 1
     updateProcess(latestProcessVersion.copy(json = someJson), false).newVersion.get.id shouldBe 2
     //without force
-    updateProcess(latestProcessVersion.copy(json = someJson), false).newVersion shouldNot be('defined)
+    updateProcess(latestProcessVersion.copy(json = someJson), false).newVersion shouldBe empty
     //now with force
     updateProcess(latestProcessVersion.copy(json = someJson), true).newVersion.get.id shouldBe 3
 
@@ -225,10 +225,10 @@ class DBFetchingProcessRepositorySpec
     ).nonEmpty
   }
 
-  private def updateProcess(processVersion: ProcessVersionEntityData, forceIncreaseVersion: Boolean): ProcessUpdated = {
+  private def updateProcess(processVersion: ProcessVersionEntityData, increaseVersionWhenJsonNotChanged: Boolean): ProcessUpdated = {
     processVersion.json shouldBe 'defined
     val json = processVersion.json.get
-    val action = UpdateProcessAction(ProcessId(processVersion.processId), GraphProcess(json), "", forceIncreaseVersion)
+    val action = UpdateProcessAction(ProcessId(processVersion.processId), GraphProcess(json), "", increaseVersionWhenJsonNotChanged)
 
     val processUpdated = repositoryManager.runInTransaction(writingRepo.updateProcess(action)).futureValue
     processUpdated shouldBe 'right

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
@@ -206,7 +206,7 @@ class DBFetchingProcessRepositorySpec
   private def updateProcess(processVersion: ProcessVersionEntityData): ProcessUpdated = {
     processVersion.json shouldBe 'defined
     val json = processVersion.json.get
-    val action = UpdateProcessAction(ProcessId(processVersion.processId), GraphProcess(json), "")
+    val action = UpdateProcessAction(ProcessId(processVersion.processId), GraphProcess(json), "", false)
 
     val processUpdated = repositoryManager.runInTransaction(writingRepo.updateProcess(action)).futureValue
     processUpdated shouldBe 'right

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
@@ -189,11 +189,33 @@ class DBFetchingProcessRepositorySpec
     val latestProcessVersion = fetchLatestProcessVersion(processName)
     latestProcessVersion.id shouldBe latestVersionId
 
-    val ProcessUpdated(oldVersionInfoOpt, newVersionInfoOpt) = updateProcess(latestProcessVersion.copy(json = Some("{}")))
+    val ProcessUpdated(oldVersionInfoOpt, newVersionInfoOpt) = updateProcess(latestProcessVersion.copy(json = Some("{}")), false)
     oldVersionInfoOpt shouldBe 'defined
     oldVersionInfoOpt.get.id shouldBe latestVersionId
     newVersionInfoOpt shouldBe 'defined
     newVersionInfoOpt.get.id shouldBe (latestVersionId + 1)
+
+  }
+
+  test("should generate new process version id on forceIncreaseVersion action param") {
+
+    val processName = ProcessName("processName")
+    val now = LocalDateTime.now()
+    val someJson = Some("{}")
+    val espProcess = EspProcessBuilder.id(processName.value)
+      .exceptionHandler()
+      .source("s", "")
+      .emptySink("s2", "")
+
+    saveProcess(espProcess, now)
+
+    val latestProcessVersion = fetchLatestProcessVersion(processName)
+    latestProcessVersion.id shouldBe 1
+    updateProcess(latestProcessVersion.copy(json = someJson), false).newVersion.get.id shouldBe 2
+    //without force
+    updateProcess(latestProcessVersion.copy(json = someJson), false).newVersion shouldNot be('defined)
+    //now with force
+    updateProcess(latestProcessVersion.copy(json = someJson), true).newVersion.get.id shouldBe 3
 
   }
 
@@ -203,10 +225,10 @@ class DBFetchingProcessRepositorySpec
     ).nonEmpty
   }
 
-  private def updateProcess(processVersion: ProcessVersionEntityData): ProcessUpdated = {
+  private def updateProcess(processVersion: ProcessVersionEntityData, forceIncreaseVersion: Boolean): ProcessUpdated = {
     processVersion.json shouldBe 'defined
     val json = processVersion.json.get
-    val action = UpdateProcessAction(ProcessId(processVersion.processId), GraphProcess(json), "", false)
+    val action = UpdateProcessAction(ProcessId(processVersion.processId), GraphProcess(json), "", forceIncreaseVersion)
 
     val processUpdated = repositoryManager.runInTransaction(writingRepo.updateProcess(action)).futureValue
     processUpdated shouldBe 'right


### PR DESCRIPTION
Fix for:
- adding comment on empty migration, when no migration was applied `ProcessModelMigrator` proceed with action `UpdateProcessAction` with comment `Migrations applied: `, it was visible in scenario comments section.
- applying the same migration over and over when migration changed nothing. Since we set not to increase version when json's are equal (useful for saving visual changes) migration has been trying to apply migrations on every NK restart. Now every migration increases version.