### PR TITLE
redirectUri made optional in the OAuth2 configuration

### DIFF
--- a/engine/security/src/it/scala/pl/touk/nussknacker/ui/security/oauth2/OpenIdConnectServiceSpec.scala
+++ b/engine/security/src/it/scala/pl/touk/nussknacker/ui/security/oauth2/OpenIdConnectServiceSpec.scala
@@ -39,7 +39,7 @@ class OpenIdConnectServiceSpec extends FunSuite with ForAllTestContainer with Ma
     val loginResult = keyCloakLogin(config)
     val authorizationCode = uri"${loginResult.header("Location").get}".params.get("code").get
 
-    val (authData, userData) = open.obtainAuthorizationAndUserInfo(authorizationCode).futureValue
+    val (authData, userData) = open.obtainAuthorizationAndUserInfo(authorizationCode, config.redirectUri.map(_.toString).get).futureValue
     userData.name shouldBe Some("Jan Kowalski")
 
     val profile = open.checkAuthorizationAndObtainUserinfo(authData.accessToken).futureValue
@@ -76,7 +76,7 @@ class OpenIdConnectServiceSpec extends FunSuite with ForAllTestContainer with Ma
       profileUri = uri"$baseUrl/userinfo".toJavaUri,
       profileFormat = None,
       accessTokenUri = uri"$baseUrl/token".toJavaUri,
-      redirectUri = new URI("http://localhost:1234"),
+      redirectUri = Some(URI.create("http://localhost:1234")),
       implicitGrantEnabled = false,
       jwt = None,
       accessTokenRequestContentType = MediaType.ApplicationXWwwFormUrlencoded.toString(),

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/BaseOAuth2Service.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/BaseOAuth2Service.scala
@@ -16,9 +16,9 @@ class BaseOAuth2Service[
 ](protected val clientApi: OAuth2ClientApi[UserInfoData, AuthorizationData])
  (implicit ec: ExecutionContext) extends OAuth2Service[UserInfoData, AuthorizationData] with LazyLogging {
 
-  final def obtainAuthorizationAndUserInfo(authorizationCode: String): Future[(AuthorizationData, UserInfoData)] = {
+  final def obtainAuthorizationAndUserInfo(authorizationCode: String, redirectUri: String): Future[(AuthorizationData, UserInfoData)] = {
     for {
-      authorizationData <- obtainAuthorization(authorizationCode)
+      authorizationData <- obtainAuthorization(authorizationCode, redirectUri)
       userInfo <- obtainUserInfo(authorizationData)
     } yield (authorizationData, userInfo)
   }
@@ -29,8 +29,8 @@ class BaseOAuth2Service[
       userInfo <- obtainUserInfo(accessToken)
     } yield (userInfo, deadline)
 
-  protected def obtainAuthorization(authorizationCode: String): Future[AuthorizationData] =
-    clientApi.accessTokenRequest(authorizationCode)
+  protected def obtainAuthorization(authorizationCode: String, redirectUri: String): Future[AuthorizationData] =
+    clientApi.accessTokenRequest(authorizationCode, redirectUri)
 
   /*
   Override this method in a subclass making use of signed tokens or an introspection endpoint

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/CachingOAuth2Service.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/CachingOAuth2Service.scala
@@ -17,8 +17,8 @@ class CachingOAuth2Service[
     override def expireAfterWriteFn(key: String, value: (UserInfoData, Deadline), now: Deadline): Option[Deadline] = Some(value._2)
   }))
 
-  def obtainAuthorizationAndUserInfo(authorizationCode: String): Future[(AuthorizationData, UserInfoData)] = {
-    delegate.obtainAuthorizationAndUserInfo(authorizationCode).map { case (authorization, userInfo) =>
+  def obtainAuthorizationAndUserInfo(authorizationCode: String, redirectUri: String): Future[(AuthorizationData, UserInfoData)] = {
+    delegate.obtainAuthorizationAndUserInfo(authorizationCode, redirectUri).map { case (authorization, userInfo) =>
       authorizationsCache.put(authorization.accessToken) {
         Future((userInfo, Deadline.now + authorization.expirationPeriod.getOrElse(defaultExpiration)))
       }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/JwtOAuth2Service.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/JwtOAuth2Service.scala
@@ -58,8 +58,8 @@ class JwtOAuth2Service[
     }
   }
 
-  override protected def obtainAuthorization(authorizationCode: String): Future[AuthorizationData] =
-    clientApi.accessTokenRequest(authorizationCode)
+  override protected def obtainAuthorization(authorizationCode: String, redirectUri: String): Future[AuthorizationData] =
+    clientApi.accessTokenRequest(authorizationCode, redirectUri)
       .andThen { case Success(authorization) if accessTokenIsJwt => introspectAccessToken(authorization.accessToken) }
 }
 

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ClientApi.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ClientApi.scala
@@ -16,12 +16,12 @@ class OAuth2ClientApi[ProfileResponse: Decoder, AccessTokenResponse: Decoder]
 (implicit ec: ExecutionContext, backend: SttpBackend[Future, Nothing, NothingT]) extends LazyLogging {
   import io.circe.syntax._
 
-  def accessTokenRequest(authorizationCode: String): Future[AccessTokenResponse] = {
+  def accessTokenRequest(authorizationCode: String, redirectUri: String): Future[AccessTokenResponse] = {
     val payload: Map[String, String] = Map(
       "client_id" -> configuration.clientId,
       "client_secret" -> configuration.clientSecret,
       "code" -> authorizationCode,
-      "redirect_uri" -> configuration.redirectUrl
+      "redirect_uri" -> redirectUri
     ) ++ configuration.accessTokenParams
 
     var request =

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2Configuration.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2Configuration.scala
@@ -21,7 +21,7 @@ case class OAuth2Configuration(usersFile: URI,
                                profileUri: URI,
                                profileFormat: Option[ProfileFormat],
                                accessTokenUri: URI,
-                               redirectUri: URI,
+                               redirectUri: Option[URI],
                                implicitGrantEnabled: Boolean = false,
                                jwt: Option[JwtConfiguration],
                                accessTokenParams: Map[String, String] = Map.empty,
@@ -34,14 +34,14 @@ case class OAuth2Configuration(usersFile: URI,
                               ) extends AuthenticationConfiguration {
   override def name: String = OAuth2Configuration.name
 
-  def authorizeUrl: Option[URI] = Option(Uri(authorizeUri).params(Map(
-    "client_id" -> clientId,
-    "redirect_uri" -> redirectUrl
-  ) ++ authorizeParams).toJavaUri)
+  def authorizeUrl: Option[URI] = Option(
+    Uri(authorizeUri)
+      .param("client_id", clientId)
+      .param("redirect_uri", redirectUri.map(_.toString))
+      .params(authorizeParams))
+    .map(_.toJavaUri)
 
   def authSeverPublicKey: Option[PublicKey] = Option.empty
-
-  def redirectUrl: String = redirectUri.toString
 
   def idTokenNonceVerificationRequired: Boolean = jwt.exists(_.idTokenNonceVerificationRequired)
 }

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceFactory.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ServiceFactory.scala
@@ -14,7 +14,12 @@ trait OAuth2AuthorizationData {
 }
 
 trait OAuth2Service[+UserInfoData, +AuthorizationData <: OAuth2AuthorizationData] {
-  def obtainAuthorizationAndUserInfo(authorizationCode: String): Future[(AuthorizationData, UserInfoData)]
+  /*
+  According to the OAuth2 specification, the redirect URI previously passed to the authorization endpoint is required
+  along with an authorization code to obtain an access token. At this step, the URI is used solely for verification.
+   String comparison is performed by the authorization server, hence the type.
+   */
+  def obtainAuthorizationAndUserInfo(authorizationCode: String, redirectUri: String): Future[(AuthorizationData, UserInfoData)]
   def checkAuthorizationAndObtainUserinfo(accessToken: String): Future[(UserInfoData, Option[Deadline])]
 }
 

--- a/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/UserMappingOAuth2Service.scala
+++ b/engine/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/UserMappingOAuth2Service.scala
@@ -15,8 +15,8 @@ class UserMappingOAuth2Service[UserInfoData: Decoder, AuthorizationData <: OAuth
 (implicit ec: ExecutionContext, backend: SttpBackend[Future, Nothing, NothingT])
   extends OAuth2Service[AuthenticatedUser, AuthorizationData] {
 
-  def obtainAuthorizationAndUserInfo(authorizationCode: String): Future[(AuthorizationData, AuthenticatedUser)] =
-    delegate.obtainAuthorizationAndUserInfo(authorizationCode).map { case (authorization, userInfo) =>
+  def obtainAuthorizationAndUserInfo(authorizationCode: String, redirectUri: String): Future[(AuthorizationData, AuthenticatedUser)] =
+    delegate.obtainAuthorizationAndUserInfo(authorizationCode, redirectUri).map { case (authorization, userInfo) =>
       (authorization, loggedUserFunction(userInfo))
     }
 

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/DefaultOAuth2ServiceFactorySpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/DefaultOAuth2ServiceFactorySpec.scala
@@ -38,7 +38,7 @@ class DefaultOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .whenRequestMatches(_.uri.equals((Uri(config.profileUri))))
       .thenRespond(validUserInfo.asJson.toString())
     val service = DefaultOAuth2ServiceFactory.service(config)
-    val (data, _) = service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP").futureValue
+    val (data, _) = service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP", "http://ignored").futureValue
 
     data shouldBe a[OAuth2AuthorizationData]
     data.accessToken shouldBe validAuthorizationData.accessToken
@@ -52,7 +52,7 @@ class DefaultOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .whenRequestMatches(_.uri.equals(Uri(config.accessTokenUri)))
       .thenRespond(Response(None, StatusCode.BadRequest))
     val service = DefaultOAuth2ServiceFactory.service(config)
-    service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP")
+    service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP", "http://ignored")
       .transform {
         case Failure(OAuth2CompoundException(_)) => Success(succeed)
         case _ => Failure(fail())
@@ -66,7 +66,7 @@ class DefaultOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .whenRequestMatches(_.uri.equals(Uri(config.accessTokenUri)))
       .thenRespond(Response(None, StatusCode.InternalServerError))
     val service = DefaultOAuth2ServiceFactory.service(config)
-    service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP")
+    service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP", "http://ignored")
       .transform {
         case Failure(OAuth2CompoundException(errors)) if errors.toList.exists(_.isInstanceOf[OAuth2ServerError]) => Success(succeed)
         case _ => Failure(fail())
@@ -83,7 +83,7 @@ class DefaultOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .thenRespond(validUserInfo.asJson.toString())
     val service = DefaultOAuth2ServiceFactory.service(config)
 
-    val user = service.obtainAuthorizationAndUserInfo("code")
+    val user = service.obtainAuthorizationAndUserInfo("code", "http://ignored")
       .flatMap { case (authorizationData, _) => service.checkAuthorizationAndObtainUserinfo(authorizationData.accessToken) }
       .map { case (user, _) => LoggedUser(user, rules, List.empty) }.futureValue
 
@@ -106,7 +106,7 @@ class DefaultOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .thenRespond(validUserWithAdminTabInfo.asJson.toString())
     val service = DefaultOAuth2ServiceFactory.service(config)
 
-    val user = service.obtainAuthorizationAndUserInfo("code")
+    val user = service.obtainAuthorizationAndUserInfo("code", "http://ignored")
       .flatMap { case (authorizationData, _) => service.checkAuthorizationAndObtainUserinfo(authorizationData.accessToken) }
       .map { case (user, _) => LoggedUser(user, rules, List.empty) }.futureValue
 
@@ -133,7 +133,7 @@ class DefaultOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .thenRespond(validAdminUserInfo.asJson.toString())
     val service = DefaultOAuth2ServiceFactory.service(config)
 
-    val user = service.obtainAuthorizationAndUserInfo("code")
+    val user = service.obtainAuthorizationAndUserInfo("code", "http://ignored")
       .flatMap { case (authorizationData, _) => service.checkAuthorizationAndObtainUserinfo(authorizationData.accessToken) }
       .map { case (user, _) => LoggedUser(user, rules, List.empty) }.futureValue
 
@@ -161,7 +161,7 @@ class DefaultOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .thenRespond(validUserInfoWithoutEmail.asJson.toString())
     val service = DefaultOAuth2ServiceFactory.service(config)
 
-    val user = service.obtainAuthorizationAndUserInfo("code")
+    val user = service.obtainAuthorizationAndUserInfo("code", "http://ignored")
       .flatMap { case (authorizationData, _) => service.checkAuthorizationAndObtainUserinfo(authorizationData.accessToken) }
       .map { case (user, _) => LoggedUser(user, rules, List.empty) }.futureValue
 
@@ -184,7 +184,7 @@ class DefaultOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .thenRespond(Response(None, StatusCode.BadRequest))
     val service = DefaultOAuth2ServiceFactory.service(config)
 
-    service.obtainAuthorizationAndUserInfo("code")
+    service.obtainAuthorizationAndUserInfo("code", "http://ignored")
       .flatMap { case (authorizationData, _) => service.checkAuthorizationAndObtainUserinfo(authorizationData.accessToken) }
       .transform {
         case Failure(OAuth2CompoundException(_)) => Success(succeed)
@@ -202,7 +202,7 @@ class DefaultOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .thenRespond(Response(None, StatusCode.InternalServerError))
     val service = DefaultOAuth2ServiceFactory.service(config)
 
-    service.obtainAuthorizationAndUserInfo("code")
+    service.obtainAuthorizationAndUserInfo("code", "http://ignored")
       .flatMap { case (authorizationData, _) => service.checkAuthorizationAndObtainUserinfo(authorizationData.accessToken) }
       .transform {
         case Failure(OAuth2CompoundException(errors)) if errors.toList.exists(_.isInstanceOf[OAuth2ServerError]) => Success(succeed)

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactory.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactory.scala
@@ -14,9 +14,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ExampleOAuth2Service(clientApi: OAuth2ClientApi[TestProfileResponse, TestAccessTokenResponse], configuration: OAuth2Configuration)(implicit ec: ExecutionContext, sttpBackend: SttpBackend[Future, Nothing, NothingT]) extends OAuth2Service[AuthenticatedUser, OAuth2AuthorizationData] with LazyLogging {
 
-  def obtainAuthorizationAndUserInfo(authorizationCode: String): Future[(OAuth2AuthorizationData, AuthenticatedUser)] =
+  def obtainAuthorizationAndUserInfo(authorizationCode: String, redirectUri: String): Future[(OAuth2AuthorizationData, AuthenticatedUser)] =
     for {
-      accessTokenResponse <- clientApi.accessTokenRequest(authorizationCode)
+      accessTokenResponse <- clientApi.accessTokenRequest(authorizationCode, redirectUri)
       authenticatedUser <- checkAuthorizationAndObtainUserinfo(accessTokenResponse.accessToken).map(_._1)
     } yield (accessTokenResponse, authenticatedUser)
 
@@ -54,7 +54,7 @@ object ExampleOAuth2ServiceFactory {
       URI.create("https://api.github.com/user"),
       Some(ProfileFormat.GITHUB),
       URI.create("https://github.com/login/oauth/access_token"),
-      URI.create("http://demo.nussknacker.pl"),
+      None,
       false,
       None
     )

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactorySpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/ExampleOAuth2ServiceFactorySpec.scala
@@ -39,7 +39,7 @@ class ExampleOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
       .thenRespond(userInfo.asJson.toString)
     val service = ExampleOAuth2ServiceFactory.service(config)
 
-    val (data, _) = service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP").futureValue
+    val (data, _) = service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP", "http://ignored").futureValue
 
     data shouldBe a[OAuth2AuthorizationData]
     data.accessToken shouldBe tokenResponse.accessToken
@@ -48,14 +48,14 @@ class ExampleOAuth2ServiceFactorySpec extends FlatSpec with Matchers with Patien
 
   it should ("handling BadRequest response from authenticate request") in {
     val service = createErrorOAuth2Service(config.accessTokenUri, StatusCode.BadRequest)
-    service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP").recover {
+    service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP", "http://ignored").recover {
       case OAuth2ErrorHandler(_) => succeed
     }.futureValue
   }
 
   it should ("should InternalServerError response from authenticate request") in {
     val service = createErrorOAuth2Service(config.accessTokenUri, StatusCode.InternalServerError)
-    service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP").recover {
+    service.obtainAuthorizationAndUserInfo("6V1reBXblpmfjRJP", "http://ignored").recover {
       case ex@OAuth2CompoundException(errors) => errors.toList.collectFirst {
         case _: OAuth2ServerError => succeed
       }.getOrElse(throw ex)

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/JwtTokenAuthenticationSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/JwtTokenAuthenticationSpec.scala
@@ -36,7 +36,6 @@ class JwtTokenAuthenticationSpec extends FunSpec with Matchers with ScalatestRou
        |  profileUri: "${userinfoUri}"
        |  profileFormat: "oidc"
        |  accessTokenUri: "http://authorization.server/token"
-       |  redirectUri: "http://ignored"
        |  jwt: {
        |    accessTokenIsJwt: true
        |    publicKey: "${Base64.getEncoder.encodeToString(keyPair.getPublic.getEncoded)}"

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationResourcesSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationResourcesSpec.scala
@@ -53,7 +53,7 @@ class OAuth2AuthenticationResourcesSpec extends FunSpec with Matchers with Scala
   }
 
   def authenticationOauth2(resource: OAuth2AuthenticationResources, authorizationCode: String) = {
-    Get(s"/authentication/oauth2?code=$authorizationCode") ~> routes(resource)
+    Get(s"/authentication/oauth2?code=$authorizationCode&redirect_uri=http://some.url/") ~> routes(resource)
   }
 
   it("should return 400 for wrong authorize token") {

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ClientApiSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2ClientApiSpec.scala
@@ -32,7 +32,7 @@ class OAuth2ClientApiSpec extends FlatSpec with Matchers with BeforeAndAfter wit
       config.copy(accessTokenRequestContentType = MediaType.ApplicationXWwwFormUrlencoded.toString())
     )
 
-    client.accessTokenRequest("6V1reBXblpmfjRJP").futureValue
+    client.accessTokenRequest("6V1reBXblpmfjRJP", "http://ignored").futureValue
 
     val request = testingBackend.allInteractions.head._1
     inside(request.body) {
@@ -47,7 +47,7 @@ class OAuth2ClientApiSpec extends FlatSpec with Matchers with BeforeAndAfter wit
       config.copy(accessTokenRequestContentType = MediaType.ApplicationJson.toString())
     )
 
-    client.accessTokenRequest("6V1reBXblpmfjRJP").futureValue
+    client.accessTokenRequest("6V1reBXblpmfjRJP", "http://ignored").futureValue
 
     val request = testingBackend.allInteractions.head._1
     inside(request.body) {

--- a/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OpaqueTokenAuthenticationSpec.scala
+++ b/engine/security/src/test/scala/pl/touk/nussknacker/ui/security/oauth2/OpaqueTokenAuthenticationSpec.scala
@@ -29,7 +29,6 @@ class OpaqueTokenAuthenticationSpec extends FunSpec with Matchers with Scalatest
        |  profileUri: "${userinfoUri}"
        |  profileFormat: "oidc"
        |  accessTokenUri: "${tokenUri}"
-       |  redirectUri: "http://ignored"
        |}""".stripMargin)
 
   private val validAccessToken = "aValidAccessToken"
@@ -63,7 +62,7 @@ class OpaqueTokenAuthenticationSpec extends FunSpec with Matchers with Scalatest
   }
 
   it("should permit an authorized user to a restricted resource") {
-    Get("/authentication/oauth2?code=test") ~> authenticationResources.routeWithPathPrefix ~> check {
+    Get("/authentication/oauth2?code=test&redirect_uri=http://ignored/") ~> authenticationResources.routeWithPathPrefix ~> check {
       status shouldEqual StatusCodes.OK
       val accessToken = responseAs[Oauth2AuthenticationResponse].accessToken
       Get("/config").addCredentials(HttpCredentials.createOAuth2BearerToken(accessToken)) ~> testRoute ~> check {

--- a/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/Implicits.scala
+++ b/engine/util/src/main/scala/pl/touk/nussknacker/engine/util/Implicits.scala
@@ -71,4 +71,11 @@ object Implicits {
   implicit object SourceIsReleasable extends Releasable[scala.io.Source] {
     def release(resource: scala.io.Source): Unit = resource.close()
   }
+
+  implicit class RichIterable[T](iterable: Iterable[T]) {
+    def exactlyOne: Option[T] = iterable match {
+      case head :: Nil => Some(head)
+      case _ => None
+    }
+  }
 }

--- a/ui/client/http/HttpService.ts
+++ b/ui/client/http/HttpService.ts
@@ -405,8 +405,8 @@ class HttpService {
       .catch(error => this.addError(i18next.t("notification.error.failedToSendSignal", "Failed to send signal"), error))
   }
 
-  fetchOAuth2AccessToken<T>(authorizeCode: string | string[]) {
-    return api.get<T>(`/authentication/oauth2?code=${authorizeCode}`)
+  fetchOAuth2AccessToken<T>(authorizeCode: string | string[], redirectUri: string | null) {
+    return api.get<T>(`/authentication/oauth2?code=${authorizeCode}` + (redirectUri ? `&redirect_uri=${redirectUri}` : ""))
   }
 
   fetchAuthenticationSettings(authenticationProvider: string) {


### PR DESCRIPTION
… in favor of dynamic evaluation in the FE

The redirect URI is unnecessary in configuration. When the frontend needs to call the authorization endpoint it already knows its own location, so there is no need to take this value from the backend settings. Though I left such an option for a yet-unknown reason.