### PR TITLE
Docs refinement

### DIFF
--- a/docs/installation_configuration_guide/Configuration.md
+++ b/docs/installation_configuration_guide/Configuration.md
@@ -10,7 +10,7 @@ Nussknacker configuration is divided into several configuration areas, each area
 
 * [Designer](/about/GLOSSARY#nussknacker-designer) configuration
 * Scenario Types configuration, comprising of:
-    * [Deployment manager](/about/GLOSSARY#deployment-manager) / [Executor](/about/GLOSSARY#executor) configuration
+    * [Deployment Manager](/about/GLOSSARY#deployment-manager) / [Executor](/about/GLOSSARY#executor) configuration
     * [Model](/about/GLOSSARY#executor) configuration
 
 Designer configuration  contains all settings for Nussknacker Designer - e.g. web application ports, security, various UI settings. 
@@ -18,7 +18,7 @@ Designer configuration  contains all settings for Nussknacker Designer - e.g. we
 One Nussknacker Designer deployment may be used to create various Scenario Types which:
                           
 * can be deployed with various [Deployment Managers](DeploymentManagerConfiguration.md)  to e.g. different Flink clusters 
-* Use different components and [Model configurations](ModelConfiguration.md) 
+* Use different components and [model configurations](ModelConfiguration.md) 
 
 See [development configuration](https://github.com/TouK/nussknacker/blob/staging/nussknacker-dist/src/universal/conf/dev-application.conf#L33) (used to test various Nussknacker features) for an example of configuration with more than one Scenario Type.
 
@@ -26,6 +26,9 @@ Diagram below presents main relationships between configuration areas.
 
 ![Configuration areas](img/configuration_areas.png "configuration areas")
 
+## Environment variables
+
+Environment variables are described in [Installation guide](./Installation.md), they are mostly helpful in the docker setup.
 
 ## Hocon - configuration format
 
@@ -39,4 +42,4 @@ Following Nussknacker specific rules apply:
 * [defaultUiConfig.conf](https://github.com/TouK/nussknacker/blob/staging/ui/server/src/main/resources/defaultUiConfig.conf) contains defaults for Nussknacker Designer
 * `config.override_with_env_vars` is set to true, so it’s possible to override settings with env variables
 
-It’s important to remember that Model configuration is prepared a bit differently. Please read [Model configuration](ModelConfiguration.md) for the details. 
+It’s important to remember that model configuration is prepared a bit differently. Please read [model configuration](ModelConfiguration.md) for the details. 

--- a/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
+++ b/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
@@ -3,8 +3,8 @@ sidebar_position: 3
 ---
 # Deployment manager configuration
 
-Configuration of deployment manager, which is responsible for communication with scenario executor (e.g. FLink). 
-Type of deployment manager is defined with `type` parameter, e.g. for running scenarios with Flink streaming job we would configure: 
+Configuration of Deployment Manager, which is responsible for communication with scenario Executor (e.g. FLink). 
+Type of Deployment Manager is defined with `type` parameter, e.g. for running scenarios with Flink streaming job we would configure: 
 ```
 deploymentConfig {     
   type: "flinkStreaming"
@@ -12,7 +12,7 @@ deploymentConfig {
 }
 ```
 
-`flinkStreaming` deployment manager has following configuration options:
+`flinkStreaming` Deployment Manager has following configuration options:
 
 | Parameter | Type | Default value | Description  |
 | --------- | ---- | ------------- | ------------ |

--- a/docs/installation_configuration_guide/DesignerConfiguration.md
+++ b/docs/installation_configuration_guide/DesignerConfiguration.md
@@ -9,7 +9,7 @@ sidebar_position: 4
 | --------------                              | ---------- | ----     | ------------- | -----------                                                                                                                                                                    |
 | http.port                                   | High       | int      | 8080          | HTTP Port of Designer app                                                                                                                                                      |
 | http.interface                              | High       | string   | "0.0.0.0"     | HTTP interface for Designer app                                                                                                                                                |
-| http.publicPath                             | Medium     | string   | ""            | if Designer used with reverse proxy and custom path, use this configuration to generate links in designer properly (Designer app is always served from root path)              |
+| http.publicPath                             | Medium     | string   | ""            | if Designer used with reverse proxy and custom path, use this configuration to generate links in Designer properly (Designer app is always served from root path)              |
 | ssl.enabled                                 | Medium     | boolean  | false         | Should Designer app be served with SSL                                                                                                                                         |
 | ssl.keyStore.location                       | Medium     | string   |               | Keystore file location (required if SSL enabled)                                                                                                                               |
 | ssl.keyStore.password                       | Medium     | string   |               | Keystore file password (required if SSL enabled)                                                                                                                               |
@@ -37,9 +37,9 @@ The table below presents most important options, or the ones that have Nussknack
 | db.user              | High       | string | "SA"                                                      |                                                                                             |
 | db.password          | High       | string | ""                                                        |                                                                                             |
 | db.connectionTimeout | Low        | int    | 30000                                                     |                                                                                             |
-| db.maximumPoolSize   | Low        | int    | 5                                                         | We have lower limits than default config, since then designer is not heavy-load application |
-| db.minimumIdle       | Low        | int    | 1                                                         | We have lower limits than default config, since then designer is not heavy-load application |
-| db.numThreads        | Low        | int    | 5                                                         | We have lower limits than default config, since then designer is not heavy-load application |
+| db.maximumPoolSize   | Low        | int    | 5                                                         | We have lower limits than default config, since then Designer is not heavy-load application |
+| db.minimumIdle       | Low        | int    | 1                                                         | We have lower limits than default config, since then Designer is not heavy-load application |
+| db.numThreads        | Low        | int    | 5                                                         | We have lower limits than default config, since then Designer is not heavy-load application |
 
 ## Metrics settings
                                                                      

--- a/docs/installation_configuration_guide/Installation.md
+++ b/docs/installation_configuration_guide/Installation.md
@@ -120,7 +120,7 @@ If you want to install them from the scratch or use already installed at your or
     - Telegraf's configuration - some metric tags and names need to be cleaned
     - Importing scenario dashboard to Grafana configuration
 - Flink savepoint configuration. To be able to use scenario verification
-  (see `shouldVerifyBeforeDeploy` property in [Deployment manager documentation](./DeploymentManagerConfiguration.md))
+  (see `shouldVerifyBeforeDeploy` property in [Deployment Manager documentation](./DeploymentManagerConfiguration.md))
   you have to make sure that savepoint location is available from Nussknacker designer (e.g. via NFS like in quickstart setup)
 
 # Configuration

--- a/docs/installation_configuration_guide/ModelConfiguration.md
+++ b/docs/installation_configuration_guide/ModelConfiguration.md
@@ -3,7 +3,7 @@ sidebar_position: 5
 ---
 # Model configuration
 
-This part of configuration defines how to configure the executor (e.g. Flink job) and its components for a given scenario type. It is processed not only at the designer but also passed to the execution engine (e.g. Flink), that’s why it’s parsed and processed a bit differently: 
+This part of configuration defines how to configure the Executor (e.g. Flink job) and its components for a given scenario type. It is processed not only at the Designer but also passed to the execution engine (e.g. Flink), that’s why it’s parsed and processed a bit differently: 
 
 * Defaults can be defined in `defaultModelConfig.conf`. Standard deployment (e.g. with docker sample) has it [here](https://github.com/TouK/nussknacker/blob/staging/engine/flink/generic/src/main/resources/defaultModelConfig.conf).
 * defaultModelConfig.conf is currently resolved both on designer (to extract information about types of data or during scenario testing) and on execution engine (e.g. on Flink). That’s why all environment variables used there have to be defined also on all Flink hosts (!). This is a technical limitation and may change in the future.

--- a/docs/scenarios_authoring/AggregatesInTimeWindows.md
+++ b/docs/scenarios_authoring/AggregatesInTimeWindows.md
@@ -1,3 +1,4 @@
+
 ---
 sidebar_position: 4
 ---
@@ -63,7 +64,7 @@ Let’s map the above statement on the parameters of the Nussknacker Aggregate c
 * Sum - computes sum of values
 * List - returns list of inputs received by the aggregator; see aggregateBy to understand what is meant by inputs
 * Set - the result is a set of inputs received by the aggregator. Can be very ineffective for large sets, try to use ApproximateSetCardinality in this case
-* ApproximateSetCardinality - computes approximate cardinality of set using [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog) algorithm.
+* ApproximateSetCardinality - computes approximate cardinality of a set using [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog) algorithm. Please note that this aggregator treats null as a unique value. If this is undesirable and the set passed to ApproximateSetCardinality aggregator contained null (this can be tested with safe navigation in [SpEL](Spel#safe-navigation)), subtract 1 from the obtained result. 
 
 **output** - name of the variable which will hold the result of the aggregator.
 


### PR DESCRIPTION
Names of NK components (Designer, Executor Manager) should be capitalized.
Model is a concept, not a NK component -> use lower case instead of upper case.
Minor improvement of ApproximateSetCardinality aggregator description.