### PR TITLE
Concise expected class extraction result in test

### DIFF
--- a/engine/flink/generic/src/test/resources/extractedTypes/genericCreator.json
+++ b/engine/flink/generic/src/test/resources/extractedTypes/genericCreator.json
@@ -1,25821 +1,9839 @@
 [
   {
-    "clazzName" : {
-      "display" : "Array",
-      "params" : [
-      ],
-      "refClazzName" : "[Ljava.lang.Object;",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toString" : [
+    "clazzName": {"refClazzName": "[Ljava.lang.Object;"},
+    "methods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Boolean",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Boolean",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "booleanValue" : [
+    "clazzName": {"refClazzName": "java.lang.Boolean"},
+    "methods": {
+      "booleanValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "FALSE" : [
+    "staticMethods": {
+      "FALSE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "TRUE" : [
+      "TRUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getBoolean" : [
+      "getBoolean": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "logicalAnd" : [
+      "logicalAnd": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "logicalOr" : [
+      "logicalOr": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "logicalXor" : [
+      "logicalXor": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "parseBoolean" : [
+      "parseBoolean": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Byte",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Byte",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Byte"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareUnsigned" : [
+      "compareUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "decode" : [
+      "decode": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "parseByte" : [
+      "parseByte": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUnsignedInt" : [
+      "toUnsignedInt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toUnsignedLong" : [
+      "toUnsignedLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "CharSequence",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.CharSequence",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "charAt" : [
+    "clazzName": {"refClazzName": "java.lang.CharSequence"},
+    "methods": {
+      "charAt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Character",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Character",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Character"},
+          "varArgs": false
         }
       ],
-      "length" : [
+      "length": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Character",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Character",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toString" : [
+    "clazzName": {"refClazzName": "java.lang.Character"},
+    "methods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "toString" : [
+    "staticMethods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Character",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Character",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Character"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Double",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Double",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Double"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "infinite" : [
+      "infinite": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isInfinite" : [
+      "isInfinite": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isNaN" : [
+      "isNaN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "naN" : [
+      "naN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_EXPONENT" : [
+      "MAX_EXPONENT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "MIN_EXPONENT" : [
+      "MIN_EXPONENT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MIN_NORMAL" : [
+      "MIN_NORMAL": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "NEGATIVE_INFINITY" : [
+      "NEGATIVE_INFINITY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "NaN" : [
+      "NaN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "POSITIVE_INFINITY" : [
+      "POSITIVE_INFINITY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleToLongBits" : [
+      "doubleToLongBits": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "doubleToRawLongBits" : [
+      "doubleToRawLongBits": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "isFinite" : [
+      "isFinite": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isInfinite" : [
+      "isInfinite": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isNaN" : [
+      "isNaN": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "longBitsToDouble" : [
+      "longBitsToDouble": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "parseDouble" : [
+      "parseDouble": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "toHexString" : [
+      "toHexString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Float",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Float",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Float"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "infinite" : [
+      "infinite": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isInfinite" : [
+      "isInfinite": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isNaN" : [
+      "isNaN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "naN" : [
+      "naN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_EXPONENT" : [
+      "MAX_EXPONENT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "MIN_EXPONENT" : [
+      "MIN_EXPONENT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MIN_NORMAL" : [
+      "MIN_NORMAL": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "NEGATIVE_INFINITY" : [
+      "NEGATIVE_INFINITY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "NaN" : [
+      "NaN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "POSITIVE_INFINITY" : [
+      "POSITIVE_INFINITY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "floatToIntBits" : [
+      "floatToIntBits": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "floatToRawIntBits" : [
+      "floatToRawIntBits": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "intBitsToFloat" : [
+      "intBitsToFloat": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "isFinite" : [
+      "isFinite": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isInfinite" : [
+      "isInfinite": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isNaN" : [
+      "isNaN": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "parseFloat" : [
+      "parseFloat": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "toHexString" : [
+      "toHexString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Integer",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Integer",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Integer"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "bitCount" : [
+      "bitCount": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareUnsigned" : [
+      "compareUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "decode" : [
+      "decode": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "divideUnsigned" : [
+      "divideUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getInteger" : [
+      "getInteger": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "highestOneBit" : [
+      "highestOneBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "lowestOneBit" : [
+      "lowestOneBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "numberOfLeadingZeros" : [
+      "numberOfLeadingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "numberOfTrailingZeros" : [
+      "numberOfTrailingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "parseInt" : [
+      "parseInt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "parseUnsignedInt" : [
+      "parseUnsignedInt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "remainderUnsigned" : [
+      "remainderUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "reverse" : [
+      "reverse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "reverseBytes" : [
+      "reverseBytes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "rotateLeft" : [
+      "rotateLeft": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "rotateRight" : [
+      "rotateRight": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "signum" : [
+      "signum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toBinaryString" : [
+      "toBinaryString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toHexString" : [
+      "toHexString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toOctalString" : [
+      "toOctalString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUnsignedLong" : [
+      "toUnsignedLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toUnsignedString" : [
+      "toUnsignedString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Long",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Long",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Long"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "bitCount" : [
+      "bitCount": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareUnsigned" : [
+      "compareUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "decode" : [
+      "decode": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "divideUnsigned" : [
+      "divideUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getLong" : [
+      "getLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "highestOneBit" : [
+      "highestOneBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "lowestOneBit" : [
+      "lowestOneBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "numberOfLeadingZeros" : [
+      "numberOfLeadingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "numberOfTrailingZeros" : [
+      "numberOfTrailingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "parseLong" : [
+      "parseLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "parseUnsignedLong" : [
+      "parseUnsignedLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "remainderUnsigned" : [
+      "remainderUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "reverse" : [
+      "reverse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "reverseBytes" : [
+      "reverseBytes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "rotateLeft" : [
+      "rotateLeft": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "rotateRight" : [
+      "rotateRight": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "signum" : [
+      "signum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toBinaryString" : [
+      "toBinaryString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toHexString" : [
+      "toHexString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toOctalString" : [
+      "toOctalString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUnsignedString" : [
+      "toUnsignedString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Number",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Number",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Number"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Short",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Short",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Short"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareUnsigned" : [
+      "compareUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "decode" : [
+      "decode": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "parseShort" : [
+      "parseShort": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "reverseBytes" : [
+      "reverseBytes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUnsignedInt" : [
+      "toUnsignedInt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toUnsignedLong" : [
+      "toUnsignedLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "String",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.String",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "blank" : [
+    "clazzName": {"refClazzName": "java.lang.String"},
+    "methods": {
+      "blank": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "charAt" : [
+      "charAt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Character",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Character",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Character"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareToIgnoreCase" : [
+      "compareToIgnoreCase": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "concat" : [
+      "concat": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "contains" : [
+      "contains": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "endsWith" : [
+      "endsWith": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "equalsIgnoreCase" : [
+      "equalsIgnoreCase": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "indexOf" : [
+      "indexOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isBlank" : [
+      "isBlank": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "lastIndexOf" : [
+      "lastIndexOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "length" : [
+      "length": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "matches" : [
+      "matches": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "replaceAll" : [
+      "replaceAll": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "replaceFirst" : [
+      "replaceFirst": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "split" : [
+      "split": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Array[String]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Array[String]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "startsWith" : [
+      "startsWith": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "strip" : [
+      "strip": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "stripLeading" : [
+      "stripLeading": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "stripTrailing" : [
+      "stripTrailing": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "substring" : [
+      "substring": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toLowerCase" : [
+      "toLowerCase": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUpperCase" : [
+      "toUpperCase": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "trim" : [
+      "trim": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "format" : [
+    "staticMethods": {
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Array",
-                "params" : [
-                ],
-                "refClazzName" : "[Ljava.lang.Object;",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "[Ljava.lang.Object;"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : true
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": true
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Array",
-                "params" : [
-                ],
-                "refClazzName" : "[Ljava.lang.Object;",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.util.Locale"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "[Ljava.lang.Object;"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : true
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": true
         }
       ],
-      "join" : [
+      "join": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Array[CharSequence]",
-                "params" : [
+              "name": "arg1",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "CharSequence",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.CharSequence",
-                    "type" : "TypedClass"
+                    "display": "CharSequence",
+                    "params": [],
+                    "refClazzName": "java.lang.CharSequence",
+                    "type": "TypedClass"
                   }
                 ],
-                "refClazzName" : "[Ljava.lang.Object;",
-                "type" : "TypedClass"
+                "refClazzName": "[Ljava.lang.Object;"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : true
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": true
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Iterable[Unknown]",
-                "params" : [
+              "name": "arg1",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.lang.Iterable",
-                "type" : "TypedClass"
+                "refClazzName": "java.lang.Iterable"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "BigDecimal",
-      "params" : [
-      ],
-      "refClazzName" : "java.math.BigDecimal",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "abs" : [
+    "clazzName": {"refClazzName": "java.math.BigDecimal"},
+    "methods": {
+      "abs": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "add" : [
+      "add": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "byteValue" : [
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "byteValueExact" : [
+      "byteValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "divide" : [
+      "divide": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "RoundingMode",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.RoundingMode",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.math.RoundingMode"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "RoundingMode",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.RoundingMode",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.RoundingMode"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "divideAndRemainder" : [
+      "divideAndRemainder": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "Array[BigDecimal]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
+                "display": "BigDecimal",
+                "params": [],
+                "refClazzName": "java.math.BigDecimal",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "Array[BigDecimal]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
+                "display": "BigDecimal",
+                "params": [],
+                "refClazzName": "java.math.BigDecimal",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "divideToIntegralValue" : [
+      "divideToIntegralValue": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "intValueExact" : [
+      "intValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "longValueExact" : [
+      "longValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "movePointLeft" : [
+      "movePointLeft": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "movePointRight" : [
+      "movePointRight": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "multiply" : [
+      "multiply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "negate" : [
+      "negate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "plus" : [
+      "plus": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "pow" : [
+      "pow": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "precision" : [
+      "precision": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "remainder" : [
+      "remainder": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "round" : [
+      "round": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "scale" : [
+      "scale": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "scaleByPowerOfTen" : [
+      "scaleByPowerOfTen": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "setScale" : [
+      "setScale": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "RoundingMode",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.RoundingMode",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.RoundingMode"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "shortValueExact" : [
+      "shortValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "signum" : [
+      "signum": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "sqrt" : [
+      "sqrt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "stripTrailingZeros" : [
+      "stripTrailingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "subtract" : [
+      "subtract": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "toBigInteger" : [
+      "toBigInteger": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "toBigIntegerExact" : [
+      "toBigIntegerExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "toEngineeringString" : [
+      "toEngineeringString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toPlainString" : [
+      "toPlainString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ulp" : [
+      "ulp": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "unscaledValue" : [
+      "unscaledValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "ONE" : [
+    "staticMethods": {
+      "ONE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "ROUND_CEILING" : [
+      "ROUND_CEILING": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_DOWN" : [
+      "ROUND_DOWN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_FLOOR" : [
+      "ROUND_FLOOR": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_HALF_DOWN" : [
+      "ROUND_HALF_DOWN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_HALF_EVEN" : [
+      "ROUND_HALF_EVEN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_HALF_UP" : [
+      "ROUND_HALF_UP": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_UNNECESSARY" : [
+      "ROUND_UNNECESSARY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_UP" : [
+      "ROUND_UP": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "TEN" : [
+      "TEN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "ZERO" : [
+      "ZERO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "BigInteger",
-      "params" : [
-      ],
-      "refClazzName" : "java.math.BigInteger",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "abs" : [
+    "clazzName": {"refClazzName": "java.math.BigInteger"},
+    "methods": {
+      "abs": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "add" : [
+      "add": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "and" : [
+      "and": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "andNot" : [
+      "andNot": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "bitCount" : [
+      "bitCount": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "bitLength" : [
+      "bitLength": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "byteValue" : [
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "byteValueExact" : [
+      "byteValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "clearBit" : [
+      "clearBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "divide" : [
+      "divide": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "divideAndRemainder" : [
+      "divideAndRemainder": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "Array[BigInteger]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
+                "display": "BigInteger",
+                "params": [],
+                "refClazzName": "java.math.BigInteger",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "flipBit" : [
+      "flipBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "gcd" : [
+      "gcd": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "getLowestSetBit" : [
+      "getLowestSetBit": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "intValueExact" : [
+      "intValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isProbablePrime" : [
+      "isProbablePrime": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "longValueExact" : [
+      "longValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "lowestSetBit" : [
+      "lowestSetBit": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "mod" : [
+      "mod": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "modInverse" : [
+      "modInverse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "modPow" : [
+      "modPow": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "multiply" : [
+      "multiply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "negate" : [
+      "negate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "nextProbablePrime" : [
+      "nextProbablePrime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "not" : [
+      "not": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "or" : [
+      "or": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "pow" : [
+      "pow": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "remainder" : [
+      "remainder": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "setBit" : [
+      "setBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "shiftLeft" : [
+      "shiftLeft": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "shiftRight" : [
+      "shiftRight": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "shortValueExact" : [
+      "shortValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "signum" : [
+      "signum": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "sqrt" : [
+      "sqrt": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "sqrtAndRemainder" : [
+      "sqrtAndRemainder": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[BigInteger]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
+                "display": "BigInteger",
+                "params": [],
+                "refClazzName": "java.math.BigInteger",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "subtract" : [
+      "subtract": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "testBit" : [
+      "testBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "toByteArray" : [
+      "toByteArray": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[Byte]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
+                "display": "Byte",
+                "params": [],
+                "refClazzName": "java.lang.Byte",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "xor" : [
+      "xor": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "ONE" : [
+    "staticMethods": {
+      "ONE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "TEN" : [
+      "TEN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "TWO" : [
+      "TWO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "ZERO" : [
+      "ZERO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "probablePrime" : [
+      "probablePrime": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Random",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Random",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Random"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "DayOfWeek",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.DayOfWeek",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "java.time.DayOfWeek"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDisplayName" : [
+      "getDisplayName": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "TextStyle",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.TextStyle",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.TextStyle"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getValue" : [
+      "getValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "minus" : [
+      "minus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plus" : [
+      "plus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "value" : [
+      "value": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "FRIDAY" : [
+    "staticMethods": {
+      "FRIDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "MONDAY" : [
+      "MONDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "SATURDAY" : [
+      "SATURDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "SUNDAY" : [
+      "SUNDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "THURSDAY" : [
+      "THURSDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "TUESDAY" : [
+      "TUESDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "WEDNESDAY" : [
+      "WEDNESDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[DayOfWeek]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "DayOfWeek",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.DayOfWeek",
-                "type" : "TypedClass"
+                "display": "DayOfWeek",
+                "params": [],
+                "refClazzName": "java.time.DayOfWeek",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Duration",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.Duration",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "abs" : [
+    "clazzName": {"refClazzName": "java.time.Duration"},
+    "methods": {
+      "abs": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Duration",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Duration",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Duration"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dividedBy" : [
+      "dividedBy": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Duration",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Duration",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Duration"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getSeconds" : [
+      "getSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getUnits" : [
+      "getUnits": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "List[TemporalUnit]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TemporalUnit",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.temporal.TemporalUnit",
-                "type" : "TypedClass"
+                "display": "TemporalUnit",
+                "params": [],
+                "refClazzName": "java.time.temporal.TemporalUnit",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.List",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.List"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "isNegative" : [
+      "isNegative": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isZero" : [
+      "isZero": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minus" : [
+      "minus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Duration",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Duration",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Duration"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusMillis" : [
+      "minusMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "multipliedBy" : [
+      "multipliedBy": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "negated" : [
+      "negated": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "negative" : [
+      "negative": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "plus" : [
+      "plus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Duration",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Duration",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Duration"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusMillis" : [
+      "plusMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "seconds" : [
+      "seconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toDays" : [
+      "toDays": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toDaysPart" : [
+      "toDaysPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toHours" : [
+      "toHours": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toHoursPart" : [
+      "toHoursPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toMillis" : [
+      "toMillis": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toMillisPart" : [
+      "toMillisPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toMinutes" : [
+      "toMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toMinutesPart" : [
+      "toMinutesPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toNanos" : [
+      "toNanos": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toNanosPart" : [
+      "toNanosPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toSeconds" : [
+      "toSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toSecondsPart" : [
+      "toSecondsPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "units" : [
+      "units": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "List[TemporalUnit]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TemporalUnit",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.temporal.TemporalUnit",
-                "type" : "TypedClass"
+                "display": "TemporalUnit",
+                "params": [],
+                "refClazzName": "java.time.temporal.TemporalUnit",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.List",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.List"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "withNanos" : [
+      "withNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "withSeconds" : [
+      "withSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "zero" : [
+      "zero": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "ZERO" : [
+    "staticMethods": {
+      "ZERO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofDays" : [
+      "ofDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofHours" : [
+      "ofHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofMillis" : [
+      "ofMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofMinutes" : [
+      "ofMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofNanos" : [
+      "ofNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofSeconds" : [
+      "ofSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Instant",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.Instant",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atOffset" : [
+    "clazzName": {"refClazzName": "java.time.Instant"},
+    "methods": {
+      "atOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "atZone" : [
+      "atZone": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "epochSecond" : [
+      "epochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getEpochSecond" : [
+      "getEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusMillis" : [
+      "minusMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plusMillis" : [
+      "plusMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "toEpochMilli" : [
+      "toEpochMilli": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "EPOCH" : [
+    "staticMethods": {
+      "EPOCH": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "MAX" : [
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "ofEpochMilli" : [
+      "ofEpochMilli": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "ofEpochSecond" : [
+      "ofEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "LocalDate",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.LocalDate",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atStartOfDay" : [
+    "clazzName": {"refClazzName": "java.time.LocalDate"},
+    "methods": {
+      "atStartOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "atTime" : [
+      "atTime": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dayOfMonth" : [
+      "dayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dayOfWeek" : [
+      "dayOfWeek": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "dayOfYear" : [
+      "dayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "format" : [
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getDayOfMonth" : [
+      "getDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDayOfWeek" : [
+      "getDayOfWeek": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "getDayOfYear" : [
+      "getDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMonth" : [
+      "getMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "getMonthValue" : [
+      "getMonthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getYear" : [
+      "getYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isLeapYear" : [
+      "isLeapYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "leapYear" : [
+      "leapYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "lengthOfMonth" : [
+      "lengthOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "lengthOfYear" : [
+      "lengthOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "minusWeeks" : [
+      "minusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "month" : [
+      "month": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "monthValue" : [
+      "monthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "plusWeeks" : [
+      "plusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "toEpochDay" : [
+      "toEpochDay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "until" : [
+      "until": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "withDayOfMonth" : [
+      "withDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "withDayOfYear" : [
+      "withDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "withMonth" : [
+      "withMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "withYear" : [
+      "withYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "year" : [
+      "year": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "EPOCH" : [
+    "staticMethods": {
+      "EPOCH": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "MAX" : [
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.Month"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "ofEpochDay" : [
+      "ofEpochDay": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "ofYearDay" : [
+      "ofYearDay": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "LocalDateTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.LocalDateTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atOffset" : [
+    "clazzName": {"refClazzName": "java.time.LocalDateTime"},
+    "methods": {
+      "atOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "atZone" : [
+      "atZone": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoLocalDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
+          ],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "dayOfMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "dayOfWeek": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
+        }
+      ],
+      "dayOfYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "format": [
+        {
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
+          ],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfWeek": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getHour": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getMinute": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
+        }
+      ],
+      "getMonthValue": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getNano": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getSecond": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "hour": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "isAfter": [
+        {
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfWeek" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "format" : [
-        {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfWeek" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getHour" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMinute" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMonthValue" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getNano" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getSecond" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "hour" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "isAfter" : [
-        {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoLocalDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoLocalDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoLocalDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusWeeks" : [
+      "minusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "month" : [
+      "month": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "monthValue" : [
+      "monthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusWeeks" : [
+      "plusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toInstant" : [
+      "toInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "toLocalDate" : [
+      "toLocalDate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "toLocalTime" : [
+      "toLocalTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "withDayOfMonth" : [
+      "withDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withDayOfYear" : [
+      "withDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withMonth" : [
+      "withMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withYear" : [
+      "withYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "year" : [
+      "year": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg6",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg6", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.Month"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.Month"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg6",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.Month"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg6", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "ofEpochSecond" : [
+      "ofEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "LocalTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.LocalTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atDate" : [
+    "clazzName": {"refClazzName": "java.time.LocalTime"},
+    "methods": {
+      "atDate": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "atOffset" : [
+      "atOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "format" : [
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getHour" : [
+      "getHour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMinute" : [
+      "getMinute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getSecond" : [
+      "getSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "hour" : [
+      "hour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toNanoOfDay" : [
+      "toNanoOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toSecondOfDay" : [
+      "toSecondOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "MIDNIGHT" : [
+      "MIDNIGHT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "NOON" : [
+      "NOON": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "ofNanoOfDay" : [
+      "ofNanoOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "ofSecondOfDay" : [
+      "ofSecondOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Month",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.Month",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "java.time.Month"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "firstDayOfYear" : [
+      "firstDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "firstMonthOfQuarter" : [
+      "firstMonthOfQuarter": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "getDisplayName" : [
+      "getDisplayName": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "TextStyle",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.TextStyle",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.TextStyle"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getValue" : [
+      "getValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "length" : [
+      "length": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "maxLength" : [
+      "maxLength": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "minLength" : [
+      "minLength": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "minus" : [
+      "minus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plus" : [
+      "plus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "value" : [
+      "value": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "APRIL" : [
+    "staticMethods": {
+      "APRIL": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "AUGUST" : [
+      "AUGUST": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "DECEMBER" : [
+      "DECEMBER": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "FEBRUARY" : [
+      "FEBRUARY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "JANUARY" : [
+      "JANUARY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "JULY" : [
+      "JULY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "JUNE" : [
+      "JUNE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "MARCH" : [
+      "MARCH": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "MAY" : [
+      "MAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "NOVEMBER" : [
+      "NOVEMBER": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "OCTOBER" : [
+      "OCTOBER": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "SEPTEMBER" : [
+      "SEPTEMBER": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[Month]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
+                "display": "Month",
+                "params": [],
+                "refClazzName": "java.time.Month",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "OffsetDateTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.OffsetDateTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atZoneSameInstant" : [
+    "clazzName": {"refClazzName": "java.time.OffsetDateTime"},
+    "methods": {
+      "atZoneSameInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "atZoneSimilarLocal" : [
+      "atZoneSimilarLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetDateTime"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dayOfMonth" : [
+      "dayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dayOfWeek" : [
+      "dayOfWeek": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "dayOfYear" : [
+      "dayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "format" : [
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getDayOfMonth" : [
+      "getDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDayOfWeek" : [
+      "getDayOfWeek": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "getDayOfYear" : [
+      "getDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getHour" : [
+      "getHour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMinute" : [
+      "getMinute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMonth" : [
+      "getMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "getMonthValue" : [
+      "getMonthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getOffset" : [
+      "getOffset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "getSecond" : [
+      "getSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getYear" : [
+      "getYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "hour" : [
+      "hour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetDateTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetDateTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetDateTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusWeeks" : [
+      "minusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "month" : [
+      "month": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "monthValue" : [
+      "monthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "offset" : [
+      "offset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusWeeks" : [
+      "plusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toInstant" : [
+      "toInstant": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "toLocalDate" : [
+      "toLocalDate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "toLocalDateTime" : [
+      "toLocalDateTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "toLocalTime" : [
+      "toLocalTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "toOffsetTime" : [
+      "toOffsetTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toZonedDateTime" : [
+      "toZonedDateTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withDayOfMonth" : [
+      "withDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withDayOfYear" : [
+      "withDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withMonth" : [
+      "withMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withOffsetSameInstant" : [
+      "withOffsetSameInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withOffsetSameLocal" : [
+      "withOffsetSameLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withYear" : [
+      "withYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "year" : [
+      "year": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg6",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg7",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg6", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg7", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.LocalTime"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "timeLineOrder" : [
+      "timeLineOrder": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Comparator[OffsetDateTime]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
+                "display": "OffsetDateTime",
+                "params": [],
+                "refClazzName": "java.time.OffsetDateTime",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Comparator",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Comparator"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "OffsetTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.OffsetTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atDate" : [
+    "clazzName": {"refClazzName": "java.time.OffsetTime"},
+    "methods": {
+      "atDate": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "format" : [
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getHour" : [
+      "getHour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMinute" : [
+      "getMinute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getOffset" : [
+      "getOffset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "getSecond" : [
+      "getSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "hour" : [
+      "hour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "offset" : [
+      "offset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toLocalTime" : [
+      "toLocalTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withOffsetSameInstant" : [
+      "withOffsetSameInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withOffsetSameLocal" : [
+      "withOffsetSameLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Period",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.Period",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "days" : [
+    "clazzName": {"refClazzName": "java.time.Period"},
+    "methods": {
+      "days": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDays" : [
+      "getDays": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMonths" : [
+      "getMonths": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getUnits" : [
+      "getUnits": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "List[TemporalUnit]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TemporalUnit",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.temporal.TemporalUnit",
-                "type" : "TypedClass"
+                "display": "TemporalUnit",
+                "params": [],
+                "refClazzName": "java.time.temporal.TemporalUnit",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.List",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.List"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "getYears" : [
+      "getYears": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isNegative" : [
+      "isNegative": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isZero" : [
+      "isZero": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "months" : [
+      "months": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "multipliedBy" : [
+      "multipliedBy": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "negated" : [
+      "negated": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "negative" : [
+      "negative": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "normalized" : [
+      "normalized": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toTotalMonths" : [
+      "toTotalMonths": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "units" : [
+      "units": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "List[TemporalUnit]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TemporalUnit",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.temporal.TemporalUnit",
-                "type" : "TypedClass"
+                "display": "TemporalUnit",
+                "params": [],
+                "refClazzName": "java.time.temporal.TemporalUnit",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.List",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.List"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "withDays" : [
+      "withDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "withMonths" : [
+      "withMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "withYears" : [
+      "withYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "years" : [
+      "years": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "zero" : [
+      "zero": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "ZERO" : [
+    "staticMethods": {
+      "ZERO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "between" : [
+      "between": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.LocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "ofDays" : [
+      "ofDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "ofMonths" : [
+      "ofMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "ofWeeks" : [
+      "ofWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "ofYears" : [
+      "ofYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "ZoneId",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.ZoneId",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "getDisplayName" : [
+    "clazzName": {"refClazzName": "java.time.ZoneId"},
+    "methods": {
+      "getDisplayName": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "TextStyle",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.TextStyle",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.TextStyle"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getId" : [
+      "getId": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "id" : [
+      "id": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "normalized" : [
+      "normalized": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "SHORT_IDS" : [
+    "staticMethods": {
+      "SHORT_IDS": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Map[String,String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               },
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Map",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Map"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "availableZoneIds" : [
+      "availableZoneIds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "getAvailableZoneIds" : [
+      "getAvailableZoneIds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Map[String,String]",
-                "params" : [
+              "name": "arg1",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   },
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   }
                 ],
-                "refClazzName" : "java.util.Map",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Map"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "ofOffset" : [
+      "ofOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "systemDefault" : [
+      "systemDefault": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "ZoneOffset",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.ZoneOffset",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "java.time.ZoneOffset"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDisplayName" : [
+      "getDisplayName": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "TextStyle",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.TextStyle",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.TextStyle"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getId" : [
+      "getId": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getTotalSeconds" : [
+      "getTotalSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "id" : [
+      "id": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "normalized" : [
+      "normalized": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "totalSeconds" : [
+      "totalSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "SHORT_IDS" : [
+      "SHORT_IDS": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Map[String,String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               },
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Map",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Map"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "UTC" : [
+      "UTC": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "availableZoneIds" : [
+      "availableZoneIds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "getAvailableZoneIds" : [
+      "getAvailableZoneIds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Map[String,String]",
-                "params" : [
+              "name": "arg1",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   },
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   }
                 ],
-                "refClazzName" : "java.util.Map",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Map"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "ofHours" : [
+      "ofHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "ofHoursMinutes" : [
+      "ofHoursMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "ofHoursMinutesSeconds" : [
+      "ofHoursMinutesSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "ofOffset" : [
+      "ofOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "ofTotalSeconds" : [
+      "ofTotalSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "systemDefault" : [
+      "systemDefault": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "ZonedDateTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.ZonedDateTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "java.time.ZonedDateTime"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoZonedDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoZonedDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoZonedDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
+          ],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "dayOfMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "dayOfWeek": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
+        }
+      ],
+      "dayOfYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "format": [
+        {
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
+          ],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfWeek": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getHour": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getMinute": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
+        }
+      ],
+      "getMonthValue": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getNano": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getOffset": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
+        }
+      ],
+      "getSecond": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getZone": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
+        }
+      ],
+      "hour": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "isAfter": [
+        {
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfWeek" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "format" : [
-        {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfWeek" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getHour" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMinute" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMonthValue" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getNano" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getOffset" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getSecond" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getZone" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "hour" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "isAfter" : [
-        {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoZonedDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoZonedDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoZonedDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoZonedDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoZonedDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoZonedDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoZonedDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoZonedDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoZonedDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusWeeks" : [
+      "minusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "month" : [
+      "month": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "monthValue" : [
+      "monthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "offset" : [
+      "offset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusWeeks" : [
+      "plusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toInstant" : [
+      "toInstant": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "toLocalDate" : [
+      "toLocalDate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "toLocalDateTime" : [
+      "toLocalDateTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "toLocalTime" : [
+      "toLocalTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "toOffsetDateTime" : [
+      "toOffsetDateTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "withDayOfMonth" : [
+      "withDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withDayOfYear" : [
+      "withDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withEarlierOffsetAtOverlap" : [
+      "withEarlierOffsetAtOverlap": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withFixedOffsetZone" : [
+      "withFixedOffsetZone": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withLaterOffsetAtOverlap" : [
+      "withLaterOffsetAtOverlap": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withMonth" : [
+      "withMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withYear" : [
+      "withYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withZoneSameInstant" : [
+      "withZoneSameInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withZoneSameLocal" : [
+      "withZoneSameLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "year" : [
+      "year": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "zone" : [
+      "zone": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "now" : [
+    "staticMethods": {
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg6",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg7",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg6", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg7", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.LocalTime"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "ofLocal" : [
+      "ofLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "ofStrict" : [
+      "ofStrict": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Collection",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.Collection",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "contains" : [
+    "clazzName": {"refClazzName": "java.util.Collection"},
+    "methods": {
+      "contains": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsAll" : [
+      "containsAll": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Collection[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.util.Collection",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Collection"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Comparator",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.Comparator",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toString" : [
+    "clazzName": {"refClazzName": "java.util.Comparator"},
+    "methods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "List",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.List",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "contains" : [
+    "clazzName": {"refClazzName": "java.util.List"},
+    "methods": {
+      "contains": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsAll" : [
+      "containsAll": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Collection[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.util.Collection",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Collection"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "get" : [
+      "get": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "indexOf" : [
+      "indexOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Map",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.Map",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "containsKey" : [
+    "clazzName": {"refClazzName": "java.util.Map"},
+    "methods": {
+      "containsKey": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsValue" : [
+      "containsValue": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "get" : [
+      "get": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "getOrDefault" : [
+      "getOrDefault": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}},
+            {"name": "arg1", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "keySet" : [
+      "keySet": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[Unknown]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Collection[Unknown]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Collection",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Collection"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Set",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.Set",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "contains" : [
+    "clazzName": {"refClazzName": "java.util.Set"},
+    "methods": {
+      "contains": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsAll" : [
+      "containsAll": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Collection[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.util.Collection",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Collection"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "TypedMap",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.api.typed.TypedMap",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "containsKey" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.api.typed.TypedMap"},
+    "methods": {
+      "containsKey": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsValue" : [
+      "containsValue": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "get" : [
+      "get": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "getOrDefault" : [
+      "getOrDefault": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}},
+            {"name": "arg1", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "keySet" : [
+      "keySet": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[Unknown]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Collection[Unknown]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Collection",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Collection"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "AggregateHelper",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.AggregateHelper",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "approxCardinality" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.AggregateHelper"},
+    "methods": {
+      "approxCardinality": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "first" : [
+      "first": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "last" : [
+      "last": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "list" : [
+      "list": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "map" : [
+      "map": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "parts",
-              "refClazz" : {
-                "display" : "Map[String,Aggregator]",
-                "params" : [
+              "name": "parts",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   },
                   {
-                    "display" : "Aggregator",
-                    "params" : [
-                    ],
-                    "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-                    "type" : "TypedClass"
+                    "display": "Aggregator",
+                    "params": [],
+                    "refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
+                    "type": "TypedClass"
                   }
                 ],
-                "refClazzName" : "java.util.Map",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Map"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "set" : [
+      "set": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Aggregator",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toString" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+    "methods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "SessionWindowTrigger",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "OnEnd" : [
+    "staticMethods": {
+      "OnEnd": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "SessionWindowTrigger",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger"},
+          "varArgs": false
         }
       ],
-      "OnEvent" : [
+      "OnEvent": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "SessionWindowTrigger",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "name",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "name", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "SessionWindowTrigger",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[SessionWindowTrigger]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "SessionWindowTrigger",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger",
-                "type" : "TypedClass"
+                "display": "SessionWindowTrigger",
+                "params": [],
+                "refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.SessionWindowTrigger",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "TumblingWindowTrigger",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "OnEnd" : [
+    "staticMethods": {
+      "OnEnd": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "TumblingWindowTrigger",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger"},
+          "varArgs": false
         }
       ],
-      "OnEndWithExtraWindow" : [
+      "OnEndWithExtraWindow": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "TumblingWindowTrigger",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger"},
+          "varArgs": false
         }
       ],
-      "OnEvent" : [
+      "OnEvent": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "TumblingWindowTrigger",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "name",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "name", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "TumblingWindowTrigger",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[TumblingWindowTrigger]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TumblingWindowTrigger",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger",
-                "type" : "TypedClass"
+                "display": "TumblingWindowTrigger",
+                "params": [],
+                "refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.TumblingWindowTrigger",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "BranchType",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "JOINED" : [
+    "staticMethods": {
+      "JOINED": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BranchType",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType"},
+          "varArgs": false
         }
       ],
-      "MAIN" : [
+      "MAIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BranchType",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "name",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "name", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "BranchType",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[BranchType]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "BranchType",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-                "type" : "TypedClass"
+                "display": "BranchType",
+                "params": [],
+                "refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Point",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.util.functions.Point",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "lat" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"},
+    "methods": {
+      "lat": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "lon" : [
+      "lon": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "apply" : [
+    "staticMethods": {
+      "apply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "lat",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "lon",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "lat", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "lon", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Point",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.util.functions.Point",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "conversion",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.util.functions.conversion$",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toAny" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.conversion$"},
+    "methods": {
+      "toAny": [
         {
-          "description" : "Wrap param in 'Unknown' type to make it usable in places where type checking is too much restrictive",
-          "parameters" : [
-            {
-              "name" : "value",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "description": "Wrap param in 'Unknown' type to make it usable in places where type checking is too much restrictive",
+          "parameters": [
+            {"name": "value", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "toNumber" : [
+      "toNumber": [
         {
-          "description" : "Parse string to number",
-          "parameters" : [
-            {
-              "name" : "stringOrNumber",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "description": "Parse string to number",
+          "parameters": [
+            {"name": "stringOrNumber", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Number",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Number",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Number"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "date",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.util.functions.date$",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "now" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.date$"},
+    "methods": {
+      "now": [
         {
-          "description" : "Current time",
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "description": "Current time",
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "nowTimestamp" : [
+      "nowTimestamp": [
         {
-          "description" : "Current timestamp",
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "description": "Current timestamp",
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "parseToLocalDate" : [
+      "parseToLocalDate": [
         {
-          "description" : "Parse date in ISO format (e.g. '2018-11-12T11:22:33') to date object",
-          "parameters" : [
-            {
-              "name" : "dateString",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Parse date in ISO format (e.g. '2018-11-12T11:22:33') to date object",
+          "parameters": [
+            {"name": "dateString", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "parseToTimestamp" : [
+      "parseToTimestamp": [
         {
-          "description" : "Parse date in ISO format (e.g. '2018-11-12T11:22:33') to timestamp",
-          "parameters" : [
-            {
-              "name" : "dateString",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Parse date in ISO format (e.g. '2018-11-12T11:22:33') to timestamp",
+          "parameters": [
+            {"name": "dateString", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "parseToZonedDate" : [
+      "parseToZonedDate": [
         {
-          "description" : "Parse date in ISO format (e.g. '2018-11-12T11:22:33+02[Europe/Warsaw]') to date object",
-          "parameters" : [
-            {
-              "name" : "dateString",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Parse date in ISO format (e.g. '2018-11-12T11:22:33+02[Europe/Warsaw]') to date object",
+          "parameters": [
+            {"name": "dateString", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "toInstant" : [
+      "toInstant": [
         {
-          "description" : "Convert to Instant object",
-          "parameters" : [
-            {
-              "name" : "timestamp",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Convert to Instant object",
+          "parameters": [
+            {"name": "timestamp", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "zone" : [
+      "zone": [
         {
-          "description" : "Parse time zone identifier (e.g. UTC, GMT, Europe/Warsaw",
-          "parameters" : [
-            {
-              "name" : "zoneId",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Parse time zone identifier (e.g. UTC, GMT, Europe/Warsaw",
+          "parameters": [
+            {"name": "zoneId", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "geo",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.util.functions.geo$",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "distanceInKm" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.geo$"},
+    "methods": {
+      "distanceInKm": [
         {
-          "description" : "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm",
-          "parameters" : [
-            {
-              "name" : "first point latitude",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "first point longitude",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "second point latitude",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "first point longitude",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm",
+          "parameters": [
+            {"name": "first point latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "first point longitude", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "second point latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "first point longitude", "refClazz": {"refClazzName": "java.lang.Number"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         },
         {
-          "description" : "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm",
-          "parameters" : [
-            {
-              "name" : "first point",
-              "refClazz" : {
-                "display" : "Point",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.util.functions.Point",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "second point",
-              "refClazz" : {
-                "display" : "Point",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.util.functions.Point",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm",
+          "parameters": [
+            {"name": "first point", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}},
+            {"name": "second point", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "toPoint" : [
+      "toPoint": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "lat",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "lon",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "lat", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "lon", "refClazz": {"refClazzName": "java.lang.Number"}}
           ],
-          "refClazz" : {
-            "display" : "Point",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.util.functions.Point",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "math",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.util.functions.math$",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "abs" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.math$"},
+    "methods": {
+      "abs": [
         {
-          "description" : "Returns the absolute value of a value.",
-          "parameters" : [
-            {
-              "name" : "a",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Returns the absolute value of a value.",
+          "parameters": [
+            {"name": "a", "refClazz": {"refClazzName": "java.lang.Number"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floor" : [
+      "floor": [
         {
-          "description" : "Returns the largest (closest to positive infinity) value that is less than or equal to the argument and is equal to a mathematical integer.",
-          "parameters" : [
-            {
-              "name" : "a",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Returns the largest (closest to positive infinity) value that is less than or equal to the argument and is equal to a mathematical integer.",
+          "parameters": [
+            {"name": "a", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : "Returns the greater of two values.",
-          "parameters" : [
-            {
-              "name" : "a",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "b",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Returns the greater of two values.",
+          "parameters": [
+            {"name": "a", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "b", "refClazz": {"refClazzName": "java.lang.Number"}}
           ],
-          "refClazz" : {
-            "display" : "Number",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Number",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Number"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : "Returns the smaller of two values.",
-          "parameters" : [
-            {
-              "name" : "a",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "b",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Returns the smaller of two values.",
+          "parameters": [
+            {"name": "a", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "b", "refClazz": {"refClazzName": "java.lang.Number"}}
           ],
-          "refClazz" : {
-            "display" : "Number",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Number",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Number"},
+          "varArgs": false
         }
       ],
-      "pow" : [
+      "pow": [
         {
-          "description" : "Returns the value of the first argument raised to the power of the second argument",
-          "parameters" : [
-            {
-              "name" : "a",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "b",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Returns the value of the first argument raised to the power of the second argument",
+          "parameters": [
+            {"name": "a", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "b", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "numeric",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.util.functions.numeric$",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "largeSum" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.numeric$"},
+    "methods": {
+      "largeSum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "n1",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "n2",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "n1", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "n2", "refClazz": {"refClazzName": "java.lang.Number"}}
           ],
-          "refClazz" : {
-            "display" : "Number",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Number",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Number"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "n1",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "n2",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "n1", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "n2", "refClazz": {"refClazzName": "java.lang.Number"}}
           ],
-          "refClazz" : {
-            "display" : "Number",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Number",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Number"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "n1",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "n2",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "n1", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "n2", "refClazz": {"refClazzName": "java.lang.Number"}}
           ],
-          "refClazz" : {
-            "display" : "Number",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Number",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Number"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "n1",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "n2",
-              "refClazz" : {
-                "display" : "Number",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Number",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "n1", "refClazz": {"refClazzName": "java.lang.Number"}},
+            {"name": "n2", "refClazz": {"refClazzName": "java.lang.Number"}}
           ],
-          "refClazz" : {
-            "display" : "Number",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Number",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Number"},
+          "varArgs": false
         }
       ],
-      "toNumber" : [
+      "toNumber": [
         {
-          "description" : "Parse string to number",
-          "parameters" : [
-            {
-              "name" : "stringOrNumber",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "description": "Parse string to number",
+          "parameters": [
+            {"name": "stringOrNumber", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Number",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Number",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Number"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "util",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.util.functions.util$",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toString" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.util$"},
+    "methods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "uuid" : [
+      "uuid": [
         {
-          "description" : "Generate unique identifier (https://en.wikipedia.org/wiki/Universally_unique_identifier)",
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "description": "Generate unique identifier (https://en.wikipedia.org/wiki/Universally_unique_identifier)",
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "MetaVariables",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.variables.MetaVariables",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "processName" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.variables.MetaVariables"},
+    "methods": {
+      "processName": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "properties" : [
+      "properties": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "TypedMap",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.api.typed.TypedMap",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.api.typed.TypedMap"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "apply" : [
+    "staticMethods": {
+      "apply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "processName",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "properties",
-              "refClazz" : {
-                "display" : "TypedMap",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.api.typed.TypedMap",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "processName", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "properties", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.api.typed.TypedMap"}}
           ],
-          "refClazz" : {
-            "display" : "MetaVariables",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.variables.MetaVariables",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.variables.MetaVariables"},
+          "varArgs": false
         }
       ]
     }

--- a/engine/flink/management/sample/src/test/resources/extractedTypes/devCreator.json
+++ b/engine/flink/management/sample/src/test/resources/extractedTypes/devCreator.json
@@ -1,26687 +1,10348 @@
 [
   {
-    "clazzName" : {
-      "display" : "Array",
-      "params" : [
-      ],
-      "refClazzName" : "[Ljava.lang.Object;",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toString" : [
+    "clazzName": {"refClazzName": "[Ljava.lang.Object;"},
+    "methods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Cron",
-      "params" : [
-      ],
-      "refClazzName" : "com.cronutils.model.Cron",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "asString" : [
+    "clazzName": {"refClazzName": "com.cronutils.model.Cron"},
+    "methods": {
+      "asString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "cronDefinition" : [
+      "cronDefinition": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "CronDefinition",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.definition.CronDefinition",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.definition.CronDefinition"},
+          "varArgs": false
         }
       ],
-      "equivalent" : [
+      "equivalent": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CronMapper",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.mapper.CronMapper",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Cron",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.Cron",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "com.cronutils.mapper.CronMapper"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "com.cronutils.model.Cron"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Cron",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.Cron",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "com.cronutils.model.Cron"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "getCronDefinition" : [
+      "getCronDefinition": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "CronDefinition",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.definition.CronDefinition",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.definition.CronDefinition"},
+          "varArgs": false
         }
       ],
-      "retrieveFieldsAsMap" : [
+      "retrieveFieldsAsMap": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Map[CronFieldName,CronField]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "CronFieldName",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.field.CronFieldName",
-                "type" : "TypedClass"
+                "display": "CronFieldName",
+                "params": [],
+                "refClazzName": "com.cronutils.model.field.CronFieldName",
+                "type": "TypedClass"
               },
               {
-                "display" : "CronField",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.field.CronField",
-                "type" : "TypedClass"
+                "display": "CronField",
+                "params": [],
+                "refClazzName": "com.cronutils.model.field.CronField",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Map",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Map"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "validate" : [
+      "validate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Cron",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.Cron",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.Cron"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "CronType",
-      "params" : [
-      ],
-      "refClazzName" : "com.cronutils.model.CronType",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "com.cronutils.model.CronType"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "CRON4J" : [
+    "staticMethods": {
+      "CRON4J": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "CronType",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.CronType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.CronType"},
+          "varArgs": false
         }
       ],
-      "QUARTZ" : [
+      "QUARTZ": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "CronType",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.CronType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.CronType"},
+          "varArgs": false
         }
       ],
-      "SPRING" : [
+      "SPRING": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "CronType",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.CronType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.CronType"},
+          "varArgs": false
         }
       ],
-      "UNIX" : [
+      "UNIX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "CronType",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.CronType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.CronType"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "CronType",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.CronType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "com.cronutils.model.CronType"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[CronType]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "CronType",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.CronType",
-                "type" : "TypedClass"
+                "display": "CronType",
+                "params": [],
+                "refClazzName": "com.cronutils.model.CronType",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "CronConstraint",
-      "params" : [
-      ],
-      "refClazzName" : "com.cronutils.model.definition.CronConstraint",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "description" : [
+    "clazzName": {"refClazzName": "com.cronutils.model.definition.CronConstraint"},
+    "methods": {
+      "description": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getDescription" : [
+      "getDescription": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "validate" : [
+      "validate": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Cron",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.Cron",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "com.cronutils.model.Cron"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "CronDefinition",
-      "params" : [
-      ],
-      "refClazzName" : "com.cronutils.model.definition.CronDefinition",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "cronConstraints" : [
+    "clazzName": {"refClazzName": "com.cronutils.model.definition.CronDefinition"},
+    "methods": {
+      "cronConstraints": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[CronConstraint]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "CronConstraint",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.definition.CronConstraint",
-                "type" : "TypedClass"
+                "display": "CronConstraint",
+                "params": [],
+                "refClazzName": "com.cronutils.model.definition.CronConstraint",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "fieldDefinitions" : [
+      "fieldDefinitions": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[FieldDefinition]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "FieldDefinition",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.field.definition.FieldDefinition",
-                "type" : "TypedClass"
+                "display": "FieldDefinition",
+                "params": [],
+                "refClazzName": "com.cronutils.model.field.definition.FieldDefinition",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "getCronConstraints" : [
+      "getCronConstraints": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[CronConstraint]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "CronConstraint",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.definition.CronConstraint",
-                "type" : "TypedClass"
+                "display": "CronConstraint",
+                "params": [],
+                "refClazzName": "com.cronutils.model.definition.CronConstraint",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "getFieldDefinitions" : [
+      "getFieldDefinitions": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[FieldDefinition]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "FieldDefinition",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.field.definition.FieldDefinition",
-                "type" : "TypedClass"
+                "display": "FieldDefinition",
+                "params": [],
+                "refClazzName": "com.cronutils.model.field.definition.FieldDefinition",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "isMatchDayOfWeekAndDayOfMonth" : [
+      "isMatchDayOfWeekAndDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "matchDayOfWeekAndDayOfMonth" : [
+      "matchDayOfWeekAndDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "retrieveFieldDefinitionsAsMap" : [
+      "retrieveFieldDefinitionsAsMap": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Map[CronFieldName,FieldDefinition]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "CronFieldName",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.field.CronFieldName",
-                "type" : "TypedClass"
+                "display": "CronFieldName",
+                "params": [],
+                "refClazzName": "com.cronutils.model.field.CronFieldName",
+                "type": "TypedClass"
               },
               {
-                "display" : "FieldDefinition",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.field.definition.FieldDefinition",
-                "type" : "TypedClass"
+                "display": "FieldDefinition",
+                "params": [],
+                "refClazzName": "com.cronutils.model.field.definition.FieldDefinition",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Map",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Map"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "CronDefinitionBuilder",
-      "params" : [
-      ],
-      "refClazzName" : "com.cronutils.model.definition.CronDefinitionBuilder",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "instance" : [
+    "clazzName": {"refClazzName": "com.cronutils.model.definition.CronDefinitionBuilder"},
+    "methods": {
+      "instance": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "CronDefinition",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.definition.CronDefinition",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.definition.CronDefinition"},
+          "varArgs": false
         }
       ],
-      "matchDayOfWeekAndDayOfMonth" : [
+      "matchDayOfWeekAndDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "CronDefinitionBuilder",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.definition.CronDefinitionBuilder",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.definition.CronDefinitionBuilder"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "withCronValidation" : [
+      "withCronValidation": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CronConstraint",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.definition.CronConstraint",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "com.cronutils.model.definition.CronConstraint"}}
           ],
-          "refClazz" : {
-            "display" : "CronDefinitionBuilder",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.definition.CronDefinitionBuilder",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "com.cronutils.model.definition.CronDefinitionBuilder"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "defineCron" : [
+    "staticMethods": {
+      "defineCron": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "CronDefinitionBuilder",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.definition.CronDefinitionBuilder",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "com.cronutils.model.definition.CronDefinitionBuilder"},
+          "varArgs": false
         }
       ],
-      "instanceDefinitionFor" : [
+      "instanceDefinitionFor": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CronType",
-                "params" : [
-                ],
-                "refClazzName" : "com.cronutils.model.CronType",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "com.cronutils.model.CronType"}}
           ],
-          "refClazz" : {
-            "display" : "CronDefinition",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.definition.CronDefinition",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "com.cronutils.model.definition.CronDefinition"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "CronParser",
-      "params" : [
-      ],
-      "refClazzName" : "com.cronutils.parser.CronParser",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "parse" : [
+    "clazzName": {"refClazzName": "com.cronutils.parser.CronParser"},
+    "methods": {
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Cron",
-            "params" : [
-            ],
-            "refClazzName" : "com.cronutils.model.Cron",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "com.cronutils.model.Cron"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Json",
-      "params" : [
-      ],
-      "refClazzName" : "io.circe.Json",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "noSpaces" : [
+    "clazzName": {"refClazzName": "io.circe.Json"},
+    "methods": {
+      "noSpaces": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "spaces2" : [
+      "spaces2": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "spaces4" : [
+      "spaces4": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Boolean",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Boolean",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "booleanValue" : [
+    "clazzName": {"refClazzName": "java.lang.Boolean"},
+    "methods": {
+      "booleanValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "FALSE" : [
+    "staticMethods": {
+      "FALSE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "TRUE" : [
+      "TRUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getBoolean" : [
+      "getBoolean": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "logicalAnd" : [
+      "logicalAnd": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "logicalOr" : [
+      "logicalOr": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "logicalXor" : [
+      "logicalXor": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "parseBoolean" : [
+      "parseBoolean": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Byte",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Byte",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Byte"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareUnsigned" : [
+      "compareUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "decode" : [
+      "decode": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "parseByte" : [
+      "parseByte": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUnsignedInt" : [
+      "toUnsignedInt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toUnsignedLong" : [
+      "toUnsignedLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Byte"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "CharSequence",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.CharSequence",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "charAt" : [
+    "clazzName": {"refClazzName": "java.lang.CharSequence"},
+    "methods": {
+      "charAt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Character",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Character",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Character"},
+          "varArgs": false
         }
       ],
-      "length" : [
+      "length": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Character",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Character",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toString" : [
+    "clazzName": {"refClazzName": "java.lang.Character"},
+    "methods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "toString" : [
+    "staticMethods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Character",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Character",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Character"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Double",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Double",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Double"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "infinite" : [
+      "infinite": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isInfinite" : [
+      "isInfinite": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isNaN" : [
+      "isNaN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "naN" : [
+      "naN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_EXPONENT" : [
+      "MAX_EXPONENT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "MIN_EXPONENT" : [
+      "MIN_EXPONENT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MIN_NORMAL" : [
+      "MIN_NORMAL": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "NEGATIVE_INFINITY" : [
+      "NEGATIVE_INFINITY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "NaN" : [
+      "NaN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "POSITIVE_INFINITY" : [
+      "POSITIVE_INFINITY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleToLongBits" : [
+      "doubleToLongBits": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "doubleToRawLongBits" : [
+      "doubleToRawLongBits": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "isFinite" : [
+      "isFinite": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isInfinite" : [
+      "isInfinite": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isNaN" : [
+      "isNaN": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "longBitsToDouble" : [
+      "longBitsToDouble": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "parseDouble" : [
+      "parseDouble": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "toHexString" : [
+      "toHexString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Float",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Float",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Float"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "infinite" : [
+      "infinite": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isInfinite" : [
+      "isInfinite": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isNaN" : [
+      "isNaN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "naN" : [
+      "naN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_EXPONENT" : [
+      "MAX_EXPONENT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "MIN_EXPONENT" : [
+      "MIN_EXPONENT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MIN_NORMAL" : [
+      "MIN_NORMAL": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "NEGATIVE_INFINITY" : [
+      "NEGATIVE_INFINITY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "NaN" : [
+      "NaN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "POSITIVE_INFINITY" : [
+      "POSITIVE_INFINITY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "floatToIntBits" : [
+      "floatToIntBits": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "floatToRawIntBits" : [
+      "floatToRawIntBits": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "intBitsToFloat" : [
+      "intBitsToFloat": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "isFinite" : [
+      "isFinite": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isInfinite" : [
+      "isInfinite": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isNaN" : [
+      "isNaN": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "parseFloat" : [
+      "parseFloat": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "toHexString" : [
+      "toHexString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Float",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Float",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Float"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Integer",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Integer",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Integer"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "bitCount" : [
+      "bitCount": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareUnsigned" : [
+      "compareUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "decode" : [
+      "decode": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "divideUnsigned" : [
+      "divideUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getInteger" : [
+      "getInteger": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "highestOneBit" : [
+      "highestOneBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "lowestOneBit" : [
+      "lowestOneBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "numberOfLeadingZeros" : [
+      "numberOfLeadingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "numberOfTrailingZeros" : [
+      "numberOfTrailingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "parseInt" : [
+      "parseInt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "parseUnsignedInt" : [
+      "parseUnsignedInt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "remainderUnsigned" : [
+      "remainderUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "reverse" : [
+      "reverse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "reverseBytes" : [
+      "reverseBytes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "rotateLeft" : [
+      "rotateLeft": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "rotateRight" : [
+      "rotateRight": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "signum" : [
+      "signum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toBinaryString" : [
+      "toBinaryString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toHexString" : [
+      "toHexString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toOctalString" : [
+      "toOctalString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUnsignedLong" : [
+      "toUnsignedLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toUnsignedString" : [
+      "toUnsignedString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Long",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Long",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Long"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "bitCount" : [
+      "bitCount": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareUnsigned" : [
+      "compareUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "decode" : [
+      "decode": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "divideUnsigned" : [
+      "divideUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getLong" : [
+      "getLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "highestOneBit" : [
+      "highestOneBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "lowestOneBit" : [
+      "lowestOneBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "numberOfLeadingZeros" : [
+      "numberOfLeadingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "numberOfTrailingZeros" : [
+      "numberOfTrailingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "parseLong" : [
+      "parseLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "parseUnsignedLong" : [
+      "parseUnsignedLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "remainderUnsigned" : [
+      "remainderUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "reverse" : [
+      "reverse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "reverseBytes" : [
+      "reverseBytes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "rotateLeft" : [
+      "rotateLeft": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "rotateRight" : [
+      "rotateRight": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "signum" : [
+      "signum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toBinaryString" : [
+      "toBinaryString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toHexString" : [
+      "toHexString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toOctalString" : [
+      "toOctalString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUnsignedString" : [
+      "toUnsignedString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Number",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Number",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Number"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Short",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.Short",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "byteValue" : [
+    "clazzName": {"refClazzName": "java.lang.Short"},
+    "methods": {
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "BYTES" : [
+    "staticMethods": {
+      "BYTES": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "MAX_VALUE" : [
+      "MAX_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "MIN_VALUE" : [
+      "MIN_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "SIZE" : [
+      "SIZE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compare" : [
+      "compare": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareUnsigned" : [
+      "compareUnsigned": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "decode" : [
+      "decode": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "parseShort" : [
+      "parseShort": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "reverseBytes" : [
+      "reverseBytes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUnsignedInt" : [
+      "toUnsignedInt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toUnsignedLong" : [
+      "toUnsignedLong": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Short",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Short",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Short"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "String",
-      "params" : [
-      ],
-      "refClazzName" : "java.lang.String",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "blank" : [
+    "clazzName": {"refClazzName": "java.lang.String"},
+    "methods": {
+      "blank": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "charAt" : [
+      "charAt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Character",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Character",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Character"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "compareToIgnoreCase" : [
+      "compareToIgnoreCase": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "concat" : [
+      "concat": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "contains" : [
+      "contains": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "endsWith" : [
+      "endsWith": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "equalsIgnoreCase" : [
+      "equalsIgnoreCase": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "indexOf" : [
+      "indexOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isBlank" : [
+      "isBlank": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "lastIndexOf" : [
+      "lastIndexOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "length" : [
+      "length": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "matches" : [
+      "matches": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "replaceAll" : [
+      "replaceAll": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "replaceFirst" : [
+      "replaceFirst": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "split" : [
+      "split": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Array[String]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Array[String]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "startsWith" : [
+      "startsWith": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "strip" : [
+      "strip": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "stripLeading" : [
+      "stripLeading": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "stripTrailing" : [
+      "stripTrailing": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "substring" : [
+      "substring": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toLowerCase" : [
+      "toLowerCase": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toUpperCase" : [
+      "toUpperCase": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "trim" : [
+      "trim": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "format" : [
+    "staticMethods": {
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Array",
-                "params" : [
-                ],
-                "refClazzName" : "[Ljava.lang.Object;",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "[Ljava.lang.Object;"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : true
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": true
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Array",
-                "params" : [
-                ],
-                "refClazzName" : "[Ljava.lang.Object;",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.util.Locale"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "[Ljava.lang.Object;"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : true
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": true
         }
       ],
-      "join" : [
+      "join": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Array[CharSequence]",
-                "params" : [
+              "name": "arg1",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "CharSequence",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.CharSequence",
-                    "type" : "TypedClass"
+                    "display": "CharSequence",
+                    "params": [],
+                    "refClazzName": "java.lang.CharSequence",
+                    "type": "TypedClass"
                   }
                 ],
-                "refClazzName" : "[Ljava.lang.Object;",
-                "type" : "TypedClass"
+                "refClazzName": "[Ljava.lang.Object;"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : true
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": true
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Iterable[Unknown]",
-                "params" : [
+              "name": "arg1",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.lang.Iterable",
-                "type" : "TypedClass"
+                "refClazzName": "java.lang.Iterable"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "BigDecimal",
-      "params" : [
-      ],
-      "refClazzName" : "java.math.BigDecimal",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "abs" : [
+    "clazzName": {"refClazzName": "java.math.BigDecimal"},
+    "methods": {
+      "abs": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "add" : [
+      "add": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "byteValue" : [
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "byteValueExact" : [
+      "byteValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "divide" : [
+      "divide": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "RoundingMode",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.RoundingMode",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.math.RoundingMode"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "RoundingMode",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.RoundingMode",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.RoundingMode"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "divideAndRemainder" : [
+      "divideAndRemainder": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "Array[BigDecimal]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
+                "display": "BigDecimal",
+                "params": [],
+                "refClazzName": "java.math.BigDecimal",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "Array[BigDecimal]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
+                "display": "BigDecimal",
+                "params": [],
+                "refClazzName": "java.math.BigDecimal",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "divideToIntegralValue" : [
+      "divideToIntegralValue": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "intValueExact" : [
+      "intValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "longValueExact" : [
+      "longValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "movePointLeft" : [
+      "movePointLeft": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "movePointRight" : [
+      "movePointRight": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "multiply" : [
+      "multiply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "negate" : [
+      "negate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "plus" : [
+      "plus": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "pow" : [
+      "pow": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "precision" : [
+      "precision": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "remainder" : [
+      "remainder": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "round" : [
+      "round": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "scale" : [
+      "scale": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "scaleByPowerOfTen" : [
+      "scaleByPowerOfTen": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "setScale" : [
+      "setScale": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "RoundingMode",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.RoundingMode",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.RoundingMode"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "shortValueExact" : [
+      "shortValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "signum" : [
+      "signum": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "sqrt" : [
+      "sqrt": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "stripTrailingZeros" : [
+      "stripTrailingZeros": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "subtract" : [
+      "subtract": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigDecimal",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigDecimal",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "MathContext",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.MathContext",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigDecimal"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.MathContext"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "toBigInteger" : [
+      "toBigInteger": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "toBigIntegerExact" : [
+      "toBigIntegerExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "toEngineeringString" : [
+      "toEngineeringString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toPlainString" : [
+      "toPlainString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ulp" : [
+      "ulp": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "unscaledValue" : [
+      "unscaledValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "ONE" : [
+    "staticMethods": {
+      "ONE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "ROUND_CEILING" : [
+      "ROUND_CEILING": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_DOWN" : [
+      "ROUND_DOWN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_FLOOR" : [
+      "ROUND_FLOOR": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_HALF_DOWN" : [
+      "ROUND_HALF_DOWN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_HALF_EVEN" : [
+      "ROUND_HALF_EVEN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_HALF_UP" : [
+      "ROUND_HALF_UP": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_UNNECESSARY" : [
+      "ROUND_UNNECESSARY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "ROUND_UP" : [
+      "ROUND_UP": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "TEN" : [
+      "TEN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "ZERO" : [
+      "ZERO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Double",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Double",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Double"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigDecimal",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigDecimal",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigDecimal"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "BigInteger",
-      "params" : [
-      ],
-      "refClazzName" : "java.math.BigInteger",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "abs" : [
+    "clazzName": {"refClazzName": "java.math.BigInteger"},
+    "methods": {
+      "abs": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "add" : [
+      "add": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "and" : [
+      "and": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "andNot" : [
+      "andNot": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "bitCount" : [
+      "bitCount": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "bitLength" : [
+      "bitLength": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "byteValue" : [
+      "byteValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "byteValueExact" : [
+      "byteValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Byte",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Byte",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Byte"},
+          "varArgs": false
         }
       ],
-      "clearBit" : [
+      "clearBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "divide" : [
+      "divide": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "divideAndRemainder" : [
+      "divideAndRemainder": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "Array[BigInteger]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
+                "display": "BigInteger",
+                "params": [],
+                "refClazzName": "java.math.BigInteger",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "doubleValue" : [
+      "doubleValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Double",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Double",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Double"},
+          "varArgs": false
         }
       ],
-      "flipBit" : [
+      "flipBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "floatValue" : [
+      "floatValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Float",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Float",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Float"},
+          "varArgs": false
         }
       ],
-      "gcd" : [
+      "gcd": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "getLowestSetBit" : [
+      "getLowestSetBit": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "intValue" : [
+      "intValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "intValueExact" : [
+      "intValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isProbablePrime" : [
+      "isProbablePrime": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "longValue" : [
+      "longValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "longValueExact" : [
+      "longValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "lowestSetBit" : [
+      "lowestSetBit": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "mod" : [
+      "mod": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "modInverse" : [
+      "modInverse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "modPow" : [
+      "modPow": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "multiply" : [
+      "multiply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "negate" : [
+      "negate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "nextProbablePrime" : [
+      "nextProbablePrime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "not" : [
+      "not": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "or" : [
+      "or": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "pow" : [
+      "pow": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "remainder" : [
+      "remainder": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "setBit" : [
+      "setBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "shiftLeft" : [
+      "shiftLeft": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "shiftRight" : [
+      "shiftRight": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "shortValue" : [
+      "shortValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "shortValueExact" : [
+      "shortValueExact": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Short",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Short",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Short"},
+          "varArgs": false
         }
       ],
-      "signum" : [
+      "signum": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "sqrt" : [
+      "sqrt": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "sqrtAndRemainder" : [
+      "sqrtAndRemainder": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[BigInteger]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
+                "display": "BigInteger",
+                "params": [],
+                "refClazzName": "java.math.BigInteger",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "subtract" : [
+      "subtract": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "testBit" : [
+      "testBit": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "toByteArray" : [
+      "toByteArray": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[Byte]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Byte",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Byte",
-                "type" : "TypedClass"
+                "display": "Byte",
+                "params": [],
+                "refClazzName": "java.lang.Byte",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "xor" : [
+      "xor": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "BigInteger",
-                "params" : [
-                ],
-                "refClazzName" : "java.math.BigInteger",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.math.BigInteger"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "ONE" : [
+    "staticMethods": {
+      "ONE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "TEN" : [
+      "TEN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "TWO" : [
+      "TWO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "ZERO" : [
+      "ZERO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "probablePrime" : [
+      "probablePrime": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Random",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Random",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Random"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "BigInteger",
-            "params" : [
-            ],
-            "refClazzName" : "java.math.BigInteger",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.math.BigInteger"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "DayOfWeek",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.DayOfWeek",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "java.time.DayOfWeek"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDisplayName" : [
+      "getDisplayName": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "TextStyle",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.TextStyle",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.TextStyle"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getValue" : [
+      "getValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "minus" : [
+      "minus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plus" : [
+      "plus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "value" : [
+      "value": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "FRIDAY" : [
+    "staticMethods": {
+      "FRIDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "MONDAY" : [
+      "MONDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "SATURDAY" : [
+      "SATURDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "SUNDAY" : [
+      "SUNDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "THURSDAY" : [
+      "THURSDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "TUESDAY" : [
+      "TUESDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "WEDNESDAY" : [
+      "WEDNESDAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[DayOfWeek]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "DayOfWeek",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.DayOfWeek",
-                "type" : "TypedClass"
+                "display": "DayOfWeek",
+                "params": [],
+                "refClazzName": "java.time.DayOfWeek",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Duration",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.Duration",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "abs" : [
+    "clazzName": {"refClazzName": "java.time.Duration"},
+    "methods": {
+      "abs": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Duration",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Duration",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Duration"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dividedBy" : [
+      "dividedBy": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Duration",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Duration",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Duration"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getSeconds" : [
+      "getSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getUnits" : [
+      "getUnits": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "List[TemporalUnit]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TemporalUnit",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.temporal.TemporalUnit",
-                "type" : "TypedClass"
+                "display": "TemporalUnit",
+                "params": [],
+                "refClazzName": "java.time.temporal.TemporalUnit",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.List",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.List"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "isNegative" : [
+      "isNegative": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isZero" : [
+      "isZero": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minus" : [
+      "minus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Duration",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Duration",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Duration"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusMillis" : [
+      "minusMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "multipliedBy" : [
+      "multipliedBy": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "negated" : [
+      "negated": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "negative" : [
+      "negative": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "plus" : [
+      "plus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Duration",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Duration",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Duration"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusMillis" : [
+      "plusMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "seconds" : [
+      "seconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toDays" : [
+      "toDays": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toDaysPart" : [
+      "toDaysPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toHours" : [
+      "toHours": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toHoursPart" : [
+      "toHoursPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toMillis" : [
+      "toMillis": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toMillisPart" : [
+      "toMillisPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toMinutes" : [
+      "toMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toMinutesPart" : [
+      "toMinutesPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toNanos" : [
+      "toNanos": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toNanosPart" : [
+      "toNanosPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toSeconds" : [
+      "toSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toSecondsPart" : [
+      "toSecondsPart": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "units" : [
+      "units": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "List[TemporalUnit]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TemporalUnit",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.temporal.TemporalUnit",
-                "type" : "TypedClass"
+                "display": "TemporalUnit",
+                "params": [],
+                "refClazzName": "java.time.temporal.TemporalUnit",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.List",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.List"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "withNanos" : [
+      "withNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "withSeconds" : [
+      "withSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "zero" : [
+      "zero": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "ZERO" : [
+    "staticMethods": {
+      "ZERO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofDays" : [
+      "ofDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofHours" : [
+      "ofHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofMillis" : [
+      "ofMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofMinutes" : [
+      "ofMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofNanos" : [
+      "ofNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "ofSeconds" : [
+      "ofSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "Duration",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Duration",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Duration"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Instant",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.Instant",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atOffset" : [
+    "clazzName": {"refClazzName": "java.time.Instant"},
+    "methods": {
+      "atOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "atZone" : [
+      "atZone": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "epochSecond" : [
+      "epochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getEpochSecond" : [
+      "getEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusMillis" : [
+      "minusMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plusMillis" : [
+      "plusMillis": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "toEpochMilli" : [
+      "toEpochMilli": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "EPOCH" : [
+    "staticMethods": {
+      "EPOCH": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "MAX" : [
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "ofEpochMilli" : [
+      "ofEpochMilli": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "ofEpochSecond" : [
+      "ofEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "LocalDate",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.LocalDate",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atStartOfDay" : [
+    "clazzName": {"refClazzName": "java.time.LocalDate"},
+    "methods": {
+      "atStartOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "atTime" : [
+      "atTime": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dayOfMonth" : [
+      "dayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dayOfWeek" : [
+      "dayOfWeek": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "dayOfYear" : [
+      "dayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "format" : [
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getDayOfMonth" : [
+      "getDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDayOfWeek" : [
+      "getDayOfWeek": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "getDayOfYear" : [
+      "getDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMonth" : [
+      "getMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "getMonthValue" : [
+      "getMonthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getYear" : [
+      "getYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isLeapYear" : [
+      "isLeapYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "leapYear" : [
+      "leapYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "lengthOfMonth" : [
+      "lengthOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "lengthOfYear" : [
+      "lengthOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "minusWeeks" : [
+      "minusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "month" : [
+      "month": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "monthValue" : [
+      "monthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "plusWeeks" : [
+      "plusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "toEpochDay" : [
+      "toEpochDay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "until" : [
+      "until": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.chrono.ChronoLocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "withDayOfMonth" : [
+      "withDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "withDayOfYear" : [
+      "withDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "withMonth" : [
+      "withMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "withYear" : [
+      "withYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "year" : [
+      "year": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "EPOCH" : [
+    "staticMethods": {
+      "EPOCH": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "MAX" : [
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.Month"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "ofEpochDay" : [
+      "ofEpochDay": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "ofYearDay" : [
+      "ofYearDay": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "LocalDateTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.LocalDateTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atOffset" : [
+    "clazzName": {"refClazzName": "java.time.LocalDateTime"},
+    "methods": {
+      "atOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "atZone" : [
+      "atZone": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoLocalDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
+          ],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "dayOfMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "dayOfWeek": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
+        }
+      ],
+      "dayOfYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "format": [
+        {
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
+          ],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfWeek": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getHour": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getMinute": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
+        }
+      ],
+      "getMonthValue": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getNano": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getSecond": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "hour": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "isAfter": [
+        {
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfWeek" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "format" : [
-        {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfWeek" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getHour" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMinute" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMonthValue" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getNano" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getSecond" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "hour" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "isAfter" : [
-        {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoLocalDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoLocalDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoLocalDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoLocalDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoLocalDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusWeeks" : [
+      "minusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "month" : [
+      "month": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "monthValue" : [
+      "monthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusWeeks" : [
+      "plusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toInstant" : [
+      "toInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "toLocalDate" : [
+      "toLocalDate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "toLocalTime" : [
+      "toLocalTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "withDayOfMonth" : [
+      "withDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withDayOfYear" : [
+      "withDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withMonth" : [
+      "withMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "withYear" : [
+      "withYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "year" : [
+      "year": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg6",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg6", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.Month"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.Month"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg6",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.Month"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg6", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "ofEpochSecond" : [
+      "ofEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "LocalTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.LocalTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atDate" : [
+    "clazzName": {"refClazzName": "java.time.LocalTime"},
+    "methods": {
+      "atDate": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "atOffset" : [
+      "atOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "format" : [
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getHour" : [
+      "getHour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMinute" : [
+      "getMinute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getSecond" : [
+      "getSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "hour" : [
+      "hour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toNanoOfDay" : [
+      "toNanoOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toSecondOfDay" : [
+      "toSecondOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "MIDNIGHT" : [
+      "MIDNIGHT": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "NOON" : [
+      "NOON": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "ofNanoOfDay" : [
+      "ofNanoOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "ofSecondOfDay" : [
+      "ofSecondOfDay": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Month",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.Month",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "java.time.Month"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "firstDayOfYear" : [
+      "firstDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "firstMonthOfQuarter" : [
+      "firstMonthOfQuarter": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "getDisplayName" : [
+      "getDisplayName": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "TextStyle",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.TextStyle",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.TextStyle"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getValue" : [
+      "getValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "length" : [
+      "length": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Boolean",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Boolean",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "maxLength" : [
+      "maxLength": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "minLength" : [
+      "minLength": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "minus" : [
+      "minus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "plus" : [
+      "plus": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "value" : [
+      "value": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "APRIL" : [
+    "staticMethods": {
+      "APRIL": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "AUGUST" : [
+      "AUGUST": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "DECEMBER" : [
+      "DECEMBER": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "FEBRUARY" : [
+      "FEBRUARY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "JANUARY" : [
+      "JANUARY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "JULY" : [
+      "JULY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "JUNE" : [
+      "JUNE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "MARCH" : [
+      "MARCH": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "MAY" : [
+      "MAY": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "NOVEMBER" : [
+      "NOVEMBER": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "OCTOBER" : [
+      "OCTOBER": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "SEPTEMBER" : [
+      "SEPTEMBER": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[Month]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Month",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Month",
-                "type" : "TypedClass"
+                "display": "Month",
+                "params": [],
+                "refClazzName": "java.time.Month",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "OffsetDateTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.OffsetDateTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atZoneSameInstant" : [
+    "clazzName": {"refClazzName": "java.time.OffsetDateTime"},
+    "methods": {
+      "atZoneSameInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "atZoneSimilarLocal" : [
+      "atZoneSimilarLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetDateTime"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dayOfMonth" : [
+      "dayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "dayOfWeek" : [
+      "dayOfWeek": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "dayOfYear" : [
+      "dayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "format" : [
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getDayOfMonth" : [
+      "getDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDayOfWeek" : [
+      "getDayOfWeek": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
         }
       ],
-      "getDayOfYear" : [
+      "getDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getHour" : [
+      "getHour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMinute" : [
+      "getMinute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMonth" : [
+      "getMonth": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "getMonthValue" : [
+      "getMonthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getOffset" : [
+      "getOffset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "getSecond" : [
+      "getSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getYear" : [
+      "getYear": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "hour" : [
+      "hour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetDateTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetDateTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetDateTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusWeeks" : [
+      "minusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "month" : [
+      "month": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "monthValue" : [
+      "monthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "offset" : [
+      "offset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusWeeks" : [
+      "plusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toInstant" : [
+      "toInstant": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "toLocalDate" : [
+      "toLocalDate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "toLocalDateTime" : [
+      "toLocalDateTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "toLocalTime" : [
+      "toLocalTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "toOffsetTime" : [
+      "toOffsetTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toZonedDateTime" : [
+      "toZonedDateTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withDayOfMonth" : [
+      "withDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withDayOfYear" : [
+      "withDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withMonth" : [
+      "withMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withOffsetSameInstant" : [
+      "withOffsetSameInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withOffsetSameLocal" : [
+      "withOffsetSameLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "withYear" : [
+      "withYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "year" : [
+      "year": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg6",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg7",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg6", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg7", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.LocalTime"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "timeLineOrder" : [
+      "timeLineOrder": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Comparator[OffsetDateTime]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "OffsetDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetDateTime",
-                "type" : "TypedClass"
+                "display": "OffsetDateTime",
+                "params": [],
+                "refClazzName": "java.time.OffsetDateTime",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Comparator",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Comparator"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "OffsetTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.OffsetTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "atDate" : [
+    "clazzName": {"refClazzName": "java.time.OffsetTime"},
+    "methods": {
+      "atDate": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "compareTo" : [
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "format" : [
+      "format": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getHour" : [
+      "getHour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMinute" : [
+      "getMinute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getNano" : [
+      "getNano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getOffset" : [
+      "getOffset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "getSecond" : [
+      "getSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "hour" : [
+      "hour": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isAfter" : [
+      "isAfter": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "OffsetTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.OffsetTime",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.OffsetTime"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "offset" : [
+      "offset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toLocalTime" : [
+      "toLocalTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withOffsetSameInstant" : [
+      "withOffsetSameInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withOffsetSameLocal" : [
+      "withOffsetSameLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "now" : [
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "OffsetTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.OffsetTime"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Period",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.Period",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "days" : [
+    "clazzName": {"refClazzName": "java.time.Period"},
+    "methods": {
+      "days": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDays" : [
+      "getDays": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getMonths" : [
+      "getMonths": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getUnits" : [
+      "getUnits": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "List[TemporalUnit]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TemporalUnit",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.temporal.TemporalUnit",
-                "type" : "TypedClass"
+                "display": "TemporalUnit",
+                "params": [],
+                "refClazzName": "java.time.temporal.TemporalUnit",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.List",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.List"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "getYears" : [
+      "getYears": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isNegative" : [
+      "isNegative": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isZero" : [
+      "isZero": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "months" : [
+      "months": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "multipliedBy" : [
+      "multipliedBy": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "negated" : [
+      "negated": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "negative" : [
+      "negative": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "normalized" : [
+      "normalized": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toTotalMonths" : [
+      "toTotalMonths": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "units" : [
+      "units": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "List[TemporalUnit]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TemporalUnit",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.temporal.TemporalUnit",
-                "type" : "TypedClass"
+                "display": "TemporalUnit",
+                "params": [],
+                "refClazzName": "java.time.temporal.TemporalUnit",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.List",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.List"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "withDays" : [
+      "withDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "withMonths" : [
+      "withMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "withYears" : [
+      "withYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "years" : [
+      "years": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "zero" : [
+      "zero": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "ZERO" : [
+    "staticMethods": {
+      "ZERO": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "between" : [
+      "between": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.LocalDate"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "ofDays" : [
+      "ofDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "ofMonths" : [
+      "ofMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "ofWeeks" : [
+      "ofWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "ofYears" : [
+      "ofYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "Period",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Period",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.Period"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "ZoneId",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.ZoneId",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "getDisplayName" : [
+    "clazzName": {"refClazzName": "java.time.ZoneId"},
+    "methods": {
+      "getDisplayName": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "TextStyle",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.TextStyle",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.TextStyle"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getId" : [
+      "getId": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "id" : [
+      "id": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "normalized" : [
+      "normalized": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "SHORT_IDS" : [
+    "staticMethods": {
+      "SHORT_IDS": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Map[String,String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               },
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Map",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Map"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "availableZoneIds" : [
+      "availableZoneIds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "getAvailableZoneIds" : [
+      "getAvailableZoneIds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Map[String,String]",
-                "params" : [
+              "name": "arg1",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   },
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   }
                 ],
-                "refClazzName" : "java.util.Map",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Map"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "ofOffset" : [
+      "ofOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "systemDefault" : [
+      "systemDefault": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "ZoneOffset",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.ZoneOffset",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "java.time.ZoneOffset"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "getDisplayName" : [
+      "getDisplayName": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "TextStyle",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.TextStyle",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Locale",
-                "params" : [
-                ],
-                "refClazzName" : "java.util.Locale",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.TextStyle"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.util.Locale"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getId" : [
+      "getId": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "getTotalSeconds" : [
+      "getTotalSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "id" : [
+      "id": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "normalized" : [
+      "normalized": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "totalSeconds" : [
+      "totalSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "MAX" : [
+    "staticMethods": {
+      "MAX": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "MIN" : [
+      "MIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "SHORT_IDS" : [
+      "SHORT_IDS": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Map[String,String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               },
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Map",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Map"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "UTC" : [
+      "UTC": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "availableZoneIds" : [
+      "availableZoneIds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "getAvailableZoneIds" : [
+      "getAvailableZoneIds": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[String]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Map[String,String]",
-                "params" : [
+              "name": "arg1",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   },
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   }
                 ],
-                "refClazzName" : "java.util.Map",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Map"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "ofHours" : [
+      "ofHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "ofHoursMinutes" : [
+      "ofHoursMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "ofHoursMinutesSeconds" : [
+      "ofHoursMinutesSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "ofOffset" : [
+      "ofOffset": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ],
-      "ofTotalSeconds" : [
+      "ofTotalSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "systemDefault" : [
+      "systemDefault": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "ZonedDateTime",
-      "params" : [
-      ],
-      "refClazzName" : "java.time.ZonedDateTime",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "java.time.ZonedDateTime"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoZonedDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoZonedDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoZonedDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
+          ],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "dayOfMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "dayOfWeek": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
+        }
+      ],
+      "dayOfYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "format": [
+        {
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
+          ],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfWeek": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.DayOfWeek"},
+          "varArgs": false
+        }
+      ],
+      "getDayOfYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getHour": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getMinute": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getMonth": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
+        }
+      ],
+      "getMonthValue": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getNano": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getOffset": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
+        }
+      ],
+      "getSecond": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getYear": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "getZone": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
+        }
+      ],
+      "hour": [
+        {
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
+        }
+      ],
+      "isAfter": [
+        {
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfWeek" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "dayOfYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "format" : [
-        {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfWeek" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "DayOfWeek",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.DayOfWeek",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getDayOfYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getHour" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMinute" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMonth" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getMonthValue" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getNano" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getOffset" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getSecond" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getYear" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "getZone" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "hour" : [
-        {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
-        }
-      ],
-      "isAfter" : [
-        {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoZonedDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoZonedDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoZonedDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isBefore" : [
+      "isBefore": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoZonedDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoZonedDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoZonedDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEqual" : [
+      "isEqual": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ChronoZonedDateTime[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.time.chrono.ChronoZonedDateTime",
-                "type" : "TypedClass"
+                "refClazzName": "java.time.chrono.ChronoZonedDateTime"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "minusDays" : [
+      "minusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusHours" : [
+      "minusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMinutes" : [
+      "minusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusMonths" : [
+      "minusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusNanos" : [
+      "minusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusSeconds" : [
+      "minusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusWeeks" : [
+      "minusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minusYears" : [
+      "minusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "minute" : [
+      "minute": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "month" : [
+      "month": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Month",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Month",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Month"},
+          "varArgs": false
         }
       ],
-      "monthValue" : [
+      "monthValue": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "nano" : [
+      "nano": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "offset" : [
+      "offset": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneOffset",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneOffset",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneOffset"},
+          "varArgs": false
         }
       ],
-      "plusDays" : [
+      "plusDays": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusHours" : [
+      "plusHours": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMinutes" : [
+      "plusMinutes": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusMonths" : [
+      "plusMonths": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusNanos" : [
+      "plusNanos": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusSeconds" : [
+      "plusSeconds": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusWeeks" : [
+      "plusWeeks": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "plusYears" : [
+      "plusYears": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Long"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "second" : [
+      "second": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toEpochSecond" : [
+      "toEpochSecond": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "toInstant" : [
+      "toInstant": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Instant",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.Instant",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.Instant"},
+          "varArgs": false
         }
       ],
-      "toLocalDate" : [
+      "toLocalDate": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDate",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDate",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDate"},
+          "varArgs": false
         }
       ],
-      "toLocalDateTime" : [
+      "toLocalDateTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ],
-      "toLocalTime" : [
+      "toLocalTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "LocalTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.LocalTime"},
+          "varArgs": false
         }
       ],
-      "toOffsetDateTime" : [
+      "toOffsetDateTime": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "OffsetDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.OffsetDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.OffsetDateTime"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "withDayOfMonth" : [
+      "withDayOfMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withDayOfYear" : [
+      "withDayOfYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withEarlierOffsetAtOverlap" : [
+      "withEarlierOffsetAtOverlap": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withFixedOffsetZone" : [
+      "withFixedOffsetZone": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withHour" : [
+      "withHour": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withLaterOffsetAtOverlap" : [
+      "withLaterOffsetAtOverlap": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withMinute" : [
+      "withMinute": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withMonth" : [
+      "withMonth": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withNano" : [
+      "withNano": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withSecond" : [
+      "withSecond": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withYear" : [
+      "withYear": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withZoneSameInstant" : [
+      "withZoneSameInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "withZoneSameLocal" : [
+      "withZoneSameLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "year" : [
+      "year": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "zone" : [
+      "zone": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZoneId",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZoneId",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZoneId"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "now" : [
+    "staticMethods": {
+      "now": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Clock",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Clock",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Clock"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "of" : [
+      "of": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg3",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg4",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg5",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg6",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg7",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg3", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg4", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg5", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg6", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "arg7", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDate",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDate",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "LocalTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDate"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.LocalTime"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "ofInstant" : [
+      "ofInstant": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Instant",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.Instant",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.Instant"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "ofLocal" : [
+      "ofLocal": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneId"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneOffset"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "ofStrict" : [
+      "ofStrict": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "LocalDateTime",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.LocalDateTime",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "ZoneOffset",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneOffset",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg2",
-              "refClazz" : {
-                "display" : "ZoneId",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.ZoneId",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.time.LocalDateTime"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.ZoneOffset"}},
+            {"name": "arg2", "refClazz": {"refClazzName": "java.time.ZoneId"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ],
-      "parse" : [
+      "parse": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "CharSequence",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.CharSequence",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "DateTimeFormatter",
-                "params" : [
-                ],
-                "refClazzName" : "java.time.format.DateTimeFormatter",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+            {"name": "arg1", "refClazz": {"refClazzName": "java.time.format.DateTimeFormatter"}}
           ],
-          "refClazz" : {
-            "display" : "ZonedDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.ZonedDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.ZonedDateTime"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Collection",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.Collection",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "contains" : [
+    "clazzName": {"refClazzName": "java.util.Collection"},
+    "methods": {
+      "contains": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsAll" : [
+      "containsAll": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Collection[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.util.Collection",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Collection"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Comparator",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.Comparator",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toString" : [
+    "clazzName": {"refClazzName": "java.util.Comparator"},
+    "methods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "List",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.List",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "contains" : [
+    "clazzName": {"refClazzName": "java.util.List"},
+    "methods": {
+      "contains": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsAll" : [
+      "containsAll": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Collection[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.util.Collection",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Collection"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "get" : [
+      "get": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Integer"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "indexOf" : [
+      "indexOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Map",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.Map",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "containsKey" : [
+    "clazzName": {"refClazzName": "java.util.Map"},
+    "methods": {
+      "containsKey": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsValue" : [
+      "containsValue": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "get" : [
+      "get": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "getOrDefault" : [
+      "getOrDefault": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}},
+            {"name": "arg1", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "keySet" : [
+      "keySet": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[Unknown]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Collection[Unknown]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Collection",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Collection"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Set",
-      "params" : [
-      ],
-      "refClazzName" : "java.util.Set",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "contains" : [
+    "clazzName": {"refClazzName": "java.util.Set"},
+    "methods": {
+      "contains": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsAll" : [
+      "containsAll": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Collection[Unknown]",
-                "params" : [
+              "name": "arg0",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.util.Collection",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Collection"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "TypedMap",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.api.typed.TypedMap",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "containsKey" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.api.typed.TypedMap"},
+    "methods": {
+      "containsKey": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "containsValue" : [
+      "containsValue": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "empty" : [
+      "empty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "get" : [
+      "get": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "getOrDefault" : [
+      "getOrDefault": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            },
-            {
-              "name" : "arg1",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}},
+            {"name": "arg1", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Unknown",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Object",
-            "type" : "Unknown"
-          },
-          "varArgs" : false
+          "refClazz": {"type": "Unknown"},
+          "varArgs": false
         }
       ],
-      "isEmpty" : [
+      "isEmpty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "keySet" : [
+      "keySet": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Set[Unknown]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Set",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Set"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "size" : [
+      "size": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Collection[Unknown]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Collection",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Collection"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "ReturningTestCaseClass",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.flink.util.source.ReturningTestCaseClass",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "someMethod" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.source.ReturningTestCaseClass"},
+    "methods": {
+      "someMethod": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "apply" : [
+    "staticMethods": {
+      "apply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "someMethod",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "someMethod", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "ReturningTestCaseClass",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.source.ReturningTestCaseClass",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.source.ReturningTestCaseClass"},
+          "varArgs": false
         }
       ],
-      "unapply" : [
+      "unapply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "x$0",
-              "refClazz" : {
-                "display" : "ReturningTestCaseClass",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.flink.util.source.ReturningTestCaseClass",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "x$0", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.source.ReturningTestCaseClass"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "AggregateHelper",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.AggregateHelper",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "approxCardinality" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.AggregateHelper"},
+    "methods": {
+      "approxCardinality": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "first" : [
+      "first": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "last" : [
+      "last": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "list" : [
+      "list": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "map" : [
+      "map": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "parts",
-              "refClazz" : {
-                "display" : "Map[String,Aggregator]",
-                "params" : [
+              "name": "parts",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   },
                   {
-                    "display" : "Aggregator",
-                    "params" : [
-                    ],
-                    "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-                    "type" : "TypedClass"
+                    "display": "Aggregator",
+                    "params": [],
+                    "refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
+                    "type": "TypedClass"
                   }
                 ],
-                "refClazzName" : "java.util.Map",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Map"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "max" : [
+      "max": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "min" : [
+      "min": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "set" : [
+      "set": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "sum" : [
+      "sum": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Aggregator",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "Aggregator",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "toString" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.aggregate.Aggregator"},
+    "methods": {
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "BranchType",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "JOINED" : [
+    "staticMethods": {
+      "JOINED": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BranchType",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType"},
+          "varArgs": false
         }
       ],
-      "MAIN" : [
+      "MAIN": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "BranchType",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "name",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "name", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "BranchType",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[BranchType]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "BranchType",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
-                "type" : "TypedClass"
+                "display": "BranchType",
+                "params": [],
+                "refClazzName": "pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "TariffType",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.management.sample.TariffType",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.TariffType"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "GOLD" : [
+    "staticMethods": {
+      "GOLD": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "TariffType",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.management.sample.TariffType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.TariffType"},
+          "varArgs": false
         }
       ],
-      "NORMAL" : [
+      "NORMAL": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "TariffType",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.management.sample.TariffType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.TariffType"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "name",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "name", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "TariffType",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.management.sample.TariffType",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.TariffType"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[TariffType]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "TariffType",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.management.sample.TariffType",
-                "type" : "TypedClass"
+                "display": "TariffType",
+                "params": [],
+                "refClazzName": "pl.touk.nussknacker.engine.management.sample.TariffType",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "Client",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.Client",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "asJson" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.Client"},
+    "methods": {
+      "asJson": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Json",
-            "params" : [
-            ],
-            "refClazzName" : "io.circe.Json",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "io.circe.Json"},
+          "varArgs": false
         }
       ],
-      "id" : [
+      "id": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "originalDisplay" : [
+      "originalDisplay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "apply" : [
+    "staticMethods": {
+      "apply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "id",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "name",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "id", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "name", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "Client",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.Client",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.Client"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "ComplexObject",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.ComplexObject",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "asJson" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.ComplexObject"},
+    "methods": {
+      "asJson": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Json",
-            "params" : [
-            ],
-            "refClazzName" : "io.circe.Json",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "io.circe.Json"},
+          "varArgs": false
         }
       ],
-      "foo" : [
+      "foo": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Map[String,Unknown]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               },
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Map",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Map"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ],
-      "originalDisplay" : [
+      "originalDisplay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "apply" : [
+    "staticMethods": {
+      "apply": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
             {
-              "name" : "foo",
-              "refClazz" : {
-                "display" : "Map[String,Unknown]",
-                "params" : [
+              "name": "foo",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   },
                   {
-                    "display" : "Unknown",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.Object",
-                    "type" : "Unknown"
+                    "display": "Unknown",
+                    "params": [],
+                    "refClazzName": "java.lang.Object",
+                    "type": "Unknown"
                   }
                 ],
-                "refClazzName" : "java.util.Map",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Map"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "ComplexObject",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.ComplexObject",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.ComplexObject"},
+          "varArgs": false
         }
       ],
-      "unapply" : [
+      "unapply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "x$0",
-              "refClazz" : {
-                "display" : "ComplexObject",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.ComplexObject",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "x$0", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.ComplexObject"}}
           ],
-          "refClazz" : {
-            "display" : "Map[String,Unknown]",
-            "params" : [
+          "refClazz": {
+            "params": [
               {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
+                "display": "String",
+                "params": [],
+                "refClazzName": "java.lang.String",
+                "type": "TypedClass"
               },
               {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
+                "display": "Unknown",
+                "params": [],
+                "refClazzName": "java.lang.Object",
+                "type": "Unknown"
               }
             ],
-            "refClazzName" : "java.util.Map",
-            "type" : "TypedClass"
+            "refClazzName": "java.util.Map"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "CsvRecord",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.CsvRecord",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "asJson" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.CsvRecord"},
+    "methods": {
+      "asJson": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Json",
-            "params" : [
-            ],
-            "refClazzName" : "io.circe.Json",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "io.circe.Json"},
+          "varArgs": false
         }
       ],
-      "firstField" : [
+      "firstField": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "originalDisplay" : [
+      "originalDisplay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "RichObject",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.RichObject",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "field1" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.RichObject"},
+    "methods": {
+      "field1": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "field2" : [
+      "field2": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "field3" : [
+      "field3": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "apply" : [
+    "staticMethods": {
+      "apply": [
         {
-          "description" : null,
-          "parameters" : [
+          "parameters": [
+            {"name": "field1", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "field2", "refClazz": {"refClazzName": "java.lang.Long"}},
             {
-              "name" : "field1",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "field2",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "field3",
-              "refClazz" : {
-                "display" : "Optional[String]",
-                "params" : [
+              "name": "field3",
+              "refClazz": {
+                "params": [
                   {
-                    "display" : "String",
-                    "params" : [
-                    ],
-                    "refClazzName" : "java.lang.String",
-                    "type" : "TypedClass"
+                    "display": "String",
+                    "params": [],
+                    "refClazzName": "java.lang.String",
+                    "type": "TypedClass"
                   }
                 ],
-                "refClazzName" : "java.util.Optional",
-                "type" : "TypedClass"
+                "refClazzName": "java.util.Optional"
               }
             }
           ],
-          "refClazz" : {
-            "display" : "RichObject",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.RichObject",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.RichObject"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "SampleProduct",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.SampleProduct",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "asJson" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.SampleProduct"},
+    "methods": {
+      "asJson": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Json",
-            "params" : [
-            ],
-            "refClazzName" : "io.circe.Json",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "io.circe.Json"},
+          "varArgs": false
         }
       ],
-      "id" : [
+      "id": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "originalDisplay" : [
+      "originalDisplay": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "someProperty" : [
+      "someProperty": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "apply" : [
+    "staticMethods": {
+      "apply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "id",
-              "refClazz" : {
-                "display" : "Long",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Long",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "name",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "someProperty",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "id", "refClazz": {"refClazzName": "java.lang.Long"}},
+            {"name": "name", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "someProperty", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "SampleProduct",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.management.sample.dto.SampleProduct",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.dto.SampleProduct"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "DateProcessHelper",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.management.sample.helper.DateProcessHelper$",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "noDocsMethod" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.helper.DateProcessHelper$"},
+    "methods": {
+      "noDocsMethod": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "date",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            },
-            {
-              "name" : "format",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "date", "refClazz": {"type": "Unknown"}},
+            {"name": "format", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "nowTimestamp" : [
+      "nowTimestamp": [
         {
-          "description" : "Returns current time in milliseconds",
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Long",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Long",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "description": "Returns current time in milliseconds",
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Long"},
+          "varArgs": false
         }
       ],
-      "paramsOnlyMethod" : [
+      "paramsOnlyMethod": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "number",
-              "refClazz" : {
-                "display" : "Integer",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Integer",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "format",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "number", "refClazz": {"refClazzName": "java.lang.Integer"}},
+            {"name": "format", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "parseDate" : [
+      "parseDate": [
         {
-          "description" : "Just parses a date.\nLorem ipsum dolor sit amet enim. Etiam ullamcorper. Suspendisse a pellentesque dui, non felis. Maecenas malesuada elit lectus felis, malesuada ultricies. Curabitur et ligula",
-          "parameters" : [
-            {
-              "name" : "dateString",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "description": "Just parses a date.\nLorem ipsum dolor sit amet enim. Etiam ullamcorper. Suspendisse a pellentesque dui, non felis. Maecenas malesuada elit lectus felis, malesuada ultricies. Curabitur et ligula",
+          "parameters": [
+            {"name": "dateString", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "LocalDateTime",
-            "params" : [
-            ],
-            "refClazzName" : "java.time.LocalDateTime",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.time.LocalDateTime"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "LockOutput",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.management.sample.signal.SampleSignalHandlingTransformer$LockOutput",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "lockEnabled" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.management.sample.signal.SampleSignalHandlingTransformer$LockOutput"},
+    "methods": {
+      "lockEnabled": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Boolean",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Boolean",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Boolean"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-
-    }
+    "staticMethods": {}
   },
   {
-    "clazzName" : {
-      "display" : "MetaVariables",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.nussknacker.engine.variables.MetaVariables",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "processName" : [
+    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.variables.MetaVariables"},
+    "methods": {
+      "processName": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "properties" : [
+      "properties": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "TypedMap",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.api.typed.TypedMap",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.api.typed.TypedMap"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "apply" : [
+    "staticMethods": {
+      "apply": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "processName",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            },
-            {
-              "name" : "properties",
-              "refClazz" : {
-                "display" : "TypedMap",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.nussknacker.engine.api.typed.TypedMap",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "processName", "refClazz": {"refClazzName": "java.lang.String"}},
+            {"name": "properties", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.api.typed.TypedMap"}}
           ],
-          "refClazz" : {
-            "display" : "MetaVariables",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.nussknacker.engine.variables.MetaVariables",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.variables.MetaVariables"},
+          "varArgs": false
         }
       ]
     }
   },
   {
-    "clazzName" : {
-      "display" : "JavaSampleEnum",
-      "params" : [
-      ],
-      "refClazzName" : "pl.touk.sample.JavaSampleEnum",
-      "type" : "TypedClass"
-    },
-    "methods" : {
-      "compareTo" : [
+    "clazzName": {"refClazzName": "pl.touk.sample.JavaSampleEnum"},
+    "methods": {
+      "compareTo": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Enum",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Enum",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Enum"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         },
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "arg0",
-              "refClazz" : {
-                "display" : "Unknown",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.Object",
-                "type" : "Unknown"
-              }
-            }
+          "parameters": [
+            {"name": "arg0", "refClazz": {"type": "Unknown"}}
           ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "name" : [
+      "name": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ],
-      "ordinal" : [
+      "ordinal": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Integer",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.Integer",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.Integer"},
+          "varArgs": false
         }
       ],
-      "toString" : [
+      "toString": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "String",
-            "params" : [
-            ],
-            "refClazzName" : "java.lang.String",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "java.lang.String"},
+          "varArgs": false
         }
       ]
     },
-    "staticMethods" : {
-      "FIRST_VALUE" : [
+    "staticMethods": {
+      "FIRST_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "JavaSampleEnum",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.sample.JavaSampleEnum",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.sample.JavaSampleEnum"},
+          "varArgs": false
         }
       ],
-      "SECOND_VALUE" : [
+      "SECOND_VALUE": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "JavaSampleEnum",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.sample.JavaSampleEnum",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "parameters": [],
+          "refClazz": {"refClazzName": "pl.touk.sample.JavaSampleEnum"},
+          "varArgs": false
         }
       ],
-      "valueOf" : [
+      "valueOf": [
         {
-          "description" : null,
-          "parameters" : [
-            {
-              "name" : "name",
-              "refClazz" : {
-                "display" : "String",
-                "params" : [
-                ],
-                "refClazzName" : "java.lang.String",
-                "type" : "TypedClass"
-              }
-            }
+          "parameters": [
+            {"name": "name", "refClazz": {"refClazzName": "java.lang.String"}}
           ],
-          "refClazz" : {
-            "display" : "JavaSampleEnum",
-            "params" : [
-            ],
-            "refClazzName" : "pl.touk.sample.JavaSampleEnum",
-            "type" : "TypedClass"
-          },
-          "varArgs" : false
+          "refClazz": {"refClazzName": "pl.touk.sample.JavaSampleEnum"},
+          "varArgs": false
         }
       ],
-      "values" : [
+      "values": [
         {
-          "description" : null,
-          "parameters" : [
-          ],
-          "refClazz" : {
-            "display" : "Array[JavaSampleEnum]",
-            "params" : [
+          "parameters": [],
+          "refClazz": {
+            "params": [
               {
-                "display" : "JavaSampleEnum",
-                "params" : [
-                ],
-                "refClazzName" : "pl.touk.sample.JavaSampleEnum",
-                "type" : "TypedClass"
+                "display": "JavaSampleEnum",
+                "params": [],
+                "refClazzName": "pl.touk.sample.JavaSampleEnum",
+                "type": "TypedClass"
               }
             ],
-            "refClazzName" : "[Ljava.lang.Object;",
-            "type" : "TypedClass"
+            "refClazzName": "[Ljava.lang.Object;"
           },
-          "varArgs" : false
+          "varArgs": false
         }
       ]
     }


### PR DESCRIPTION
Before the change:
```
      "compareTo" : [
        {
          "description" : null,
          "parameters" : [
            {
              "name" : "arg0",
              "refClazz" : {
                "display" : "Boolean",
                "params" : [
                ],
                "refClazzName" : "java.lang.Boolean",
                "type" : "TypedClass"
              }
            }
          ],
          "refClazz" : {
            "display" : "Integer",
            "params" : [
            ],
            "refClazzName" : "java.lang.Integer",
            "type" : "TypedClass"
          },
          "varArgs" : false
        }
      ]
```
After the change:
```
      "compareTo": [
        {
          "parameters": [
            {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Boolean"}}
          ],
          "refClazz": {"refClazzName": "java.lang.Integer"},
          "varArgs": false
        }
      ]
```