### PR TITLE
fix: module federation context overwrite

### DIFF
--- a/ui/client/containers/ExternalLib/ExternalModule.tsx
+++ b/ui/client/containers/ExternalLib/ExternalModule.tsx
@@ -1,8 +1,8 @@
 import {lazy} from "@loadable/component"
-import React, {PropsWithChildren, useMemo} from "react"
+import React, {PropsWithChildren} from "react"
 import {SuspenseSpinner} from "../../components/SuspenseSpinner"
 import {LibContextProvider} from "./store"
-import {createScript, loadComponent, splitUrl} from "./tools"
+import {loadComponent, splitUrl} from "./tools"
 import {Module, ModuleUrl} from "./types"
 
 /**
@@ -12,14 +12,9 @@ import {Module, ModuleUrl} from "./types"
  * @param children
  * @constructor
  */
-export function ExternalModule<M extends Module>({children, url}: PropsWithChildren<{url: ModuleUrl}>): JSX.Element {
-  const [, context, scriptUrl, scope, module] = splitUrl(url)
-
-  const LoadedLib = useMemo(() => lazy.lib(async () => {
-    await createScript(scriptUrl)
-    const loader = await loadComponent(scope, module)
-    return loader()
-  }), [scriptUrl, scope, module])
+export function ExternalModule<M extends Module>({children, url}: PropsWithChildren<{ url: ModuleUrl }>): JSX.Element {
+  const [, context] = splitUrl(url)
+  const LoadedLib = lazy.lib(async () => loadComponent(url))
 
   return (
     <SuspenseSpinner>

--- a/ui/client/containers/ExternalLib/tools/loadComponent.ts
+++ b/ui/client/containers/ExternalLib/tools/loadComponent.ts
@@ -1,13 +1,21 @@
-import {Container, Module, PathString, ScopeString} from "../types"
+import {Container, Module} from "../types"
+import {splitUrl} from "./splitUrl"
+import {createScript} from "./createScript"
 
-export function loadComponent<M extends Module = Module>(scope: ScopeString, module: PathString): () => Promise<M> {
-  return async () => {
-    // Initializes the share scope. This fills it with known provided modules from this build and all remotes
-    await __webpack_init_sharing__("default")
-    const container: Container = window[scope] // or get the container somewhere else
-    // Initialize the container, it may provide shared modules
-    await container.init(__webpack_share_scopes__.default)
-    const factory = await container.get<M>(module)
-    return factory()
+export async function loadComponent<M extends Module = Module>(url: string): Promise<M> {
+  const [, , scriptUrl, scope, module] = splitUrl(url)
+
+  // Initializes the share scope. This fills it with known provided modules from this build and all remotes
+  await __webpack_init_sharing__("default")
+
+  // load once
+  if (!window[scope]) {
+    await createScript(scriptUrl)
   }
+
+  const container: Container = window[scope] // or get the container somewhere else
+  // Initialize the container, it may provide shared modules
+  await container.init(__webpack_share_scopes__.default)
+  const factory = await container.get<M>(module)
+  return factory()
 }


### PR DESCRIPTION
loading module a second time (and each subsequent) was causing  context overwrite, which resulted in overwriting and bad generation of material-ui styles