### PR TITLE
Small Deployment API refactoring

### DIFF
--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManagerProvider.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManagerProvider.scala
@@ -9,7 +9,7 @@ import pl.touk.nussknacker.engine.api.queryablestate.QueryableClient
 import pl.touk.nussknacker.engine.management.FlinkConfig
 import pl.touk.nussknacker.engine.management.periodic.service.{AdditionalDeploymentDataProvider, DefaultAdditionalDeploymentDataProvider, EmptyPeriodicProcessListenerFactory, PeriodicProcessListenerFactory, ProcessConfigEnricherFactory}
 import pl.touk.nussknacker.engine.util.config.ConfigEnrichments.RichConfig
-import pl.touk.nussknacker.engine.{DeploymentManagerProvider, ModelData, TypeSpecificDataInitializer}
+import pl.touk.nussknacker.engine.{DeploymentManagerProvider, ModelData, TypeSpecificInitialData}
 import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -49,7 +49,7 @@ class PeriodicDeploymentManagerProvider(delegate: DeploymentManagerProvider,
 
   override def createQueryableClient(config: Config): Option[QueryableClient] = delegate.createQueryableClient(config)
 
-  override def typeSpecificDataInitializer: TypeSpecificDataInitializer = delegate.typeSpecificDataInitializer
+  override def typeSpecificInitialData: TypeSpecificInitialData = delegate.typeSpecificInitialData
 
   override def supportsSignals: Boolean = delegate.supportsSignals
 }

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
@@ -3,11 +3,10 @@ package pl.touk.nussknacker.engine.management.periodic
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.management.FlinkProcessStateDefinitionManager
 
 import scala.concurrent.Future
 
-class DeploymentManagerStub extends DeploymentManager {
+class DeploymentManagerStub extends BaseDeploymentManager {
 
   var jobStatus: Option[ProcessState] = None
 
@@ -29,23 +28,11 @@ class DeploymentManagerStub extends DeploymentManager {
 
   override def deploy(processVersion: ProcessVersion, deploymentData: DeploymentData, processDeploymentData: ProcessDeploymentData, savepointPath: Option[String]): Future[Option[ExternalDeploymentId]] = ???
 
-  override def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] = ???
-
   override def cancel(name: ProcessName, user: User): Future[Unit] = Future.successful(())
 
   override def test[T](name: ProcessName, json: String, testData: TestProcess.TestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
 
   override def findJobStatus(name: ProcessName): Future[Option[ProcessState]] = Future.successful(jobStatus)
 
-  override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] = ???
-
-  override def processStateDefinitionManager: ProcessStateDefinitionManager = FlinkProcessStateDefinitionManager
-
-  override def close(): Unit = ???
-
-  override def customActions: List[CustomAction] = List.empty
-
-  override def invokeCustomAction(actionRequest: CustomActionRequest, processDeploymentData: ProcessDeploymentData): Future[Either[CustomActionError, CustomActionResult]] =
-    Future.successful(Left(CustomActionNotImplemented(actionRequest)))
 }
 

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkStreamingDeploymentManagerProvider.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkStreamingDeploymentManagerProvider.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.management
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import pl.touk.nussknacker.engine.{DeploymentManagerProvider, ModelData, ProcessingTypeConfig, TypeSpecificDataInitializer}
+import pl.touk.nussknacker.engine.{DeploymentManagerProvider, ModelData, ProcessingTypeConfig, TypeSpecificInitialData}
 import pl.touk.nussknacker.engine.api.{FragmentSpecificData, ScenarioSpecificData, StreamMetaData}
 import pl.touk.nussknacker.engine.api.deployment.DeploymentManager
 import pl.touk.nussknacker.engine.api.queryablestate.QueryableClient
@@ -29,10 +29,7 @@ class FlinkStreamingDeploymentManagerProvider extends DeploymentManagerProvider 
 
   override def name: String = "flinkStreaming"
 
-  override def typeSpecificDataInitializer: TypeSpecificDataInitializer = new TypeSpecificDataInitializer {
-    override def forScenario: ScenarioSpecificData = StreamMetaData(Some(1))
-    override def forFragment: FragmentSpecificData = FragmentSpecificData(None)
-  }
+  override def typeSpecificInitialData: TypeSpecificInitialData = TypeSpecificInitialData(StreamMetaData(Some(1)))
 
   override def supportsSignals: Boolean = true
 }

--- a/ui/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/DeploymentManagerProvider.scala
+++ b/ui/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/DeploymentManagerProvider.scala
@@ -29,7 +29,7 @@ case class TypeSpecificInitialData(forScenario: ScenarioSpecificData,
 
 case class ProcessingTypeData(deploymentManager: DeploymentManager,
                               modelData: ModelData,
-                              typeSpecificDataInitializer: TypeSpecificInitialData,
+                              typeSpecificInitialData: TypeSpecificInitialData,
                               queryableClient: Option[QueryableClient],
                               supportsSignals: Boolean) extends AutoCloseable {
 

--- a/ui/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/DeploymentManagerProvider.scala
+++ b/ui/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/DeploymentManagerProvider.scala
@@ -19,19 +19,17 @@ trait DeploymentManagerProvider extends NamedServiceProvider {
 
   def createQueryableClient(config: Config): Option[QueryableClient]
 
-  def typeSpecificDataInitializer: TypeSpecificDataInitializer
+  def typeSpecificInitialData: TypeSpecificInitialData
 
   def supportsSignals: Boolean
 }
 
-trait TypeSpecificDataInitializer {
-  def forScenario: ScenarioSpecificData
-  def forFragment: FragmentSpecificData
-}
+case class TypeSpecificInitialData(forScenario: ScenarioSpecificData,
+                                   forFragment: FragmentSpecificData = FragmentSpecificData())
 
 case class ProcessingTypeData(deploymentManager: DeploymentManager,
                               modelData: ModelData,
-                              typeSpecificDataInitializer: TypeSpecificDataInitializer,
+                              typeSpecificDataInitializer: TypeSpecificInitialData,
                               queryableClient: Option[QueryableClient],
                               supportsSignals: Boolean) extends AutoCloseable {
 
@@ -76,7 +74,7 @@ object ProcessingTypeData {
     ProcessingTypeData(
       manager,
       modelData,
-      deploymentManagerProvider.typeSpecificDataInitializer,
+      deploymentManagerProvider.typeSpecificInitialData,
       queryableClient,
       deploymentManagerProvider.supportsSignals)
   }

--- a/ui/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/BaseDeploymentManager.scala
+++ b/ui/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/BaseDeploymentManager.scala
@@ -1,0 +1,28 @@
+package pl.touk.nussknacker.engine.api.deployment
+
+import pl.touk.nussknacker.engine.api.deployment.simple.SimpleProcessStateDefinitionManager
+import pl.touk.nussknacker.engine.api.process.ProcessName
+
+import scala.concurrent.Future
+
+trait BaseDeploymentManager extends DeploymentManager {
+
+  override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] = {
+    Future.failed(new UnsupportedOperationException(s"Cannot make savepoint with ${getClass.getSimpleName}"))
+  }
+
+  override def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] = {
+    Future.failed(new UnsupportedOperationException(s"Cannot stop scenario with ${getClass.getSimpleName}"))
+  }
+
+  override def processStateDefinitionManager: ProcessStateDefinitionManager = SimpleProcessStateDefinitionManager
+
+  override def close(): Unit = {}
+
+  override def customActions: List[CustomAction] = List.empty
+
+  override def invokeCustomAction(actionRequest: CustomActionRequest,
+                                  processDeploymentData: ProcessDeploymentData): Future[Either[CustomActionError, CustomActionResult]] =
+    Future.successful(Left(CustomActionNotImplemented(actionRequest)))
+
+}

--- a/ui/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
+++ b/ui/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.api.deployment.simple.SimpleProcessStateDefini
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.queryablestate.QueryableClient
 import pl.touk.nussknacker.engine.api.{FragmentSpecificData, ProcessVersion, ScenarioSpecificData, StreamMetaData}
-import pl.touk.nussknacker.engine.{DeploymentManagerProvider, ModelData, TypeSpecificDataInitializer}
+import pl.touk.nussknacker.engine.{DeploymentManagerProvider, ModelData, TypeSpecificInitialData}
 import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -50,10 +50,7 @@ class DeploymentManagerProviderStub extends DeploymentManagerProvider {
 
   override def name: String = "stub"
 
-  override def typeSpecificDataInitializer: TypeSpecificDataInitializer = new TypeSpecificDataInitializer {
-    override def forScenario: ScenarioSpecificData = StreamMetaData()
-    override def forFragment: FragmentSpecificData = FragmentSpecificData(None)
-  }
+  override def typeSpecificInitialData: TypeSpecificInitialData = TypeSpecificInitialData(StreamMetaData())
 
   override def supportsSignals: Boolean = false
 

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/NewProcessPreparer.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/NewProcessPreparer.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.ui.process
 
-import pl.touk.nussknacker.engine.{ProcessingTypeData, TypeSpecificDataInitializer}
+import pl.touk.nussknacker.engine.{ProcessingTypeData, TypeSpecificInitialData}
 import pl.touk.nussknacker.engine.api.component.AdditionalPropertyConfig
 import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -20,7 +20,7 @@ object NewProcessPreparer {
 }
 
 class NewProcessPreparer(definitions: ProcessingTypeDataProvider[ProcessDefinition[ObjectDefinition]],
-                         emptyProcessCreate: ProcessingTypeDataProvider[TypeSpecificDataInitializer],
+                         emptyProcessCreate: ProcessingTypeDataProvider[TypeSpecificInitialData],
                          additionalFields: ProcessingTypeDataProvider[Map[String, AdditionalPropertyConfig]]) {
   def prepareEmptyProcess(processId: String, processingType: ProcessingType, isSubprocess: Boolean): CanonicalProcess = {
     val exceptionHandlerFactory = definitions.forTypeUnsafe(processingType).exceptionHandlerFactory

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/NewProcessPreparer.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/NewProcessPreparer.scala
@@ -15,7 +15,7 @@ import pl.touk.nussknacker.ui.process.processingtypedata.ProcessingTypeDataProvi
 object NewProcessPreparer {
 
   def apply(processTypes: ProcessingTypeDataProvider[ProcessingTypeData], additionalFields: ProcessingTypeDataProvider[Map[String, AdditionalPropertyConfig]]): NewProcessPreparer =
-    new NewProcessPreparer(processTypes.mapValues(_.modelData.processDefinition), processTypes.mapValues(_.typeSpecificDataInitializer), additionalFields)
+    new NewProcessPreparer(processTypes.mapValues(_.modelData.processDefinition), processTypes.mapValues(_.typeSpecificInitialData), additionalFields)
 
 }
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -95,7 +95,7 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
 
   val newProcessPreparer = new NewProcessPreparer(
     mapProcessingTypeDataProvider("streaming" ->  ProcessTestData.processDefinition),
-    mapProcessingTypeDataProvider("streaming" -> ProcessTestData.streamingTypeSpecificDataInitializer),
+    mapProcessingTypeDataProvider("streaming" -> ProcessTestData.streamingTypeSpecificInitialData),
     mapProcessingTypeDataProvider("streaming" -> Map.empty)
   )
 

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
@@ -21,7 +21,7 @@ import pl.touk.nussknacker.engine.graph.node.{Case, Split, SubprocessInputDefini
 import pl.touk.nussknacker.engine.graph.sink.SinkRef
 import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.graph.{EspProcess, node}
-import pl.touk.nussknacker.engine.{TypeSpecificDataInitializer, spel}
+import pl.touk.nussknacker.engine.{TypeSpecificInitialData, spel}
 import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder
 import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder._
 import pl.touk.nussknacker.restmodel.ProcessType
@@ -343,8 +343,6 @@ object ProcessTestData {
 
   case class ProcessUsingSubprocess(process: EspProcess, subprocess: CanonicalProcess)
 
-  val streamingTypeSpecificDataInitializer = new TypeSpecificDataInitializer {
-    override def forScenario: ScenarioSpecificData = StreamMetaData()
-    override def forFragment: FragmentSpecificData = FragmentSpecificData()
-  }
+  val streamingTypeSpecificDataInitializer = TypeSpecificInitialData(StreamMetaData(None))
+
 }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
@@ -343,6 +343,6 @@ object ProcessTestData {
 
   case class ProcessUsingSubprocess(process: EspProcess, subprocess: CanonicalProcess)
 
-  val streamingTypeSpecificDataInitializer = TypeSpecificInitialData(StreamMetaData(None))
+  val streamingTypeSpecificInitialData: TypeSpecificInitialData = TypeSpecificInitialData(StreamMetaData(None))
 
 }

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/component/DefaultComponentServiceSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/component/DefaultComponentServiceSpec.scala
@@ -386,7 +386,7 @@ class DefaultComponentServiceSpec extends FlatSpec with Matchers with PatientSca
       Streaming -> LocalModelData(streamingConfig, ComponentMarketingTestConfigCreator),
       Fraud -> LocalModelData(fraudConfig, ComponentFraudTestConfigCreator),
     ).map{ case (processingType, config) =>
-      processingType -> ProcessingTypeData(new MockDeploymentManager, config, MockManagerProvider.typeSpecificDataInitializer, None, supportsSignals = false)
+      processingType -> ProcessingTypeData(new MockDeploymentManager, config, MockManagerProvider.typeSpecificInitialData, None, supportsSignals = false)
     })
 
     val processes = List(marketingProcess, fraudProcess, fraudTestProcess, wrongCategoryProcess, archivedFraudProcess)
@@ -449,7 +449,7 @@ class DefaultComponentServiceSpec extends FlatSpec with Matchers with PatientSca
       Streaming -> LocalModelData(streamingConfig, ComponentMarketingTestConfigCreator),
       Fraud -> LocalModelData(wrongConfig, WronglyConfiguredConfigCreator),
     ).map { case (processingType, config) =>
-      processingType -> ProcessingTypeData(new MockDeploymentManager, config, MockManagerProvider.typeSpecificDataInitializer, None, supportsSignals = false)
+      processingType -> ProcessingTypeData(new MockDeploymentManager, config, MockManagerProvider.typeSpecificInitialData, None, supportsSignals = false)
     })
 
     val stubSubprocessRepository = new StubSubprocessRepository(Set.empty)

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/NewProcessPreparerSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/NewProcessPreparerSpec.scala
@@ -21,7 +21,7 @@ class NewProcessPreparerSpec extends FlatSpec with Matchers {
     val processingType = "testProcessingType"
 
     val preparer = new NewProcessPreparer(mapProcessingTypeDataProvider(processingType -> processDeffinition),
-      mapProcessingTypeDataProvider(processingType -> ProcessTestData.streamingTypeSpecificDataInitializer),
+      mapProcessingTypeDataProvider(processingType -> ProcessTestData.streamingTypeSpecificInitialData),
       mapProcessingTypeDataProvider(processingType -> Map.empty))
 
     val emptyProcess = preparer.prepareEmptyProcess("processId1", processingType, isSubprocess = false)
@@ -35,7 +35,7 @@ class NewProcessPreparerSpec extends FlatSpec with Matchers {
     val processingType = "testProcessingType"
 
     val preparer = new NewProcessPreparer(mapProcessingTypeDataProvider(processingType -> processDeffinitionWithExceptionHandler),
-      mapProcessingTypeDataProvider(processingType -> ProcessTestData.streamingTypeSpecificDataInitializer),
+      mapProcessingTypeDataProvider(processingType -> ProcessTestData.streamingTypeSpecificInitialData),
       mapProcessingTypeDataProvider(processingType -> Map.empty))
 
     val emptyProcess = preparer.prepareEmptyProcess("processId1", processingType, isSubprocess = false)

--- a/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActorSpec.scala
+++ b/ui/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActorSpec.scala
@@ -37,7 +37,7 @@ class ManagementActorSpec extends FunSuite with Matchers with PatientScalaFuture
 
   val newProcessPreparer = new NewProcessPreparer(
     mapProcessingTypeDataProvider("streaming" ->  ProcessTestData.processDefinition),
-    mapProcessingTypeDataProvider("streaming" -> ProcessTestData.streamingTypeSpecificDataInitializer),
+    mapProcessingTypeDataProvider("streaming" -> ProcessTestData.streamingTypeSpecificInitialData),
     mapProcessingTypeDataProvider("streaming" -> Map.empty)
   )
 


### PR DESCRIPTION
- BaseDeploymentManager with rarely/not used methods implemented (as "not implemented" :) )
- TypeSpecificDataInitializer => TypeSpecificInitialData case class