### PR TITLE
Workaround for flaky cypress component usages tests: commented out snapshot match checking

### DIFF
--- a/ui/client/cypress/integration/components.ts
+++ b/ui/client/cypress/integration/components.ts
@@ -110,7 +110,8 @@ describe("Components list", () => {
     cy.get("[role=row]").find("a").as("links").should("have.length", 2)
     cy.get("@links").first().click()
     cy.contains("5 more").click()
-    cy.get("#app-container").toMatchImageSnapshot()
+    // FIXME: usages contains scenario name witch causes flaky tests failing
+    // cy.get("#app-container").toMatchImageSnapshot()
   })
 
   function filterByDefaultCategory() {


### PR DESCRIPTION
example of flaky tests: https://github.com/TouK/nussknacker/pull/2695/commits/010e8f9e32cf15a3e05b48afee6f108ce86ac91e