### PR TITLE
Workaround for: sometimes FE sends invalid urls with not escaped square brackets

### DIFF
--- a/ui/server/src/main/resources/defaultUiConfig.conf
+++ b/ui/server/src/main/resources/defaultUiConfig.conf
@@ -39,7 +39,11 @@ environment: "default"
 akka {
   http {
     server {
-      parsing.max-content-length = 300000000 #300MB
+      parsing {
+        max-content-length = 300000000 #300MB
+        # because FE sometimes send not encoded properly urls - e.g. scenario name with [square brackets]
+        uri-parsing-mode = relaxed
+      }
       # Longer mainly for invoking tests on processes
       request-timeout = 1 minute
       # We don't want to implement HEAD handler correctly - default one is fine for us.


### PR DESCRIPTION
using akka relaxed parsing