### PR TITLE
Fix for: kafka-registry-typed-json not handle logical types in runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -699,7 +699,7 @@ lazy val avroUtil = (project in utils("avro-util")).
           ExclusionRule("log4j", "log4j"),
           ExclusionRule("org.slf4j", "slf4j-log4j12")
         ),
-        "tech.allegro.schema.json2avro" % "converter" % "0.2.10",
+        "tech.allegro.schema.json2avro" % "converter" % "0.2.11",
         "org.scalatest" %% "scalatest" % scalaTestV % "test"
       )
     }

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -38,6 +38,7 @@ Nussknacker versions
 * [#2686](https://github.com/TouK/nussknacker/pull/2686) Rename `ServiceWithStaticParameters` to `EagerServiceWithStaticParameters` to avoid confusion about lazy and eager parameters used by default
 * [#2695](https://github.com/TouK/nussknacker/pull/2695) Replaced `nodeId` with `NodeComponentInfo` in `NuExceptionInfo`
 * [#2746](https://github.com/TouK/nussknacker/pull/2746) `modelConfig.classPath` can handle directories
+* [#2775](https://github.com/TouK/nussknacker/pull/2775) Fixed: kafka-registry-typed-json source was recognizing logical types during typing but during evaluation were used raw, underlying types
   
 1.1.1 (Not released yet)
 --------------------

--- a/engine/flink/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/ConfluentKafkaAvroDeserializationSpec.scala
+++ b/engine/flink/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/ConfluentKafkaAvroDeserializationSpec.scala
@@ -19,7 +19,6 @@ class ConfluentKafkaAvroDeserializationSpec extends SchemaRegistryMixin with Tab
 
   test("should properly deserialize record to avro object with same schema version") {
     val schemas = List(PaymentV1.schema)
-    val version = Some(1)
 
     val table = Table[SchemaRegistryProviderSetup, Boolean, Any, GenericRecord, String](
       ("setup", "schemaEvolution", "givenObj", "expectedObj", "topic"),
@@ -29,12 +28,11 @@ class ConfluentKafkaAvroDeserializationSpec extends SchemaRegistryMixin with Tab
 
     )
 
-    runDeserializationTest(table, version, schemas)
+    runDeserializationTest(table, schemas)
   }
 
   test("should properly deserialize record to avro object with newer compatible schema version") {
     val schemas = List(PaymentV1.schema, PaymentV2.schema)
-    val version = Some(2)
 
     val table = Table[SchemaRegistryProviderSetup, Boolean, Any, GenericRecord, String](
       ("setup", "schemaEvolution", "givenObj", "expectedObj", "topic"),
@@ -43,12 +41,11 @@ class ConfluentKafkaAvroDeserializationSpec extends SchemaRegistryMixin with Tab
       (jsonSetup, true, PaymentV1.exampleData, PaymentV2.record, "json.forward.from-subject-version")
     )
 
-    runDeserializationTest(table, version, schemas)
+    runDeserializationTest(table, schemas)
   }
 
   test("should properly deserialize record to avro object with latest compatible schema version") {
     val schemas = List(PaymentV1.schema, PaymentV2.schema)
-    val version = None
 
     val table = Table[SchemaRegistryProviderSetup, Boolean, Any, GenericRecord, String](
       ("setup", "schemaEvolution", "givenObj", "expectedObj", "topic"),
@@ -57,12 +54,11 @@ class ConfluentKafkaAvroDeserializationSpec extends SchemaRegistryMixin with Tab
       (jsonSetup, true, PaymentV1.exampleData, PaymentV2.record, "json.forward.latest.from-subject-version")
     )
 
-    runDeserializationTest(table, version, schemas)
+    runDeserializationTest(table, schemas)
   }
 
   test("should properly deserialize record to avro object with older compatible schema version") {
     val schemas = List(PaymentV1.schema, PaymentV2.schema)
-    val version = Some(1)
 
     val table = Table[SchemaRegistryProviderSetup, Boolean, Any, GenericRecord, String](
       ("setup", "schemaEvolution", "givenObj", "expectedObj", "topic"),
@@ -71,7 +67,7 @@ class ConfluentKafkaAvroDeserializationSpec extends SchemaRegistryMixin with Tab
       (jsonSetup, true, PaymentV2.exampleData, PaymentV1.record, "json.backward.from-subject-version")
     )
 
-    runDeserializationTest(table, version, schemas)
+    runDeserializationTest(table, schemas)
   }
 
   test("trying to deserialize record to avro object with wrong type schema") {
@@ -98,7 +94,7 @@ class ConfluentKafkaAvroDeserializationSpec extends SchemaRegistryMixin with Tab
     }
   }
 
-  private def runDeserializationTest(table: TableFor5[SchemaRegistryProviderSetup, Boolean, Any, GenericRecord, String], version: Option[Int], schemas: List[Schema]): Assertion = {
+  private def runDeserializationTest(table: TableFor5[SchemaRegistryProviderSetup, Boolean, Any, GenericRecord, String], schemas: List[Schema]): Assertion = {
 
     forAll(table) { (setup: SchemaRegistryProviderSetup, schemaEvolution: Boolean, givenObj: Any, expectedObj: GenericRecord, topic: String) =>
       val topicConfig = createAndRegisterTopicConfig(topic, schemas)

--- a/utils/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/ConfluentJsonPayloadDeserializerFactory.scala
+++ b/utils/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/ConfluentJsonPayloadDeserializerFactory.scala
@@ -70,14 +70,11 @@ trait ConfluentJsonPayloadDeserializer {
 
     new ConfluentKafkaAvroDeserializer[T](kafkaConfig, schemaDataOpt, schemaRegistryClient, isKey, specificClass.isDefined) {
 
-      private val converter = new JsonAvroConverter()
+      private val converter = new JsonPayloadToAvroConverter(specificClass)
 
       override protected def deserialize(topic: String, isKey: lang.Boolean, payload: Array[Byte], readerSchema: Option[RuntimeSchemaData]): AnyRef = {
         val schema = readerSchema.get.schema
-        specificClass match {
-          case Some(kl) => converter.convertToSpecificRecord(payload, kl, schema)
-          case None => converter.convertToGenericDataRecord(payload, schema)
-        }
+        converter.convert(payload, schema)
       }
     }
   }

--- a/utils/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverter.scala
+++ b/utils/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverter.scala
@@ -6,14 +6,15 @@ import org.apache.avro.Conversions.UUIDConversion
 import org.apache.avro.data.TimeConversions
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.specific.SpecificRecordBase
-import org.apache.avro.{LogicalTypes, Schema}
+import org.apache.avro.{AvroRuntimeException, LogicalTypes, Schema}
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.jsonpayload.JsonPayloadToAvroConverter._
 import tech.allegro.schema.json2avro.converter.types.AvroTypeConverter
-import tech.allegro.schema.json2avro.converter.{CompositeJsonToAvroReader, JsonAvroConverter}
+import tech.allegro.schema.json2avro.converter.{CompositeJsonToAvroReader, JsonAvroConverter, PathsPrinter}
 
 import java.math.RoundingMode
 import java.time.{Instant, LocalDate, LocalTime}
 import java.util
+import scala.util.Try
 
 class JsonPayloadToAvroConverter(specificClass: Option[Class[SpecificRecordBase]]) {
 
@@ -33,114 +34,151 @@ class JsonPayloadToAvroConverter(specificClass: Option[Class[SpecificRecordBase]
 
 object JsonPayloadToAvroConverter {
 
-  object DateConverter extends AvroTypeConverter {
+  object DateConverter extends BaseAvroTypeConverter {
+
     private val conversion = new TimeConversions.DateConversion
 
     override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
       schema.getType == Schema.Type.INT && schema.getLogicalType == LogicalTypes.date()
 
-    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
-      jsonValue match {
-        case number: Number => conversion.fromInt(number.intValue(), schema, schema.getLogicalType)
-        case str: String => Decoder[LocalDate].decodeJson(fromString(str)).fold(throw _, identity)
-        case other => other
-      }
+    override def convertPF(schema: Schema, path: util.Deque[String], silently: Boolean): PartialFunction[AnyRef, AnyRef] = {
+      case number: Number => tryConvert(path, silently)(conversion.fromInt(number.intValue(), schema, schema.getLogicalType))
+      case str: String => Decoder[LocalDate].decodeJson(fromString(str)).toValue(path, silently)
     }
+
+    override val expectedFormat: String = "TODO"
+
   }
 
-  object TimeMillisConverter extends AvroTypeConverter {
+  object TimeMillisConverter extends BaseAvroTypeConverter {
+
     private val conversion = new TimeConversions.TimeMillisConversion
 
     override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
       schema.getType == Schema.Type.INT && schema.getLogicalType == LogicalTypes.timeMillis()
 
-    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
-      jsonValue match {
-        case number: Number => conversion.fromInt(number.intValue(), schema, schema.getLogicalType)
-        case str: String => Decoder[LocalTime].decodeJson(fromString(str)).fold(throw _, identity)
-        case other => other
-      }
+    override def convertPF(schema: Schema, path: util.Deque[String], silently: Boolean): PartialFunction[AnyRef, AnyRef] = {
+      case number: Number => tryConvert(path, silently)(conversion.fromInt(number.intValue(), schema, schema.getLogicalType))
+      case str: String => Decoder[LocalTime].decodeJson(fromString(str)).toValue(path, silently)
     }
+
+    override def expectedFormat: String = "TODO"
+
   }
 
-  object TimeMicrosConverter extends AvroTypeConverter {
+  object TimeMicrosConverter extends BaseAvroTypeConverter {
+
     private val conversion = new TimeConversions.TimeMicrosConversion
 
     override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
       schema.getType == Schema.Type.LONG && schema.getLogicalType == LogicalTypes.timeMicros()
 
-    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
-      jsonValue match {
-        case number: Number => conversion.fromLong(number.intValue(), schema, schema.getLogicalType)
-        case str: String => Decoder[LocalTime].decodeJson(fromString(str)).fold(throw _, identity)
-        case other => other
-      }
+    override def convertPF(schema: Schema, path: util.Deque[String], silently: Boolean): PartialFunction[AnyRef, AnyRef] = {
+      case number: Number => tryConvert(path, silently)(conversion.fromLong(number.intValue(), schema, schema.getLogicalType))
+      case str: String => Decoder[LocalTime].decodeJson(fromString(str)).toValue(path, silently)
     }
+
+    override def expectedFormat: String = "TODO"
+
   }
 
-  object TimestampMillisConverter extends AvroTypeConverter {
+  object TimestampMillisConverter extends BaseAvroTypeConverter {
+
     private val conversion = new TimeConversions.TimestampMillisConversion
 
     override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
       schema.getType == Schema.Type.LONG && schema.getLogicalType == LogicalTypes.timestampMillis()
 
-    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
-      jsonValue match {
-        case number: Number => conversion.fromLong(number.intValue(), schema, schema.getLogicalType)
-        case str: String => Decoder[Instant].decodeJson(fromString(str)).fold(throw _, identity)
-        case other => other
-      }
+    override def convertPF(schema: Schema, path: util.Deque[String], silently: Boolean): PartialFunction[AnyRef, AnyRef] = {
+      case number: Number => tryConvert(path, silently)(conversion.fromLong(number.intValue(), schema, schema.getLogicalType))
+      case str: String => Decoder[Instant].decodeJson(fromString(str)).toValue(path, silently)
     }
+
+    override def expectedFormat: String = "TODO"
+
   }
 
-  object TimestampMicrosConverter extends AvroTypeConverter {
+  object TimestampMicrosConverter extends BaseAvroTypeConverter {
+
     private val conversion = new TimeConversions.TimestampMicrosConversion
 
     override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
       schema.getType == Schema.Type.LONG && schema.getLogicalType == LogicalTypes.timestampMicros()
 
-    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
-      jsonValue match {
-        case number: Number => conversion.fromLong(number.intValue(), schema, schema.getLogicalType)
-        case str: String => Decoder[Instant].decodeJson(fromString(str)).fold(throw _, identity)
-        case other => other
-      }
+    override def convertPF(schema: Schema, path: util.Deque[String], silently: Boolean): PartialFunction[AnyRef, AnyRef] = {
+      case number: Number => tryConvert(path, silently)(conversion.fromLong(number.intValue(), schema, schema.getLogicalType))
+      case str: String => Decoder[Instant].decodeJson(fromString(str)).toValue(path, silently)
     }
+
+    override def expectedFormat: String = "TODO"
+
   }
 
-  object UUIDConverter extends AvroTypeConverter {
+  object UUIDConverter extends BaseAvroTypeConverter {
+
     private val conversion = new UUIDConversion
 
     override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
       schema.getType == Schema.Type.STRING && schema.getLogicalType == LogicalTypes.uuid()
 
-    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
-      jsonValue match {
-        case str: String => conversion.fromCharSequence(str, schema, schema.getLogicalType)
-        case other => other
-      }
+    override def convertPF(schema: Schema, path: util.Deque[String], silently: Boolean): PartialFunction[AnyRef, AnyRef] = {
+      case str: String => tryConvert(path, silently)(conversion.fromCharSequence(str, schema, schema.getLogicalType))
     }
+
+    override def expectedFormat: String = "TODO"
+
   }
 
-  object DecimalConverter extends AvroTypeConverter {
+  object DecimalConverter extends BaseAvroTypeConverter {
+
     override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
       (schema.getType == Schema.Type.FIXED || schema.getType == Schema.Type.BYTES) &&
         schema.getLogicalType.isInstanceOf[LogicalTypes.Decimal]
 
-    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
-      val scale = schema.getLogicalType.asInstanceOf[LogicalTypes.Decimal].getScale
-      jsonValue match {
-        case bigDecimal: java.math.BigDecimal =>
-          bigDecimal.setScale(scale, RoundingMode.DOWN)
-        case number: Number =>
-          val decimal = new java.math.BigDecimal(number.toString)
-          decimal.setScale(scale, RoundingMode.DOWN)
-        case str: String =>
-          val decimal = new java.math.BigDecimal(str)
-          decimal.setScale(scale, RoundingMode.DOWN)
-        case other => other
+    override def convertPF(schema: Schema, path: util.Deque[String], silently: Boolean): PartialFunction[AnyRef, AnyRef] = {
+      case bigDecimal: java.math.BigDecimal =>
+        alignDecimalScale(schema, bigDecimal)
+      case number: Number =>
+        alignDecimalScale(schema, new java.math.BigDecimal(number.toString))
+      case str: String =>
+        tryConvert(path, silently)(alignDecimalScale(schema, new java.math.BigDecimal(str)))
+    }
+
+    override def expectedFormat: String = "TODO"
+
+  }
+
+  private def alignDecimalScale(schema: Schema, bigDecimal: java.math.BigDecimal) = {
+    val scale = schema.getLogicalType.asInstanceOf[LogicalTypes.Decimal].getScale
+    bigDecimal.setScale(scale, RoundingMode.DOWN)
+  }
+
+  trait BaseAvroTypeConverter extends AvroTypeConverter {
+
+    def expectedFormat: String
+
+    override final def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
+      convertPF(schema, path, silently).lift(jsonValue).getOrElse(handleUnexpectedFormat(path, silently, None))
+    }
+
+    protected def convertPF(schema: Schema, path: util.Deque[String], silently: Boolean): PartialFunction[AnyRef, AnyRef]
+
+    protected def tryConvert(path: util.Deque[String], silently: Boolean)(doConvert: => AnyRef): AnyRef = {
+      Try(doConvert).fold(ex => handleUnexpectedFormat(path, silently, Some(ex)), identity)
+    }
+
+    protected implicit class DecoderResultExt[A <: AnyRef](decoderResult: Decoder.Result[A]) {
+      def toValue(path: util.Deque[String], silently: Boolean): AnyRef = {
+        decoderResult.fold(ex => handleUnexpectedFormat(path, silently, Some(ex)), identity)
       }
     }
+
+    protected def handleUnexpectedFormat(path: util.Deque[String], silently: Boolean, cause: Option[Throwable]): AnyRef =
+      if (silently)
+        AvroTypeConverter.INCOMPATIBLE
+      else
+        throw new AvroRuntimeException(s"Field: ${PathsPrinter.print(path)} is expected to has: $expectedFormat format", cause.orNull)
+
   }
 
 }

--- a/utils/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverter.scala
+++ b/utils/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverter.scala
@@ -46,7 +46,7 @@ object JsonPayloadToAvroConverter {
       case str: String => Decoder[LocalDate].decodeJson(fromString(str)).toValue(path, silently)
     }
 
-    override val expectedFormat: String = "TODO"
+    override val expectedFormat: String = "'yyyy-MM-dd' or number of epoch days"
 
   }
 
@@ -62,7 +62,7 @@ object JsonPayloadToAvroConverter {
       case str: String => Decoder[LocalTime].decodeJson(fromString(str)).toValue(path, silently)
     }
 
-    override def expectedFormat: String = "TODO"
+    override def expectedFormat: String = "'HH:mm:ss.SSS' or number of millis of day"
 
   }
 
@@ -78,7 +78,7 @@ object JsonPayloadToAvroConverter {
       case str: String => Decoder[LocalTime].decodeJson(fromString(str)).toValue(path, silently)
     }
 
-    override def expectedFormat: String = "TODO"
+    override def expectedFormat: String = "'HH:mm:ss.SSSSSS' or number of micros of day"
 
   }
 
@@ -94,7 +94,7 @@ object JsonPayloadToAvroConverter {
       case str: String => Decoder[Instant].decodeJson(fromString(str)).toValue(path, silently)
     }
 
-    override def expectedFormat: String = "TODO"
+    override def expectedFormat: String = "'yyyy-MM-dd`T`HH:mm:ss.SSSZ' or number of epoch millis"
 
   }
 
@@ -110,7 +110,7 @@ object JsonPayloadToAvroConverter {
       case str: String => Decoder[Instant].decodeJson(fromString(str)).toValue(path, silently)
     }
 
-    override def expectedFormat: String = "TODO"
+    override def expectedFormat: String = "'yyyy-MM-dd`T`HH:mm:ss.SSSSSSZ' or number of epoch micros"
 
   }
 
@@ -125,7 +125,7 @@ object JsonPayloadToAvroConverter {
       case str: String => tryConvert(path, silently)(conversion.fromCharSequence(str, schema, schema.getLogicalType))
     }
 
-    override def expectedFormat: String = "TODO"
+    override def expectedFormat: String = "UUID"
 
   }
 
@@ -144,7 +144,7 @@ object JsonPayloadToAvroConverter {
         tryConvert(path, silently)(alignDecimalScale(schema, new java.math.BigDecimal(str)))
     }
 
-    override def expectedFormat: String = "TODO"
+    override def expectedFormat: String = "decimal"
 
   }
 
@@ -177,7 +177,7 @@ object JsonPayloadToAvroConverter {
       if (silently)
         AvroTypeConverter.INCOMPATIBLE
       else
-        throw new AvroRuntimeException(s"Field: ${PathsPrinter.print(path)} is expected to has: $expectedFormat format", cause.orNull)
+        throw new AvroRuntimeException(s"Field: ${PathsPrinter.print(path)} is expected to has $expectedFormat format", cause.orNull)
 
   }
 

--- a/utils/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverter.scala
+++ b/utils/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverter.scala
@@ -1,0 +1,146 @@
+package pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.jsonpayload
+
+import io.circe.Decoder
+import io.circe.Json.fromString
+import org.apache.avro.Conversions.UUIDConversion
+import org.apache.avro.data.TimeConversions
+import org.apache.avro.generic.GenericRecord
+import org.apache.avro.specific.SpecificRecordBase
+import org.apache.avro.{LogicalTypes, Schema}
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.jsonpayload.JsonPayloadToAvroConverter._
+import tech.allegro.schema.json2avro.converter.types.AvroTypeConverter
+import tech.allegro.schema.json2avro.converter.{CompositeJsonToAvroReader, JsonAvroConverter}
+
+import java.math.RoundingMode
+import java.time.{Instant, LocalDate, LocalTime}
+import java.util
+
+class JsonPayloadToAvroConverter(specificClass: Option[Class[SpecificRecordBase]]) {
+
+  private val converter = new JsonAvroConverter(new CompositeJsonToAvroReader(
+    DateConverter, TimeMillisConverter, TimeMicrosConverter, TimestampMillisConverter, TimestampMicrosConverter,
+    UUIDConverter, DecimalConverter
+  ))
+
+  def convert(payload: Array[Byte], schema: Schema): GenericRecord = {
+    specificClass match {
+      case Some(kl) => converter.convertToSpecificRecord(payload, kl, schema)
+      case None => converter.convertToGenericDataRecord(payload, schema)
+    }
+  }
+
+}
+
+object JsonPayloadToAvroConverter {
+
+  object DateConverter extends AvroTypeConverter {
+    private val conversion = new TimeConversions.DateConversion
+
+    override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
+      schema.getType == Schema.Type.INT && schema.getLogicalType == LogicalTypes.date()
+
+    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
+      jsonValue match {
+        case number: Number => conversion.fromInt(number.intValue(), schema, schema.getLogicalType)
+        case str: String => Decoder[LocalDate].decodeJson(fromString(str)).fold(throw _, identity)
+        case other => other
+      }
+    }
+  }
+
+  object TimeMillisConverter extends AvroTypeConverter {
+    private val conversion = new TimeConversions.TimeMillisConversion
+
+    override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
+      schema.getType == Schema.Type.INT && schema.getLogicalType == LogicalTypes.timeMillis()
+
+    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
+      jsonValue match {
+        case number: Number => conversion.fromInt(number.intValue(), schema, schema.getLogicalType)
+        case str: String => Decoder[LocalTime].decodeJson(fromString(str)).fold(throw _, identity)
+        case other => other
+      }
+    }
+  }
+
+  object TimeMicrosConverter extends AvroTypeConverter {
+    private val conversion = new TimeConversions.TimeMicrosConversion
+
+    override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
+      schema.getType == Schema.Type.LONG && schema.getLogicalType == LogicalTypes.timeMicros()
+
+    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
+      jsonValue match {
+        case number: Number => conversion.fromLong(number.intValue(), schema, schema.getLogicalType)
+        case str: String => Decoder[LocalTime].decodeJson(fromString(str)).fold(throw _, identity)
+        case other => other
+      }
+    }
+  }
+
+  object TimestampMillisConverter extends AvroTypeConverter {
+    private val conversion = new TimeConversions.TimestampMillisConversion
+
+    override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
+      schema.getType == Schema.Type.LONG && schema.getLogicalType == LogicalTypes.timestampMillis()
+
+    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
+      jsonValue match {
+        case number: Number => conversion.fromLong(number.intValue(), schema, schema.getLogicalType)
+        case str: String => Decoder[Instant].decodeJson(fromString(str)).fold(throw _, identity)
+        case other => other
+      }
+    }
+  }
+
+  object TimestampMicrosConverter extends AvroTypeConverter {
+    private val conversion = new TimeConversions.TimestampMicrosConversion
+
+    override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
+      schema.getType == Schema.Type.LONG && schema.getLogicalType == LogicalTypes.timestampMicros()
+
+    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
+      jsonValue match {
+        case number: Number => conversion.fromLong(number.intValue(), schema, schema.getLogicalType)
+        case str: String => Decoder[Instant].decodeJson(fromString(str)).fold(throw _, identity)
+        case other => other
+      }
+    }
+  }
+
+  object UUIDConverter extends AvroTypeConverter {
+    private val conversion = new UUIDConversion
+
+    override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
+      schema.getType == Schema.Type.STRING && schema.getLogicalType == LogicalTypes.uuid()
+
+    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
+      jsonValue match {
+        case str: String => conversion.fromCharSequence(str, schema, schema.getLogicalType)
+        case other => other
+      }
+    }
+  }
+
+  object DecimalConverter extends AvroTypeConverter {
+    override def canManage(schema: Schema, path: util.Deque[String]): Boolean =
+      (schema.getType == Schema.Type.FIXED || schema.getType == Schema.Type.BYTES) &&
+        schema.getLogicalType.isInstanceOf[LogicalTypes.Decimal]
+
+    override def convert(field: Schema.Field, schema: Schema, jsonValue: AnyRef, path: util.Deque[String], silently: Boolean): AnyRef = {
+      val scale = schema.getLogicalType.asInstanceOf[LogicalTypes.Decimal].getScale
+      jsonValue match {
+        case bigDecimal: java.math.BigDecimal =>
+          bigDecimal.setScale(scale, RoundingMode.DOWN)
+        case number: Number =>
+          val decimal = new java.math.BigDecimal(number.toString)
+          decimal.setScale(scale, RoundingMode.DOWN)
+        case str: String =>
+          val decimal = new java.math.BigDecimal(str)
+          decimal.setScale(scale, RoundingMode.DOWN)
+        case other => other
+      }
+    }
+  }
+
+}

--- a/utils/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverterSpec.scala
+++ b/utils/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverterSpec.scala
@@ -1,0 +1,126 @@
+package pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.jsonpayload
+
+import io.circe.Json
+import io.circe.Json.{fromDoubleOrNull, fromString}
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+import org.scalatest.{FunSuite, Matchers, OptionValues}
+import pl.touk.nussknacker.engine.avro.encode.AvroToJsonEncoder
+import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+
+import java.nio.charset.StandardCharsets
+import java.time.{Instant, LocalDate, LocalTime}
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+class JsonPayloadToAvroConverterSpec extends FunSuite with Matchers with OptionValues {
+
+  private val jsonToAvroConverter = new JsonPayloadToAvroConverter(None)
+  val avroToJsonEncoder: PartialFunction[Any, Json] = new AvroToJsonEncoder().encoder(BestEffortJsonEncoder.defaultForTests)
+
+  test("date logical type") {
+    val schema = prepareSchema("""{ "type": "int", "logicalType": "date" }""")
+
+    val recordWithUnderlyingType = convert("123", schema)
+    recordWithUnderlyingType.fieldValue shouldEqual LocalDate.ofEpochDay(123L)
+    avroToJsonEncoder(recordWithUnderlyingType).fieldValue shouldEqual fromString("1970-05-04")
+
+    val recordWithFormattedValue = convert("\"1970-05-04\"", schema)
+    recordWithFormattedValue.fieldValue shouldEqual LocalDate.ofEpochDay(123L)
+    avroToJsonEncoder(recordWithFormattedValue).fieldValue shouldEqual fromString("1970-05-04")
+  }
+
+  test("time-millis type") {
+    val schema = prepareSchema("""{ "type": "int", "logicalType": "time-millis" }""")
+
+    val recordWithUnderlyingType = convert("123456", schema)
+    recordWithUnderlyingType.fieldValue shouldEqual LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(123456))
+    avroToJsonEncoder(recordWithUnderlyingType).fieldValue shouldEqual fromString("00:02:03.456")
+
+    val recordWithFormattedValue = convert("\"00:02:03.456\"", schema)
+    recordWithFormattedValue.fieldValue shouldEqual LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(123456))
+    avroToJsonEncoder(recordWithFormattedValue).fieldValue shouldEqual fromString("00:02:03.456")
+  }
+
+  test("time-micros type") {
+    val schema = prepareSchema("""{ "type": "long", "logicalType": "time-micros" }""")
+
+    val recordWithUnderlyingType = convert("123456", schema)
+    recordWithUnderlyingType.fieldValue shouldEqual LocalTime.ofNanoOfDay(TimeUnit.MICROSECONDS.toNanos(123456))
+    avroToJsonEncoder(recordWithUnderlyingType).fieldValue shouldEqual fromString("00:00:00.123456")
+
+    val recordWithFormattedValue = convert("\"00:00:00.123456\"", schema)
+    recordWithFormattedValue.fieldValue shouldEqual LocalTime.ofNanoOfDay(TimeUnit.MICROSECONDS.toNanos(123456))
+    avroToJsonEncoder(recordWithFormattedValue).fieldValue shouldEqual fromString("00:00:00.123456")
+  }
+
+  test("timestamp-millis logical type") {
+    val schema = prepareSchema("""{ "type": "long", "logicalType": "timestamp-millis" }""")
+
+    val recordWithUnderlyingType = convert("123", schema)
+    recordWithUnderlyingType.fieldValue shouldEqual Instant.ofEpochMilli(123L)
+    avroToJsonEncoder(recordWithUnderlyingType).fieldValue shouldEqual fromString("1970-01-01T00:00:00.123Z")
+
+    val recordWithFormattedValue = convert("\"1970-01-01T00:00:00.123Z\"", schema)
+    recordWithFormattedValue.fieldValue shouldEqual Instant.ofEpochMilli(123L)
+    avroToJsonEncoder(recordWithFormattedValue).fieldValue shouldEqual fromString("1970-01-01T00:00:00.123Z")
+  }
+
+  test("timestamp-micros logical type") {
+    val schema = prepareSchema("""{ "type": "long", "logicalType": "timestamp-micros" }""")
+
+    val recordWithUnderlyingType = convert("123", schema)
+    recordWithUnderlyingType.fieldValue shouldEqual Instant.ofEpochSecond(0, 123000L)
+    avroToJsonEncoder(recordWithUnderlyingType).fieldValue shouldEqual fromString("1970-01-01T00:00:00.000123Z")
+
+    val recordWithFormattedValue = convert("\"1970-01-01T00:00:00.000123Z\"", schema)
+    recordWithFormattedValue.fieldValue shouldEqual Instant.ofEpochSecond(0, 123000L)
+    avroToJsonEncoder(recordWithFormattedValue).fieldValue shouldEqual fromString("1970-01-01T00:00:00.000123Z")
+  }
+
+  test("uuid logical type") {
+    val schema = prepareSchema("""{ "type": "string", "logicalType": "uuid" }""")
+
+    val uuid = UUID.fromString("f8a69d18-018a-4a38-93b6-9a2479836b72")
+    val recordWithFormattedValue = convert("\"f8a69d18-018a-4a38-93b6-9a2479836b72\"", schema)
+    recordWithFormattedValue.fieldValue shouldEqual uuid
+    avroToJsonEncoder(recordWithFormattedValue).fieldValue shouldEqual fromString("f8a69d18-018a-4a38-93b6-9a2479836b72")
+  }
+
+  test("decimal logical type") {
+    val schema = prepareSchema("""{ "type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2 }""")
+
+    val recordWithNumberType = convert("123.456", schema)
+    recordWithNumberType.fieldValue shouldEqual new java.math.BigDecimal("123.45")
+    avroToJsonEncoder(recordWithNumberType).fieldValue shouldEqual fromDoubleOrNull(123.45)
+
+
+    val recordWithStringType = convert("123.456", schema)
+    recordWithStringType.fieldValue shouldEqual new java.math.BigDecimal("123.45")
+    avroToJsonEncoder(recordWithStringType).fieldValue shouldEqual fromDoubleOrNull(123.45)
+  }
+
+  private def prepareSchema(fieldType: String) = {
+    new Schema.Parser().parse(
+      s"""{
+         |  "name": "sample",
+         |  "type": "record",
+         |  "fields": [
+         |    { "name": "field", "type": $fieldType }
+         |  ]
+         |}""".stripMargin)
+  }
+
+  private def convert(fieldJsonValue: String, schema: Schema): GenericRecord = {
+    jsonToAvroConverter.convert(s"""{"field": $fieldJsonValue}""".getBytes(StandardCharsets.UTF_8), schema)
+  }
+
+  implicit class GenericRecordExt(record: GenericRecord) {
+    def fieldValue = record.get("field")
+  }
+
+  implicit class JsonRecordExt(json: Json) {
+    def fieldValue = json.asObject.value("field").value
+  }
+
+}

--- a/utils/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverterSpec.scala
+++ b/utils/avro-util/src/test/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverterSpec.scala
@@ -7,6 +7,7 @@ import org.apache.avro.generic.GenericRecord
 import org.scalatest.{FunSuite, Matchers, OptionValues}
 import pl.touk.nussknacker.engine.avro.encode.AvroToJsonEncoder
 import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import tech.allegro.schema.json2avro.converter.AvroConversionException
 
 import java.nio.charset.StandardCharsets
 import java.time.{Instant, LocalDate, LocalTime}


### PR DESCRIPTION
kafka-registry-typed-json source was recognizing logical types during typing but during evaluation were used raw, underlying types
