### PR TITLE
Rename lite split component to avoid clash with base component name

### DIFF
--- a/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/ForEachTransformer.scala
+++ b/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/ForEachTransformer.scala
@@ -14,19 +14,19 @@ import scala.language.higherKinds
 object ForEachTransformer extends CustomStreamTransformer {
 
   @MethodToInvoke(returnType = classOf[Object])
-  def invoke(@ParamName("list") list: LazyParameter[java.util.Collection[Any]],
+  def invoke(@ParamName("elements") elements: LazyParameter[java.util.Collection[Any]],
              @OutputVariableName outputVariable: String): SingleElementComponent = {
-    new ForEachTransformerComponent(list, outputVariable)
+    new ForEachTransformerComponent(elements, outputVariable)
   }
 
 }
 
-class ForEachTransformerComponent(list: LazyParameter[java.util.Collection[Any]], outputVariable: String)
+class ForEachTransformerComponent(elements: LazyParameter[java.util.Collection[Any]], outputVariable: String)
   extends SingleElementComponent with ReturningType {
 
 
   override def createSingleTransformation[F[_]:Monad, Result](continuation: DataBatch => F[ResultType[Result]], context: CustomComponentContext[F]): Context => F[ResultType[Result]] = {
-    val interpreter = context.interpreter.syncInterpretationFunction(list)
+    val interpreter = context.interpreter.syncInterpretationFunction(elements)
     (ctx: Context) => {
       val partsToRun = interpreter(ctx)
       val partsToInterpret = partsToRun.asScala.toList.map { partToRun =>
@@ -38,7 +38,7 @@ class ForEachTransformerComponent(list: LazyParameter[java.util.Collection[Any]]
   }
 
   override def returnType: typing.TypingResult = {
-    list.returnType match {
+    elements.returnType match {
       case tc: SingleTypingResult if tc.objType.canBeSubclassOf(Typed[java.util.Collection[_]]) && tc.objType.params.nonEmpty =>
         tc.objType.params.head
       case _ => Unknown

--- a/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/ForEachTransformer.scala
+++ b/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/ForEachTransformer.scala
@@ -11,22 +11,22 @@ import pl.touk.nussknacker.engine.lite.api.utils.transformers.SingleElementCompo
 import scala.collection.JavaConverters._
 import scala.language.higherKinds
 
-object ProcessSplitter extends CustomStreamTransformer {
+object ForEachTransformer extends CustomStreamTransformer {
 
   @MethodToInvoke(returnType = classOf[Object])
-  def invoke(@ParamName("parts") parts: LazyParameter[java.util.Collection[Any]],
+  def invoke(@ParamName("list") list: LazyParameter[java.util.Collection[Any]],
              @OutputVariableName outputVariable: String): SingleElementComponent = {
-    new ProcessSplitterComponent(parts, outputVariable)
+    new ForEachTransformerComponent(list, outputVariable)
   }
 
 }
 
-class ProcessSplitterComponent(parts: LazyParameter[java.util.Collection[Any]], outputVariable: String)
+class ForEachTransformerComponent(list: LazyParameter[java.util.Collection[Any]], outputVariable: String)
   extends SingleElementComponent with ReturningType {
 
 
   override def createSingleTransformation[F[_]:Monad, Result](continuation: DataBatch => F[ResultType[Result]], context: CustomComponentContext[F]): Context => F[ResultType[Result]] = {
-    val interpreter = context.interpreter.syncInterpretationFunction(parts)
+    val interpreter = context.interpreter.syncInterpretationFunction(list)
     (ctx: Context) => {
       val partsToRun = interpreter(ctx)
       val partsToInterpret = partsToRun.asScala.toList.map { partToRun =>
@@ -38,7 +38,7 @@ class ProcessSplitterComponent(parts: LazyParameter[java.util.Collection[Any]], 
   }
 
   override def returnType: typing.TypingResult = {
-    parts.returnType match {
+    list.returnType match {
       case tc: SingleTypingResult if tc.objType.canBeSubclassOf(Typed[java.util.Collection[_]]) && tc.objType.params.nonEmpty =>
         tc.objType.params.head
       case _ => Unknown

--- a/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteBaseComponentProvider.scala
+++ b/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteBaseComponentProvider.scala
@@ -24,7 +24,7 @@ class LiteBaseComponentProvider extends ComponentProvider {
   override def create(config: Config, dependencies: ProcessObjectDependencies): List[ComponentDefinition] = {
     implicit val docsConfig: DocsConfig = new DocsConfig(config)
     List(
-      ComponentDefinition("split", ProcessSplitter),
+      ComponentDefinition("for-each", ForEachTransformer),
       ComponentDefinition("union", Union).withRelativeDocs("BasicNodes#union"),
       ComponentDefinition("dead-end", SinkFactory.noParam(DeadEndSink))
     )

--- a/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
+++ b/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
@@ -152,7 +152,7 @@ class KafkaTransactionalScenarioInterpreterTest extends fixture.FunSuite with Ka
       .parallelism(2)
       .source("source", "source", "topic" -> s"'$inputTopic'")
       .buildSimpleVariable("throw on 0", "someVar", "1 / #input.length")
-      .customNode("for-each", "splitVar", "for-each", "list" -> "{#input, 'other'}")
+      .customNode("for-each", "splitVar", "for-each", "elements" -> "{#input, 'other'}")
       .emptySink("sink", "sink", "topic" -> s"'$outputTopic'", "value" -> "#splitVar + '-add'")
 
     runScenarioWithoutErrors(fixture, scenario) {

--- a/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
+++ b/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
@@ -152,7 +152,7 @@ class KafkaTransactionalScenarioInterpreterTest extends fixture.FunSuite with Ka
       .parallelism(2)
       .source("source", "source", "topic" -> s"'$inputTopic'")
       .buildSimpleVariable("throw on 0", "someVar", "1 / #input.length")
-      .customNode("split", "splitVar", "split", "parts" -> "{#input, 'other'}")
+      .customNode("for-each", "splitVar", "for-each", "list" -> "{#input, 'other'}")
       .emptySink("sink", "sink", "topic" -> s"'$outputTopic'", "value" -> "#splitVar + '-add'")
 
     runScenarioWithoutErrors(fixture, scenario) {

--- a/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseInterpreterSpec.scala
+++ b/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseInterpreterSpec.scala
@@ -105,7 +105,7 @@ class RequestResponseInterpreterSpec extends FunSuite with Matchers with Patient
     val process = EspProcessBuilder
       .id("proc1")
       .source("start", "request1-post-source")
-      .customNode("split", "outPart", "split", "parts" -> "#input.toList()")
+      .customNode("for-each", "outPart", "for-each", "list" -> "#input.toList()")
       .buildSimpleVariable("var1", "var1", "#outPart")
       .emptySink("sink1", "response-sink", "value" -> "#outPart")
 

--- a/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseInterpreterSpec.scala
+++ b/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseInterpreterSpec.scala
@@ -105,7 +105,7 @@ class RequestResponseInterpreterSpec extends FunSuite with Matchers with Patient
     val process = EspProcessBuilder
       .id("proc1")
       .source("start", "request1-post-source")
-      .customNode("for-each", "outPart", "for-each", "list" -> "#input.toList()")
+      .customNode("for-each", "outPart", "for-each", "elements" -> "#input.toList()")
       .buildSimpleVariable("var1", "var1", "#outPart")
       .emptySink("sink1", "response-sink", "value" -> "#outPart")
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
