### PR TITLE
GH actions workaround: binding to localhost

### DIFF
--- a/engine/lite/kafka/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeBinTest.scala
+++ b/engine/lite/kafka/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeBinTest.scala
@@ -24,7 +24,9 @@ class NuKafkaRuntimeBinTest extends FunSuite with KafkaSpec with NuKafkaRuntimeT
     val shellScriptEnvs = Array(
       s"KAFKA_ADDRESS=$kafkaBoostrapServer",
       // random management port to avoid clashing of ports
-      "CONFIG_FORCE_akka_management_http_port=0"
+      "CONFIG_FORCE_akka_management_http_port=0",
+      // It looks like github-actions doesn't look binding to 0.0.0.0, was problems like: Bind failed for TCP channel on endpoint [/10.1.0.183:0]
+      "CONFIG_FORCE_akka_management_http_hostname=127.0.0.1"
     )
     withProcessExecutedInBackground(shellScriptArgs, shellScriptEnvs,
       {


### PR DESCRIPTION
trying to fix problem: 
```
2022-01-25T14:46:26.4564733Z [ERROR] [01/25/2022 14:46:26.454] [nu-kafka-runtime-akka.actor.internal-dispatcher-3] [akka://nu-kafka-runtime/system/IO-TCP/selectors/$a/0] Bind failed for TCP channel on endpoint [/10.1.0.183:0]
2022-01-25T14:46:26.4565422Z java.net.BindException: [/10.1.0.183:0] Cannot assign requested address
2022-01-25T14:46:26.4565775Z 	at java.base/sun.nio.ch.Net.bind0(Native Method)
2022-01-25T14:46:26.4567982Z 	at java.base/sun.nio.ch.Net.bind(Net.java:455)
2022-01-25T14:46:26.4568536Z 	at java.base/sun.nio.ch.Net.bind(Net.java:447)
2022-01-25T14:46:26.4569529Z 	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
2022-01-25T14:46:26.4572389Z 	at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:80)
2022-01-25T14:46:26.4572943Z 	at akka.io.TcpListener.liftedTree1$1(TcpListener.scala:
```