### PR TITLE
Minor docs cleanup and parameter rename.

### DIFF
--- a/docs/installation_configuration_guide/model/Flink.md
+++ b/docs/installation_configuration_guide/model/Flink.md
@@ -101,7 +101,7 @@ exceptionHandler {
 Out of the box, Nussknacker provides following ExceptionHandler types:
 - BrieflyLogging - log error to Flink logs (on `info` level, with stacktrace on `debug` level)
 - VerboselyLogging - log error to Flink logs on `error` level, together with all variables (should be used mainly for debugging)
-- Kafka - send errors to Kafka topic, see [common config](../ModelConfiguration#kafka-exception-handling) for the details.
+- Kafka - send errors to Kafka topic, see [common config](../ModelConfiguration/#kafka-exception-handling) for the details.
 
 ### Configuring restart strategies 
 
@@ -122,9 +122,8 @@ It's also possible to configure restart strategies per scenario, using additiona
         strategy: fixed-delay
         attempts: 30
       }
-      for-very-important {
-        strategy: fixed-delay
-        attempts: 50
+      fail-fast {
+        strategy: none
       }
     }
 ```

--- a/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/exception/FlinkEspExceptionConsumer.scala
+++ b/engine/flink/api/src/main/scala/pl/touk/nussknacker/engine/flink/api/exception/FlinkEspExceptionConsumer.scala
@@ -8,6 +8,6 @@ trait FlinkEspExceptionConsumer extends EspExceptionConsumer with Lifecycle
 
 trait FlinkEspExceptionConsumerProvider extends NamedServiceProvider {
 
-  def create(metaData: MetaData, additionalConfig: Config): FlinkEspExceptionConsumer
+  def create(metaData: MetaData, exceptionHandlerConfig: Config): FlinkEspExceptionConsumer
 
 }

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/exception/FlinkExceptionHandlerSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/exception/FlinkExceptionHandlerSpec.scala
@@ -56,8 +56,8 @@ class TestExceptionConsumerProvider extends FlinkEspExceptionConsumerProvider {
 
   override val name: String = TestExceptionConsumerProvider.typeName
 
-  override def create(metaData: MetaData, additionalConfig: Config): FlinkEspExceptionConsumer =
+  override def create(metaData: MetaData, exceptionHandlerConfig: Config): FlinkEspExceptionConsumer =
     (exceptionInfo: NuExceptionInfo[NonTransientException]) => {
-      TestExceptionConsumerProvider.threadLocal.set((metaData, additionalConfig, exceptionInfo))
+      TestExceptionConsumerProvider.threadLocal.set((metaData, exceptionHandlerConfig, exceptionInfo))
     }
 }

--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumer.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumer.scala
@@ -14,9 +14,9 @@ import pl.touk.nussknacker.engine.util.config.ConfigEnrichments.RichConfig
 
 class KafkaExceptionConsumerProvider extends FlinkEspExceptionConsumerProvider {
 
-  override def create(metaData: MetaData, additionalConfig: Config): FlinkEspExceptionConsumer = {
-    val kafkaConfig = KafkaConfig.parseConfig(additionalConfig)
-    val consumerConfig = additionalConfig.rootAs[KafkaExceptionConsumerConfig]
+  override def create(metaData: MetaData, exceptionHandlerConfig: Config): FlinkEspExceptionConsumer = {
+    val kafkaConfig = KafkaConfig.parseConfig(exceptionHandlerConfig)
+    val consumerConfig = exceptionHandlerConfig.rootAs[KafkaExceptionConsumerConfig]
     val producerCreator = kafkaProducerCreator(kafkaConfig)
     val serialization = KafkaJsonExceptionSerializationSchema(metaData, consumerConfig)
     if (consumerConfig.useSharedProducer) {

--- a/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/flink/test/RecordingExceptionConsumer.scala
+++ b/engine/flink/test-util/src/main/scala/pl/touk/nussknacker/engine/flink/test/RecordingExceptionConsumer.scala
@@ -42,8 +42,8 @@ class RecordingExceptionConsumerProvider extends FlinkEspExceptionConsumerProvid
 
   override val name: String = providerName
 
-  override def create(metaData: MetaData, additionalConfig: Config): FlinkEspExceptionConsumer = {
-    val id = additionalConfig.getOrElse[String](recordingConsumerIdPath, UUID.randomUUID().toString)
+  override def create(metaData: MetaData, exceptionHandlerConfig: Config): FlinkEspExceptionConsumer = {
+    val id = exceptionHandlerConfig.getOrElse[String](recordingConsumerIdPath, UUID.randomUUID().toString)
     new RecordingExceptionConsumer(id)
   }
 }

--- a/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/exception/DefaultExceptionConsumers.scala
+++ b/engine/flink/util/src/main/scala/pl/touk/nussknacker/engine/flink/util/exception/DefaultExceptionConsumers.scala
@@ -26,15 +26,15 @@ case class BrieflyLoggingExceptionConsumer(processMetaData: MetaData, params: Ma
 }
 
 class VerboselyLoggingExceptionConsumerProvider extends FlinkEspExceptionConsumerProvider {
-  override def create(metaData: MetaData, additionalConfig: Config): FlinkEspExceptionConsumer =
-    VerboselyLoggingExceptionConsumer(metaData, additionalConfig.getAs[Map[String, String]]("params").getOrElse(Map.empty))
+  override def create(metaData: MetaData, exceptionHandlerConfig: Config): FlinkEspExceptionConsumer =
+    VerboselyLoggingExceptionConsumer(metaData, exceptionHandlerConfig.getAs[Map[String, String]]("params").getOrElse(Map.empty))
 
   override val name: String = "VerboselyLogging"
 }
 
 class BrieflyLoggingExceptionConsumerProvider extends FlinkEspExceptionConsumerProvider {
-  override def create(metaData: MetaData, additionalConfig: Config): FlinkEspExceptionConsumer =
-    BrieflyLoggingExceptionConsumer(metaData, additionalConfig.getAs[Map[String, String]]("params").getOrElse(Map.empty))
+  override def create(metaData: MetaData, exceptionHandlerConfig: Config): FlinkEspExceptionConsumer =
+    BrieflyLoggingExceptionConsumer(metaData, exceptionHandlerConfig.getAs[Map[String, String]]("params").getOrElse(Map.empty))
 
   override val name: String = "BrieflyLogging"
 


### PR DESCRIPTION
Docs cleanup:
1. fixed url to kafka-exception-handling
2. replaced one of fixed-delay restartStrategy configuration example with some different (but still quite fundamental) strategy example

Parameter rename:
`FlinkEspExceptionConsumerProvider` does not get "additionalConfig" but full "exceptionHandler" configuration (see `FlinkExceptionHandler.extractBaseConsumer`). Here, that parameter name suggests that something else is taken into account.