### PR TITLE
Allow KafkaExceptionConsumerProvider to overwrite serializationSchema

### DIFF
--- a/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumer.scala
+++ b/engine/flink/kafka-util/src/main/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumer.scala
@@ -4,9 +4,9 @@ import com.typesafe.config.Config
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import net.ceedubs.ficus.Ficus._
 import pl.touk.nussknacker.engine.api.MetaData
-import pl.touk.nussknacker.engine.api.exception.{NuExceptionInfo, NonTransientException}
-import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
+import pl.touk.nussknacker.engine.api.exception.{NonTransientException, NuExceptionInfo}
 import pl.touk.nussknacker.engine.flink.api.exception.{FlinkEspExceptionConsumer, FlinkEspExceptionConsumerProvider}
+import pl.touk.nussknacker.engine.kafka.serialization.KafkaSerializationSchema
 import pl.touk.nussknacker.engine.kafka.sharedproducer.WithSharedKafkaProducer
 import pl.touk.nussknacker.engine.kafka.{DefaultProducerCreator, KafkaConfig, KafkaProducerCreator, KafkaUtils}
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
@@ -18,13 +18,16 @@ class KafkaExceptionConsumerProvider extends FlinkEspExceptionConsumerProvider {
     val kafkaConfig = KafkaConfig.parseConfig(exceptionHandlerConfig)
     val consumerConfig = exceptionHandlerConfig.rootAs[KafkaExceptionConsumerConfig]
     val producerCreator = kafkaProducerCreator(kafkaConfig)
-    val serialization = KafkaJsonExceptionSerializationSchema(metaData, consumerConfig)
+    val serializationSchema = createSerializationSchema(metaData, consumerConfig)
     if (consumerConfig.useSharedProducer) {
-      SharedProducerKafkaExceptionConsumer(metaData, serialization, producerCreator)
+      SharedProducerKafkaExceptionConsumer(metaData, serializationSchema, producerCreator)
     } else {
-      TempProducerKafkaExceptionConsumer(serialization, producerCreator)
+      TempProducerKafkaExceptionConsumer(serializationSchema, producerCreator)
     }
   }
+
+  protected def createSerializationSchema(metaData: MetaData, consumerConfig: KafkaExceptionConsumerConfig): KafkaSerializationSchema[NuExceptionInfo[NonTransientException]] =
+    new KafkaJsonExceptionSerializationSchema(metaData, consumerConfig)
 
   //visible for testing
   private[exception] def kafkaProducerCreator(kafkaConfig: KafkaConfig): KafkaProducerCreator.Binary = DefaultProducerCreator(kafkaConfig)
@@ -33,20 +36,20 @@ class KafkaExceptionConsumerProvider extends FlinkEspExceptionConsumerProvider {
 
 }
 
-case class TempProducerKafkaExceptionConsumer(serializationSchema: KafkaJsonExceptionSerializationSchema,
+case class TempProducerKafkaExceptionConsumer(serializationSchema: KafkaSerializationSchema[NuExceptionInfo[NonTransientException]],
                                               kafkaProducerCreator: KafkaProducerCreator.Binary) extends FlinkEspExceptionConsumer {
 
   override def consume(exceptionInfo: NuExceptionInfo[NonTransientException]): Unit = {
-    KafkaUtils.sendToKafkaWithTempProducer(serializationSchema.serialize(exceptionInfo))(kafkaProducerCreator)
+    KafkaUtils.sendToKafkaWithTempProducer(serializationSchema.serialize(exceptionInfo, System.currentTimeMillis()))(kafkaProducerCreator)
   }
 
 }
 
 case class SharedProducerKafkaExceptionConsumer(metaData: MetaData,
-                                                serializationSchema: KafkaJsonExceptionSerializationSchema,
+                                                serializationSchema: KafkaSerializationSchema[NuExceptionInfo[NonTransientException]],
                                                 kafkaProducerCreator: KafkaProducerCreator.Binary) extends FlinkEspExceptionConsumer with WithSharedKafkaProducer {
   override def consume(exceptionInfo: NuExceptionInfo[NonTransientException]): Unit = {
-    sendToKafka(serializationSchema.serialize(exceptionInfo))(SynchronousExecutionContext.ctx)
+    sendToKafka(serializationSchema.serialize(exceptionInfo, System.currentTimeMillis()))(SynchronousExecutionContext.ctx)
   }
   
 }

--- a/engine/flink/kafka-util/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSerializationSpec.scala
+++ b/engine/flink/kafka-util/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSerializationSpec.scala
@@ -24,7 +24,7 @@ class KafkaExceptionConsumerSerializationSpec extends FunSuite with Matchers {
 
   private val exception = NuExceptionInfo(Some(NodeComponentInfo("nodeId", "componentName", ComponentType.Enricher)), NonTransientException("input1", "mess", Instant.ofEpochMilli(111)), Context("ctxId"))
 
-  private val serializationSchema = KafkaJsonExceptionSerializationSchema(metaData, consumerConfig)
+  private val serializationSchema = new KafkaJsonExceptionSerializationSchema(metaData, consumerConfig)
 
   private val consumer = TempProducerKafkaExceptionConsumer(serializationSchema, MockProducerCreator(mockProducer))
 

--- a/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaSingleScenarioTaskRun.scala
+++ b/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaSingleScenarioTaskRun.scala
@@ -145,7 +145,8 @@ class KafkaSingleScenarioTaskRun(taskId: String,
   //TODO: test behaviour on transient exceptions
   private def serializeError(error: ErrorType): ProducerRecord[Array[Byte], Array[Byte]] = {
     val nonTransient = WithExceptionExtractor.extractOrThrow(error)
-    KafkaJsonExceptionSerializationSchema(metaData, engineConfig.exceptionHandlingConfig).serialize(nonTransient)
+    val schema = new KafkaJsonExceptionSerializationSchema(metaData, engineConfig.exceptionHandlingConfig)
+    schema.serialize(nonTransient, System.currentTimeMillis())
   }
 
   // See https://www.baeldung.com/kafka-exactly-once for details


### PR DESCRIPTION
Changes:
1. Allow KafkaExceptionConsumerProvider to overwrite serializationSchema
2. Use KafkaSerializationSchema as a serializationSchema