### PR TITLE
Allow to configure a WithExceptionExtractor (with default impl)

### DIFF
--- a/docs/installation_configuration_guide/model/Flink.md
+++ b/docs/installation_configuration_guide/model/Flink.md
@@ -85,6 +85,9 @@ Exception handling can be customized using provided `EspExceptionConsumer`. By d
 - `VerboselyLogging`
 More of them can be added with custom extensions. By default, basic error metrics are collected. If for some reason
   it's not desirable, metrics collector can be turned off with `withRateMeter: false` setting.
+When an exception is raised within a scenario, the handler uses `WithExceptionExtractor` to determine if it should be consumed
+  (via `EspExceptionConsumer`) or rethrown. A custom extractor can be provided and indicated with optional `exceptionExtractor` setting.
+  When no `exceptionExtractor` is set, handler uses `DefaultWithExceptionExtractor` (same as `exceptionExtractor: Default`).
 
 Some handlers can have additional properties, e.g. built in logging handlers can add custom parameters to log. See example below. 
 
@@ -92,6 +95,7 @@ Some handlers can have additional properties, e.g. built in logging handlers can
 exceptionHandler {
   type: BrieflyLogging
   withRateMeter: false
+  exceptionExtractor: SomeCustomExtractor
   params: {
     additional: "value1"
   }

--- a/engine/flink/util/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.exception.WithExceptionExtractor
+++ b/engine/flink/util/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.exception.WithExceptionExtractor
@@ -1,0 +1,1 @@
+pl.touk.nussknacker.engine.util.exception.DefaultWithExceptionExtractor

--- a/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaSingleScenarioTaskRun.scala
+++ b/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaSingleScenarioTaskRun.scala
@@ -4,11 +4,11 @@ import cats.implicits.toTraverseOps
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, ConsumerRecords, KafkaConsumer, OffsetAndMetadata}
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{AuthorizationException, InterruptException, OutOfOrderSequenceException, ProducerFencedException}
 import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
-import pl.touk.nussknacker.engine.api.{Context, MetaData, VariableConstants}
+import pl.touk.nussknacker.engine.api.{MetaData, VariableConstants}
 import pl.touk.nussknacker.engine.kafka.KafkaUtils
 import pl.touk.nussknacker.engine.kafka.exception.KafkaJsonExceptionSerializationSchema
 import pl.touk.nussknacker.engine.lite.ScenarioInterpreterFactory.ScenarioInterpreterWithLifecycle
@@ -18,7 +18,7 @@ import pl.touk.nussknacker.engine.lite.api.interpreterTypes.{ScenarioInputBatch,
 import pl.touk.nussknacker.engine.lite.kafka.KafkaTransactionalScenarioInterpreter.{EngineConfig, Input, Output}
 import pl.touk.nussknacker.engine.lite.kafka.api.LiteKafkaSource
 import pl.touk.nussknacker.engine.lite.metrics.SourceMetrics
-import pl.touk.nussknacker.engine.util.exception.WithExceptionExtractor
+import pl.touk.nussknacker.engine.util.exception.DefaultWithExceptionExtractor
 
 import java.util.UUID
 import scala.compat.java8.DurationConverters.FiniteDurationops
@@ -144,7 +144,7 @@ class KafkaSingleScenarioTaskRun(taskId: String,
 
   //TODO: test behaviour on transient exceptions
   private def serializeError(error: ErrorType): ProducerRecord[Array[Byte], Array[Byte]] = {
-    val nonTransient = WithExceptionExtractor.extractOrThrow(error)
+    val nonTransient = DefaultWithExceptionExtractor.extractOrThrow(error)
     val schema = new KafkaJsonExceptionSerializationSchema(metaData, engineConfig.exceptionHandlingConfig)
     schema.serialize(nonTransient, System.currentTimeMillis())
   }

--- a/utils/util/src/main/scala/pl/touk/nussknacker/engine/util/exception/DefaultWithExceptionExtractor.scala
+++ b/utils/util/src/main/scala/pl/touk/nussknacker/engine/util/exception/DefaultWithExceptionExtractor.scala
@@ -1,0 +1,20 @@
+package pl.touk.nussknacker.engine.util.exception
+
+import pl.touk.nussknacker.engine.api.exception.NonTransientException
+
+import java.net.ConnectException
+
+class DefaultWithExceptionExtractor extends WithExceptionExtractor {
+
+  override protected val transientExceptionExtractor: ExceptionExtractor[Exception] =
+    new DeeplyCheckingExceptionExtractor({ case a: ConnectException => a: Exception })
+
+  override protected val nonTransientExceptionExtractor: ExceptionExtractor[NonTransientException] =
+    new DeeplyCheckingExceptionExtractor({ case a: NonTransientException => a })
+
+  override def name: String = DefaultWithExceptionExtractor.name
+}
+
+object DefaultWithExceptionExtractor {
+  val name = "Default"
+}

--- a/utils/util/src/main/scala/pl/touk/nussknacker/engine/util/exception/WithExceptionExtractor.scala
+++ b/utils/util/src/main/scala/pl/touk/nussknacker/engine/util/exception/WithExceptionExtractor.scala
@@ -1,18 +1,15 @@
 package pl.touk.nussknacker.engine.util.exception
 
-import com.typesafe.config.Config
-import pl.touk.nussknacker.engine.api.{MetaData, NamedServiceProvider}
+import pl.touk.nussknacker.engine.api.NamedServiceProvider
 import pl.touk.nussknacker.engine.api.exception.{NonTransientException, NuExceptionInfo}
 import pl.touk.nussknacker.engine.api.util.ReflectUtils
 import pl.touk.nussknacker.engine.util.logging.LazyLoggingWithTraces
 
-import java.net.ConnectException
+trait WithExceptionExtractor extends NamedServiceProvider with LazyLoggingWithTraces {
 
-trait WithExceptionExtractor extends LazyLoggingWithTraces {
+  protected val transientExceptionExtractor: ExceptionExtractor[Exception]
 
-  protected val transientExceptionExtractor: ExceptionExtractor[Exception] = _ => None
-
-  protected val nonTransientExceptionExtractor: ExceptionExtractor[NonTransientException] = _ => None
+  protected val nonTransientExceptionExtractor: ExceptionExtractor[NonTransientException]
 
   final def extractOrThrow(exceptionInfo: NuExceptionInfo[_ <: Throwable]): NuExceptionInfo[NonTransientException] = {
     exceptionInfo.throwable match {
@@ -27,20 +24,5 @@ trait WithExceptionExtractor extends LazyLoggingWithTraces {
         NuExceptionInfo(exceptionInfo.nodeComponentInfo, nonTransient, exceptionInfo.context)
     }
   }
-
-}
-
-object DefaultWithExceptionExtractor extends WithExceptionExtractor {
-
-  override protected val transientExceptionExtractor: ExceptionExtractor[Exception] =
-    new DeeplyCheckingExceptionExtractor({ case a: ConnectException => a: Exception })
-
-  override protected val nonTransientExceptionExtractor: ExceptionExtractor[NonTransientException] =
-    new DeeplyCheckingExceptionExtractor({ case a: NonTransientException => a })
-}
-
-trait FlinkWithExceptionExtractorProvider extends NamedServiceProvider {
-
-  def create(metaData: MetaData, exceptionHandlerConfig: Config): WithExceptionExtractor
 
 }


### PR DESCRIPTION
Changes:
1. `WithExceptionExtractor` is configurable as a NamedServiceProvider
2. Custom implementations of `WithExceptionExtractor` should provide transient&nonTransient extractors
3. Default implementation is `DefaultWithExceptionExtractor`
4. FlinkExceptionHandler extracts name of `WithExceptionExtractor` from `exceptionHandler` configuration and loads via `ScalaServiceLoader.loadNamed`