### PR TITLE
Add explicit serialVersionUID to TimeSerializers that are serialized …

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11,6 +11,7 @@
   `nussknacker-scenario-api`, `nussknacker-extensions-api`
   * API cleanup, some classes moved to `utils` or `interpreter`, 
     untangling dependencies, see [migration guide](MigrationGuide.md) for the details
+* [#2886](https://github.com/TouK/nussknacker/pull/2886) Add explicit serialVersionUID for classes registered by `Serializers.registerSerializers`.
  
 1.2.0 (11 Feb 2022)
 ------------------------

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -26,7 +26,13 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   * `JobData` no longer contains `DeploymentData`, which is not accessible for components anymore
   * `DisplayJson`, `WithJobData`, `MultiMap` moved to `utils`
   * Some methods from API classes (e.g. `Parameter.validate`) and classes (`TestResults`, `InterpretationResult`) moved to interpreter
-  
+
+### Other changes
+
+* [#2886](https://github.com/TouK/nussknacker/pull/2886) This change can break previous flink snapshot compatibility.
+  Restoring state from previous snapshot asserts that restored serializer UID matches current serializer UID.
+  This change ensures that in further release deployments UIDs persisted within snapshots are not re-generated in runtime.
+
 ## In version 1.2.0
 
 ### Configuration changes

--- a/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/kryo/SchemaIdBasedAvroGenericRecordSerializer.scala
+++ b/engine/flink/avro-util/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/kryo/SchemaIdBasedAvroGenericRecordSerializer.scala
@@ -13,6 +13,7 @@ import pl.touk.nussknacker.engine.kafka.KafkaConfig
 
 import java.io.ByteArrayOutputStream
 
+@SerialVersionUID(20220222162000L)
 class SchemaIdBasedAvroGenericRecordSerializer(schemaRegistryClientFactory: ConfluentSchemaRegistryClientFactory, kafkaConfig: KafkaConfig)
   extends SerializerWithSpecifiedClass[GenericRecordWithSchemaId](false, false) with DatumReaderWriterMixin {
 

--- a/engine/flink/executor/src/main/java/pl/touk/nussknacker/engine/process/util/TimeSerializers.java
+++ b/engine/flink/executor/src/main/java/pl/touk/nussknacker/engine/process/util/TimeSerializers.java
@@ -50,7 +50,6 @@ import org.apache.flink.api.common.ExecutionConfig;
  * <p>
  * Implementation note: All serialization is inspired by oracles java.time.Ser.
  */
-
 public class TimeSerializers {
 
     public static void addDefaultSerializers(ExecutionConfig config) {
@@ -70,12 +69,19 @@ public class TimeSerializers {
         addSerializer(config, Period.class, new PeriodSerializer());
     }
 
+    /**
+     * See description in [[pl.touk.nussknacker.engine.process.util.Serializers]]
+     */
+    private static final long globalVersionUID = 20220222162000L;
+
     private static <T, Y extends Serializer<T> & Serializable> void addSerializer(ExecutionConfig config, Class<T> klass, Y serializer) {
       config.getRegisteredTypesWithKryoSerializers().put(klass, new ExecutionConfig.SerializableSerializer<>(serializer));
       config.getDefaultKryoSerializers().put(klass, new ExecutionConfig.SerializableSerializer<>(serializer));
     }
 
     private static class DurationSerializer extends Serializer<Duration> implements Serializable {
+        private static final long serialVersionUID = globalVersionUID;
+
         {
             setImmutable(true);
         }
@@ -93,6 +99,8 @@ public class TimeSerializers {
     }
 
     private static class InstantSerializer extends Serializer<Instant> implements Serializable {
+        private static final long serialVersionUID = globalVersionUID;
+
         {
             setImmutable(true);
         }
@@ -110,6 +118,7 @@ public class TimeSerializers {
     }
 
     private static class LocalDateSerializer extends Serializer<LocalDate> implements Serializable {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -137,6 +146,7 @@ public class TimeSerializers {
     }
 
     private static class LocalDateTimeSerializer extends Serializer<LocalDateTime> implements Serializable {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -154,6 +164,7 @@ public class TimeSerializers {
     }
 
     private static class LocalTimeSerializer extends Serializer<LocalTime> implements Serializable {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -213,6 +224,7 @@ public class TimeSerializers {
     }
 
     private static class ZoneOffsetSerializer extends Serializer<ZoneOffset> implements Serializable {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -241,6 +253,7 @@ public class TimeSerializers {
     }
 
     private static class ZoneIdSerializer extends Serializer<ZoneId> implements Serializable  {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -264,6 +277,7 @@ public class TimeSerializers {
     }
 
     private static class OffsetTimeSerializer extends Serializer<OffsetTime> implements Serializable  {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -281,6 +295,7 @@ public class TimeSerializers {
     }
 
     private static class OffsetDateTimeSerializer extends Serializer<OffsetDateTime> implements Serializable  {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -300,6 +315,7 @@ public class TimeSerializers {
     }
 
     private static class ZonedDateTimeSerializer extends Serializer<ZonedDateTime> implements Serializable  {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -319,6 +335,7 @@ public class TimeSerializers {
     }
 
     private static class YearSerializer extends Serializer<Year> implements Serializable  {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -333,6 +350,7 @@ public class TimeSerializers {
     }
 
     private static class YearMonthSerializer extends Serializer<YearMonth> implements Serializable  {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -350,6 +368,7 @@ public class TimeSerializers {
     }
 
     private static class MonthDaySerializer extends Serializer<MonthDay> implements Serializable  {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }
@@ -367,6 +386,7 @@ public class TimeSerializers {
     }
 
     private static class PeriodSerializer extends Serializer<Period> implements Serializable  {
+        private static final long serialVersionUID = globalVersionUID;
         {
             setImmutable(true);
         }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/Serializers.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/Serializers.scala
@@ -11,11 +11,13 @@ import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
 
 import scala.util.{Failure, Try}
 
-//Watch out, serializers are also serialized. Incompatible SerializationUID on serializer class can lead process state loss (unable to continue from old snapshot).
-//This is why we set SerialVersionUID explicit.
-//Look:
-//org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil.writeSerializersAndConfigsWithResilience
-//org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience
+/**
+  * Watch out, serializers are also serialized. Incompatible SerializationUID on serializer class can lead process state loss (unable to continue from old snapshot).
+  * This is why we set SerialVersionUID explicit.
+  *
+  * @see [[org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil#writeSerializersAndConfigsWithResilience]]
+  * @see [[org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil#readSerializersAndConfigsWithResilience]]
+  */
 object Serializers extends LazyLogging {
 
   def registerSerializers(modelData: ModelData, config: ExecutionConfig): Unit = {


### PR DESCRIPTION
Problem: when restoring from previous snapshot, the serialization runtime calculates a default serialVersionUID, which may differ from restored serialVersionUID, event when class is not changed.

Fix: provide explicit serialVersionUID for all classes registered by `Serializers.registerSerializers`