### PR TITLE
`fixedValueValidator` - separate list of values by comma and space

### DIFF
--- a/ui/client/components/graph/node-modal/editors/Validators.ts
+++ b/ui/client/components/graph/node-modal/editors/Validators.ts
@@ -72,7 +72,7 @@ export const mandatoryValueValidator: Validator = {
 
 export const fixedValueValidator = (possibleValues: Array<PossibleValue>): Validator => ({
   isValid: value => possibleValues.map(pv => pv.expression).includes(value),
-  message: () => i18next.t("fixedValueValidator.message", "This value has to be one of values: ") + possibleValues.map(value => value.expression).join(", "),
+  message: () => i18next.t("fixedValueValidator.message", "This value has to be one of: ") + possibleValues.map(value => value.expression).join(", "),
   description: () => i18next.t("Validator.fixed.description", "Please choose one of available values"),
   handledErrorType: HandledErrorType.InvalidPropertyFixedValue,
   validatorType: ValidatorType.Frontend,

--- a/ui/client/components/graph/node-modal/editors/Validators.ts
+++ b/ui/client/components/graph/node-modal/editors/Validators.ts
@@ -72,7 +72,7 @@ export const mandatoryValueValidator: Validator = {
 
 export const fixedValueValidator = (possibleValues: Array<PossibleValue>): Validator => ({
   isValid: value => possibleValues.map(pv => pv.expression).includes(value),
-  message: () => i18next.t("fixedValueValidator.message", "This value has to be one of values: ") + possibleValues.map(value => value.expression).join(","),
+  message: () => i18next.t("fixedValueValidator.message", "This value has to be one of values: ") + possibleValues.map(value => value.expression).join(", "),
   description: () => i18next.t("Validator.fixed.description", "Please choose one of available values"),
   handledErrorType: HandledErrorType.InvalidPropertyFixedValue,
   validatorType: ValidatorType.Frontend,


### PR DESCRIPTION
The list of possible values in error message for `fixedValuesValidator` are joined by comma. For larger lists the error message was so wide it could not fit inside the modal.
Before:
![Zrzut ekranu 2022-03-14 o 12 43 44](https://user-images.githubusercontent.com/3193882/158166266-353c6858-9052-49ec-a2c7-f487984d7ad7.png)
After:
![Zrzut ekranu 2022-03-14 o 12 44 20](https://user-images.githubusercontent.com/3193882/158166274-bca3da11-f2e8-4a72-b6b5-03f6503b9bcf.png)

Another things to consider, but not necessarily in this PR: 
1. This validator allows empty value. That's why the list starts with comma after `:`. This might be misleading to user - maybe it should be more verbose? Like `[EMPTY VALUE]` or some other placeholder? Or it should be completely removed if field is marked as required? 
2. If list of values is large (50? 100?) only return first `n` values in error message