### PR TITLE
Move inserted text in fixed values field from bottom to top

### DIFF
--- a/ui/client/components/graph/node-modal/editors/expression/FixedValuesEditor.tsx
+++ b/ui/client/components/graph/node-modal/editors/expression/FixedValuesEditor.tsx
@@ -54,6 +54,7 @@ export default class FixedValuesEditor extends React.Component<Props> {
           isDisabled={readOnly}
           formatCreateLabel={(x) => x}
           menuPortalTarget={document.body}
+          createOptionPosition={"first"}
           styles={{
             menuPortal: base => ({...base, zIndex: 1000}),
           }}


### PR DESCRIPTION
Fixed values fields can be filtered, but text inserted by user appears on the bottom of the list. If list is long, user is unable to see what was already typed.
Here I've typed `202`:
![Zrzut ekranu 2022-03-14 o 20 03 19](https://user-images.githubusercontent.com/3193882/158243794-33adbdde-55f2-4a98-9dc6-862db3d46556.png)

and `testy` here:
![Zrzut ekranu 2022-03-14 o 20 04 01](https://user-images.githubusercontent.com/3193882/158243796-720110d2-9c2b-451d-a3ce-3eebe92e0605.png)

This change moves inserted text to the top of list which should be more user-friendly.