### PR TITLE
Remove manual stream flushing from serializers

### DIFF
--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/Serializers.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/Serializers.scala
@@ -37,7 +37,6 @@ object Serializers extends LazyLogging {
       // their constructor takes different parameters than usual case class constructor
       def handleObjWithDifferentParamsCountConstructor(constructorParamsCount: Int) = {
         output.writeInt(constructorParamsCount)
-        output.flush()
 
         // in inner classes definition, '$outer' field is at the end, but in constructor it is the first parameter
         // we look for '$outer` in getFields not getDeclaredFields, cause it can be also parent's field
@@ -52,7 +51,6 @@ object Serializers extends LazyLogging {
           field.setAccessible(true)
           kryo.writeClassAndObject(output, field.get(obj))
           field.setAccessible(false)
-          output.flush()
         })
       }
 
@@ -61,15 +59,12 @@ object Serializers extends LazyLogging {
 
       if (arity == constructorParamsCount.getOrElse(0)) {
         output.writeInt(arity)
-        output.flush()
         obj.productIterator.foreach { f =>
           kryo.writeClassAndObject(output, f)
-          output.flush()
         }
       } else {
         handleObjWithDifferentParamsCountConstructor(constructorParamsCount.get)
       }
-      output.flush()
     }
 
     override def read(kryo: Kryo, input: Input, obj: Class[Product]) = {

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/SpelHack.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/SpelHack.scala
@@ -22,8 +22,6 @@ object SpelHack extends SerializerWithSpecifiedClass[java.util.List[_]](false, t
     val it = obj.iterator()
     while (it.hasNext) {
       kryo.writeClassAndObject(out, it.next())
-      // After each intermediate object, flush
-      out.flush()
     }
 
   }
@@ -58,10 +56,7 @@ object SpelMapHack extends SerializerWithSpecifiedClass[java.util.Map[_, _]](fal
       val entry = it.next()
       kryo.writeClassAndObject(out, entry.getKey)
       kryo.writeClassAndObject(out, entry.getValue)
-      // After each intermediate object, flush
-      out.flush()
     }
-
   }
 
   override def read(kryo: Kryo, in: Input, obj: Class[java.util.Map[_, _]]): java.util.Map[_, _] = {


### PR DESCRIPTION
Remove manual calls to `Output.flush` from custom serializers, it's not required and may degrade performance