### PR TITLE
Fix for OAuth2 authentication: Don't redirect when 'invalid_request' …

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,7 @@
 * [#3047](https://github.com/TouK/nussknacker/pull/3047) Remove deprecated Admin panel tabs that are replaced with Components tab: 
   Search Components and Unused Components (together with API endpoints: /processesComponents and /unusedComponents)
 * [#3049](https://github.com/TouK/nussknacker/pull/3049) Added `collector` component to lite base components
+* [#3066](https://github.com/TouK/nussknacker/pull/3066) Fix for OAuth2 authentication: Don't redirect when 'invalid_request' error is passed to avoid redirection loop  
 
 1.3.1 (Not released yet)
 ------------------------

--- a/ui/client/containers/Auth/strategies/OAuth2Strategy.ts
+++ b/ui/client/containers/Auth/strategies/OAuth2Strategy.ts
@@ -76,7 +76,12 @@ export const OAuth2Strategy: StrategyConstructor = class OAuth2Strategy implemen
       return Promise.resolve()
     }
 
-    this.redirectToAuthorizeUrl()
+    if (queryParams.error == "invalid_request") {
+      // We don't redirect in this case because it will cause redirection loop
+      console.warn("OAuth2 authentication server redirected with 'invalid_request' error code. It can be something wrong in authentication configuration or some error on authentication server side.")
+    } else {
+      this.redirectToAuthorizeUrl()
+    }
     return Promise.reject()
   }
 


### PR DESCRIPTION
…error is passed to avoid redirection loop

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
