### PR TITLE
Expose jmx prometheus metrics in nussknacker-lite-runtime

### DIFF
--- a/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
+++ b/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
@@ -22,15 +22,16 @@ have to configure `.kube/config` properly.
 
 `streaming-lite-k8s` Deployment Manager has the following configuration options:                 
 
-| Parameter                | Type                                                 | Default value                       | Description                                                                              |
-|--------------------------|------------------------------------------------------|-------------------------------------|------------------------------------------------------------------------------------------|
-| dockerImageName          | string                                               | touk/nussknacker-lite-kafka-runtime | Runtime image (please note that it's **not** touk/nussknacker - which is designer image) |
-| dockerImageTag           | string                                               | current nussknacker version         |                                                                                          |
-| scalingConfig            | {fixedReplicasCount: int} or {tasksPerReplica: int}  | { tasksPerReplica: 4 }              | see [below](#configuring-replicas-count)                                                 |
-| configExecutionOverrides | config                                               | {}                                  | see [below](#overriding-configuration-passed-to-runtime)                                 |
-| k8sDeploymentConfig      | config                                               | {}                                  | see [below](#customizing-k8s-deployment)                                                 |
-| nussknackerInstanceName  | string                                               | {?NUSSKNACKER_INSTANCE_NAME}        | see [below](#nussknacker-instance-name)                                                  |
-| logbackConfigPath        | string                                               | {}                                  | see [below](#configuring-runtime-logging)                                                |
+| Parameter                | Type                                                | Default value                      | Description                                                                                                                         |
+|--------------------------|-----------------------------------------------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| dockerImageName          | string                                              | touk/nussknacker-lite-kafka-runtime| Runtime image (please note that it's **not** touk/nussknacker - which is designer image)                                            |
+| dockerImageTag           | string                                              | current nussknacker version        |                                                                                                                                     |
+| scalingConfig            | {fixedReplicasCount: int} or {tasksPerReplica: int} | { tasksPerReplica: 4 }             | see [below](#configuring-replicas-count)                                                                                            |
+| prometheusMetrics        | {enabled: boolean, port: int }                      | { enabled: false }                 | If `enabled`: true runtime image is run with jmx prometheus agent attached and Promethues metrics are exposed under defined `port`. |
+| configExecutionOverrides | config                                              | {}                                 | see [below](#overriding-configuration-passed-to-runtime)                                                                            |
+| k8sDeploymentConfig      | config                                              | {}                                 | see [below](#customizing-k8s-deployment)                                                                                            |
+| nussknackerInstanceName  | string                                              | {?NUSSKNACKER_INSTANCE_NAME}       | see [below](#nussknacker-instance-name)                                                                                             |
+| logbackConfigPath        | string                                              | {}                                 | see [below](#configuring-runtime-logging)                                                                                           |
                                                  
 ### Customizing K8s deployment
 

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
@@ -57,9 +57,16 @@ class K8sDeploymentManagerProvider extends DeploymentManagerProvider {
   override def name: String = "streaming-lite-k8s"
 }
 
+case class PrometheusMetricsConfig(enabled: Boolean = false, port: Option[Int] = None) {
+  {
+    require(!enabled || port.isDefined, "Invalid 'prometheusMetrics' config, if enabled:true port has to be defined.")
+  }
+}
+
 case class K8sDeploymentManagerConfig(dockerImageName: String = "touk/nussknacker-lite-kafka-runtime",
                                       dockerImageTag: String = BuildInfo.version,
                                       scalingConfig: Option[K8sScalingConfig] = None,
+                                      prometheusMetrics: PrometheusMetricsConfig = PrometheusMetricsConfig(),
                                       configExecutionOverrides: Config = ConfigFactory.empty(),
                                       k8sDeploymentConfig: Config = ConfigFactory.empty(),
                                       nussknackerInstanceName: Option[String] = None,

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
@@ -7,7 +7,7 @@ import monocle.macros.GenLens
 import monocle.std.option._
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.k8s.manager.K8sDeploymentManager.{labelsForScenario, objectNameForScenario, scenarioIdLabel, scenarioVersionAnnotation}
-import pl.touk.nussknacker.k8s.manager.K8sDeploymentManagerConfig
+import pl.touk.nussknacker.k8s.manager.{K8sDeploymentManagerConfig, PrometheusMetricsConfig}
 import skuber.EnvVar.FieldRef
 import skuber.LabelSelector.IsEqualRequirement
 import skuber.apps.v1.Deployment
@@ -70,10 +70,11 @@ class DeploymentPreparer(config: K8sDeploymentManagerConfig) extends LazyLogging
         // We pass POD_NAME, because there is no option to pass only replica hash which is appended to pod name.
         // Hash will be extracted on entrypoint side.
         EnvVar("POD_NAME", FieldRef("metadata.name"))
-      ),
+      ) ++ config.prometheusMetrics.envVars,
       volumeMounts = List(
         Volume.Mount(name = "configmap", mountPath = "/data"),
       ),
+      ports = config.prometheusMetrics.containerPorts,
       // used standard AkkaManagement see HealthCheckServerRunner for details
       // TODO we should tune failureThreshold to some lower value
       readinessProbe = Some(Probe(new HTTPGetAction(Left(8558), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60))),
@@ -99,5 +100,10 @@ class DeploymentPreparer(config: K8sDeploymentManagerConfig) extends LazyLogging
       case single :: Nil => List(modifyRuntimeContainer(single))
       case _ => throw new IllegalStateException("Deployment should have only one 'runtime' container")
     }) ++ nonRuntimeContainers
+  }
+
+  private implicit class RichPrometheusMetricsConfig(config: PrometheusMetricsConfig) {
+    def envVars: List[EnvVar] = if (config.enabled) List(EnvVar("PROMETHEUS_METRICS_PORT", s"${config.port.get}")) else Nil
+    def containerPorts: List[Container.Port] = if(config.enabled) List(Container.Port(config.port.get, name = "metrics")) else Nil
   }
 }

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerProviderTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerProviderTest.scala
@@ -293,21 +293,21 @@ class K8sDeploymentManagerProviderTest extends FunSuite with Matchers with Extre
 
       pod.metadata.annotations should contain theSameElementsAs annotations
 
-//      val portForward: Process = new ProcessBuilder("kubectl", "port-forward", s"${pod.name}", s"$port:$port")
-//        .directory(new File("/tmp"))
-//        .start()
-//      implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
-//
-//      try {
-//        eventually {
-//          basicRequest
-//            .get(uri"http://localhost:$port")
-//            .send()
-//            .body.right.get.contains("jvm_memory_bytes_committed") shouldBe true
-//        }
-//      } finally {
-//        portForward.destroy()
-//      }
+      val portForward: Process = new ProcessBuilder("kubectl", "port-forward", s"${pod.name}", s"$port:$port")
+        .directory(new File("/tmp"))
+        .start()
+      implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
+
+      try {
+        eventually {
+          basicRequest
+            .get(uri"http://localhost:$port")
+            .send()
+            .body.right.get.contains("jvm_memory_bytes_committed") shouldBe true
+        }
+      } finally {
+        portForward.destroy()
+      }
     }
   }
 

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerProviderTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerProviderTest.scala
@@ -293,21 +293,21 @@ class K8sDeploymentManagerProviderTest extends FunSuite with Matchers with Extre
 
       pod.metadata.annotations should contain theSameElementsAs annotations
 
-      val portForward: Process = new ProcessBuilder("kubectl", "port-forward", s"${pod.name}", s"$port:$port")
-        .directory(new File("/tmp"))
-        .start()
-      implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
-
-      try {
-        eventually {
-          basicRequest
-            .get(uri"http://localhost:$port")
-            .send()
-            .body.right.get.contains("jvm_memory_bytes_committed") shouldBe true
-        }
-      } finally {
-        portForward.destroy()
-      }
+//      val portForward: Process = new ProcessBuilder("kubectl", "port-forward", s"${pod.name}", s"$port:$port")
+//        .directory(new File("/tmp"))
+//        .start()
+//      implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
+//
+//      try {
+//        eventually {
+//          basicRequest
+//            .get(uri"http://localhost:$port")
+//            .send()
+//            .body.right.get.contains("jvm_memory_bytes_committed") shouldBe true
+//        }
+//      } finally {
+//        portForward.destroy()
+//      }
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
