### PR TITLE
Add space after comma in 'missing field' error message

### DIFF
--- a/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/delayed/DelayedKafkaSourceFactory.scala
+++ b/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/delayed/DelayedKafkaSourceFactory.scala
@@ -84,7 +84,7 @@ object DelayedKafkaSourceFactory {
       case TypedObjectTypingResult(fields, _, _) => fields.get(field) match {
         case Some(fieldTypingResult) if List(Typed[java.lang.Long], Typed[Long]).contains(fieldTypingResult) => List.empty
         case Some(fieldTypingResult) => List(new CustomNodeError(nodeId.id, s"Field: '$field' has invalid type: ${fieldTypingResult.display}.", Some(TimestampFieldParamName)))
-        case None => List(new CustomNodeError(nodeId.id, s"Field: '$field' doesn't exist in definition: ${fields.keys.mkString(",")}.", Some(TimestampFieldParamName)))
+        case None => List(new CustomNodeError(nodeId.id, s"Field: '$field' doesn't exist in definition: ${fields.keys.mkString(", ")}.", Some(TimestampFieldParamName)))
       }
       case _ => throw new IllegalArgumentException(s"Not supported delayed source type definition: ${typingResult.getClass.getSimpleName}")
     }


### PR DESCRIPTION
When field list is long (more than 8-10 elements) concatenated list of fields in error message is wider than modal. Space after comma resolves this issue.