### PR TITLE
Typed.fromInstance(null) works now the same as literal null in SpEL

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
@@ -191,7 +191,8 @@ object typing {
     def fromInstance(obj: Any): TypingResult = {
       obj match {
         case null =>
-          Typed.empty
+          // TODO: add better type for null like Null.type - similar to Unknown but e.g. "foo".canBeSubclassOf(TypedNull) should return false
+          Unknown
         case map: Map[String@unchecked, _]  =>
           val fieldTypes = typeMapFields(map)
           TypedObjectTypingResult(fieldTypes, typedClass(classOf[Map[_, _]], List(Typed[String], Unknown)))

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypedFromInstanceTest.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypedFromInstanceTest.scala
@@ -11,7 +11,7 @@ class TypedFromInstanceTest extends FunSuite with Matchers with LoneElement with
   import scala.collection.JavaConverters._
 
   test("should type null") {
-    Typed.fromInstance(null: Any) shouldBe Typed.empty
+    Typed.fromInstance(null: Any) shouldBe Unknown
   }
 
   test("should type map types") {

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -167,7 +167,7 @@ private[spel] class Typer(classLoader: ClassLoader, commonSupertypeFinder: Commo
       case e: RealLiteral => valid(Typed(Typed[java.lang.Float]))
       case e: FloatLiteral => valid(Typed[java.lang.Float])
       case e: StringLiteral => valid(Typed[String])
-      case e: NullLiteral => valid(Unknown)
+      case e: NullLiteral => valid(Typed.fromInstance(null))
 
 
       case e: InlineList => withTypedChildren { children =>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
