### PR TITLE
Fix/fetch remote scenario version

### DIFF
--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -144,7 +144,7 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
 
   private def fetchProcessVersion(id: String, remoteProcessVersion: Option[VersionId])
                                  (implicit ec: ExecutionContext): Future[Either[EspError, ProcessDetails]] = {
-    invokeJson[ProcessDetails](HttpMethods.GET, List("processes", id) ++ remoteProcessVersion.map(_.toString).toList, Query())
+    invokeJson[ProcessDetails](HttpMethods.GET, List("processes", id) ++ remoteProcessVersion.map(_.version.toString).toList, Query())
   }
 
   private def fetchProcessesDetails(names: List[ProcessName])(implicit ec: ExecutionContext) = EitherT {

--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -144,7 +144,7 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
 
   private def fetchProcessVersion(id: String, remoteProcessVersion: Option[VersionId])
                                  (implicit ec: ExecutionContext): Future[Either[EspError, ProcessDetails]] = {
-    invokeJson[ProcessDetails](HttpMethods.GET, List("processes", id) ++ remoteProcessVersion.map(_.version.toString).toList, Query())
+    invokeJson[ProcessDetails](HttpMethods.GET, List("processes", id) ++ remoteProcessVersion.map(_.value.toString).toList, Query())
   }
 
   private def fetchProcessesDetails(names: List[ProcessName])(implicit ec: ExecutionContext) = EitherT {


### PR DESCRIPTION
Right now NU raises an exception while comparing scenario with remote env version. Version id in request path seems to be wrong:
```
GET /api/processes/SOME_SCENARIO_ID/VersionId(53)
```
It should be:
```
GET /api/processes/SOME_SCENARIO_ID/53
```