### PR TITLE
Test type method reference

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/generics/ExpressionParseError.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/generics/ExpressionParseError.scala
@@ -1,7 +1,5 @@
 package pl.touk.nussknacker.engine.api.generics
 
-import cats.Eq
-import cats.kernel.Eq.neqv
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 
 trait ExpressionParseError {
@@ -11,11 +9,6 @@ trait ExpressionParseError {
 class ArgumentTypeError(val found: NoVarArgSignature, val possibleSignatures: List[Signature]) extends ExpressionParseError {
   override def message: String =
     s"Mismatch parameter types. Found: ${found.display}. Required: ${possibleSignatures.map(_.display).mkString(" or ")}"
-
-  def combine(x: ArgumentTypeError): ArgumentTypeError = {
-    if (!found.equals(x.found)) throw new IllegalArgumentException("Cannot combine ArgumentTypeErrors where found signatures differ.")
-    new ArgumentTypeError(found, possibleSignatures ::: x.possibleSignatures)
-  }
 }
 
 class GenericFunctionError(messageInner: String) extends ExpressionParseError {

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
@@ -96,7 +96,7 @@ class TypeMethodReference(methodName: String,
   // We try to combine ArgumentTypeErrors into one error. If we fail
   // then we only one first error. All regular functions return
   // only ArgumentTypeError, so we will lose information only when
-  // there are two
+  // there is more than one generic function.
   private def combineErrors(errors: NonEmptyList[(MethodInfo, ExpressionParseError)]): ExpressionParseError = errors match {
     case xs if xs.forall(_._2.isInstanceOf[ArgumentTypeError]) =>
       xs.map(_._2.asInstanceOf[ArgumentTypeError]).toList.reduce(_.combine(_))

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/typer/TypeMethodReference.scala
@@ -94,7 +94,7 @@ class TypeMethodReference(methodName: String,
   }
 
   // We try to combine ArgumentTypeErrors into one error. If we fail
-  // then we return only first error. All regular functions return
+  // then we only one first error. All regular functions return
   // only ArgumentTypeError, so we will lose information only when
   // there are two
   private def combineErrors(errors: NonEmptyList[(MethodInfo, ExpressionParseError)]): ExpressionParseError = errors match {

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/TypeMethodReferenceSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/TypeMethodReferenceSpec.scala
@@ -1,0 +1,186 @@
+package pl.touk.nussknacker.engine.spel
+
+import cats.data.{NonEmptyList, Validated}
+import cats.implicits.catsSyntaxValidatedId
+import org.scalatest.Inside.inside
+import org.scalatest.{FunSuite, Matchers}
+import pl.touk.nussknacker.engine.api.generics.{ArgumentTypeError, ExpressionParseError, GenericFunctionError, GenericType, NoVarArgSignature, TypingFunction}
+import pl.touk.nussknacker.engine.api.process.ClassExtractionSettings
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
+import pl.touk.nussknacker.engine.spel.typer.TypeMethodReference
+
+class TypeMethodReferenceSpec extends FunSuite with Matchers {
+  private case class Helper() {
+    def simpleFunction(a: Int): Int = ???
+
+
+    def simpleOverloadedFunction(a: Int, b: Double): String = ???
+
+    def simpleOverloadedFunction(a: String, b: Double, c: String): Int = ???
+
+    def simpleOverloadedFunction(a: Double, b: Long, c: Int): String = ???
+
+
+    @GenericType(typingFunction = classOf[GenericFunctionHelper])
+    def genericFunction(a: Int): String = ???
+
+
+    @GenericType(typingFunction = classOf[OverloadedGenericFunctionHelper])
+    def overloadedGenericFunction(a: Double, b: Double): String = ???
+
+    def overloadedGenericFunction(a: String, b: Int): Long = ???
+
+    def overloadedGenericFunction(a: Int, b: String, c: Float): Long = ???
+
+
+    @GenericType(typingFunction = classOf[OverloadedMultipleGenericFunctionHelperA])
+    def overloadedMultipleGenericFunction(a: Long): String = ???
+
+    @GenericType(typingFunction = classOf[OverloadedMultipleGenericFunctionHelperB])
+    def overloadedMultipleGenericFunction(a: String): Long = ???
+
+    @GenericType(typingFunction = classOf[OverloadedMultipleGenericFunctionHelperC])
+    def overloadedMultipleGenericFunction(a: Int, b: Double): Float = ???
+  }
+
+  private def extractMethod(name: String, args: List[TypingResult]): Either[ExpressionParseError, TypingResult] = {
+    TypeMethodReference(name, Typed[Helper], args, isStatic = false, methodExecutionForUnknownAllowed = false)(ClassExtractionSettings.Default)
+  }
+
+  private def checkErrorEquality(a: ArgumentTypeError, b: ArgumentTypeError): Unit = {
+    a.found.display shouldBe b.found.display
+    a.possibleSignatures.map(_.display) should contain theSameElementsAs b.possibleSignatures.map(_.display)
+  }
+
+  private def checkErrorEquality(a: GenericFunctionError, b: GenericFunctionError): Unit =
+    a.message shouldBe b.message
+
+  test("should get single method") {
+    val name = "simpleFunction"
+    val expectedTypes = List(Typed[Int])
+
+    extractMethod(name, expectedTypes) shouldBe Right(Typed[Int])
+
+    inside(extractMethod(name, List(Typed[String]))) {
+      case Left(error: ArgumentTypeError) => checkErrorEquality(error, new ArgumentTypeError(
+        new NoVarArgSignature(name, List(Typed[String])),
+        List(new NoVarArgSignature(name, expectedTypes))
+      ))
+    }
+  }
+
+  test("should get overloaded methods") {
+    val name = "simpleOverloadedFunction"
+    val expectedTypesA = List(Typed[Int], Typed[Double])
+    val expectedTypesB = List(Typed[String], Typed[Double], Typed[String])
+    val expectedTypesC = List(Typed[Double], Typed[Long], Typed[Int])
+
+    extractMethod(name, expectedTypesA) shouldBe Right(Typed[String])
+    extractMethod(name, expectedTypesB) shouldBe Right(Typed[Int])
+    extractMethod(name, expectedTypesC) shouldBe Right(Typed[String])
+
+    inside(extractMethod(name, List())) {
+      case Left(error: ArgumentTypeError) => checkErrorEquality(error, new ArgumentTypeError(
+        new NoVarArgSignature(name, List()),
+        List(
+          new NoVarArgSignature(name, expectedTypesA),
+          new NoVarArgSignature(name, expectedTypesB),
+          new NoVarArgSignature(name, expectedTypesC)
+        )
+      ))
+    }
+  }
+
+  test("should get single generic method") {
+    val name = "genericFunction"
+    val expectedTypes = List(Typed[Int])
+
+    extractMethod(name, expectedTypes) shouldBe Right(Typed[String])
+
+    inside(extractMethod(name, List())) {
+      case Left(error: GenericFunctionError) => checkErrorEquality(error, new GenericFunctionError("error"))
+    }
+  }
+
+  test("should get overloaded generic method") {
+    val name = "overloadedGenericFunction"
+    val expectedTypesA = List(Typed[Double], Typed[Double])
+    val expectedTypesB = List(Typed[String], Typed[Int])
+    val expectedTypesC = List(Typed[Int], Typed[String], Typed[Float])
+
+    extractMethod("overloadedGenericFunction", expectedTypesA) shouldBe Right(Typed[String])
+    extractMethod("overloadedGenericFunction", expectedTypesB) shouldBe Right(Typed[Long])
+    extractMethod("overloadedGenericFunction", expectedTypesC) shouldBe Right(Typed[Long])
+
+    inside(extractMethod("overloadedGenericFunction", List())) {
+      case Left(error: ArgumentTypeError) => checkErrorEquality(error, new ArgumentTypeError(
+        new NoVarArgSignature(name, List()),
+        List(new NoVarArgSignature(name, expectedTypesC))
+      ))
+    }
+  }
+
+  test("should gen one of overloaded generic methods") {
+    val name = "overloadedMultipleGenericFunction"
+    val expectedTypesA = List(Typed[Long])
+    val expectedTypesB = List(Typed[String])
+    val expectedTypesC = List(Typed[Int], Typed[Double])
+
+    extractMethod(name, expectedTypesA) shouldBe Right(Typed[String])
+    extractMethod(name, expectedTypesB) shouldBe Right(Typed[Long])
+    extractMethod(name, expectedTypesC) shouldBe Right(Typed[Float])
+
+    inside(extractMethod(name, List())) {
+      case Left(error: GenericFunctionError) => checkErrorEquality(error, new GenericFunctionError("errorC"))
+    }
+  }
+}
+
+trait CustomErrorTypingFunctionHelper extends TypingFunction {
+  def expectedArguments: List[TypingResult]
+  def result: TypingResult
+  def error: String
+
+  override def computeResultType(arguments: List[TypingResult]): Validated[NonEmptyList[ExpressionParseError], TypingResult] =
+    if (arguments == expectedArguments) result.validNel else new GenericFunctionError(error).invalidNel
+}
+
+trait TypingFunctionHelper extends CustomErrorTypingFunctionHelper {
+  override def error: String = "error"
+}
+
+case class GenericFunctionHelper() extends TypingFunctionHelper {
+  override def expectedArguments: List[TypingResult] = List(Typed[Int])
+
+  override def result: TypingResult = Typed[String]
+}
+
+case class OverloadedGenericFunctionHelper() extends TypingFunctionHelper {
+  override def expectedArguments: List[TypingResult] = List(Typed[Double], Typed[Double])
+
+  override def result: TypingResult = Typed[String]
+}
+
+case class OverloadedMultipleGenericFunctionHelperA() extends CustomErrorTypingFunctionHelper {
+  override def expectedArguments: List[TypingResult] = List(Typed[Long])
+
+  override def result: TypingResult = Typed[String]
+
+  override def error: String = "errorA"
+}
+
+case class OverloadedMultipleGenericFunctionHelperB() extends CustomErrorTypingFunctionHelper {
+  override def expectedArguments: List[TypingResult] = List(Typed[String])
+
+  override def result: TypingResult = Typed[Long]
+
+  override def error: String = "errorB"
+}
+
+case class OverloadedMultipleGenericFunctionHelperC() extends CustomErrorTypingFunctionHelper {
+  override def expectedArguments: List[TypingResult] = List(Typed[Int], Typed[Double])
+
+  override def result: TypingResult = Typed[Float]
+
+  override def error: String = "errorC"
+}


### PR DESCRIPTION
Added tests for type method reference, because before it was possible to make any use of overloaded functions cause errors and still pass all tests. Also made handling typing errors caused by overloaded functions more deterministic.