### PR TITLE
refactor UniversalSchemaSupport

### DIFF
--- a/engine/flink/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/sink/flink/FlinkKafkaUniversalSink.scala
+++ b/engine/flink/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/sink/flink/FlinkKafkaUniversalSink.scala
@@ -55,7 +55,7 @@ class FlinkKafkaUniversalSink(preparedTopic: PreparedKafkaTopic,
     override def map(ctx: ValueWithContext[KeyedValue[AnyRef, AnyRef]]): KeyedValue[AnyRef, AnyRef] = {
       ctx.value.mapValue { data =>
         exceptionHandler.handling(Some(NodeComponentInfo(nodeId, "flinkKafkaAvroSink", ComponentType.Sink)), ctx.context) {
-          val encode = UniversalSchemaSupport(schema.getParsedSchema).sinkValueEncoder(schema.getParsedSchema, validationMode)
+          val encode = UniversalSchemaSupport.forSchemaType(schema.getParsedSchema.schemaType()).sinkValueEncoder(schema.getParsedSchema, validationMode)
           encode(data)
         }.orNull
       }

--- a/engine/flink/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/sink/flink/FlinkKafkaUniversalSink.scala
+++ b/engine/flink/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/sink/flink/FlinkKafkaUniversalSink.scala
@@ -9,7 +9,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import pl.touk.nussknacker.engine.api.component.{ComponentType, NodeComponentInfo}
 import pl.touk.nussknacker.engine.api.{Context, LazyParameter, ValueWithContext}
 import pl.touk.nussknacker.engine.avro.encode.ValidationMode
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
 import pl.touk.nussknacker.engine.flink.api.exception.{ExceptionHandler, WithExceptionHandler}
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkSink}
 import pl.touk.nussknacker.engine.flink.util.keyed.KeyedValueMapper
@@ -55,7 +55,8 @@ class FlinkKafkaUniversalSink(preparedTopic: PreparedKafkaTopic,
     override def map(ctx: ValueWithContext[KeyedValue[AnyRef, AnyRef]]): KeyedValue[AnyRef, AnyRef] = {
       ctx.value.mapValue { data =>
         exceptionHandler.handling(Some(NodeComponentInfo(nodeId, "flinkKafkaAvroSink", ComponentType.Sink)), ctx.context) {
-          UniversalSchemaSupport.sinkValueEncoder(schema.getParsedSchema, validationMode)(data)
+          val encode = schema.getParsedSchema.sinkValueEncoderFactory(validationMode)
+          encode(data)
         }.orNull
       }
     }

--- a/engine/flink/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/sink/flink/FlinkKafkaUniversalSink.scala
+++ b/engine/flink/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/sink/flink/FlinkKafkaUniversalSink.scala
@@ -9,7 +9,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import pl.touk.nussknacker.engine.api.component.{ComponentType, NodeComponentInfo}
 import pl.touk.nussknacker.engine.api.{Context, LazyParameter, ValueWithContext}
 import pl.touk.nussknacker.engine.avro.encode.ValidationMode
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport
 import pl.touk.nussknacker.engine.flink.api.exception.{ExceptionHandler, WithExceptionHandler}
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkSink}
 import pl.touk.nussknacker.engine.flink.util.keyed.KeyedValueMapper
@@ -55,7 +55,7 @@ class FlinkKafkaUniversalSink(preparedTopic: PreparedKafkaTopic,
     override def map(ctx: ValueWithContext[KeyedValue[AnyRef, AnyRef]]): KeyedValue[AnyRef, AnyRef] = {
       ctx.value.mapValue { data =>
         exceptionHandler.handling(Some(NodeComponentInfo(nodeId, "flinkKafkaAvroSink", ComponentType.Sink)), ctx.context) {
-          val encode = schema.getParsedSchema.sinkValueEncoderFactory(validationMode)
+          val encode = UniversalSchemaSupport(schema.getParsedSchema).sinkValueEncoder(schema.getParsedSchema, validationMode)
           encode(data)
         }.orNull
       }

--- a/engine/lite/components/kafka/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalSinkImplFactory.scala
+++ b/engine/lite/components/kafka/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalSinkImplFactory.scala
@@ -5,9 +5,9 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import pl.touk.nussknacker.engine.api.process.Sink
 import pl.touk.nussknacker.engine.api.{LazyParameter, LazyParameterInterpreter}
 import pl.touk.nussknacker.engine.avro.RuntimeSchemaData
-import pl.touk.nussknacker.engine.avro.encode.{BestEffortAvroEncoder, ValidationMode}
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport
-import pl.touk.nussknacker.engine.avro.sink.{KafkaAvroSinkImplFactory, UniversalKafkaSinkImplFactory}
+import pl.touk.nussknacker.engine.avro.encode.ValidationMode
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
+import pl.touk.nussknacker.engine.avro.sink.UniversalKafkaSinkImplFactory
 import pl.touk.nussknacker.engine.kafka.serialization.KafkaSerializationSchema
 import pl.touk.nussknacker.engine.kafka.{KafkaConfig, PreparedKafkaTopic}
 import pl.touk.nussknacker.engine.lite.api.utils.sinks.LazyParamSink
@@ -17,7 +17,7 @@ object LiteKafkaUniversalSinkImplFactory extends UniversalKafkaSinkImplFactory {
   override def createSink(preparedTopic: PreparedKafkaTopic, keyParam: LazyParameter[AnyRef], valueParam: LazyParameter[AnyRef],
                           kafkaConfig: KafkaConfig, serializationSchema: KafkaSerializationSchema[KeyedValue[AnyRef, AnyRef]], clientId: String,
                           schema: RuntimeSchemaData[ParsedSchema], validationMode: ValidationMode): Sink = {
-    lazy val encode = UniversalSchemaSupport.sinkValueEncoder(schema.schema, validationMode)
+    lazy val encode = schema.schema.sinkValueEncoderFactory(validationMode)
 
     new LazyParamSink[ProducerRecord[Array[Byte], Array[Byte]]] {
       override def prepareResponse(implicit evaluateLazyParameter: LazyParameterInterpreter): LazyParameter[ProducerRecord[Array[Byte], Array[Byte]]] = {

--- a/engine/lite/components/kafka/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalSinkImplFactory.scala
+++ b/engine/lite/components/kafka/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalSinkImplFactory.scala
@@ -17,7 +17,7 @@ object LiteKafkaUniversalSinkImplFactory extends UniversalKafkaSinkImplFactory {
   override def createSink(preparedTopic: PreparedKafkaTopic, keyParam: LazyParameter[AnyRef], valueParam: LazyParameter[AnyRef],
                           kafkaConfig: KafkaConfig, serializationSchema: KafkaSerializationSchema[KeyedValue[AnyRef, AnyRef]], clientId: String,
                           schema: RuntimeSchemaData[ParsedSchema], validationMode: ValidationMode): Sink = {
-    lazy val encode = UniversalSchemaSupport(schema.schema).sinkValueEncoder(schema.schema,validationMode)
+    lazy val encode = UniversalSchemaSupport.forSchemaType(schema.schema.schemaType()).sinkValueEncoder(schema.schema,validationMode)
 
     new LazyParamSink[ProducerRecord[Array[Byte], Array[Byte]]] {
       override def prepareResponse(implicit evaluateLazyParameter: LazyParameterInterpreter): LazyParameter[ProducerRecord[Array[Byte], Array[Byte]]] = {

--- a/engine/lite/components/kafka/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalSinkImplFactory.scala
+++ b/engine/lite/components/kafka/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalSinkImplFactory.scala
@@ -6,7 +6,7 @@ import pl.touk.nussknacker.engine.api.process.Sink
 import pl.touk.nussknacker.engine.api.{LazyParameter, LazyParameterInterpreter}
 import pl.touk.nussknacker.engine.avro.RuntimeSchemaData
 import pl.touk.nussknacker.engine.avro.encode.ValidationMode
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport
 import pl.touk.nussknacker.engine.avro.sink.UniversalKafkaSinkImplFactory
 import pl.touk.nussknacker.engine.kafka.serialization.KafkaSerializationSchema
 import pl.touk.nussknacker.engine.kafka.{KafkaConfig, PreparedKafkaTopic}
@@ -17,7 +17,7 @@ object LiteKafkaUniversalSinkImplFactory extends UniversalKafkaSinkImplFactory {
   override def createSink(preparedTopic: PreparedKafkaTopic, keyParam: LazyParameter[AnyRef], valueParam: LazyParameter[AnyRef],
                           kafkaConfig: KafkaConfig, serializationSchema: KafkaSerializationSchema[KeyedValue[AnyRef, AnyRef]], clientId: String,
                           schema: RuntimeSchemaData[ParsedSchema], validationMode: ValidationMode): Sink = {
-    lazy val encode = schema.schema.sinkValueEncoderFactory(validationMode)
+    lazy val encode = UniversalSchemaSupport(schema.schema).sinkValueEncoder(schema.schema,validationMode)
 
     new LazyParamSink[ProducerRecord[Array[Byte], Array[Byte]]] {
       override def prepareResponse(implicit evaluateLazyParameter: LazyParameterInterpreter): LazyParameter[ProducerRecord[Array[Byte], Array[Byte]]] = {

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/ParsedSchemaSupport.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/ParsedSchemaSupport.scala
@@ -1,0 +1,119 @@
+package pl.touk.nussknacker.engine.avro.schemaregistry.confluent
+
+import cats.data.ValidatedNel
+import io.circe.Json
+import io.confluent.kafka.schemaregistry.ParsedSchema
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import io.confluent.kafka.schemaregistry.json.JsonSchema
+import org.apache.avro.io.DecoderFactory
+import org.apache.kafka.common.errors.SerializationException
+import org.apache.kafka.common.serialization.Serializer
+import pl.touk.nussknacker.engine.api.NodeId
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
+import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
+import pl.touk.nussknacker.engine.avro.KafkaAvroBaseComponentTransformer.SinkValueParamName
+import pl.touk.nussknacker.engine.avro.encode.{AvroSchemaOutputValidator, BestEffortAvroEncoder, BestEffortJsonSchemaEncoder, JsonSchemaOutputValidator, ValidationMode}
+import pl.touk.nussknacker.engine.avro.schema.DefaultAvroSchemaEvolution
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.client.{AvroSchemaWithJsonPayload, ConfluentSchemaRegistryClient}
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.formatter.{ConfluentAvroMessageFormatter, ConfluentAvroMessageReader}
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.{ConfluentAvroPayloadDeserializer, ConfluentJsonPayloadDeserializer, ConfluentJsonSchemaPayloadDeserializer, ConfluentKafkaAvroSerializer, UniversalSchemaPayloadDeserializer}
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.jsonpayload.JsonPayloadKafkaSerializer
+import pl.touk.nussknacker.engine.avro.sink.AvroSinkValueParameter
+import pl.touk.nussknacker.engine.avro.typed.AvroSchemaTypeDefinitionExtractor
+import pl.touk.nussknacker.engine.json.{JsonSchemaTypeDefinitionExtractor, JsonSinkValueParameter}
+import pl.touk.nussknacker.engine.kafka.KafkaConfig
+import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.output.OutputValidatorError
+import pl.touk.nussknacker.engine.util.sinkvalue.SinkValueData.SinkValueParameter
+
+import java.nio.charset.StandardCharsets
+
+sealed trait ParsedSchemaSupport[+S <: ParsedSchema] extends UniversalSchemaSupport {
+  val schema: S
+}
+
+case class AvroSchemaSupport(schema: AvroSchema) extends ParsedSchemaSupport[AvroSchema] {
+  override val payloadDeserializer: UniversalSchemaPayloadDeserializer = ConfluentAvroPayloadDeserializer.default
+
+  override def serializerFactory[T]: (ConfluentSchemaRegistryClient, KafkaConfig, Boolean) => Serializer[T] =
+    (client, kafkaConfig, isKey) => ConfluentKafkaAvroSerializer(kafkaConfig, client, Some(schema), isKey = isKey).asInstanceOf[Serializer[T]]
+
+  override def messageFormatterFactory: SchemaRegistryClient => Any => Json =
+    (client: SchemaRegistryClient) => (obj: Any) => new ConfluentAvroMessageFormatter(client).asJson(obj)
+
+  override def messageReaderFactory: SchemaRegistryClient => (Json, String) => Array[Byte] =
+    client => (jsonObj, subject) => new ConfluentAvroMessageReader(client).readJson(jsonObj, schema.rawSchema(), subject)
+
+
+  override def typeDefinition: TypingResult = AvroSchemaTypeDefinitionExtractor.typeDefinition(schema.rawSchema())
+
+  override def extractSinkValueParameter(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SinkValueParameter] = AvroSinkValueParameter(schema.rawSchema())
+
+  override def sinkValueEncoderFactory: ValidationMode => Any => AnyRef = validationMode => (value: Any) => BestEffortAvroEncoder(validationMode).encodeOrError(value, schema.rawSchema())
+
+  override def rawOutputValidatorFactory(implicit nodeId: NodeId): (TypingResult, ValidationMode) => ValidatedNel[OutputValidatorError, Unit] =
+    (t, mode: ValidationMode) => new AvroSchemaOutputValidator(mode).validateTypingResultToSchema(t, schema.rawSchema())
+}
+
+
+
+case class JsonSchemaSupport(schema: JsonSchema) extends ParsedSchemaSupport[JsonSchema] {
+  override val payloadDeserializer: UniversalSchemaPayloadDeserializer = ConfluentJsonSchemaPayloadDeserializer
+
+  override def serializerFactory[T]: (ConfluentSchemaRegistryClient, KafkaConfig, Boolean) => Serializer[T] = (_, _, _) =>
+    (topic: String, data: T) => data match {
+      case j: Json => j.noSpaces.getBytes()
+      case _ => throw new SerializationException(s"Expecting json but got: $data")
+    }
+
+  override def messageFormatterFactory: SchemaRegistryClient => Any => Json =
+    _ => (obj: Any) => BestEffortJsonEncoder(failOnUnkown = false, classLoader = getClass.getClassLoader).encode(obj)
+
+  override def messageReaderFactory: SchemaRegistryClient => (Json, String) => Array[Byte] =
+    _ => (jsonObj, _) => jsonObj match {
+      // we handle strings this way because we want to keep result value compact and JString is formatted in quotes
+      case j if j.isString => j.asString.get.getBytes(StandardCharsets.UTF_8)
+      case other => other.noSpaces.getBytes(StandardCharsets.UTF_8)
+    }
+
+  override def typeDefinition: TypingResult = JsonSchemaTypeDefinitionExtractor.typeDefinition(schema.rawSchema())
+
+  override def extractSinkValueParameter(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SinkValueParameter] = JsonSinkValueParameter(schema.rawSchema(), defaultParamName = SinkValueParamName)
+
+  override def sinkValueEncoderFactory: ValidationMode => Any => AnyRef =
+    validationMode => (value: Any) => new BestEffortJsonSchemaEncoder(ValidationMode.lax) //todo: pass real validation mode, when BestEffortJsonSchemaEncoder supports it
+      .encodeOrError(value, schema.rawSchema())
+
+  override def rawOutputValidatorFactory(implicit nodeId: NodeId): (TypingResult, ValidationMode) => ValidatedNel[OutputValidatorError, Unit] =
+    (t, mode: ValidationMode) => new JsonSchemaOutputValidator(mode).validateTypingResultToSchema(t, schema.rawSchema())
+
+}
+
+
+
+case class AvroSchemaWithJsonPayloadSupport(schema: AvroSchemaWithJsonPayload) extends ParsedSchemaSupport[AvroSchemaWithJsonPayload] {
+  override val payloadDeserializer: UniversalSchemaPayloadDeserializer = ConfluentJsonPayloadDeserializer
+
+  override def serializerFactory[T]: (ConfluentSchemaRegistryClient, KafkaConfig, Boolean) => Serializer[T] =
+    (client, kafkaConfig, isKey) => new JsonPayloadKafkaSerializer(kafkaConfig, client, new DefaultAvroSchemaEvolution, Some(schema.avroSchema), isKey = isKey).asInstanceOf[Serializer[T]]
+
+  override def messageFormatterFactory: SchemaRegistryClient => Any => Json =
+    _ => (obj: Any) => BestEffortJsonEncoder(failOnUnkown = false, classLoader = getClass.getClassLoader).encode(obj)
+
+  override def messageReaderFactory: SchemaRegistryClient => (Json, String) => Array[Byte] =
+    _ => (jsonObj, _) => jsonObj match {
+      // we handle strings this way because we want to keep result value compact and JString is formatted in quotes
+      case j if j.isString => j.asString.get.getBytes(StandardCharsets.UTF_8)
+      case other => other.noSpaces.getBytes(StandardCharsets.UTF_8)
+    }
+
+  override def typeDefinition: TypingResult = AvroSchemaTypeDefinitionExtractor.typeDefinition(schema.rawSchema())
+
+  override def extractSinkValueParameter(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SinkValueParameter] = AvroSinkValueParameter(schema.rawSchema())
+
+  override def sinkValueEncoderFactory: ValidationMode => Any => AnyRef = validationMode => (value: Any) => BestEffortAvroEncoder(validationMode).encodeOrError(value, schema.rawSchema())
+
+  override def rawOutputValidatorFactory(implicit nodeId: NodeId): (TypingResult, ValidationMode) => ValidatedNel[OutputValidatorError, Unit] =
+    (t, mode: ValidationMode) => new AvroSchemaOutputValidator(mode).validateTypingResultToSchema(t, schema.rawSchema())
+}

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/UniversalSchemaSupport.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/UniversalSchemaSupport.scala
@@ -6,107 +6,47 @@ import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.json.JsonSchema
-import org.apache.avro.io.DecoderFactory
-import org.apache.kafka.common.errors.SerializationException
 import org.apache.kafka.common.serialization.Serializer
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
-import pl.touk.nussknacker.engine.avro.KafkaAvroBaseComponentTransformer.SinkValueParamName
-import pl.touk.nussknacker.engine.avro.RuntimeSchemaData
-import pl.touk.nussknacker.engine.avro.encode.{AvroSchemaOutputValidator, BestEffortAvroEncoder, BestEffortJsonSchemaEncoder, JsonSchemaOutputValidator, ValidationMode}
-import pl.touk.nussknacker.engine.avro.schema.DefaultAvroSchemaEvolution
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.client.{AvroSchemaWithJsonPayload, ConfluentSchemaRegistryClientFactory}
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.formatter.{ConfluentAvroMessageFormatter, ConfluentAvroMessageReader, UniversalMessageFormatter, UniversalMessageReader}
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.jsonpayload.JsonPayloadKafkaSerializer
+import pl.touk.nussknacker.engine.avro.encode._
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.client.{AvroSchemaWithJsonPayload, ConfluentSchemaRegistryClient}
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization._
-import pl.touk.nussknacker.engine.avro.sink.AvroSinkValueParameter
-import pl.touk.nussknacker.engine.avro.typed.AvroSchemaTypeDefinitionExtractor
-import pl.touk.nussknacker.engine.json.{JsonSchemaTypeDefinitionExtractor, JsonSinkValueParameter}
 import pl.touk.nussknacker.engine.kafka.KafkaConfig
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
 import pl.touk.nussknacker.engine.util.output.OutputValidatorError
 import pl.touk.nussknacker.engine.util.sinkvalue.SinkValueData.SinkValueParameter
 
-import java.nio.charset.StandardCharsets
-
 object UniversalSchemaSupport {
 
-  def createPayloadDeserializer(schema: ParsedSchema): UniversalSchemaPayloadDeserializer = schema match {
-    case _: AvroSchema => new ConfluentAvroPayloadDeserializer(false, false, false, DecoderFactory.get())
-    case _: AvroSchemaWithJsonPayload => ConfluentJsonPayloadDeserializer
-    case _: JsonSchema => ConfluentJsonSchemaPayloadDeserializer
-    case _ => throw new UnsupportedSchemaType(schema)
-  }
-
-  def createSerializer[T](schemaRegistryClientFactory: ConfluentSchemaRegistryClientFactory,
-                          kafkaConfig: KafkaConfig,
-                          schemaOpt: Option[RuntimeSchemaData[ParsedSchema]],
-                          isKey: Boolean): Serializer[T] = {
-    val schemaRegistryClient = schemaRegistryClientFactory.create(kafkaConfig)
-
-    val serializer = schemaOpt.map(_.schema) match {
-      case Some(schema: AvroSchema) => ConfluentKafkaAvroSerializer(kafkaConfig, schemaRegistryClient, Some(schema), isKey = isKey)
-      case Some(schema: AvroSchemaWithJsonPayload) => new JsonPayloadKafkaSerializer(kafkaConfig, schemaRegistryClient, new DefaultAvroSchemaEvolution, Some(schema.avroSchema), isKey = isKey)
-      case Some(_: JsonSchema) =>
-        new Serializer[T] {
-          override def serialize(topic: String, data: T): Array[Byte] = data match {
-            case j: Json => j.noSpaces.getBytes()
-            case _ => throw new SerializationException(s"Expecting json but got: $data")
-          }
-        }
-      case Some(schema) => throw new UnsupportedSchemaType(schema)
-      case None => throw new IllegalArgumentException("SchemaData should be defined for universal serializer")
+  implicit class RichParsedSchema(parsedSchema: ParsedSchema) extends UniversalSchemaSupport {
+    private lazy val support: ParsedSchemaSupport[ParsedSchema] = parsedSchema match {
+      case schema: AvroSchema => AvroSchemaSupport(schema)
+      case schema: AvroSchemaWithJsonPayload => AvroSchemaWithJsonPayloadSupport(schema)
+      case schema: JsonSchema => JsonSchemaSupport(schema)
+      case _ => throw new UnsupportedSchemaType(parsedSchema)
     }
-    serializer.asInstanceOf[Serializer[T]]
-  }
 
-  def createMessageFormatter(schemaRegistryClient: SchemaRegistryClient): UniversalMessageFormatter = (obj: Any, schema: ParsedSchema) => schema match {
-    case _: AvroSchema => new ConfluentAvroMessageFormatter(schemaRegistryClient).asJson(obj)
-    case _: JsonSchema | _: AvroSchemaWithJsonPayload => BestEffortJsonEncoder(failOnUnkown = false, classLoader = getClass.getClassLoader).encode(obj)
-    case _ => throw new UnsupportedSchemaType(schema)
+    override val payloadDeserializer: UniversalSchemaPayloadDeserializer = support.payloadDeserializer
+    override def serializerFactory[T]: (ConfluentSchemaRegistryClient, KafkaConfig, Boolean) => Serializer[T] = support.serializerFactory
+    override def messageFormatterFactory: SchemaRegistryClient => Any => Json = support.messageFormatterFactory
+    override def messageReaderFactory: SchemaRegistryClient => (Json, String) => Array[Byte] = support.messageReaderFactory
+    override def typeDefinition: TypingResult = support.typeDefinition
+    override def extractSinkValueParameter(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SinkValueParameter] = support.extractSinkValueParameter
+    override def sinkValueEncoderFactory: ValidationMode => Any => AnyRef = support.sinkValueEncoderFactory
+    override def rawOutputValidatorFactory(implicit nodeId: NodeId): (TypingResult, ValidationMode) => ValidatedNel[OutputValidatorError, Unit] = support.rawOutputValidatorFactory
   }
+}
 
-  def createMessageReader(schemaRegistryClient: SchemaRegistryClient): UniversalMessageReader = (jsonObj: Json, schema: ParsedSchema, subject: String) => schema match {
-    case schema: AvroSchema => new ConfluentAvroMessageReader(schemaRegistryClient).readJson(jsonObj, schema.rawSchema(), subject)
-    case _: JsonSchema | _: AvroSchemaWithJsonPayload => jsonObj match {
-      // we handle strings this way because we want to keep result value compact and JString is formatted in quotes
-      case j if j.isString => j.asString.get.getBytes(StandardCharsets.UTF_8)
-      case other => other.noSpaces.getBytes(StandardCharsets.UTF_8)
-    }
-    case _ => throw new UnsupportedSchemaType(schema)
-  }
-
-  def typeDefinition(schema: ParsedSchema): TypingResult = schema match {
-    case schema: AvroSchemaWithJsonPayload => AvroSchemaTypeDefinitionExtractor.typeDefinition(schema.rawSchema())
-    case schema: AvroSchema => AvroSchemaTypeDefinitionExtractor.typeDefinition(schema.rawSchema())
-    case schema: JsonSchema => JsonSchemaTypeDefinitionExtractor.typeDefinition(schema.rawSchema())
-    case _ => throw new UnsupportedSchemaType(schema)
-  }
-
-  def extractSinkValueParameter(schema: ParsedSchema)(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SinkValueParameter] = schema match {
-    case schema: AvroSchema => AvroSinkValueParameter(schema.rawSchema())
-    case schema: AvroSchemaWithJsonPayload => AvroSinkValueParameter(schema.rawSchema())
-    case schema: JsonSchema => JsonSinkValueParameter(schema.rawSchema(), defaultParamName = SinkValueParamName)
-    case _ => throw new UnsupportedSchemaType(schema)
-  }
-
-  def sinkValueEncoder(schema: ParsedSchema, validationMode: ValidationMode): Any => AnyRef = schema match {
-    case schema: AvroSchema => (value: Any) => BestEffortAvroEncoder(validationMode).encodeOrError(value, schema.rawSchema())
-    case schema: AvroSchemaWithJsonPayload => (value: Any) => BestEffortAvroEncoder(validationMode).encodeOrError(value, schema.rawSchema())
-    case schema: JsonSchema => (value: Any) =>
-      new BestEffortJsonSchemaEncoder(ValidationMode.lax) //todo: pass real validation mode, when BestEffortJsonSchemaEncoder supports it
-        .encodeOrError(value, schema.rawSchema())
-    case _ => throw new UnsupportedSchemaType(schema)
-  }
-
-  def rawOutputValidator(schema: ParsedSchema)(implicit nodeId: NodeId): (TypingResult, ValidationMode) => ValidatedNel[OutputValidatorError, Unit] = (t: TypingResult, validationMode: ValidationMode) =>
-    schema match {
-      case schema: AvroSchema => new AvroSchemaOutputValidator(validationMode).validateTypingResultToSchema(t, schema.rawSchema())
-      case AvroSchemaWithJsonPayload(avroSchema) => new AvroSchemaOutputValidator(validationMode).validateTypingResultToSchema(t, avroSchema.rawSchema())
-      case schema: JsonSchema => new JsonSchemaOutputValidator(validationMode).validateTypingResultToSchema(t, schema.rawSchema())
-      case _ => throw new UnsupportedSchemaType(schema)
-    }
+trait UniversalSchemaSupport {
+  val payloadDeserializer: UniversalSchemaPayloadDeserializer
+  def serializerFactory[T]: (ConfluentSchemaRegistryClient, KafkaConfig, Boolean) => Serializer[T]
+  def messageFormatterFactory: SchemaRegistryClient => Any => Json
+  def messageReaderFactory: SchemaRegistryClient => (Json, String) => Array[Byte]
+  def typeDefinition: TypingResult
+  def extractSinkValueParameter(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SinkValueParameter]
+  def sinkValueEncoderFactory: ValidationMode => Any => AnyRef
+  def rawOutputValidatorFactory(implicit nodeId: NodeId): (TypingResult, ValidationMode) => ValidatedNel[OutputValidatorError, Unit]
 }
 
 class UnsupportedSchemaType(parsedSchema: ParsedSchema) extends IllegalArgumentException(s"Unsupported schema type: ${parsedSchema.schemaType()}")

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/UniversalSchemaSupport.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/UniversalSchemaSupport.scala
@@ -18,11 +18,11 @@ import pl.touk.nussknacker.engine.util.output.OutputValidatorError
 import pl.touk.nussknacker.engine.util.sinkvalue.SinkValueData.SinkValueParameter
 
 object UniversalSchemaSupport {
-  def apply(parsedSchema: ParsedSchema): UniversalSchemaSupport = parsedSchema match {
-    case _: AvroSchema => AvroSchemaSupport
-    case _: AvroSchemaWithJsonPayload => AvroSchemaWithJsonPayloadSupport
-    case _: JsonSchema => JsonSchemaSupport
-    case _ => throw new UnsupportedSchemaType(parsedSchema)
+  def forSchemaType(schemaType: String): UniversalSchemaSupport = schemaType match {
+    case AvroSchema.TYPE => AvroSchemaSupport
+    case AvroSchemaWithJsonPayload.TYPE => AvroSchemaWithJsonPayloadSupport
+    case JsonSchema.TYPE => JsonSchemaSupport
+    case _ => throw new UnsupportedSchemaType(schemaType)
   }
 }
 
@@ -37,4 +37,4 @@ trait UniversalSchemaSupport {
   def validateRawOutput(schema: ParsedSchema, t: TypingResult, mode: ValidationMode)(implicit nodeId: NodeId): ValidatedNel[OutputValidatorError, Unit]
 }
 
-class UnsupportedSchemaType(parsedSchema: ParsedSchema) extends IllegalArgumentException(s"Unsupported schema type: ${parsedSchema.schemaType()}")
+class UnsupportedSchemaType(schemaType: String) extends IllegalArgumentException(s"Unsupported schema type: $schemaType")

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/client/AvroSchemaWithJsonPayload.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/client/AvroSchemaWithJsonPayload.scala
@@ -7,8 +7,12 @@ import org.apache.avro.Schema
 
 import java.util
 
+object AvroSchemaWithJsonPayload {
+  val TYPE = "AVRO_JSON_PAYLOAD"
+}
+
 case class AvroSchemaWithJsonPayload(avroSchema: AvroSchema) extends ParsedSchema {
-  override def schemaType(): String = "AVRO_JSON_PAYLOAD"
+  override def schemaType(): String = AvroSchemaWithJsonPayload.TYPE
 
   override def name(): String = avroSchema.name()
 

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/formatter/UniversalToJsonFormatterFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/formatter/UniversalToJsonFormatterFactory.scala
@@ -41,8 +41,8 @@ class UniversalToJsonFormatter[K: ClassTag, V: ClassTag](kafkaConfig: KafkaConfi
                                                          deserializationSchema: serialization.KafkaDeserializationSchema[ConsumerRecord[K, V]]
                                                         ) extends RecordFormatter {
 
-  private def formatter(schema: ParsedSchema) = UniversalSchemaSupport(schema).messageFormatter(schemaRegistryClient)
-  private def reader(schema: ParsedSchema) = UniversalSchemaSupport(schema).messageReader(schema, schemaRegistryClient)
+  private def formatter(schema: ParsedSchema) = UniversalSchemaSupport.forSchemaType(schema.schemaType()).messageFormatter(schemaRegistryClient)
+  private def reader(schema: ParsedSchema) = UniversalSchemaSupport.forSchemaType(schema.schemaType()).messageReader(schema, schemaRegistryClient)
 
   /**
    * Step 1: Deserialize raw kafka event to GenericRecord/SpecificRecord domain.

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/AbstractConfluentKafkaAvroDeserializer.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/AbstractConfluentKafkaAvroDeserializer.scala
@@ -51,6 +51,11 @@ abstract class AbstractConfluentKafkaAvroDeserializer extends AbstractKafkaAvroD
   }
 }
 
+object ConfluentAvroPayloadDeserializer {
+  val default = new ConfluentAvroPayloadDeserializer(false, false, false, DecoderFactory.get())
+}
+
+
 class ConfluentAvroPayloadDeserializer(
                                         useSchemaReflection: Boolean,
                                         useSpecificAvroReader: Boolean,

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaDeserializerFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaDeserializerFactory.scala
@@ -9,13 +9,12 @@ import pl.touk.nussknacker.engine.avro.RuntimeSchemaData
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.ConfluentUtils.readIdAndGetBuffer
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.client.{ConfluentSchemaRegistryClient, ConfluentSchemaRegistryClientFactory}
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.universal.ConfluentUniversalKafkaSerde._
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.{ConfluentUtils, UniversalSchemaSupport}
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.ConfluentUtils
 import pl.touk.nussknacker.engine.avro.serialization.KafkaSchemaBasedKeyValueDeserializationSchemaFactory
 import pl.touk.nussknacker.engine.kafka.KafkaConfig
-
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
 import java.nio.ByteBuffer
 import scala.reflect.ClassTag
-import scala.util.Try
 
 class MismatchReaderWriterSchemaException(expectedType: String, actualType: String) extends IllegalArgumentException(s"Expecting schema of type $expectedType. but got payload with $actualType schema type")
 
@@ -44,8 +43,8 @@ class ConfluentUniversalKafkaDeserializer[T](schemaRegistryClient: ConfluentSche
 
     val writerSchemaData = new RuntimeSchemaData(new NkSerializableParsedSchema[ParsedSchema](writerSchema), Some(writerSchemaId.value))
 
-    UniversalSchemaSupport
-      .createPayloadDeserializer(writerSchema)
+    writerSchema
+      .payloadDeserializer
       .deserialize(readerSchemaDataOpt, writerSchemaData, writerSchemaId.buffer, writerSchemaId.bufferStartPosition)
       .asInstanceOf[T]
   }

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaDeserializerFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaDeserializerFactory.scala
@@ -43,7 +43,7 @@ class ConfluentUniversalKafkaDeserializer[T](schemaRegistryClient: ConfluentSche
 
     val writerSchemaData = new RuntimeSchemaData(new NkSerializableParsedSchema[ParsedSchema](writerSchema), Some(writerSchemaId.value))
 
-    UniversalSchemaSupport(writerSchema)
+    UniversalSchemaSupport.forSchemaType(writerSchema.schemaType())
       .payloadDeserializer
       .deserialize(readerSchemaDataOpt, writerSchemaData, writerSchemaId.buffer, writerSchemaId.bufferStartPosition)
       .asInstanceOf[T]

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaDeserializerFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaDeserializerFactory.scala
@@ -9,10 +9,10 @@ import pl.touk.nussknacker.engine.avro.RuntimeSchemaData
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.ConfluentUtils.readIdAndGetBuffer
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.client.{ConfluentSchemaRegistryClient, ConfluentSchemaRegistryClientFactory}
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.universal.ConfluentUniversalKafkaSerde._
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.ConfluentUtils
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.{ConfluentUtils, UniversalSchemaSupport}
 import pl.touk.nussknacker.engine.avro.serialization.KafkaSchemaBasedKeyValueDeserializationSchemaFactory
 import pl.touk.nussknacker.engine.kafka.KafkaConfig
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
+
 import java.nio.ByteBuffer
 import scala.reflect.ClassTag
 
@@ -43,7 +43,7 @@ class ConfluentUniversalKafkaDeserializer[T](schemaRegistryClient: ConfluentSche
 
     val writerSchemaData = new RuntimeSchemaData(new NkSerializableParsedSchema[ParsedSchema](writerSchema), Some(writerSchemaId.value))
 
-    writerSchema
+    UniversalSchemaSupport(writerSchema)
       .payloadDeserializer
       .deserialize(readerSchemaDataOpt, writerSchemaData, writerSchemaId.buffer, writerSchemaId.bufferStartPosition)
       .asInstanceOf[T]

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaSerializationSchemaFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaSerializationSchemaFactory.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.u
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import org.apache.kafka.common.serialization.Serializer
 import pl.touk.nussknacker.engine.avro.RuntimeSchemaData
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.client.ConfluentSchemaRegistryClientFactory
 import pl.touk.nussknacker.engine.avro.serialization.KafkaSchemaBasedValueSerializationSchemaFactory
 import pl.touk.nussknacker.engine.kafka.KafkaConfig
@@ -12,10 +12,9 @@ class ConfluentUniversalKafkaSerializationSchemaFactory(schemaRegistryClientFact
   extends KafkaSchemaBasedValueSerializationSchemaFactory {
 
   override protected def createValueSerializer(schemaOpt: Option[RuntimeSchemaData[ParsedSchema]], kafkaConfig: KafkaConfig): Serializer[Any] = {
-    val schema: ParsedSchema =  schemaOpt.map(_.schema).getOrElse(throw new IllegalArgumentException("SchemaData should be defined for universal serializer"))
-    val createSerializer = schema.serializerFactory[Any]
+    val schema: ParsedSchema = schemaOpt.map(_.schema).getOrElse(throw new IllegalArgumentException("SchemaData should be defined for universal serializer"))
     val client = schemaRegistryClientFactory.create(kafkaConfig)
-
-    createSerializer(client, kafkaConfig, false)
+    UniversalSchemaSupport(schema)
+      .serializer[Any](schema, client, kafkaConfig, isKey = false)
   }
 }

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaSerializationSchemaFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaSerializationSchemaFactory.scala
@@ -3,15 +3,19 @@ package pl.touk.nussknacker.engine.avro.schemaregistry.confluent.serialization.u
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import org.apache.kafka.common.serialization.Serializer
 import pl.touk.nussknacker.engine.avro.RuntimeSchemaData
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
 import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.client.ConfluentSchemaRegistryClientFactory
 import pl.touk.nussknacker.engine.avro.serialization.KafkaSchemaBasedValueSerializationSchemaFactory
 import pl.touk.nussknacker.engine.kafka.KafkaConfig
 
-
 class ConfluentUniversalKafkaSerializationSchemaFactory(schemaRegistryClientFactory: ConfluentSchemaRegistryClientFactory)
   extends KafkaSchemaBasedValueSerializationSchemaFactory {
 
-  override protected def createValueSerializer(schemaOpt: Option[RuntimeSchemaData[ParsedSchema]], kafkaConfig: KafkaConfig): Serializer[Any] =
-    UniversalSchemaSupport.createSerializer(schemaRegistryClientFactory, kafkaConfig, schemaOpt, isKey = false)
+  override protected def createValueSerializer(schemaOpt: Option[RuntimeSchemaData[ParsedSchema]], kafkaConfig: KafkaConfig): Serializer[Any] = {
+    val schema: ParsedSchema =  schemaOpt.map(_.schema).getOrElse(throw new IllegalArgumentException("SchemaData should be defined for universal serializer"))
+    val createSerializer = schema.serializerFactory[Any]
+    val client = schemaRegistryClientFactory.create(kafkaConfig)
+
+    createSerializer(client, kafkaConfig, false)
+  }
 }

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaSerializationSchemaFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaSerializationSchemaFactory.scala
@@ -14,7 +14,7 @@ class ConfluentUniversalKafkaSerializationSchemaFactory(schemaRegistryClientFact
   override protected def createValueSerializer(schemaOpt: Option[RuntimeSchemaData[ParsedSchema]], kafkaConfig: KafkaConfig): Serializer[Any] = {
     val schema: ParsedSchema = schemaOpt.map(_.schema).getOrElse(throw new IllegalArgumentException("SchemaData should be defined for universal serializer"))
     val client = schemaRegistryClientFactory.create(kafkaConfig)
-    UniversalSchemaSupport(schema)
+    UniversalSchemaSupport.forSchemaType(schema.schemaType())
       .serializer[Any](schema, client, kafkaConfig, isKey = false)
   }
 }

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/sink/UniversalKafkaSinkFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/sink/UniversalKafkaSinkFactory.scala
@@ -65,7 +65,7 @@ class UniversalKafkaSinkFactory(val schemaRegistryClientFactory: SchemaRegistryC
       val validationResult = determinedSchema.map(_.schema)
         .andThen(schemaBasedMessagesSerdeProvider.validateSchema(_).leftMap(_.map(e => CustomNodeError(nodeId.id, e.getMessage, None))))
         .andThen { schema =>
-          UniversalSchemaSupport(schema)
+          UniversalSchemaSupport.forSchemaType(schema.schemaType())
             .validateRawOutput(schema, value.returnType, extractValidationMode(mode))
             .leftMap(outputValidatorErrorsConverter.convertValidationErrors)
             .leftMap(NonEmptyList.one)
@@ -92,7 +92,7 @@ class UniversalKafkaSinkFactory(val schemaRegistryClientFactory: SchemaRegistryC
           .leftMap(_.map(e => CustomNodeError(nodeId.id, e.getMessage, None)))
       }
       validatedSchema.andThen { schemaData =>
-        UniversalSchemaSupport(schemaData.schema)
+        UniversalSchemaSupport.forSchemaType(schemaData.schema.schemaType())
           .extractSinkValueParameter(schemaData.schema)
           .map { valueParam =>
           val state = TransformationState(schemaData, valueParam)

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/source/UniversalKafkaSourceFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/source/UniversalKafkaSourceFactory.scala
@@ -12,14 +12,13 @@ import pl.touk.nussknacker.engine.api.process.{ContextInitializer, ProcessObject
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.api.{MetaData, NodeId}
 import pl.touk.nussknacker.engine.avro.KafkaAvroBaseComponentTransformer.SchemaVersionParamName
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
 import pl.touk.nussknacker.engine.avro.schemaregistry._
 import pl.touk.nussknacker.engine.avro.source.UniversalKafkaSourceFactory.UniversalKafkaSourceFactoryState
 import pl.touk.nussknacker.engine.avro.{KafkaUniversalComponentTransformer, RuntimeSchemaData}
 import pl.touk.nussknacker.engine.kafka.PreparedKafkaTopic
 import pl.touk.nussknacker.engine.kafka.source.KafkaContextInitializer
 import pl.touk.nussknacker.engine.kafka.source.KafkaSourceFactory.KafkaSourceImplFactory
-
 import scala.reflect.ClassTag
 
 /**
@@ -60,7 +59,7 @@ class UniversalKafkaSourceFactory[K: ClassTag, V: ClassTag](val schemaRegistryCl
   protected def determineSchemaAndType(schemaDeterminer: ParsedSchemaDeterminer, paramName: Option[String])(implicit nodeId: NodeId):
   Validated[ProcessCompilationError, (Option[RuntimeSchemaData[ParsedSchema]], TypingResult)] = {
     schemaDeterminer.determineSchemaUsedInTyping.map { schemaData =>
-      (Some(schemaData), UniversalSchemaSupport.typeDefinition(schemaData.schema))
+      (Some(schemaData), schemaData.schema.typeDefinition)
     }.leftMap(error => CustomNodeError(error.getMessage, paramName))
   }
 

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/source/UniversalKafkaSourceFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/source/UniversalKafkaSourceFactory.scala
@@ -12,13 +12,14 @@ import pl.touk.nussknacker.engine.api.process.{ContextInitializer, ProcessObject
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.api.{MetaData, NodeId}
 import pl.touk.nussknacker.engine.avro.KafkaAvroBaseComponentTransformer.SchemaVersionParamName
-import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport._
 import pl.touk.nussknacker.engine.avro.schemaregistry._
+import pl.touk.nussknacker.engine.avro.schemaregistry.confluent.UniversalSchemaSupport
 import pl.touk.nussknacker.engine.avro.source.UniversalKafkaSourceFactory.UniversalKafkaSourceFactoryState
 import pl.touk.nussknacker.engine.avro.{KafkaUniversalComponentTransformer, RuntimeSchemaData}
 import pl.touk.nussknacker.engine.kafka.PreparedKafkaTopic
 import pl.touk.nussknacker.engine.kafka.source.KafkaContextInitializer
 import pl.touk.nussknacker.engine.kafka.source.KafkaSourceFactory.KafkaSourceImplFactory
+
 import scala.reflect.ClassTag
 
 /**
@@ -59,7 +60,8 @@ class UniversalKafkaSourceFactory[K: ClassTag, V: ClassTag](val schemaRegistryCl
   protected def determineSchemaAndType(schemaDeterminer: ParsedSchemaDeterminer, paramName: Option[String])(implicit nodeId: NodeId):
   Validated[ProcessCompilationError, (Option[RuntimeSchemaData[ParsedSchema]], TypingResult)] = {
     schemaDeterminer.determineSchemaUsedInTyping.map { schemaData =>
-      (Some(schemaData), schemaData.schema.typeDefinition)
+      val schema = schemaData.schema
+      (Some(schemaData), UniversalSchemaSupport(schema).typeDefinition(schema))
     }.leftMap(error => CustomNodeError(error.getMessage, paramName))
   }
 

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/source/UniversalKafkaSourceFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/source/UniversalKafkaSourceFactory.scala
@@ -61,7 +61,7 @@ class UniversalKafkaSourceFactory[K: ClassTag, V: ClassTag](val schemaRegistryCl
   Validated[ProcessCompilationError, (Option[RuntimeSchemaData[ParsedSchema]], TypingResult)] = {
     schemaDeterminer.determineSchemaUsedInTyping.map { schemaData =>
       val schema = schemaData.schema
-      (Some(schemaData), UniversalSchemaSupport(schema).typeDefinition(schema))
+      (Some(schemaData), UniversalSchemaSupport.forSchemaType(schema.schemaType()).typeDefinition(schema))
     }.leftMap(error => CustomNodeError(error.getMessage, paramName))
   }
 


### PR DESCRIPTION
* `UnsupportedSchemaType` is thrown once in one place
* When introducing new schema type, implementation of all "support methods" is now forced by interface