### PR TITLE
UniversalKakfaSource optimization - if message without schemaId, using cache when getting one

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -40,6 +40,7 @@
   Universal kafka source/sink, handling multiple scenarios like: avro message for avro schema, json message for json schema 
   * [#3317](https://github.com/TouK/nussknacker/pull/3317) Support json schema in universal source
   * [#3332](https://github.com/TouK/nussknacker/pull/3332) Config option to handle json payload with avro schema
+  * [#3354](https://github.com/TouK/nussknacker/pull/3354) Universal source optimization - if message without schemaId, using cache when getting one
 * [#3249](https://github.com/TouK/nussknacker/pull/3249) Confluent 5.5->7.2, avro 1.9->1.11 bump
 * [#3250](https://github.com/TouK/nussknacker/pull/3250) [#3302](https://github.com/TouK/nussknacker/pull/3302) Kafka 2.4 -> 2.8, Flink 1.14.4 -> 1.14.5
 * [#3270](https://github.com/TouK/nussknacker/pull/3270) Added type representing null

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/SchemaRegistryClient.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/SchemaRegistryClient.scala
@@ -17,6 +17,8 @@ trait SchemaRegistryClient extends Serializable {
     */
   protected def getLatestFreshSchema(topic: String, isKey: Boolean): Validated[SchemaRegistryError, SchemaWithMetadata]
 
+  def getLatestSchemaId(topic: String, isKey: Boolean): Validated[SchemaRegistryError, Int]
+
   def getFreshSchema(topic: String, version: Option[Int], isKey: Boolean): Validated[SchemaRegistryError, SchemaWithMetadata] =
     version
       .map(ver => getBySubjectAndVersion(topic, ver, isKey))

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/client/CachedConfluentSchemaRegistryClientFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/client/CachedConfluentSchemaRegistryClientFactory.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.avro.schemaregistry.confluent.client
 
 import com.typesafe.scalalogging.LazyLogging
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
-import pl.touk.nussknacker.engine.avro.schemaregistry.{SchemaWithMetadata}
+import pl.touk.nussknacker.engine.avro.schemaregistry.SchemaWithMetadata
 import pl.touk.nussknacker.engine.kafka.{SchemaRegistryCacheConfig, SchemaRegistryClientKafkaConfig}
 import pl.touk.nussknacker.engine.util.cache.{CacheConfig, DefaultCache, SingleValueCache}
 
@@ -34,6 +34,7 @@ class SchemaRegistryCaches(cacheConfig: SchemaRegistryCacheConfig) extends LazyL
 
   import cacheConfig._
 
+  val latestSchemaIdCache = new DefaultCache[String, Int](CacheConfig(maximumSize, parsedSchemaAccessExpirationTime, Option.empty))
   val schemaCache = new DefaultCache[String, SchemaWithMetadata](CacheConfig(maximumSize, parsedSchemaAccessExpirationTime, Option.empty))
   val versionsCache = new DefaultCache[String, List[Integer]](CacheConfig(maximumSize, Option.empty, availableSchemasExpirationTime))
   val topicsCache = new SingleValueCache[List[String]](Option.empty, availableSchemasExpirationTime)

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/client/ConfluentSchemaRegistryClient.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/client/ConfluentSchemaRegistryClient.scala
@@ -66,6 +66,7 @@ class DefaultConfluentSchemaRegistryClient(override val client: CSchemaRegistryC
     SchemaWithMetadata(new SchemaMetadata(id, unknownVersion, rawSchema.schemaType(), rawSchema.references(), rawSchema.canonicalString()), config)
   }
 
+  override def getLatestSchemaId(topic: String, isKey: Boolean): Validated[SchemaRegistryError, Int] = getLatestFreshSchema(topic, isKey).map(_.id)
 }
 
 object ConfluentSchemaRegistryClient {

--- a/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaDeserializerFactory.scala
+++ b/utils/avro-components-utils/src/main/scala/pl/touk/nussknacker/engine/avro/schemaregistry/confluent/serialization/universal/ConfluentUniversalKafkaDeserializerFactory.scala
@@ -62,7 +62,7 @@ class ConfluentUniversalKafkaDeserializer[T](schemaRegistryClient: ConfluentSche
       case None =>
         val idAndBuffer = ConfluentUtils.readIdAndGetBuffer(data).toOption
           .getOrElse(schemaRegistryClient
-            .getFreshSchema(topic, None, isKey = isKey).map(_.id).map((_, ByteBuffer.wrap(data)))
+            .getLatestSchemaId(topic, isKey = isKey).map((_, ByteBuffer.wrap(data)))
             .valueOr(e => throw new RuntimeException("Missing schemaId in kafka header and in payload. Trying to fetch latest schema for this topic but it failed", e)))
         SchemaIdWithPositionedBuffer(idAndBuffer._1, buffer = idAndBuffer._2)
     }


### PR DESCRIPTION
* SchemaRegistryClient - introduced `getLatestSchemaId` operation
* ConfluentUniversalKafkaDeserializer fix - latest schemaId taken from cache
