### PR TITLE
Change to eclipse-temurin base image due to openjdk deprecation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -307,7 +307,7 @@ val jmxPrometheusJavaagentV = "0.16.1"
 
 lazy val commonDockerSettings = {
   Seq(
-    dockerBaseImage := "openjdk:11-jre-slim",
+    dockerBaseImage := "eclipse-temurin:11-jre-jammy",
     dockerUsername := dockerUserName,
     dockerUpdateLatest := dockerUpLatestFromProp.getOrElse(!isSnapshot.value),
     dockerBuildCommand := {
@@ -342,8 +342,7 @@ lazy val distDockerSettings = {
   val nussknackerDir = "/opt/nussknacker"
 
   commonDockerSettings ++ Seq(
-    //we use openjdk:11-jre for designer because *-slim based images lack /usr/local/openjdk-11/lib/libfontmanager.so file necessary during pdf export
-    dockerBaseImage := "openjdk:11-jre",
+    dockerBaseImage := "eclipse-temurin:11-jre-jammy",
     dockerEntrypoint := Seq(s"$nussknackerDir/bin/nussknacker-entrypoint.sh"),
     dockerExposedPorts := Seq(dockerPort),
     dockerEnvVars := Map(

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+1.7.0 (Not released yet)
+------------------------
+* [#3524](https://github.com/TouK/nussknacker/pull/3524) Change base docker image to eclipse temurin due to openjdk deprecation.
+
 1.6.0 (Not released yet)
 ------------------------
 * [#3382](https://github.com/TouK/nussknacker/pull/3382) Security fix: Http cookie created by NU when using OAuth2 is now secure.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
