### PR TITLE
UI: Order test cases by context id

### DIFF
--- a/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/ui/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -81,11 +81,10 @@ object ManagementResources {
 
     override def apply(a: TestResults[Json]): Json = a match {
       case TestResults(nodeResults, invocationResults, mockedResults, exceptions, _) => Json.obj(
-        "nodeResults" -> nodeResults.asJson,
-        "invocationResults" -> invocationResults.asJson,
-        
-        "mockedResults" -> mockedResults.asJson,
-        "exceptions" -> exceptions.asJson
+        "nodeResults" -> nodeResults.map { case (node, list) => node -> list.sortBy(_.context.id) }.asJson,
+        "invocationResults" -> invocationResults.map { case (node, list) => node -> list.sortBy(_.contextId) }.asJson,
+        "mockedResults" -> mockedResults.map { case (node, list) => node -> list.sortBy(_.contextId) }.asJson,
+        "exceptions" -> exceptions.sortBy(_.context.id).asJson
       )
     }
   }


### PR DESCRIPTION
The list of test cases is in random order (as returned from backend) and might differ from one node to another. The goal of this change is to have a consistent ordering of test cases (ordered by context id).