### PR TITLE
Allow to return scenario without validation

### DIFF
--- a/designer/client/containers/hooks/useClashedNames.tsx
+++ b/designer/client/containers/hooks/useClashedNames.tsx
@@ -6,7 +6,8 @@ export function useClashedNames(shouldDownload: boolean): string[] {
   useEffect(
     () => {
       if (shouldDownload) {
-        HttpService.fetchProcessesNames().then(names => {
+        HttpService.fetchProcesses().then(processes => {
+          const names = processes.data.map(process => process.name)
           setClashedNames(prevState => [].concat(prevState, names))
         })
       }

--- a/designer/client/http/HttpService.ts
+++ b/designer/client/http/HttpService.ts
@@ -215,7 +215,7 @@ class HttpService {
     return api.get<ComponentUsageType[]>(`/components/${encodeURIComponent(componentId)}/usages`)
   }
 
-  fetchProcesses(data: FetchProcessQueryParams = {}) {
+  fetchProcesses(data: FetchProcessQueryParams = {}): Promise<AxiosResponse<ProcessType[]>> {
     return api.get<ProcessType[]>("/processes", {params: data})
   }
 
@@ -521,16 +521,6 @@ class HttpService {
 
   fetchAuthenticationSettings(authenticationProvider: string) {
     return api.get<AuthenticationSettings>(`/authentication/${authenticationProvider.toLowerCase()}/settings`)
-  }
-
-  async fetchProcessesNames() {
-    const responses = await Promise.all([
-      this.fetchProcesses(),
-      this.fetchProcesses({isArchived: true}),
-    ])
-    return responses
-      .reduce((result, {data}) => result.concat(data), [])
-      .map(process => process.name)
   }
 
   #addInfo(message: string) {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppResources.scala
@@ -17,6 +17,7 @@ import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, Validat
 import pl.touk.nussknacker.restmodel.processdetails.BaseProcessDetails
 import pl.touk.nussknacker.ui.process.processingtypedata.{ProcessingTypeDataProvider, ProcessingTypeDataReload}
 import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.process.{ProcessObjectsFinder, ProcessService}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.ui.validation.ProcessValidation
@@ -122,7 +123,7 @@ class AppResources(config: Config,
 
   private def notRunningProcessesThatShouldRun(implicit ec: ExecutionContext, user: LoggedUser): Future[Map[String, ProcessState]] = {
     for {
-      processes <- processRepository.fetchDeployedProcessesDetails[Unit]()
+      processes <- processRepository.fetchProcessesDetails[Unit](FetchProcessesDetailsQuery.deployed)
       statusMap <- Future.sequence(statusList(processes)).map(_.toMap)
     } yield {
       statusMap.filterNot{
@@ -134,7 +135,7 @@ class AppResources(config: Config,
   }
 
   private def processesWithValidationErrors(implicit ec: ExecutionContext, user: LoggedUser): Future[List[String]] = {
-    processRepository.fetchProcessesDetails[DisplayableProcess]().map { processes =>
+    processRepository.fetchProcessesDetails[DisplayableProcess](FetchProcessesDetailsQuery.unarchivedProcesses).map { processes =>
       val processesWithErrors = processes
         .map(process => new ValidatedDisplayableProcess(process.json, processValidation.validate(process.json, process.processCategory)))
         .filter(process => !process.validationResult.errors.isEmpty)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -362,4 +362,8 @@ object ProcessesResources {
       names = names.map(_.map(ProcessName(_))),
     )
   }
+
+  object ProcessesQuery {
+    def empty: ProcessesQuery = ProcessesQuery(None, None, None, None, None, None)
+  }
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -108,7 +108,8 @@ class ProcessesResources(
           // To be removed in NU 1.8.
           get {
             complete {
-              val subProcesses = processRepository.fetchSubProcessesDetails[CanonicalProcess]()
+              val query = FetchProcessesDetailsQuery(isSubprocess = Some(true), isArchived = Some(false))
+              val subProcesses = processRepository.fetchProcessesDetails[CanonicalProcess](query)
               validateAndReverseResolveAll(subProcesses)
             }
           }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -177,7 +177,7 @@ class ProcessesResources(
             canWrite(processId) {
               complete {
                 processService
-                  .renameProcess(processId, newName)
+                  .renameProcess(processId, ProcessName(newName))
                   .withSideEffect(response => sideEffectAction(response) { resp =>
                     OnRenamed(processId.id, resp.oldName, resp.newName)
                   })

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -116,12 +116,6 @@ class ProcessesResources(
               }
             }
           }
-        } ~ path("subProcesses") {
-          get {
-            complete {
-              processRepository.fetchSubProcessesDetails[Unit]().toBasicProcess
-            }
-          }
         } ~ path("subProcessesDetails") {
           // To be removed in NU 1.8.
           get {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -355,7 +355,7 @@ object ProcessesResources {
                            ) {
     def toRepositoryQuery: FetchProcessesDetailsQuery = FetchProcessesDetailsQuery(
       isSubprocess = isSubprocess,
-      isArchived = isArchived.orElse(Option(false)), //Back compatibility,
+      isArchived = isArchived,
       isDeployed = isDeployed,
       categories = categories,
       processingTypes = processingTypes,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/QueryableStateResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/QueryableStateResources.scala
@@ -12,6 +12,7 @@ import pl.touk.nussknacker.ui.process.{ProcessObjectsFinder, ProcessService}
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
 import pl.touk.nussknacker.restmodel.process.ProcessIdWithName
 import pl.touk.nussknacker.ui.process.processingtypedata.ProcessingTypeDataProvider
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -51,7 +52,7 @@ class QueryableStateResources(typeToConfig: ProcessingTypeDataProvider[Processin
   }
 
   private def prepareQueryableStates()(implicit user: LoggedUser): Future[Map[String, List[QueryableStateName]]] = {
-    processRepository.fetchAllProcessesDetails[DisplayableProcess]().map { processList =>
+    processRepository.fetchProcessesDetails[DisplayableProcess](FetchProcessesDetailsQuery.unarchived).map { processList =>
       ProcessObjectsFinder.findQueries(processList, typeToConfig.all.values.map(_.modelData.processDefinition))
     }
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResources.scala
@@ -20,6 +20,7 @@ import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.engine.api.process.{ProcessId, VersionId}
 import pl.touk.nussknacker.ui.EspError.XError
 import pl.touk.nussknacker.restmodel.processdetails.ProcessDetails
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 class RemoteEnvironmentResources(remoteEnvironment: RemoteEnvironment,
@@ -39,9 +40,8 @@ class RemoteEnvironmentResources(remoteEnvironment: RemoteEnvironment,
             get {
               complete {
                 for {
-                  processes <- processRepository.fetchProcessesDetails[DisplayableProcess]()
-                  subprocesses <- processRepository.fetchSubProcessesDetails[DisplayableProcess]()
-                  comparison <- compareProcesses(processes ++ subprocesses)
+                  processes <- processRepository.fetchProcessesDetails[DisplayableProcess](FetchProcessesDetailsQuery.unarchived)
+                  comparison <- compareProcesses(processes)
                 } yield EspErrorToHttp.toResponseEither(comparison)
               }
             }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/SignalsResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/SignalsResources.scala
@@ -11,6 +11,7 @@ import pl.touk.nussknacker.ui.process.ProcessObjectsFinder
 import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
 import pl.touk.nussknacker.ui.process.processingtypedata.ProcessingTypeDataProvider
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -52,7 +53,7 @@ class SignalsResources(modelData: ProcessingTypeDataProvider[ModelData],
 
   private def prepareSignalDefinitions(implicit user: LoggedUser): Future[Map[String, SignalDefinition]] = {
     //TODO: only processes that are deployed right now??
-    processRepository.fetchAllProcessesDetails[DisplayableProcess]().map { processList =>
+    processRepository.fetchProcessesDetails[DisplayableProcess](FetchProcessesDetailsQuery.unarchivedProcesses).map { processList =>
       ProcessObjectsFinder.findSignals(processList, modelData.all.values.map(_.processDefinition))
     }
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/db/entity/BaseEntityFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/db/entity/BaseEntityFactory.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.ui.db.entity
 
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionType
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
-import pl.touk.nussknacker.engine.api.process.{ProcessId, VersionId}
+import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId}
 import slick.ast.BaseTypedType
 import slick.jdbc.{JdbcProfile, JdbcType}
 
@@ -10,8 +10,11 @@ trait BaseEntityFactory {
   protected val profile: JdbcProfile
   import profile.api._
 
-  implicit def procesIdMapping: BaseColumnType[ProcessId] =
+  implicit def processIdMapping: BaseColumnType[ProcessId] =
     MappedColumnType.base[ProcessId, Long](_.value, ProcessId.apply)
+
+  implicit def processNameMapping: BaseColumnType[ProcessName] =
+    MappedColumnType.base[ProcessName, String](_.value, ProcessName.apply)
 
   implicit def versionIdMapping: BaseColumnType[VersionId] =
     MappedColumnType.base[VersionId, Long](_.value, VersionId(_))

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/db/entity/ProcessEntityFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/db/entity/ProcessEntityFactory.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.ui.db.entity
 
-import pl.touk.nussknacker.engine.api.process.ProcessId
+import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName}
 import pl.touk.nussknacker.restmodel.process.ProcessingType
 import slick.lifted.{ProvenShape, TableQuery => LTableQuery}
 import slick.sql.SqlProfile.ColumnOption.NotNull
@@ -17,8 +17,7 @@ trait ProcessEntityFactory extends BaseEntityFactory {
     
     def id: Rep[ProcessId] = column[ProcessId]("id", O.PrimaryKey, O.AutoInc)
 
-    // TODO: ProcessName?
-    def name: Rep[String] = column[String]("name", NotNull)
+    def name: Rep[ProcessName] = column[ProcessName]("name", NotNull)
 
     def description: Rep[Option[String]] = column[Option[String]]("description", O.Length(1000))
 
@@ -41,7 +40,7 @@ trait ProcessEntityFactory extends BaseEntityFactory {
 }
 
 case class ProcessEntityData(id: ProcessId,
-                             name: String,
+                             name: ProcessName,
                              description: Option[String],
                              processCategory: String,
                              processingType: ProcessingType,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/db/entity/ProcessEntityFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/db/entity/ProcessEntityFactory.scala
@@ -17,6 +17,7 @@ trait ProcessEntityFactory extends BaseEntityFactory {
     
     def id: Rep[ProcessId] = column[ProcessId]("id", O.PrimaryKey, O.AutoInc)
 
+    // TODO: ProcessName?
     def name: Rep[String] = column[String]("name", NotNull)
 
     def description: Rep[Option[String]] = column[Option[String]]("description", O.Length(1000))

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/initialization/Initialization.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/initialization/Initialization.scala
@@ -12,6 +12,7 @@ import pl.touk.nussknacker.restmodel.processdetails.ProcessDetails
 import pl.touk.nussknacker.ui.db.entity.EnvironmentsEntityData
 import pl.touk.nussknacker.ui.process.migrate.ProcessModelMigrator
 import pl.touk.nussknacker.ui.process.processingtypedata.ProcessingTypeDataProvider
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.process.repository._
 import pl.touk.nussknacker.ui.security.api.{LoggedUser, NussknackerInternalUser}
 import slick.dbio.DBIOAction
@@ -84,9 +85,7 @@ class AutomaticMigration(migrations: ProcessingTypeDataProvider[ProcessMigration
 
   def runOperation(implicit ec: ExecutionContext, lu: LoggedUser): DB[Unit] = {
     val results : DB[List[Unit]] = for {
-      processes <- fetchingProcessRepository.fetchProcessesDetails[DisplayableProcess]()
-      subprocesses <- fetchingProcessRepository.fetchSubProcessesDetails[DisplayableProcess]()
-      allToMigrate = processes ++ subprocesses
+      allToMigrate <- fetchingProcessRepository.fetchProcessesDetails[DisplayableProcess](FetchProcessesDetailsQuery.unarchived)
       migrated <- allToMigrate.map(migrateOne).sequence[DB, Unit]
     } yield migrated
     results.map(_ => ())

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/metrics/RepositoryGauges.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/metrics/RepositoryGauges.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.ui.metrics
 
 import io.dropwizard.metrics5.{CachedGauge, Gauge, MetricName, MetricRegistry}
 import pl.touk.nussknacker.ui.process.repository.DBFetchingProcessRepository
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.security.api.{LoggedUser, NussknackerInternalUser}
 
 import java.util.concurrent.TimeUnit
@@ -27,13 +28,7 @@ class RepositoryGauges(metricRegistry: MetricRegistry,
   private class GlobalGauge extends CachedGauge[Values](cacheLengthSeconds, TimeUnit.SECONDS) {
     override def loadValue(): Values = {
       implicit val user: LoggedUser = NussknackerInternalUser
-      val result = processRepository.fetchProcesses[Unit](
-        isSubprocess = None,
-        isArchived = Some(false),
-        isDeployed = None,
-        categories = None,
-        processingTypes = None
-      ).map { scenarios =>
+      val result = processRepository.fetchProcessesDetails[Unit](FetchProcessesDetailsQuery(isArchived = Some(false))).map { scenarios =>
         val all = scenarios.size
         val deployed = scenarios.count(_.isDeployed)
         val fragments = scenarios.count(_.isSubprocess)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
@@ -24,6 +24,7 @@ import pl.touk.nussknacker.ui.process.ProcessService.{CreateProcessCommand, Empt
 import pl.touk.nussknacker.ui.process.deployment.{Cancel, CheckStatus, Deploy}
 import pl.touk.nussknacker.ui.process.exception.{DeployingInvalidScenarioError, ProcessIllegalAction, ProcessValidationError}
 import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.process.repository.ProcessDBQueryRepository.ProcessNotFoundError
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.{CreateProcessAction, ProcessCreated, UpdateProcessAction}
 import pl.touk.nussknacker.ui.process.repository.{FetchingProcessRepository, ProcessActionRepository, ProcessRepository, RepositoryManager, UpdateProcessComment}
@@ -272,7 +273,7 @@ class DBProcessService(managerActor: ActorRef,
   //TODO: It's temporary solution to return Set[SubprocessDetails], in future we should replace it by Set[BaseProcessDetails[PS]]
   override def getSubProcesses(processingTypes: Option[List[ProcessingType]])(implicit user: LoggedUser): Future[Set[SubprocessDetails]] = {
     fetchingProcessRepository
-      .fetchProcesses[CanonicalProcess](isSubprocess = Some(true), isArchived = Some(false), None, None, processingTypes = processingTypes)
+      .fetchProcessesDetails[CanonicalProcess](FetchProcessesDetailsQuery(isSubprocess = Some(true), isArchived = Some(false), processingTypes = processingTypes))
       .map(processes => processes.map(sub => {
         SubprocessDetails(sub.json, sub.processCategory)
       }).toSet)
@@ -371,7 +372,7 @@ class DBProcessService(managerActor: ActorRef,
   private def getProcesses[PS: ProcessShapeFetchStrategy](user: LoggedUser, isArchived: Boolean): Future[List[BaseProcessDetails[PS]]] = {
     val userCategories = processCategoryService.getUserCategories(user)
     val shapeStrategy = implicitly[ProcessShapeFetchStrategy[PS]]
-    fetchingProcessRepository.fetchProcesses(None, isArchived = Some(isArchived), None, categories = Some(userCategories), None)(shapeStrategy, user, ec)
+    fetchingProcessRepository.fetchProcessesDetails(FetchProcessesDetailsQuery(isArchived = Some(isArchived), categories = Some(userCategories)))(shapeStrategy, user, ec)
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
@@ -62,7 +62,7 @@ trait ProcessService {
 
   def cancelProcess(processIdWithName: ProcessIdWithName, deploymentComment: Option[DeploymentComment])(implicit user: LoggedUser): Future[EmptyResponse]
 
-  def renameProcess(processIdWithName: ProcessIdWithName, name: String)(implicit user: LoggedUser): Future[XError[UpdateProcessNameResponse]]
+  def renameProcess(processIdWithName: ProcessIdWithName, name: ProcessName)(implicit user: LoggedUser): Future[XError[UpdateProcessNameResponse]]
 
   def updateCategory(processIdWithName: ProcessIdWithName, category: String)(implicit user: LoggedUser): Future[XError[UpdateProcessCategoryResponse]]
 
@@ -179,14 +179,14 @@ class DBProcessService(managerActor: ActorRef,
       }
     }
 
-  override def renameProcess(processIdWithName: ProcessIdWithName, name: String)(implicit user: LoggedUser): Future[XError[UpdateProcessNameResponse]] =
+  override def renameProcess(processIdWithName: ProcessIdWithName, name: ProcessName)(implicit user: LoggedUser): Future[XError[UpdateProcessNameResponse]] =
     withNotArchivedProcess(processIdWithName, "Can't rename archived scenario.") { process =>
       withNotRunningState(process, "Can't change name still running scenario.") { _ =>
         repositoryManager.runInTransaction(
           processRepository
             .renameProcess(processIdWithName, name)
             .map {
-              case Right(_) => Right(UpdateProcessNameResponse.create(process.name, name))
+              case Right(_) => Right(UpdateProcessNameResponse.create(process.name, name.value))
               case Left(value) => Left(value)
             }
         )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentService.scala
@@ -13,6 +13,7 @@ import pl.touk.nussknacker.ui.api.ListenerApiUser
 import pl.touk.nussknacker.ui.db.entity.ProcessActionEntityData
 import pl.touk.nussknacker.ui.listener.ProcessChangeEvent.{OnDeployActionFailed, OnDeployActionSuccess, OnFinished}
 import pl.touk.nussknacker.ui.listener.{ProcessChangeListener, User => ListenerUser}
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.process.repository.ProcessDBQueryRepository.ProcessNotFoundError
 import pl.touk.nussknacker.ui.process.repository.{DbProcessActionRepository, DeploymentComment, FetchingProcessRepository}
 import pl.touk.nussknacker.ui.security.api.{LoggedUser, NussknackerInternalUser}
@@ -44,7 +45,7 @@ class DeploymentService(processRepository: FetchingProcessRepository[Future],
     for {
       deployedProcesses <- {
         implicit val userFetchingDataFromRepository: LoggedUser = NussknackerInternalUser
-        processRepository.fetchProcesses[CanonicalProcess](Some(false), Some(false), isDeployed = Some(true), None, Some(Seq(processingType)))
+        processRepository.fetchProcessesDetails[CanonicalProcess](FetchProcessesDetailsQuery(isSubprocess = Some(false), isArchived = Some(false), isDeployed = Some(true), processingTypes = Some(Seq(processingType))))
       }
       dataList <- Future.sequence(deployedProcesses.flatMap { details =>
         val lastDeployAction = details.lastDeployedAction.get

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -139,7 +139,7 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
   }
 
   private def fetchProcesses(implicit ec: ExecutionContext): Future[Either[EspError, List[BasicProcess]]] = {
-    invokeJson[List[BasicProcess]](HttpMethods.GET, List("processes"))
+    invokeJson[List[BasicProcess]](HttpMethods.GET, List("processes"), Query(("isArchived", "false"), ("isSubprocess", "false")))
   }
 
   private def fetchProcessVersion(id: String, remoteProcessVersion: Option[VersionId])
@@ -151,7 +151,10 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
     invokeJson[List[ValidatedProcessDetails]](
       HttpMethods.GET,
       "processesDetails" :: Nil,
-      Query(("names", names.map(ns => URLEncoder.encode(ns.value, StandardCharsets.UTF_8.displayName())).mkString(",")))
+      Query(
+        ("names", names.map(ns => URLEncoder.encode(ns.value, StandardCharsets.UTF_8.displayName())).mkString(",")),
+        ("isArchived", "false"),
+      )
     )
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -87,7 +87,7 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
       result.fold(_ => List(), _.history)
     }
 
-  protected def request(path: Uri, method: HttpMethod, request: MessageEntity): Future[HttpResponse]
+  protected def request(uri: Uri, method: HttpMethod, request: MessageEntity): Future[HttpResponse]
 
   override def compare(localProcess: DisplayableProcess, remoteProcessVersion: Option[VersionId])(implicit ec: ExecutionContext) : Future[Either[EspError, Map[String, Difference]]] = {
     val id = localProcess.id
@@ -156,6 +156,7 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
   }
 
   private def fetchSubProcessesDetails(implicit ec: ExecutionContext): Future[Either[EspError, List[ValidatedProcessDetails]]] = {
+    // To be switched to processesDetails?isSubprocess=true in NU 1.8.
     invokeJson[List[ValidatedProcessDetails]](HttpMethods.GET, List("subProcessesDetails"))
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
@@ -43,25 +43,6 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](val dbConfig: DbConfig) 
     }, query.isDeployed))
   }
 
-  override def fetchProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]] = {
-    run(fetchProcessDetailsByQueryActionUnarchived(p => !p.isSubprocess))
-  }
-
-  override def fetchDeployedProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]] =
-    run(fetchProcessDetailsByQueryActionUnarchived(p => !p.isSubprocess, Option(true)))
-
-  override def fetchSubProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]] = {
-    run(fetchProcessDetailsByQueryActionUnarchived(p => p.isSubprocess))
-  }
-
-  override def fetchAllProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]] = {
-    run(fetchProcessDetailsByQueryActionUnarchived(_ => true))
-  }
-
-  private def fetchProcessDetailsByQueryActionUnarchived[PS: ProcessShapeFetchStrategy](query: ProcessEntityFactory#ProcessEntity => Rep[Boolean], isDeployed: Option[Boolean] = None)
-                                                                                       (implicit loggedUser: LoggedUser, ec: ExecutionContext) =
-    fetchProcessDetailsByQueryAction(e => query(e) && !e.isArchived, isDeployed)
-
   private def fetchProcessDetailsByQueryAction[PS: ProcessShapeFetchStrategy](query: ProcessEntityFactory#ProcessEntity => Rep[Boolean],
                                                                               isDeployed: Option[Boolean])(implicit loggedUser: LoggedUser, ec: ExecutionContext): DBIOAction[List[BaseProcessDetails[PS]], NoStream, Effect.All with Effect.Read] = {
     (for {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
@@ -35,7 +35,7 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](val dbConfig: DbConfig) 
       query.isArchived.map(arg => process => process.isArchived === arg),
       query.categories.map(arg => process => process.processCategory.inSet(arg)),
       query.processingTypes.map(arg => process => process.processingType.inSet(arg)),
-      query.names.map(arg => process => process.name.inSet(arg.map(_.value))),
+      query.names.map(arg => process => process.name.inSet(arg)),
     )
 
     run(fetchProcessDetailsByQueryAction({ process =>
@@ -93,15 +93,15 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](val dbConfig: DbConfig) 
   }
 
   override def fetchProcessId(processName: ProcessName)(implicit ec: ExecutionContext): F[Option[ProcessId]] = {
-    run(processesTable.filter(_.name === processName.value).map(_.id).result.headOption.map(_.map(id => id)))
+    run(processesTable.filter(_.name === processName).map(_.id).result.headOption.map(_.map(id => id)))
   }
 
   def fetchProcessName(processId: ProcessId)(implicit ec: ExecutionContext): F[Option[ProcessName]] = {
-    run(processesTable.filter(_.id === processId).map(_.name).result.headOption.map(_.map(ProcessName(_))))
+    run(processesTable.filter(_.id === processId).map(_.name).result.headOption)
   }
 
   override def fetchProcessDetails(processName: ProcessName)(implicit ec: ExecutionContext): F[Option[ProcessEntityData]] = {
-    run(processesTable.filter(_.name === processName.value).result.headOption)
+    run(processesTable.filter(_.name === processName).result.headOption)
   }
 
   override def fetchProcessActions(processId: ProcessId)(implicit ec: ExecutionContext): F[List[ProcessAction]] =
@@ -154,9 +154,9 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](val dbConfig: DbConfig) 
                                                                tags: Seq[TagsEntityData] = List.empty,
                                                                history: Seq[ProcessVersion] = List.empty)(implicit loggedUser: LoggedUser): BaseProcessDetails[PS] = {
     BaseProcessDetails[PS](
-      id = process.name, //TODO: replace by Long / ProcessId
+      id = process.name.value, //TODO: replace by Long / ProcessId
       processId = process.id, //TODO: Remove it weh we will support Long / ProcessId
-      name = process.name,
+      name = process.name.value,
       processVersionId = processVersion.id,
       isLatestVersion = isLatestVersion,
       isArchived = process.isArchived,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
@@ -8,8 +8,18 @@ import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
-
 import pl.touk.nussknacker.restmodel.process.ProcessingType
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
+
+object FetchingProcessRepository {
+  case class FetchProcessesDetailsQuery(isSubprocess: Option[Boolean] = None,
+                                        isArchived: Option[Boolean] = None,
+                                        isDeployed: Option[Boolean] = None,
+                                        categories: Option[Seq[String]] = None,
+                                        processingTypes: Option[Seq[String]] = None,
+                                        names: Option[Seq[ProcessName]] = None,
+                                       )
+}
 
 abstract class FetchingProcessRepository[F[_]: Monad] extends ProcessDBQueryRepository[F] {
 
@@ -24,6 +34,8 @@ abstract class FetchingProcessRepository[F[_]: Monad] extends ProcessDBQueryRepo
                                                     categories: Option[Seq[String]],
                                                     processingTypes: Option[Seq[String]])
                                                    (implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
+
+  def fetchProcessesDetails[PS: ProcessShapeFetchStrategy](query: FetchProcessesDetailsQuery)(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
 
   def fetchProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
@@ -19,6 +19,13 @@ object FetchingProcessRepository {
                                         processingTypes: Option[Seq[String]] = None,
                                         names: Option[Seq[ProcessName]] = None,
                                        )
+
+  object FetchProcessesDetailsQuery {
+    def unarchived: FetchProcessesDetailsQuery = FetchProcessesDetailsQuery(isArchived = Some(false))
+    def unarchivedProcesses: FetchProcessesDetailsQuery = unarchived.copy(isSubprocess = Some(false))
+    def unarchivedSubProcesses: FetchProcessesDetailsQuery = unarchived.copy(isSubprocess = Some(true))
+    def deployed: FetchProcessesDetailsQuery = unarchivedProcesses.copy(isDeployed = Some(true))
+  }
 }
 
 abstract class FetchingProcessRepository[F[_]: Monad] extends ProcessDBQueryRepository[F] {
@@ -29,14 +36,6 @@ abstract class FetchingProcessRepository[F[_]: Monad] extends ProcessDBQueryRepo
                                                              (implicit loggedUser: LoggedUser, ec: ExecutionContext): F[Option[BaseProcessDetails[PS]]]
 
   def fetchProcessesDetails[PS: ProcessShapeFetchStrategy](query: FetchProcessesDetailsQuery)(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
-
-  def fetchProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
-
-  def fetchDeployedProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
-
-  def fetchSubProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
-
-  def fetchAllProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
 
   def fetchProcessId(processName: ProcessName)(implicit ec: ExecutionContext): F[Option[ProcessId]]
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/FetchingProcessRepository.scala
@@ -28,20 +28,11 @@ abstract class FetchingProcessRepository[F[_]: Monad] extends ProcessDBQueryRepo
   def fetchProcessDetailsForId[PS: ProcessShapeFetchStrategy](processId: ProcessId, versionId: VersionId)
                                                              (implicit loggedUser: LoggedUser, ec: ExecutionContext): F[Option[BaseProcessDetails[PS]]]
 
-  def fetchProcesses[PS: ProcessShapeFetchStrategy](isSubprocess: Option[Boolean],
-                                                    isArchived: Option[Boolean],
-                                                    isDeployed: Option[Boolean],
-                                                    categories: Option[Seq[String]],
-                                                    processingTypes: Option[Seq[String]])
-                                                   (implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
-
   def fetchProcessesDetails[PS: ProcessShapeFetchStrategy](query: FetchProcessesDetailsQuery)(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
 
   def fetchProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
 
   def fetchDeployedProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
-
-  def fetchProcessesDetails[PS: ProcessShapeFetchStrategy](processNames: List[ProcessName])(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
 
   def fetchSubProcessesDetails[PS: ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): F[List[BaseProcessDetails[PS]]]
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessDBQueryRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessDBQueryRepository.scala
@@ -83,7 +83,7 @@ trait ProcessDBQueryRepository[F[_]] extends Repository[F] with EspTables {
 
   protected def latestProcessVersionsNoJsonQuery(processName: ProcessName): Query[ProcessVersionEntityFactory#BaseProcessVersionEntity, ProcessVersionEntityData, Seq] =
     processesTable
-      .filter(_.name === processName.value)
+      .filter(_.name === processName)
       .join(processVersionsTableNoJson)
       .on { case (process, version) => process.id === version.processId }
       .map(_._2)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/subprocess/SubprocessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/subprocess/SubprocessRepository.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.ui.process.subprocess
 
-import pl.touk.nussknacker.engine.api.process.VersionId
+import pl.touk.nussknacker.engine.api.process.{ProcessName, VersionId}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.ui.db.entity.{ProcessEntityData, ProcessVersionEntityData}
 import pl.touk.nussknacker.ui.db.{DbConfig, EspTables}
@@ -48,7 +48,7 @@ class DbSubprocessRepository(db: DbConfig, ec: ExecutionContext) extends Subproc
   def listSubprocesses(versions: Map[String, VersionId], category: Option[String]) : Future[Set[SubprocessDetails]] = {
     val versionSubprocesses = Future.sequence {
       versions.map { case (subprocessId, subprocessVersion) =>
-        fetchSubprocess(subprocessId, subprocessVersion, category)
+        fetchSubprocess(ProcessName(subprocessId), subprocessVersion, category)
       }
     }
     val fetchedSubprocesses = for {
@@ -74,7 +74,7 @@ class DbSubprocessRepository(db: DbConfig, ec: ExecutionContext) extends Subproc
     db.run(action).map(_.flatten.toSet)
   }
 
-  private def fetchSubprocess(subprocessName: String, version: VersionId, category: Option[String]) : Future[SubprocessDetails] = {
+  private def fetchSubprocess(subprocessName: ProcessName, version: VersionId, category: Option[String]) : Future[SubprocessDetails] = {
     val action = for {
       subprocessVersion <- processVersionsTable.filter(p => p.id === version)
         .join(subprocessesQueryByName(subprocessName, category))
@@ -101,7 +101,7 @@ class DbSubprocessRepository(db: DbConfig, ec: ExecutionContext) extends Subproc
       .getOrElse(query)
   }
 
-  private def subprocessesQueryByName(subprocessName: String, category: Option[String]) =
+  private def subprocessesQueryByName(subprocessName: ProcessName, category: Option[String]) =
     subprocessesQuery(category).filter(_.name === subprocessName)
 }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -190,13 +190,13 @@ class ManagementResourcesSpec extends AnyFunSuite with ScalatestRouteTest with F
     deployProcess(SampleProcess.process.id) ~> check {
       status shouldBe StatusCodes.OK
 
-      forScenariosReturned(ProcessesQuery.empty) { processes =>
+      forScenariosReturned(ProcessesQuery()) { processes =>
         val process = processes.find(_.name == SampleProcess.process.id).head
         process.lastActionVersionId shouldBe Some(2L)
         process.isDeployed shouldBe true
 
         cancelProcess(SampleProcess.process.id) ~> check {
-          forScenariosReturned(ProcessesQuery.empty) { processes =>
+          forScenariosReturned(ProcessesQuery()) { processes =>
             val process = processes.find(_.name == SampleProcess.process.id).head
             process.lastActionVersionId shouldBe Some(2L)
             process.isCanceled shouldBe true

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -30,6 +30,7 @@ import pl.touk.nussknacker.ui.process.repository.DbProcessActivityRepository.Pro
 import pl.touk.nussknacker.ui.util.MultipartUtils
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.ui.api.ProcessesResources.ProcessesQuery
 
 import java.time.Instant
 
@@ -190,13 +191,13 @@ class ManagementResourcesSpec extends AnyFunSuite with ScalatestRouteTest with F
     deployProcess(SampleProcess.process.id) ~> check {
       status shouldBe StatusCodes.OK
 
-      forScenariosReturned(ProcessesQuery()) { processes =>
+      forScenariosReturned(ProcessesQuery.empty) { processes =>
         val process = processes.find(_.name == SampleProcess.process.id).head
         process.lastActionVersionId shouldBe Some(2L)
         process.isDeployed shouldBe true
 
         cancelProcess(SampleProcess.process.id) ~> check {
-          forScenariosReturned(ProcessesQuery()) { processes =>
+          forScenariosReturned(ProcessesQuery.empty) { processes =>
             val process = processes.find(_.name == SampleProcess.process.id).head
             process.lastActionVersionId shouldBe Some(2L)
             process.isCanceled shouldBe true

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -62,8 +62,11 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
   test("return list of process") {
     val processId = createEmptyProcess(processName)
 
-    forScenariosReturned(ProcessesQuery.empty) { processes =>
+    forScenariosReturned(ProcessesQuery()) { processes =>
       processes.exists(_.processId == processId.value) shouldBe true
+    }
+    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+      processes.exists(_.processId.value == processId.value) shouldBe true
     }
   }
 
@@ -212,6 +215,9 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       process.id shouldBe sampleSubprocess.id
       process.isArchived shouldBe false
     }
+    forScenariosDetailsReturned(ProcessesQuery().subprocess()) { processes =>
+      processes should have size 1
+    }
 
     archiveProcess(ProcessName(sampleSubprocess.id)) { status =>
       status shouldEqual StatusCodes.OK
@@ -220,11 +226,17 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     forScenariosReturned(ProcessesQuery().subprocess()) { processes =>
       processes shouldBe 'empty
     }
+    forScenariosDetailsReturned(ProcessesQuery().subprocess()) { processes =>
+      processes shouldBe 'empty
+    }
     forScenariosReturned(ProcessesQuery().subprocess().archived()) { processes =>
       processes should have size 1
       val process = processes.head
       process.id shouldBe sampleSubprocess.id
       process.isArchived shouldBe true
+    }
+    forScenariosDetailsReturned(ProcessesQuery().subprocess().archived()) { processes =>
+      processes should have size 1
     }
   }
 
@@ -240,8 +252,11 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
   test("return list of process without archived process") {
     createArchivedProcess(processName)
 
-    forScenariosReturned(ProcessesQuery.empty) { processes =>
-      processes.find(_.name == processName.value) shouldBe None
+    forScenariosReturned(ProcessesQuery()) { processes =>
+      processes shouldBe 'empty
+    }
+    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+      processes shouldBe 'empty
     }
   }
 
@@ -261,6 +276,9 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     }
 
     forScenariosReturned(ProcessesQuery().archived()) { processes =>
+      processes.find(_.name == processName.value).map(_.name) shouldBe Some(processName.value)
+    }
+    forScenariosDetailsReturned(ProcessesQuery().archived()) { processes =>
       processes.find(_.name == processName.value).map(_.name) shouldBe Some(processName.value)
     }
   }
@@ -324,7 +342,10 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       status shouldEqual StatusCodes.NotFound
     }
 
-    forScenariosReturned(ProcessesQuery.empty) { processes =>
+    forScenariosReturned(ProcessesQuery()) { processes =>
+      processes.isEmpty shouldBe true
+    }
+    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
       processes.isEmpty shouldBe true
     }
   }
@@ -339,28 +360,43 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       process.processCategory shouldEqual category
     }
 
-    forScenariosReturned(ProcessesQuery.empty, isAdmin = true) { processes =>
+    forScenariosReturned(ProcessesQuery(), isAdmin = true) { processes =>
       processes.exists(_.processId == processId.value) shouldBe true
+    }
+    forScenariosDetailsReturned(ProcessesQuery(), isAdmin = true) { processes =>
+      processes.exists(_.processId.value == processId.value) shouldBe true
     }
   }
 
   test("search processes by categories") {
-    createEmptyProcess(ProcessName("Processor1"), TestCat)
-    createEmptyProcess(ProcessName("Processor2"), TestCat2)
+    createEmptyProcess(ProcessName("proc1"), TestCat)
+    createEmptyProcess(ProcessName("proc2"), TestCat2)
 
-    forScenariosReturned(ProcessesQuery.empty) { processes =>
+    forScenariosReturned(ProcessesQuery()) { processes =>
+      processes.size shouldBe 2
+    }
+    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
       processes.size shouldBe 2
     }
 
     forScenariosReturned(ProcessesQuery().categories(List(TestCat))) { processes =>
-      processes.size shouldBe 1
+      processes.loneElement.name shouldBe "proc1"
+    }
+    forScenariosDetailsReturned(ProcessesQuery().categories(List(TestCat))) { processes =>
+      processes.loneElement.name shouldBe "proc1"
     }
 
     forScenariosReturned(ProcessesQuery().categories(List(TestCat2))) { processes =>
-      processes.size shouldBe 1
+      processes.loneElement.name shouldBe "proc2"
+    }
+    forScenariosDetailsReturned(ProcessesQuery().categories(List(TestCat2))) { processes =>
+      processes.loneElement.name shouldBe "proc2"
     }
 
     forScenariosReturned(ProcessesQuery().categories(List(TestCat, TestCat2))) { processes =>
+      processes.size shouldBe 2
+    }
+    forScenariosDetailsReturned(ProcessesQuery().categories(List(TestCat, TestCat2))) { processes =>
       processes.size shouldBe 2
     }
   }
@@ -371,7 +407,13 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     forScenariosReturned(ProcessesQuery().processingTypes(List(Streaming))) { processes =>
       processes.size shouldBe 1
     }
+    forScenariosDetailsReturned(ProcessesQuery().processingTypes(List(Streaming))) { processes =>
+      processes.size shouldBe 1
+    }
     forScenariosReturned(ProcessesQuery().processingTypes(List(Fraud))) { processes =>
+      processes.size shouldBe 0
+    }
+    forScenariosDetailsReturned(ProcessesQuery().processingTypes(List(Fraud))) { processes =>
       processes.size shouldBe 0
     }
   }
@@ -383,7 +425,38 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     forScenariosReturned(ProcessesQuery().names(List("proc1"))) { processes =>
       processes.loneElement.name shouldBe "proc1"
     }
+    forScenariosDetailsReturned(ProcessesQuery().names(List("proc1"))) { processes =>
+      processes.loneElement.name shouldBe "proc1"
+    }
     forScenariosReturned(ProcessesQuery().names(List("proc3"))) { processes =>
+      processes.size shouldBe 0
+    }
+    forScenariosDetailsReturned(ProcessesQuery().names(List("proc3"))) { processes =>
+      processes.size shouldBe 0
+    }
+  }
+
+  test("search processes with multiple parameters") {
+    createEmptyProcess(ProcessName("proc1"), TestCat)
+    createEmptyProcess(ProcessName("proc2"), TestCat2)
+    createArchivedProcess(ProcessName("proc3"))
+
+    forScenariosReturned(ProcessesQuery().names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming))) { processes =>
+      processes.loneElement.name shouldBe "proc1"
+    }
+    forScenariosDetailsReturned(ProcessesQuery().names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming))) { processes =>
+      processes.loneElement.name shouldBe "proc1"
+    }
+    forScenariosReturned(ProcessesQuery().names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming)).archived()) { processes =>
+      processes.loneElement.name shouldBe "proc3"
+    }
+    forScenariosDetailsReturned(ProcessesQuery().names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming)).archived()) { processes =>
+      processes.loneElement.name shouldBe "proc3"
+    }
+    forScenariosReturned(ProcessesQuery().names(List("proc1")).categories(List("unknown"))) { processes =>
+      processes.size shouldBe 0
+    }
+    forScenariosDetailsReturned(ProcessesQuery().names(List("proc1")).categories(List("unknown"))) { processes =>
       processes.size shouldBe 0
     }
   }
@@ -397,16 +470,22 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     createDeployedCanceledProcess(secondProcessor)
     createDeployedProcess(thirdProcessor)
 
-    forScenariosReturned(ProcessesQuery.empty) { processes =>
+    forScenariosReturned(ProcessesQuery()) { processes =>
       processes.size shouldBe 3
       val status = processes.find(_.name == firstProcessor.value).flatMap(_.stateStatus)
       status shouldBe Some(SimpleStateStatus.NotDeployed.name)
+    }
+    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+      processes.size shouldBe 3
     }
 
     forScenariosReturned(ProcessesQuery().deployed()) { processes =>
       processes.size shouldBe 1
       val status = processes.find(_.name == thirdProcessor.value).flatMap(_.stateStatus)
       status shouldBe Some(SimpleStateStatus.Running.name)
+    }
+    forScenariosDetailsReturned(ProcessesQuery().deployed()) { processes =>
+      processes.size shouldBe 1
     }
 
     forScenariosReturned(ProcessesQuery().notDeployed()) { processes =>
@@ -417,6 +496,9 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
 
       val canceledProcess = processes.find(_.name == secondProcessor.value).flatMap(_.stateStatus)
       canceledProcess shouldBe Some(SimpleStateStatus.Canceled.name)
+    }
+    forScenariosDetailsReturned(ProcessesQuery().notDeployed()) { processes =>
+      processes.size shouldBe 2
     }
   }
 
@@ -507,12 +589,15 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       status shouldEqual StatusCodes.OK
     }
 
-    forScenariosReturned(ProcessesQuery.empty) { processes =>
+    forScenariosReturned(ProcessesQuery()) { processes =>
       val process = processes.find(_.name == SampleProcess.process.id)
 
       withClue(process) {
         process.isDefined shouldBe true
       }
+    }
+    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+      processes.find(_.name == SampleProcess.process.id).isDefined shouldBe true
     }
   }
 
@@ -709,22 +794,6 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     }
   }
 
-  test("return all processes with details") {
-    val firstProcessName = ProcessName("firstProcessName")
-    val secondProcessName = ProcessName("secondProcessName")
-
-    saveProcess(firstProcessName, ProcessTestData.validProcessWithId(firstProcessName.value)) {
-      saveProcess(secondProcessName, ProcessTestData.validProcessWithId(secondProcessName.value)) {
-        Get("/processesDetails") ~> routeWithAllPermissions ~> check {
-          status shouldEqual StatusCodes.OK
-          val processes = responseAs[List[ValidatedProcessDetails]]
-          processes should have size 2
-          processes.map(_.name) should contain only (firstProcessName.value, secondProcessName.value)
-        }
-      }
-    }
-  }
-
   test("return all non-validated processes with details") {
     val firstProcessName = ProcessName("firstProcessName")
     val secondProcessName = ProcessName("secondProcessName")
@@ -738,69 +807,6 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
           processes.map(_.name) should contain only(firstProcessName.value, secondProcessName.value)
           responseAs[String] should not include "validationResult"
           Unmarshal(response).to[List[ValidatedProcessDetails]].failed.futureValue shouldBe a[DecodingFailure]
-        }
-      }
-    }
-  }
-
-  test("return filtered processes details list (just matching)") {
-    val firstProcessName = ProcessName("firstProcessName")
-    val secondProcessName = ProcessName("secondProcessName")
-
-    saveProcess(firstProcessName, ProcessTestData.validProcessWithId(firstProcessName.value)) {
-      saveProcess(secondProcessName, ProcessTestData.validProcessWithId(secondProcessName.value)) {
-        Get(s"/processesDetails?names=${firstProcessName.value}") ~> routeWithAllPermissions ~> check {
-          val processes = responseAs[List[ValidatedProcessDetails]]
-          processes should have size 1
-          processes.map(_.name) should contain only firstProcessName.value
-        }
-      }
-    }
-  }
-
-  test("return filtered and non-validated processes details list (just matching)") {
-    val firstProcessName = ProcessName("firstProcessName")
-    val secondProcessName = ProcessName("secondProcessName")
-
-    saveProcess(firstProcessName, ProcessTestData.validProcessWithId(firstProcessName.value)) {
-      saveProcess(secondProcessName, ProcessTestData.validProcessWithId(secondProcessName.value)) {
-        Get(s"/processesDetails?names=${firstProcessName.value}&skipValidateAndResolve=true") ~> routeWithAllPermissions ~> check {
-          val processes = responseAs[List[ProcessDetails]]
-          processes should have size 1
-          processes.map(_.name) should contain only firstProcessName.value
-          responseAs[String] should not include "validationResult"
-          Unmarshal(response).to[List[ValidatedProcessDetails]].failed.futureValue shouldBe a[DecodingFailure]
-        }
-      }
-    }
-  }
-
-  test("return filtered processes details list (multiple)") {
-    val firstProcessName = ProcessName("firstProcessName")
-    val secondProcessName = ProcessName("secondProcessName")
-
-    saveProcess(firstProcessName, ProcessTestData.validProcessWithId(firstProcessName.value)) {
-      saveProcess(secondProcessName, ProcessTestData.validProcessWithId(secondProcessName.value)) {
-        Get(s"/processesDetails?names=${firstProcessName.value},${secondProcessName.value}") ~> routeWithAllPermissions ~> check {
-          status shouldEqual StatusCodes.OK
-          val processes = responseAs[List[ValidatedProcessDetails]]
-          processes should have size 2
-          processes.map(_.name) should contain only(firstProcessName.value, secondProcessName.value)
-        }
-      }
-    }
-  }
-
-  test("return filtered processes details list (empty)") {
-    val firstProcessName = ProcessName("firstProcessName")
-    val secondProcessName = ProcessName("secondProcessName")
-
-    saveProcess(firstProcessName, ProcessTestData.validProcessWithId(firstProcessName.value)) {
-      saveProcess(secondProcessName, ProcessTestData.validProcessWithId(secondProcessName.value)) {
-        Get(s"/processesDetails?names=non-existing-name") ~> routeWithAllPermissions ~> check {
-          status shouldEqual StatusCodes.OK
-          val processes = responseAs[List[ValidatedProcessDetails]]
-          processes shouldBe 'empty
         }
       }
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -207,26 +207,25 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       status shouldEqual StatusCodes.OK
     }
 
-    Get("/subProcesses") ~> routeWithAllPermissions ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[String] should include (sampleSubprocess.id)
-      val subprocesses = responseAs[List[BasicProcess]]
-      subprocesses should have size 1
-      subprocesses.map(_.name.value) should contain only sampleSubprocess.id
+    forScenariosReturned(ProcessesQuery.subprocess(isArchived = Some(false))) { processes =>
+      processes should have size 1
+      val process = processes.head
+      process.id shouldBe sampleSubprocess.id
+      process.isArchived shouldBe false
     }
 
     archiveProcess(ProcessName(sampleSubprocess.id)) { status =>
       status shouldEqual StatusCodes.OK
     }
 
-    Get("/subProcesses") ~> routeWithAllPermissions ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[String] should not include sampleSubprocess.id
-      responseAs[List[Json]] shouldBe 'empty
-    }
-
     forScenariosReturned(ProcessesQuery.subprocess(isArchived = Some(false))) { processes =>
-      processes.find(_.name == sampleSubprocess.id) shouldBe None
+      processes shouldBe 'empty
+    }
+    forScenariosReturned(ProcessesQuery.subprocess(isArchived = Some(true))) { processes =>
+      processes should have size 1
+      val process = processes.head
+      process.id shouldBe sampleSubprocess.id
+      process.isArchived shouldBe true
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -225,10 +225,10 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       status shouldEqual StatusCodes.OK
     }
 
-    forScenariosReturned(ProcessesQuery.empty.subprocess()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.subprocess().unarchived()) { processes =>
       processes shouldBe 'empty
     }
-    forScenariosDetailsReturned(ProcessesQuery.empty.subprocess()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.subprocess().unarchived()) { processes =>
       processes shouldBe 'empty
     }
     forScenariosReturned(ProcessesQuery.empty.subprocess().archived()) { processes =>
@@ -254,10 +254,10 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
   test("return list of process without archived process") {
     createArchivedProcess(processName)
 
-    forScenariosReturned(ProcessesQuery.empty) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.unarchived()) { processes =>
       processes shouldBe 'empty
     }
-    forScenariosDetailsReturned(ProcessesQuery.empty) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.unarchived()) { processes =>
       processes shouldBe 'empty
     }
   }
@@ -282,6 +282,18 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     }
     forScenariosDetailsReturned(ProcessesQuery.empty.archived()) { processes =>
       processes.find(_.name == processName.value).map(_.name) shouldBe Some(processName.value)
+    }
+  }
+
+  test("return list of all processes") {
+    createValidProcess(ProcessName("unarchived"))
+    createArchivedProcess(ProcessName("archived"))
+
+    forScenariosReturned(ProcessesQuery.empty) { processes =>
+      processes.map(_.name) should contain only("unarchived", "archived")
+    }
+    forScenariosDetailsReturned(ProcessesQuery.empty) { processes =>
+      processes.map(_.name) should contain only("unarchived", "archived")
     }
   }
 
@@ -443,10 +455,10 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     createEmptyProcess(ProcessName("proc2"), TestCat2)
     createArchivedProcess(ProcessName("proc3"))
 
-    forScenariosReturned(ProcessesQuery.empty.names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming)).unarchived()) { processes =>
       processes.loneElement.name shouldBe "proc1"
     }
-    forScenariosDetailsReturned(ProcessesQuery.empty.names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming)).unarchived()) { processes =>
       processes.loneElement.name shouldBe "proc1"
     }
     forScenariosReturned(ProcessesQuery.empty.names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming)).archived()) { processes =>

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -22,6 +22,7 @@ import pl.touk.nussknacker.restmodel.processdetails.{ProcessDetails, ValidatedPr
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationResult
 import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.ui.EspError.XError
+import pl.touk.nussknacker.ui.api.ProcessesResources.ProcessesQuery
 import pl.touk.nussknacker.ui.api.helpers.TestFactory._
 import pl.touk.nussknacker.ui.api.helpers.TestProcessingTypes.{Fraud, Streaming}
 import pl.touk.nussknacker.ui.api.helpers._
@@ -44,6 +45,7 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
 
   import io.circe._, io.circe.parser._
   import TestCategories._
+  import ProcessesQueryEnrichments.RichProcessesQuery
 
   private implicit final val string: FromEntityUnmarshaller[String] = Unmarshaller.stringUnmarshaller.forContentTypes(ContentTypeRange.*)
 
@@ -62,10 +64,10 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
   test("return list of process") {
     val processId = createEmptyProcess(processName)
 
-    forScenariosReturned(ProcessesQuery()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty) { processes =>
       processes.exists(_.processId == processId.value) shouldBe true
     }
-    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty) { processes =>
       processes.exists(_.processId.value == processId.value) shouldBe true
     }
   }
@@ -209,13 +211,13 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       status shouldEqual StatusCodes.OK
     }
 
-    forScenariosReturned(ProcessesQuery().subprocess()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.subprocess()) { processes =>
       processes should have size 1
       val process = processes.head
       process.id shouldBe sampleSubprocess.id
       process.isArchived shouldBe false
     }
-    forScenariosDetailsReturned(ProcessesQuery().subprocess()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.subprocess()) { processes =>
       processes should have size 1
     }
 
@@ -223,19 +225,19 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       status shouldEqual StatusCodes.OK
     }
 
-    forScenariosReturned(ProcessesQuery().subprocess()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.subprocess()) { processes =>
       processes shouldBe 'empty
     }
-    forScenariosDetailsReturned(ProcessesQuery().subprocess()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.subprocess()) { processes =>
       processes shouldBe 'empty
     }
-    forScenariosReturned(ProcessesQuery().subprocess().archived()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.subprocess().archived()) { processes =>
       processes should have size 1
       val process = processes.head
       process.id shouldBe sampleSubprocess.id
       process.isArchived shouldBe true
     }
-    forScenariosDetailsReturned(ProcessesQuery().subprocess().archived()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.subprocess().archived()) { processes =>
       processes should have size 1
     }
   }
@@ -252,10 +254,10 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
   test("return list of process without archived process") {
     createArchivedProcess(processName)
 
-    forScenariosReturned(ProcessesQuery()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty) { processes =>
       processes shouldBe 'empty
     }
-    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty) { processes =>
       processes shouldBe 'empty
     }
   }
@@ -275,10 +277,10 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       responseAs[String] should include(processName.value)
     }
 
-    forScenariosReturned(ProcessesQuery().archived()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.archived()) { processes =>
       processes.find(_.name == processName.value).map(_.name) shouldBe Some(processName.value)
     }
-    forScenariosDetailsReturned(ProcessesQuery().archived()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.archived()) { processes =>
       processes.find(_.name == processName.value).map(_.name) shouldBe Some(processName.value)
     }
   }
@@ -342,10 +344,10 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       status shouldEqual StatusCodes.NotFound
     }
 
-    forScenariosReturned(ProcessesQuery()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty) { processes =>
       processes.isEmpty shouldBe true
     }
-    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty) { processes =>
       processes.isEmpty shouldBe true
     }
   }
@@ -360,10 +362,10 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       process.processCategory shouldEqual category
     }
 
-    forScenariosReturned(ProcessesQuery(), isAdmin = true) { processes =>
+    forScenariosReturned(ProcessesQuery.empty, isAdmin = true) { processes =>
       processes.exists(_.processId == processId.value) shouldBe true
     }
-    forScenariosDetailsReturned(ProcessesQuery(), isAdmin = true) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty, isAdmin = true) { processes =>
       processes.exists(_.processId.value == processId.value) shouldBe true
     }
   }
@@ -372,31 +374,31 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     createEmptyProcess(ProcessName("proc1"), TestCat)
     createEmptyProcess(ProcessName("proc2"), TestCat2)
 
-    forScenariosReturned(ProcessesQuery()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty) { processes =>
       processes.size shouldBe 2
     }
-    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty) { processes =>
       processes.size shouldBe 2
     }
 
-    forScenariosReturned(ProcessesQuery().categories(List(TestCat))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.categories(List(TestCat))) { processes =>
       processes.loneElement.name shouldBe "proc1"
     }
-    forScenariosDetailsReturned(ProcessesQuery().categories(List(TestCat))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.categories(List(TestCat))) { processes =>
       processes.loneElement.name shouldBe "proc1"
     }
 
-    forScenariosReturned(ProcessesQuery().categories(List(TestCat2))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.categories(List(TestCat2))) { processes =>
       processes.loneElement.name shouldBe "proc2"
     }
-    forScenariosDetailsReturned(ProcessesQuery().categories(List(TestCat2))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.categories(List(TestCat2))) { processes =>
       processes.loneElement.name shouldBe "proc2"
     }
 
-    forScenariosReturned(ProcessesQuery().categories(List(TestCat, TestCat2))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.categories(List(TestCat, TestCat2))) { processes =>
       processes.size shouldBe 2
     }
-    forScenariosDetailsReturned(ProcessesQuery().categories(List(TestCat, TestCat2))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.categories(List(TestCat, TestCat2))) { processes =>
       processes.size shouldBe 2
     }
   }
@@ -404,16 +406,16 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
   test("search processes by processing types") {
     createEmptyProcess(processName)
 
-    forScenariosReturned(ProcessesQuery().processingTypes(List(Streaming))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.processingTypes(List(Streaming))) { processes =>
       processes.size shouldBe 1
     }
-    forScenariosDetailsReturned(ProcessesQuery().processingTypes(List(Streaming))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.processingTypes(List(Streaming))) { processes =>
       processes.size shouldBe 1
     }
-    forScenariosReturned(ProcessesQuery().processingTypes(List(Fraud))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.processingTypes(List(Fraud))) { processes =>
       processes.size shouldBe 0
     }
-    forScenariosDetailsReturned(ProcessesQuery().processingTypes(List(Fraud))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.processingTypes(List(Fraud))) { processes =>
       processes.size shouldBe 0
     }
   }
@@ -422,16 +424,16 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     createEmptyProcess(ProcessName("proc1"))
     createEmptyProcess(ProcessName("proc2"))
 
-    forScenariosReturned(ProcessesQuery().names(List("proc1"))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.names(List("proc1"))) { processes =>
       processes.loneElement.name shouldBe "proc1"
     }
-    forScenariosDetailsReturned(ProcessesQuery().names(List("proc1"))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.names(List("proc1"))) { processes =>
       processes.loneElement.name shouldBe "proc1"
     }
-    forScenariosReturned(ProcessesQuery().names(List("proc3"))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.names(List("proc3"))) { processes =>
       processes.size shouldBe 0
     }
-    forScenariosDetailsReturned(ProcessesQuery().names(List("proc3"))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.names(List("proc3"))) { processes =>
       processes.size shouldBe 0
     }
   }
@@ -441,22 +443,22 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     createEmptyProcess(ProcessName("proc2"), TestCat2)
     createArchivedProcess(ProcessName("proc3"))
 
-    forScenariosReturned(ProcessesQuery().names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming))) { processes =>
       processes.loneElement.name shouldBe "proc1"
     }
-    forScenariosDetailsReturned(ProcessesQuery().names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming))) { processes =>
       processes.loneElement.name shouldBe "proc1"
     }
-    forScenariosReturned(ProcessesQuery().names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming)).archived()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming)).archived()) { processes =>
       processes.loneElement.name shouldBe "proc3"
     }
-    forScenariosDetailsReturned(ProcessesQuery().names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming)).archived()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.names(List("proc1", "proc3", "procNotExisting")).categories(List(TestCat)).processingTypes(List(Streaming)).archived()) { processes =>
       processes.loneElement.name shouldBe "proc3"
     }
-    forScenariosReturned(ProcessesQuery().names(List("proc1")).categories(List("unknown"))) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.names(List("proc1")).categories(List("unknown"))) { processes =>
       processes.size shouldBe 0
     }
-    forScenariosDetailsReturned(ProcessesQuery().names(List("proc1")).categories(List("unknown"))) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.names(List("proc1")).categories(List("unknown"))) { processes =>
       processes.size shouldBe 0
     }
   }
@@ -470,25 +472,25 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     createDeployedCanceledProcess(secondProcessor)
     createDeployedProcess(thirdProcessor)
 
-    forScenariosReturned(ProcessesQuery()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty) { processes =>
       processes.size shouldBe 3
       val status = processes.find(_.name == firstProcessor.value).flatMap(_.stateStatus)
       status shouldBe Some(SimpleStateStatus.NotDeployed.name)
     }
-    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty) { processes =>
       processes.size shouldBe 3
     }
 
-    forScenariosReturned(ProcessesQuery().deployed()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.deployed()) { processes =>
       processes.size shouldBe 1
       val status = processes.find(_.name == thirdProcessor.value).flatMap(_.stateStatus)
       status shouldBe Some(SimpleStateStatus.Running.name)
     }
-    forScenariosDetailsReturned(ProcessesQuery().deployed()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.deployed()) { processes =>
       processes.size shouldBe 1
     }
 
-    forScenariosReturned(ProcessesQuery().notDeployed()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty.notDeployed()) { processes =>
       processes.size shouldBe 2
 
       val status = processes.find(_.name == thirdProcessor.value).flatMap(_.stateStatus)
@@ -497,7 +499,7 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       val canceledProcess = processes.find(_.name == secondProcessor.value).flatMap(_.stateStatus)
       canceledProcess shouldBe Some(SimpleStateStatus.Canceled.name)
     }
-    forScenariosDetailsReturned(ProcessesQuery().notDeployed()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty.notDeployed()) { processes =>
       processes.size shouldBe 2
     }
   }
@@ -589,14 +591,14 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
       status shouldEqual StatusCodes.OK
     }
 
-    forScenariosReturned(ProcessesQuery()) { processes =>
+    forScenariosReturned(ProcessesQuery.empty) { processes =>
       val process = processes.find(_.name == SampleProcess.process.id)
 
       withClue(process) {
         process.isDefined shouldBe true
       }
     }
-    forScenariosDetailsReturned(ProcessesQuery()) { processes =>
+    forScenariosDetailsReturned(ProcessesQuery.empty) { processes =>
       processes.find(_.name == SampleProcess.process.id).isDefined shouldBe true
     }
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -261,30 +261,10 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
   }
 
   object ProcessesQuery {
-    def empty: ProcessesQuery =
-      ProcessesQuery(List.empty, isArchived = None, isSubprocess = None, isDeployed = None)
-
-    def categories(categories: List[String]): ProcessesQuery =
-      ProcessesQuery(categories, isArchived = None, isSubprocess = None, isDeployed = None)
-
-    def archived(categories: List[String] = List.empty, isSubprocess: Option[Boolean] = Some(false)): ProcessesQuery =
-      ProcessesQuery(categories, isSubprocess = isSubprocess, isArchived = Some(true), isDeployed = None)
-
-    def subprocess(categories: List[String ] = List.empty, isArchived: Option[Boolean] = Some(false)): ProcessesQuery =
-      ProcessesQuery(categories, isSubprocess = Some(true), isArchived = isArchived, isDeployed = None)
-
-    def deployed(categories: List[String ] = List.empty): ProcessesQuery =
-      ProcessesQuery(categories, isSubprocess = Some(false), isArchived = Some(false), isDeployed = Some(true))
-
-    def notDeployed(categories: List[String ] = List.empty): ProcessesQuery =
-      ProcessesQuery(categories, isSubprocess = Some(false), isArchived = Some(false), isDeployed = Some(false))
+    def empty: ProcessesQuery = ProcessesQuery()
 
     def createQueryParamsUrl(query: ProcessesQuery): String = {
       var url = s"/processes?fake=true"
-
-      if (query.categories.nonEmpty) {
-        url += s"&categories=${query.categories.mkString(",")}"
-      }
 
       query.isArchived.foreach { isArchived =>
         url += s"&isArchived=$isArchived"
@@ -298,12 +278,52 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
         url += s"&isDeployed=$isDeployed"
       }
 
+      query.categories.foreach { categories =>
+        url += s"&categories=${categories.mkString(",")}"
+      }
+
+      query.processingTypes.foreach { processingTypes =>
+        url += s"&processingTypes=${processingTypes.mkString(",")}"
+      }
+
+      query.names.foreach { names =>
+        url += s"&names=${names.mkString(",")}"
+      }
+
       url
     }
 
   }
 
-  case class ProcessesQuery(categories: List[String], isSubprocess: Option[Boolean], isArchived: Option[Boolean], isDeployed: Option[Boolean])
+  case class ProcessesQuery(isSubprocess: Option[Boolean] = None,
+                            isArchived: Option[Boolean] = None,
+                            isDeployed: Option[Boolean] = None,
+                            categories: Option[List[String]] = None,
+                            processingTypes: Option[List[String]] = None,
+                            names: Option[List[String]] = None,
+                           ) {
+
+    def subprocess(): ProcessesQuery =
+      copy(isSubprocess = Some(true))
+
+    def archived(): ProcessesQuery =
+      copy(isArchived = Some(true))
+
+    def deployed(): ProcessesQuery =
+      copy(isDeployed = Some(true))
+
+    def notDeployed(): ProcessesQuery =
+      copy(isDeployed = Some(false))
+
+    def names(names: List[String]): ProcessesQuery =
+      copy(names = Some(names))
+
+    def categories(categories: List[String]): ProcessesQuery =
+      copy(categories = Some(categories))
+
+    def processingTypes(processingTypes: List[String]): ProcessesQuery =
+      copy(processingTypes = Some(processingTypes))
+  }
 
   protected def routeWithPermissions(route: RouteWithUser, isAdmin: Boolean = false): Route =
     if (isAdmin) withAdminPermissions(route) else withAllPermissions(route)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -425,6 +425,9 @@ object ProcessesQueryEnrichments {
     def subprocess(): ProcessesQuery =
       query.copy(isSubprocess = Some(true))
 
+    def unarchived(): ProcessesQuery =
+      query.copy(isArchived = Some(false))
+
     def archived(): ProcessesQuery =
       query.copy(isArchived = Some(true))
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -30,6 +30,7 @@ import pl.touk.nussknacker.ui.db.entity.ProcessActionEntityData
 import pl.touk.nussknacker.ui.process.ProcessService.UpdateProcessCommand
 import pl.touk.nussknacker.ui.process._
 import pl.touk.nussknacker.ui.process.deployment.{DeploymentService, ManagementActor}
+import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
 import pl.touk.nussknacker.ui.process.processingtypedata.{DefaultProcessingTypeDeploymentService, MapBasedProcessingTypeDataProvider, ProcessingTypeDataProvider, ProcessingTypeDataReader}
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.CreateProcessAction
 import pl.touk.nussknacker.ui.process.repository._
@@ -178,6 +179,11 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
     Post(s"/processes/${processName.value}/$TestCat?isSubprocess=false") ~> processesRouteWithAllPermissions ~> check {
       callback(status)
     }
+
+  protected def saveSubProcess(process: CanonicalProcess)(testCode: => Assertion): Assertion = {
+    val displayable = ProcessConverter.toDisplayable(process, TestProcessingTypes.Streaming)
+    saveSubProcess(displayable)(testCode)
+  }
 
   protected def saveSubProcess(process: DisplayableProcess)(testCode: => Assertion): Assertion =
     Post(s"/processes/${process.id}/$TestCat?isSubprocess=true") ~> processesRouteWithAllPermissions ~> check {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepository.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepository.scala
@@ -10,7 +10,7 @@ import pl.touk.nussknacker.restmodel.processdetails.{BaseProcessDetails, Process
 import pl.touk.nussknacker.restmodel.processdetails
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.ui.db.DbConfig
-import pl.touk.nussknacker.ui.db.entity.{ProcessEntityData, ProcessVersionEntityData}
+import pl.touk.nussknacker.ui.db.entity.ProcessEntityData
 import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
 import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.process.repository.{BasicRepository, FetchingProcessRepository}
@@ -25,18 +25,6 @@ class MockFetchingProcessRepository(processes: List[BaseProcessDetails[_]])(impl
   //It's only for BasicRepository implementation, we don't use it
   private val config: Config = ConfigFactory.parseString("""db {url: "jdbc:hsqldb:mem:none"}""".stripMargin)
   val dbConfig: DbConfig = DbConfig(JdbcBackend.Database.forConfig("db", config), HsqldbProfile)
-
-  override def fetchProcessesDetails[PS: processdetails.ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[processdetails.BaseProcessDetails[PS]]] =
-    filterProcesses[PS](isSubprocess = Some(false), isArchived = Some(false))
-
-  override def fetchDeployedProcessesDetails[PS: processdetails.ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[processdetails.BaseProcessDetails[PS]]] =
-    filterProcesses[PS](isSubprocess = Some(false), isArchived = Some(false), isDeployed = Some(true))
-
-  override def fetchSubProcessesDetails[PS: processdetails.ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[processdetails.BaseProcessDetails[PS]]] =
-    filterProcesses[PS](isSubprocess = Some(true), isArchived = Some(false))
-
-  override def fetchAllProcessesDetails[PS: processdetails.ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[processdetails.BaseProcessDetails[PS]]] =
-    filterProcesses[PS](isArchived = Some(false))
 
   override def fetchProcessesDetails[PS: ProcessShapeFetchStrategy](q: FetchProcessesDetailsQuery)(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[BaseProcessDetails[PS]]] =
     getUserProcesses[PS].map(_.filter(
@@ -63,12 +51,6 @@ class MockFetchingProcessRepository(processes: List[BaseProcessDetails[_]])(impl
 
   //TODO: Implement
   override def fetchProcessDetails(processName: ProcessName)(implicit ec: ExecutionContext): Future[Option[ProcessEntityData]] = ???
-
-  private def filterProcesses[PS: processdetails.ProcessShapeFetchStrategy](isSubprocess: Option[Boolean] = None, isArchived: Option[Boolean] = None, isDeployed: Option[Boolean] = None, categories: Option[Seq[String]] = None, processingTypes: Option[Seq[String]] = None)(implicit loggedUser: LoggedUser, ec: ExecutionContext) = {
-    getUserProcesses[PS].map(_.filter(p => {
-      check(isSubprocess, p.isSubprocess) && check(isArchived, p.isArchived) && check(isDeployed, p.isDeployed) && checkSeq(categories, p.processCategory) && checkSeq(processingTypes, p.processingType)
-    }))
-  }
 
   private def getUserProcesses[PS: ProcessShapeFetchStrategy](implicit loggedUser: LoggedUser) = getProcesses[PS].map(_.filter(p =>
     loggedUser.isAdmin || loggedUser.can(p.processCategory, Permission.Read)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepository.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepository.scala
@@ -32,9 +32,6 @@ class MockFetchingProcessRepository(processes: List[BaseProcessDetails[_]])(impl
   override def fetchDeployedProcessesDetails[PS: processdetails.ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[processdetails.BaseProcessDetails[PS]]] =
     filterProcesses[PS](isSubprocess = Some(false), isArchived = Some(false), isDeployed = Some(true))
 
-  override def fetchProcessesDetails[PS: processdetails.ProcessShapeFetchStrategy](processNames: List[ProcessName])(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[processdetails.BaseProcessDetails[PS]]] =
-    filterProcesses[PS](isSubprocess = Some(false), isArchived = Some(false)).map(_.filter(p => processNames.contains(p.idWithName.name)))
-
   override def fetchSubProcessesDetails[PS: processdetails.ProcessShapeFetchStrategy]()(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[processdetails.BaseProcessDetails[PS]]] =
     filterProcesses[PS](isSubprocess = Some(true), isArchived = Some(false))
 
@@ -60,11 +57,6 @@ class MockFetchingProcessRepository(processes: List[BaseProcessDetails[_]])(impl
 
   override def fetchProcessingType(processId: ProcessId)(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[String] =
     getUserProcesses[Unit].map(_.find(p => p.processId == processId).map(_.processingType).get)
-
-  override def fetchProcesses[PS: processdetails.ProcessShapeFetchStrategy](isSubprocess: Option[Boolean], isArchived: Option[Boolean], isDeployed: Option[Boolean], categories: Option[Seq[String]], processingTypes: Option[Seq[String]])(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[List[processdetails.BaseProcessDetails[PS]]] =
-    getUserProcesses[PS].map(_.filter(
-      p => check(isSubprocess, p.isSubprocess) && check(isArchived, p.isArchived) && check(isDeployed, p.isDeployed) && checkSeq(categories, p.processCategory) && checkSeq(processingTypes, p.processingType)
-    ))
 
   //TODO: Implement
   override def fetchProcessActions(processId: ProcessId)(implicit ec: ExecutionContext): Future[List[processdetails.ProcessAction]] = ???

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepositorySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepositorySpec.scala
@@ -75,7 +75,7 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
     )
 
     forAll(testingData) { (user: LoggedUser, expected: List[ProcessDetails]) =>
-      val result = mockRepository.fetchProcessesDetails()(DisplayableShape, user, global).futureValue
+      val result = mockRepository.fetchProcessesDetails(FetchProcessesDetailsQuery.unarchivedProcesses)(DisplayableShape, user, global).futureValue
       result shouldBe expected
     }
   }
@@ -89,7 +89,7 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
     )
 
     forAll(testingData) { (user: LoggedUser, expected: List[ProcessDetails]) =>
-      val result = mockRepository.fetchDeployedProcessesDetails()(DisplayableShape, user, global).futureValue
+      val result = mockRepository.fetchProcessesDetails(FetchProcessesDetailsQuery.deployed)(DisplayableShape, user, global).futureValue
       result shouldBe expected
     }
   }
@@ -118,7 +118,7 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
     )
 
     forAll(testingData) { (user: LoggedUser, expected: List[ProcessDetails]) =>
-      val result = mockRepository.fetchSubProcessesDetails()(DisplayableShape, user, global).futureValue
+      val result = mockRepository.fetchProcessesDetails(FetchProcessesDetailsQuery.unarchivedSubProcesses)(DisplayableShape, user, global).futureValue
       result shouldBe expected
     }
   }
@@ -132,9 +132,9 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
     val canonicalSubProcesses = displayableSubProcesses.map(p => p.copy(json = ProcessConverter.fromDisplayable(p.json)))
     val noneSubProcesses = displayableSubProcesses.map(p => p.copy(json = ()))
 
-    mixedMockRepository.fetchSubProcessesDetails()(DisplayableShape, admin, global).futureValue shouldBe displayableSubProcesses
-    mixedMockRepository.fetchSubProcessesDetails()(CanonicalShape, admin, global).futureValue shouldBe canonicalSubProcesses
-    mixedMockRepository.fetchSubProcessesDetails()(NoneShape, admin, global).futureValue shouldBe noneSubProcesses
+    mixedMockRepository.fetchProcessesDetails(FetchProcessesDetailsQuery.unarchivedSubProcesses)(DisplayableShape, admin, global).futureValue shouldBe displayableSubProcesses
+    mixedMockRepository.fetchProcessesDetails(FetchProcessesDetailsQuery.unarchivedSubProcesses)(CanonicalShape, admin, global).futureValue shouldBe canonicalSubProcesses
+    mixedMockRepository.fetchProcessesDetails(FetchProcessesDetailsQuery.unarchivedSubProcesses)(NoneShape, admin, global).futureValue shouldBe noneSubProcesses
   }
 
   it should "fetchAllProcessesDetails for each user" in {
@@ -146,7 +146,7 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
     )
 
     forAll(testingData) { (user: LoggedUser, expected: List[ProcessDetails]) =>
-      val result = mockRepository.fetchAllProcessesDetails()(DisplayableShape, user, global).futureValue
+      val result = mockRepository.fetchProcessesDetails(FetchProcessesDetailsQuery.unarchived)(DisplayableShape, user, global).futureValue
       result shouldBe expected
     }
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepositorySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepositorySpec.scala
@@ -9,6 +9,7 @@ import pl.touk.nussknacker.restmodel.processdetails.{ProcessDetails, ProcessShap
 import pl.touk.nussknacker.ui.api.helpers.TestProcessUtil._
 import pl.touk.nussknacker.ui.api.helpers.TestProcessingTypes._
 import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import java.util
@@ -103,7 +104,7 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
 
     forAll(testingData) { (user: LoggedUser, expected: List[ProcessDetails]) =>
       val names = processes.map(_.idWithName.name)
-      val result = mockRepository.fetchProcessesDetails(names)(DisplayableShape, user, global).futureValue
+      val result = mockRepository.fetchProcessesDetails(FetchProcessesDetailsQuery(names = Some(names), isArchived = Some(false), isSubprocess = Some(false)))(DisplayableShape, user, global).futureValue
       result shouldBe expected
     }
   }
@@ -224,41 +225,41 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
 
   it should "fetchProcesses for each user by mixed FetchQuery" in {
     //given
-    val processesQuery = FetchQuery(None, None, None, None, None)
-    val processesCategoryQuery = FetchQuery(None, None, None, Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), None)
-    val processesCategoryTypesQuery = FetchQuery(None, None, None, Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), Some(List(Streaming)))
+    val allProcessesQuery = FetchProcessesDetailsQuery()
+    val allProcessesCategoryQuery = allProcessesQuery.copy(categories = Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)))
+    val allProcessesCategoryTypesQuery = allProcessesCategoryQuery.copy(processingTypes = Some(List(Streaming)))
 
-    val allProcessesQuery = FetchQuery(Some(false), Some(false), None, None, None)
-    val deployedProcessesQuery = FetchQuery(Some(false), Some(false), Some(true), None, None)
-    val deployedProcessesCategoryQuery = FetchQuery(Some(false), Some(false), Some(true), Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), None)
-    val deployedProcessesCategoryProcessingTypesQuery = FetchQuery(Some(false), Some(false), Some(true), Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), Some(List(Streaming)))
+    val processesQuery = FetchProcessesDetailsQuery(isSubprocess = Some(false), isArchived = Some(false))
+    val deployedProcessesQuery = processesQuery.copy(isDeployed = Some(true))
+    val deployedProcessesCategoryQuery = deployedProcessesQuery.copy(categories = Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)))
+    val deployedProcessesCategoryProcessingTypesQuery = deployedProcessesCategoryQuery.copy(processingTypes = Some(List(Streaming)))
 
-    val notDeployedProcessesQuery = FetchQuery(Some(false), Some(false), Some(false), None, None)
-    val notDeployedProcessesCategoryQuery = FetchQuery(Some(false), Some(false), Some(false), Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), None)
-    val notDeployedProcessesCategoryProcessingTypesQuery = FetchQuery(Some(false), Some(false), Some(false), Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), Some(List(Streaming)))
+    val notDeployedProcessesQuery = processesQuery.copy(isDeployed = Some(false))
+    val notDeployedProcessesCategoryQuery = notDeployedProcessesQuery.copy(categories = Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)))
+    val notDeployedProcessesCategoryProcessingTypesQuery = notDeployedProcessesCategoryQuery.copy(processingTypes = Some(List(Streaming)))
 
-    val archivedQuery = FetchQuery(None, Some(true), None, None, None)
-    val archivedProcessesQuery = FetchQuery(Some(false), Some(true), None, None, None)
-    val archivedProcessesCategoryQuery = FetchQuery(Some(false), Some(true), None, Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), None)
-    val archivedProcessesCategoryProcessingTypesQuery = FetchQuery(Some(false), Some(true), None, Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), Some(List(Streaming)))
+    val archivedQuery = FetchProcessesDetailsQuery(isArchived = Some(true))
+    val archivedProcessesQuery = archivedQuery.copy(isSubprocess = Some(false))
+    val archivedProcessesCategoryQuery = archivedProcessesQuery.copy(categories = Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)))
+    val archivedProcessesCategoryProcessingTypesQuery = archivedProcessesCategoryQuery.copy(processingTypes = Some(List(Streaming)))
 
-    val subProcessesQuery = FetchQuery(Some(true), None, None, None, None)
-    val allSubProcessesQuery = FetchQuery(Some(true), Some(false), None, None, None)
-    val allSubProcessesCategoryQuery = FetchQuery(Some(true), Some(false), None, Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), None)
-    val allSubProcessesCategoryTypesQuery = FetchQuery(Some(true), Some(false), None, Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), Some(List(Streaming)))
+    val allSubProcessesQuery = FetchProcessesDetailsQuery(isSubprocess = Some(true))
+    val subProcessesQuery = allSubProcessesQuery.copy(isArchived = Some(false))
+    val subProcessesCategoryQuery = subProcessesQuery.copy(categories = Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)))
+    val subProcessesCategoryTypesQuery = subProcessesCategoryQuery.copy(processingTypes = Some(List(Streaming)))
 
-    val allArchivedSubProcessesQuery = FetchQuery(Some(true), Some(true), None, None, None)
-    val allArchivedSubProcessesCategoryQuery = FetchQuery(Some(true), Some(true), None, Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), None)
-    val allArchivedSubProcessesCategoryTypesQuery = FetchQuery(Some(true), Some(true), None, Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)), Some(List(Streaming)))
+    val archivedSubProcessesQuery = FetchProcessesDetailsQuery(isSubprocess = Some(true), isArchived = Some(true))
+    val archivedSubProcessesCategoryQuery = archivedSubProcessesQuery.copy(categories = Some(Seq(categoryMarketing, categoryFraud, categoryFraudSecond)))
+    val archivedSubProcessesCategoryTypesQuery = archivedSubProcessesCategoryQuery.copy(processingTypes = Some(List(Streaming)))
 
     //when
     val testingData = Table(
       ("user", "query", "expected"),
       //admin user
-      (admin, processesQuery, processes),
-      (admin, processesCategoryQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess, fraudProcess, fraudArchivedProcess, fraudSubprocess, fraudArchivedSubprocess, fraudSecondProcess, fraudSecondSubprocess)),
-      (admin, processesCategoryTypesQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess)),
-      (admin, allProcessesQuery, List(marketingProcess, fraudProcess, fraudSecondProcess, secretProcess)),
+      (admin, allProcessesQuery, processes),
+      (admin, allProcessesCategoryQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess, fraudProcess, fraudArchivedProcess, fraudSubprocess, fraudArchivedSubprocess, fraudSecondProcess, fraudSecondSubprocess)),
+      (admin, allProcessesCategoryTypesQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess)),
+      (admin, processesQuery, List(marketingProcess, fraudProcess, fraudSecondProcess, secretProcess)),
       (admin, deployedProcessesQuery, List(marketingProcess, fraudProcess)),
       (admin, deployedProcessesCategoryQuery, List(marketingProcess, fraudProcess)),
       (admin, deployedProcessesCategoryProcessingTypesQuery, List(marketingProcess)),
@@ -269,19 +270,19 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
       (admin, archivedProcessesQuery, List(marketingArchivedProcess, fraudArchivedProcess, secretArchivedProcess)),
       (admin, archivedProcessesCategoryQuery, List(marketingArchivedProcess, fraudArchivedProcess)),
       (admin, archivedProcessesCategoryProcessingTypesQuery, List(marketingArchivedProcess)),
-      (admin, subProcessesQuery, List(marketingSubprocess, marketingArchivedSubprocess, fraudSubprocess, fraudArchivedSubprocess, fraudSecondSubprocess, secretSubprocess, secretArchivedSubprocess)),
-      (admin, allSubProcessesQuery, List(marketingSubprocess, fraudSubprocess, fraudSecondSubprocess, secretSubprocess)),
-      (admin, allSubProcessesCategoryQuery, List(marketingSubprocess, fraudSubprocess, fraudSecondSubprocess)),
-      (admin, allSubProcessesCategoryTypesQuery, List(marketingSubprocess)),
-      (admin, allArchivedSubProcessesQuery, List(marketingArchivedSubprocess, fraudArchivedSubprocess, secretArchivedSubprocess)),
-      (admin, allArchivedSubProcessesCategoryQuery, List(marketingArchivedSubprocess, fraudArchivedSubprocess)),
-      (admin, allArchivedSubProcessesCategoryTypesQuery, List(marketingArchivedSubprocess)),
+      (admin, allSubProcessesQuery, List(marketingSubprocess, marketingArchivedSubprocess, fraudSubprocess, fraudArchivedSubprocess, fraudSecondSubprocess, secretSubprocess, secretArchivedSubprocess)),
+      (admin, subProcessesQuery, List(marketingSubprocess, fraudSubprocess, fraudSecondSubprocess, secretSubprocess)),
+      (admin, subProcessesCategoryQuery, List(marketingSubprocess, fraudSubprocess, fraudSecondSubprocess)),
+      (admin, subProcessesCategoryTypesQuery, List(marketingSubprocess)),
+      (admin, archivedSubProcessesQuery, List(marketingArchivedSubprocess, fraudArchivedSubprocess, secretArchivedSubprocess)),
+      (admin, archivedSubProcessesCategoryQuery, List(marketingArchivedSubprocess, fraudArchivedSubprocess)),
+      (admin, archivedSubProcessesCategoryTypesQuery, List(marketingArchivedSubprocess)),
 
       //marketing user
-      (marketingUser, processesQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess)),
-      (marketingUser, processesCategoryQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess)),
-      (marketingUser, processesCategoryTypesQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess)),
-      (marketingUser, allProcessesQuery, List(marketingProcess)),
+      (marketingUser, allProcessesQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess)),
+      (marketingUser, allProcessesCategoryQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess)),
+      (marketingUser, allProcessesCategoryTypesQuery, List(marketingProcess, marketingArchivedProcess, marketingSubprocess, marketingArchivedSubprocess)),
+      (marketingUser, processesQuery, List(marketingProcess)),
       (marketingUser, deployedProcessesQuery, List(marketingProcess)),
       (marketingUser, deployedProcessesCategoryQuery, List(marketingProcess)),
       (marketingUser, deployedProcessesCategoryProcessingTypesQuery, List(marketingProcess)),
@@ -292,19 +293,19 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
       (marketingUser, archivedProcessesQuery, List(marketingArchivedProcess)),
       (marketingUser, archivedProcessesCategoryQuery, List(marketingArchivedProcess)),
       (marketingUser, archivedProcessesCategoryProcessingTypesQuery, List(marketingArchivedProcess)),
-      (marketingUser, subProcessesQuery, List(marketingSubprocess, marketingArchivedSubprocess)),
-      (marketingUser, allSubProcessesQuery, List(marketingSubprocess)),
-      (marketingUser, allSubProcessesCategoryQuery, List(marketingSubprocess)),
-      (marketingUser, allSubProcessesCategoryTypesQuery, List(marketingSubprocess)),
-      (marketingUser, allArchivedSubProcessesQuery, List(marketingArchivedSubprocess)),
-      (marketingUser, allArchivedSubProcessesCategoryQuery, List(marketingArchivedSubprocess)),
-      (marketingUser, allArchivedSubProcessesCategoryTypesQuery, List(marketingArchivedSubprocess)),
+      (marketingUser, allSubProcessesQuery, List(marketingSubprocess, marketingArchivedSubprocess)),
+      (marketingUser, subProcessesQuery, List(marketingSubprocess)),
+      (marketingUser, subProcessesCategoryQuery, List(marketingSubprocess)),
+      (marketingUser, subProcessesCategoryTypesQuery, List(marketingSubprocess)),
+      (marketingUser, archivedSubProcessesQuery, List(marketingArchivedSubprocess)),
+      (marketingUser, archivedSubProcessesCategoryQuery, List(marketingArchivedSubprocess)),
+      (marketingUser, archivedSubProcessesCategoryTypesQuery, List(marketingArchivedSubprocess)),
 
       //fraud user
-      (fraudUser, processesQuery, List(fraudProcess, fraudArchivedProcess, fraudSubprocess, fraudArchivedSubprocess, fraudSecondProcess, fraudSecondSubprocess)),
-      (fraudUser, processesCategoryQuery, List(fraudProcess, fraudArchivedProcess, fraudSubprocess, fraudArchivedSubprocess, fraudSecondProcess, fraudSecondSubprocess)),
-      (fraudUser, processesCategoryTypesQuery, List()),
-      (fraudUser, allProcessesQuery, List(fraudProcess, fraudSecondProcess)),
+      (fraudUser, allProcessesQuery, List(fraudProcess, fraudArchivedProcess, fraudSubprocess, fraudArchivedSubprocess, fraudSecondProcess, fraudSecondSubprocess)),
+      (fraudUser, allProcessesCategoryQuery, List(fraudProcess, fraudArchivedProcess, fraudSubprocess, fraudArchivedSubprocess, fraudSecondProcess, fraudSecondSubprocess)),
+      (fraudUser, allProcessesCategoryTypesQuery, List()),
+      (fraudUser, processesQuery, List(fraudProcess, fraudSecondProcess)),
       (fraudUser, deployedProcessesQuery, List(fraudProcess)),
       (fraudUser, deployedProcessesCategoryQuery, List(fraudProcess)),
       (fraudUser, deployedProcessesCategoryProcessingTypesQuery, List()),
@@ -315,24 +316,21 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
       (fraudUser, archivedProcessesQuery, List(fraudArchivedProcess)),
       (fraudUser, archivedProcessesCategoryQuery, List(fraudArchivedProcess)),
       (fraudUser, archivedProcessesCategoryProcessingTypesQuery, List()),
-      (fraudUser, subProcessesQuery, List(fraudSubprocess, fraudArchivedSubprocess, fraudSecondSubprocess)),
-      (fraudUser, allSubProcessesQuery, List(fraudSubprocess, fraudSecondSubprocess)),
-      (fraudUser, allSubProcessesCategoryQuery, List(fraudSubprocess, fraudSecondSubprocess)),
-      (fraudUser, allSubProcessesCategoryTypesQuery, List()),
-      (fraudUser, allArchivedSubProcessesQuery, List(fraudArchivedSubprocess)),
-      (fraudUser, allArchivedSubProcessesQuery, List(fraudArchivedSubprocess)),
-      (fraudUser, allArchivedSubProcessesCategoryQuery, List(fraudArchivedSubprocess)),
-      (fraudUser, allArchivedSubProcessesCategoryTypesQuery, List()),
+      (fraudUser, allSubProcessesQuery, List(fraudSubprocess, fraudArchivedSubprocess, fraudSecondSubprocess)),
+      (fraudUser, subProcessesQuery, List(fraudSubprocess, fraudSecondSubprocess)),
+      (fraudUser, subProcessesCategoryQuery, List(fraudSubprocess, fraudSecondSubprocess)),
+      (fraudUser, subProcessesCategoryTypesQuery, List()),
+      (fraudUser, archivedSubProcessesQuery, List(fraudArchivedSubprocess)),
+      (fraudUser, archivedSubProcessesQuery, List(fraudArchivedSubprocess)),
+      (fraudUser, archivedSubProcessesCategoryQuery, List(fraudArchivedSubprocess)),
+      (fraudUser, archivedSubProcessesCategoryTypesQuery, List()),
     )
 
-    forAll(testingData) { (user: LoggedUser, query: FetchQuery, expected: List[ProcessDetails]) =>
-      val result = mockRepository.fetchProcesses(query.isSubprocess, query.isArchived, query.isDeployed, query.categories, query.processingTypes)(DisplayableShape, user, global).futureValue
+    forAll(testingData) { (user: LoggedUser, query: FetchProcessesDetailsQuery, expected: List[ProcessDetails]) =>
+      val result = mockRepository.fetchProcessesDetails(query)(DisplayableShape, user, global).futureValue
 
       //then
       result shouldBe expected
     }
   }
-
-  //TODO: Move it as Query Object and replace params at FetchingProcessRepository.fetchProcesses(isSubprocess, isArchived, isDeployed, categories, processingTypes)
-  case class FetchQuery(isSubprocess: Option[Boolean], isArchived: Option[Boolean], isDeployed: Option[Boolean], categories: Option[Seq[String]], processingTypes: Option[Seq[String]])
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/initialization/InitializationOnHsqlItSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/initialization/InitializationOnHsqlItSpec.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.ui.initialization
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.{BeforeAndAfterEach}
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 import pl.touk.nussknacker.engine.api.process.ProcessName
@@ -9,6 +9,7 @@ import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.ui.api.helpers.TestFactory.mapProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.api.helpers.{ProcessTestData, TestFactory, TestProcessingTypes, WithHsqlDbTesting}
 import pl.touk.nussknacker.ui.process.migrate.TestMigrations
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.CreateProcessAction
 
 class InitializationOnHsqlItSpec extends AnyFlatSpec with ScalatestRouteTest with Matchers with PatientScalaFutures with BeforeAndAfterEach with WithHsqlDbTesting {
@@ -33,7 +34,7 @@ class InitializationOnHsqlItSpec extends AnyFlatSpec with ScalatestRouteTest wit
 
     Initialization.init(migrations, db, "env1")
 
-    repository.fetchProcessesDetails[Unit]().futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("proc1", Some(2)))
+    repository.fetchProcessesDetails[Unit](FetchProcessesDetailsQuery.unarchivedProcesses).futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("proc1", Some(2)))
   }
 
   it should "migrate processes when fragments present" in {
@@ -47,7 +48,7 @@ class InitializationOnHsqlItSpec extends AnyFlatSpec with ScalatestRouteTest wit
 
     Initialization.init(migrations, db, "env1")
 
-    repository.fetchProcessesDetails[Unit]().futureValue.map(d => (d.name, d.modelVersion)).toSet shouldBe (1 to 20).map(id => (s"id$id", Some(2))).toSet
+    repository.fetchProcessesDetails[Unit](FetchProcessesDetailsQuery.unarchivedProcesses).futureValue.map(d => (d.name, d.modelVersion)).toSet shouldBe (1 to 20).map(id => (s"id$id", Some(2))).toSet
 
   }
 
@@ -67,7 +68,7 @@ class InitializationOnHsqlItSpec extends AnyFlatSpec with ScalatestRouteTest wit
 
     exception.getMessage shouldBe "made to fail.."
 
-    repository.fetchProcessesDetails[Unit]().futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("proc1", Some(1)))
+    repository.fetchProcessesDetails[Unit](FetchProcessesDetailsQuery.unarchivedProcesses).futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("proc1", Some(1)))
   }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/initialization/InitializationOnPostgresItSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/initialization/InitializationOnPostgresItSpec.scala
@@ -10,6 +10,7 @@ import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.ui.api.helpers.TestFactory.mapProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.api.helpers._
 import pl.touk.nussknacker.ui.process.migrate.TestMigrations
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.CreateProcessAction
 
 import scala.concurrent.ExecutionContextExecutor
@@ -45,7 +46,7 @@ class InitializationOnPostgresItSpec
 
     Initialization.init(migrations, db, "env1")
 
-    repository.fetchProcessesDetails[Unit]().futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("proc1", Some(2)))
+    repository.fetchProcessesDetails[Unit](FetchProcessesDetailsQuery.unarchivedProcesses).futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("proc1", Some(2)))
   }
 
   it should "migrate processes when fragments present" in {
@@ -54,7 +55,7 @@ class InitializationOnPostgresItSpec
 
     Initialization.init(migrations, db, "env1")
 
-    repository.fetchProcessesDetails[Unit]().futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("id1", Some(2)))
+    repository.fetchProcessesDetails[Unit](FetchProcessesDetailsQuery.unarchivedProcesses).futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("id1", Some(2)))
   }
 
   private def saveSampleProcess(processName: String = processId, subprocess: Boolean = false): Unit = {
@@ -73,7 +74,7 @@ class InitializationOnPostgresItSpec
 
     exception.getMessage shouldBe "made to fail.."
 
-    repository.fetchProcessesDetails[Unit]().futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("proc1", Some(1)))
+    repository.fetchProcessesDetails[Unit](FetchProcessesDetailsQuery.unarchivedProcesses).futureValue.map(d => (d.name, d.modelVersion)) shouldBe List(("proc1", Some(1)))
   }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
@@ -15,6 +15,7 @@ import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.ui.api.helpers.ProcessTestData.toValidatedDisplayable
 import pl.touk.nussknacker.ui.api.helpers.TestFactory.mapProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.api.helpers.TestProcessUtil._
+import pl.touk.nussknacker.ui.api.helpers.TestProcessingTypes.Streaming
 import pl.touk.nussknacker.ui.api.helpers.{ProcessTestData, TestFactory, TestProcessUtil, TestProcessingTypes}
 import pl.touk.nussknacker.ui.process.ProcessService.UpdateProcessCommand
 import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
@@ -40,7 +41,7 @@ class StandardRemoteEnvironmentSpec extends AnyFlatSpec with Matchers with Patie
 
     override implicit val materializer = Materializer(system)
 
-    override def testModelMigrations: TestModelMigrations = new TestModelMigrations(mapProcessingTypeDataProvider(), TestFactory.processValidation)
+    override def testModelMigrations: TestModelMigrations = new TestModelMigrations(mapProcessingTypeDataProvider(Streaming -> new TestMigrations(1, 2)), TestFactory.processValidation)
 
   }
 
@@ -306,6 +307,9 @@ class StandardRemoteEnvironmentSpec extends AnyFlatSpec with Matchers with Patie
       subProcesses = TestProcessUtil.validatedToProcess(toValidatedDisplayable(ProcessTestData.sampleSubprocess)) :: Nil
     )
 
-    remoteEnvironment.testMigration().futureValue.value
+    val migrationResult = remoteEnvironment.testMigration().futureValue.value
+
+    migrationResult should have size 2
+    migrationResult.map(_.converted.id) should contain only (ProcessTestData.validProcessDetails.name, ProcessTestData.sampleSubprocess.id)
   }
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
@@ -133,14 +133,14 @@ class StandardRemoteEnvironmentSpec extends AnyFlatSpec with Matchers with Patie
     override protected def request(uri: Uri, method: HttpMethod, request: MessageEntity): Future[HttpResponse] = {
       object GetBasicProcesses {
         def unapply(arg: (Uri, HttpMethod)): Boolean = {
-          arg._1.toString() == s"$baseUri/processes" && arg._2 == HttpMethods.GET
+          arg._1.toString() == s"$baseUri/processes?isArchived=false&isSubprocess=false" && arg._2 == HttpMethods.GET
         }
       }
 
       object GetProcessesDetails {
         def unapply(arg: (Uri, HttpMethod)): Option[Set[String]] = {
           val uri = arg._1
-          if (uri.toString().startsWith(s"$baseUri/processesDetails") && arg._2 == HttpMethods.GET) {
+          if (uri.toString().startsWith(s"$baseUri/processesDetails") && uri.query().get("isArchived").contains("false") && arg._2 == HttpMethods.GET) {
             uri.query().get("names").map(_.split(",").toSet)
           } else {
             None

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
@@ -235,7 +235,7 @@ class DBFetchingProcessRepositorySpec
 
   private def fetchMetaDataIdsForAllVersions(name: ProcessName) = {
     fetching.fetchProcessId(name).futureValue.toSeq.flatMap { processId =>
-      fetching.fetchAllProcessesDetails[DisplayableProcess]().futureValue
+      fetching.fetchProcessesDetails[DisplayableProcess](FetchProcessesDetailsQuery.unarchived).futureValue
         .filter(_.processId.value == processId.value)
         .map(_.json)
         .map(_.metaData.id)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
@@ -15,6 +15,7 @@ import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.ui.api.helpers.TestFactory.mapProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.api.helpers._
 import pl.touk.nussknacker.ui.process.repository.DbProcessActivityRepository.Comment
+import pl.touk.nussknacker.ui.process.repository.FetchingProcessRepository.FetchProcessesDetailsQuery
 import pl.touk.nussknacker.ui.process.repository.ProcessDBQueryRepository.ProcessAlreadyExists
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.{CreateProcessAction, ProcessUpdated, UpdateProcessAction}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
@@ -62,7 +63,7 @@ class DBFetchingProcessRepositorySpec
 
     saveProcessForCategory("c1")
     saveProcessForCategory("c2")
-    val processes= fetching.fetchProcesses(None, isArchived = Some(false), None, None, None)(ProcessShapeFetchStrategy.NotFetch, c1Reader, implicitly[ExecutionContext]).futureValue
+    val processes= fetching.fetchProcessesDetails(FetchProcessesDetailsQuery(isArchived = Some(false)))(ProcessShapeFetchStrategy.NotFetch, c1Reader, implicitly[ExecutionContext]).futureValue
 
     processes.map(_.name) shouldEqual "categorized-c1"::Nil
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepositorySpec.scala
@@ -95,7 +95,7 @@ class DBFetchingProcessRepositorySpec
     val before = fetchMetaDataIdsForAllVersions(oldName)
     before.toSet shouldBe Set(oldName.value)
 
-    renameProcess(oldName, newName.value) shouldBe 'right
+    renameProcess(oldName, newName) shouldBe 'right
 
     processExists(oldName) shouldBe false
     processExists(oldName2) shouldBe true
@@ -122,7 +122,7 @@ class DBFetchingProcessRepositorySpec
     )
     processExists(newName) shouldBe false
 
-    renameProcess(oldName, newName.value) shouldBe 'right
+    renameProcess(oldName, newName) shouldBe 'right
 
     val comments = fetching.fetchProcessId(newName)
       .flatMap(v => activities.findActivity(ProcessIdWithName(v.get, newName)).map(_.comments))
@@ -155,7 +155,7 @@ class DBFetchingProcessRepositorySpec
     processExists(oldName) shouldBe true
     processExists(existingName) shouldBe true
 
-    renameProcess(oldName, existingName.value) shouldBe ProcessAlreadyExists(existingName.value).asLeft
+    renameProcess(oldName, existingName) shouldBe ProcessAlreadyExists(existingName.value).asLeft
   }
 
   test("should generate new process version id based on latest version id") {
@@ -228,7 +228,7 @@ class DBFetchingProcessRepositorySpec
     repositoryManager.runInTransaction(writingRepo.saveNewProcess(action)).futureValue shouldBe 'right
   }
 
-  private def renameProcess(processName: ProcessName, newName: String) = {
+  private def renameProcess(processName: ProcessName, newName: ProcessName) = {
     val processId = fetching.fetchProcessId(processName).futureValue.get
     repositoryManager.runInTransaction(writingRepo.renameProcess(ProcessIdWithName(processId, processName), newName)).futureValue
   }

--- a/designer/submodules/packages/components/src/scenarios/useScenariosQuery.tsx
+++ b/designer/submodules/packages/components/src/scenarios/useScenariosQuery.tsx
@@ -12,8 +12,8 @@ function useScenariosQuery(): UseQueryResult<ProcessType[]> {
     return useQuery({
         queryKey: ["scenarios"],
         queryFn: async () => {
-            const results = await Promise.all([api.fetchProcesses(), api.fetchProcesses({ isArchived: true })]);
-            return results.flatMap(({ data }) => data).map(({ createdAt, modificationDate, ...row }) => ({
+            const results = await api.fetchProcesses();
+            return results.data.map(({ createdAt, modificationDate, ...row }) => ({
                 ...row,
                 createdAt: createdAt && DateTime.fromISO(createdAt).toFormat("yyyy-MM-dd HH:mm:ss"),
                 modificationDate: modificationDate && DateTime.fromISO(modificationDate).toFormat("yyyy-MM-dd HH:mm:ss"),

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8,6 +8,9 @@
 * [#3606](https://github.com/TouK/nussknacker/pull/3606) Removed nussknacker-request-response-app. See MigrationGuide for details.
 * [#3626](https://github.com/TouK/nussknacker/pull/3626) Fix for: using Typed.fromDetailedType with scala type aliases cause exception
 * [#3560](https://github.com/TouK/nussknacker/pull/3560), [#3595](https://github.com/TouK/nussknacker/pull/3595) Remove Flink Scala API
+* [#3576](https://github.com/TouK/nussknacker/pull/3576) Unified `/processes` and `/processesDetails`. Both endpoints support the same query parameters.
+  Added option `skipValidateAndResolve` in `/processesDetails`, `/processes/{name}` and `/processes/{name}/{versionId}`
+  to return scenario JSON omitting validation and dictionary resolving.
 
 1.6.0 (18 Oct 2022)
 ------------------------

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -13,6 +13,8 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   * Lite k8s engine with request-response processing mode
   * `request-response-embedded` Deployment Manager
 * [#3610](https://github.com/TouK/nussknacker/pull/3610) Removed deprecated code. For details see changes in pull request.
+* [#3576](https://github.com/TouK/nussknacker/pull/3576) `/processes` endpoint without query parameters returns all scenarios - the previous behaviour was to return only unarchived ones.
+  To fetch only unarchived scenarios `isArchived=false` query parameter has to be passed.
 
 ## In version 1.6.0
 * [#3440](https://github.com/TouK/nussknacker/pull/3440) Feature: allow to define fragment's outputs


### PR DESCRIPTION
Third party NU based apps that have to fetch scenarios do not necessarily rely on validation results. Since validation is time consuming, skipping it can can significantly speed up such applications, e.g. initialization time.

Optional parameter `skipValidateAndResolve` has been added to the following endpoints:
* `/processesDetails`
* `/processes/{name}`
* `/processes/{name}/{versionId}`