### PR TITLE
Change to eclipse-temurin base image due to openjdk deprecation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -308,7 +308,7 @@ val jmxPrometheusJavaagentV = "0.16.1"
 
 lazy val commonDockerSettings = {
   Seq(
-    dockerBaseImage := "openjdk:11-jre-slim",
+    dockerBaseImage := "eclipse-temurin:11-jre-jammy",
     dockerUsername := dockerUserName,
     dockerUpdateLatest := dockerUpLatestFromProp.getOrElse(!isSnapshot.value),
     dockerBuildCommand := {
@@ -343,8 +343,7 @@ lazy val distDockerSettings = {
   val nussknackerDir = "/opt/nussknacker"
 
   commonDockerSettings ++ Seq(
-    //we use openjdk:11-jre for designer because *-slim based images lack /usr/local/openjdk-11/lib/libfontmanager.so file necessary during pdf export
-    dockerBaseImage := "openjdk:11-jre",
+    dockerBaseImage := "eclipse-temurin:11-jre-jammy",
     dockerEntrypoint := Seq(s"$nussknackerDir/bin/nussknacker-entrypoint.sh"),
     dockerExposedPorts := Seq(dockerPort),
     dockerEnvVars := Map(

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+1.7.0 (Not released yet)
+------------------------
+* [#3524](https://github.com/TouK/nussknacker/pull/3524) Change base docker image to eclipse temurin due to openjdk deprecation.
+
 1.6.0 (Not released yet)
 ------------------------
 * [#3382](https://github.com/TouK/nussknacker/pull/3382) Security fix: Http cookie created by NU when using OAuth2 is now secure.

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,10 +1,6 @@
 
 # Changelog
 
-1.7.0 (Not released yet)
-------------------------
-* [#3524](https://github.com/TouK/nussknacker/pull/3524) Change base docker image to eclipse temurin due to openjdk deprecation.
-
 1.6.0 (Not released yet)
 ------------------------
 * [#3382](https://github.com/TouK/nussknacker/pull/3382) Security fix: Http cookie created by NU when using OAuth2 is now secure.
@@ -40,6 +36,7 @@
 * [#3619](https://github.com/TouK/nussknacker/pull/3619) Patch `KafkaMetricWrapper.java` until Flink 1.15.3 is released. Read [more](https://issues.apache.org/jira/browse/FLINK-28488) about this bug. 
 * [#3574](https://github.com/TouK/nussknacker/pull/3574) Feature: instance logo can be shown next to Nu logo, by convention it has
   to be available at path `<nu host>/assets/img/instance-logo.svg`
+* [#3524](https://github.com/TouK/nussknacker/pull/3524) Change base docker image to eclipse temurin due to openjdk deprecation.
 
 1.5.0 (16 Aug 2022)
 ------------------------

--- a/docs/installation_configuration_guide/Installation.md
+++ b/docs/installation_configuration_guide/Installation.md
@@ -31,7 +31,7 @@ More information you can find at [Docker hub](https://hub.docker.com/r/touk/nuss
 
 ### Base Image
 
-As a base image we use `openjdk:11-jre`. See [Open JDK's Docker hub](https://hub.docker.com/_/openjdk) for more
+As a base image we use `eclipse-temurin:11-jre-jammy`. See [Eclipse Temurin Docker hub](https://hub.docker.com/_/eclipse-temurin) for more
 details.
 
 ### Container configuration


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
