### PR TITLE
Fix for serving OpenApi definition and SwaggerUI for deployed RequestResponse scenarios in embedded mode

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,9 @@
 
 # Changelog
 
+1.6.1 (Not released yet)
+* [#3647](https://github.com/TouK/nussknacker/pull/3647) Fix for serving OpenApi definition and SwaggerUI for deployed RequestResponse scenarios in embedded mode
+
 1.6.0 (18 Oct 2022)
 ------------------------
 * [#3382](https://github.com/TouK/nussknacker/pull/3382) Security fix: Http cookie created by NU when using OAuth2 is now secure.

--- a/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/requestresponse/ScenarioDispatcherRoute.scala
+++ b/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/requestresponse/ScenarioDispatcherRoute.scala
@@ -15,7 +15,7 @@ class ScenarioDispatcherRoute(scenarioRoutes: scala.collection.Map[String, Scena
   protected def logDirective(scenarioName: String): Directive0 = DebuggingDirectives.logRequestResult((s"request-response-$scenarioName", Logging.DebugLevel))
 
   def route(implicit ec: ExecutionContext, mat: Materializer): Route =
-    path("scenario" / Segment) { scenarioSlug =>
+    pathPrefix("scenario" / Segment) { scenarioSlug =>
       handle(scenarioSlug)(_.combinedRoute)
     }
 

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/RequestResponseEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/RequestResponseEmbeddedDeploymentManagerTest.scala
@@ -91,6 +91,8 @@ class RequestResponseEmbeddedDeploymentManagerTest extends AnyFunSuite with Matc
     request.body("""Not a correct json""").send().body shouldBe Left("""[{"message":"#: expected type: JSONObject, found: String","nodeId":"source"}]""")
     request.body("""{ productId: "11"}""").send().body shouldBe Left("""[{"message":"#/productId: expected type: Integer, found: String","nodeId":"source"}]""")
 
+    basicRequest.get(uri"http://localhost".port(port).path("scenario", name.value, "definition")).send().body.right.get should include ("\"openapi\"")
+
     manager.cancel(name, User("a", "b")).futureValue
 
     manager.findJobStatus(name).futureValue shouldBe None


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
