### PR TITLE
Fix schema validation when using additionalProperties without required

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -3,6 +3,7 @@
 
 1.6.1 (Not released yet)
 * [#3647](https://github.com/TouK/nussknacker/pull/3647) Fix for serving OpenApi definition and SwaggerUI for deployed RequestResponse scenarios in embedded mode
+* [#3657](https://github.com/TouK/nussknacker/pull/3657) Fix for json-schema additionalProperties validation
 
 1.6.0 (18 Oct 2022)
 ------------------------

--- a/engine/lite/request-response/app/src/test/scala/pl/touk/nussknacker/engine/requestresponse/http/RequestResponseHttpJsonSchemaSpec.scala
+++ b/engine/lite/request-response/app/src/test/scala/pl/touk/nussknacker/engine/requestresponse/http/RequestResponseHttpJsonSchemaSpec.scala
@@ -96,6 +96,24 @@ class RequestResponseHttpJsonSchemaSpec extends RequestResponseHttpTest {
     }
   }
 
+  it should "should handle additionalProperties without required" in {
+    assertProcessNotRunning(procId)
+    Post("/deploy", toEntity(deploymentData(
+      jsonSchemaProcess(
+        inputSchema = """{"type":"object","properties": {"field1": {"type": "integer"}}}""",
+        outputSchema = """{"type":"object","properties": {"field1": {"type": "integer"}}, "additionalProperties": false}""",
+        outputValue = """{"field1": #input.field1}""".strip()
+      )
+    ))) ~> managementRoute ~> check {
+      status shouldBe StatusCodes.OK
+      Post(s"/${procId.value}", toEntity(Map("field1" -> 101))) ~> processesRoute ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String] shouldBe """{"field1":101}""".strip()
+        cancelProcess(procId)
+      }
+    }
+  }
+
   it should "should fill empty request with default values" in {
     assertProcessNotRunning(procId)
     Post("/deploy", toEntity(deploymentData(

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaSubclassDeterminer.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaSubclassDeterminer.scala
@@ -53,7 +53,7 @@ class JsonSchemaSubclassDeterminer(parentSchema: Schema) extends LazyLogging {
     }
 
     val additionalPropertiesValidation = {
-      val additionalProperties = e.fields.keySet.diff(requiredFieldNames)
+      val additionalProperties = e.fields.keySet.diff(objectProperties.keySet)
       condNel(objectSchema.permitsAdditionalProperties || additionalProperties.isEmpty, (),
         msgWithLocation(s"The object has redundant fields: $additionalProperties"))
     }


### PR DESCRIPTION
```
{
  "properties": {
    "msisdn": {
      "type": "string"
    }
  },
  "additionalProperties": false,
} 
```
Before fix above example didn't allowed to pass request as `{"msisdn": "test"}` - It was required to add `"required": ["msisdn"]`. 