### PR TITLE
Fix contextId assignment for the output of ForEachTransformer

### DIFF
--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
@@ -23,8 +23,10 @@ object ForEachTransformer extends CustomStreamTransformer {
       stream
         .flatMap(ctx.lazyParameterHelper.lazyMapFunction(elements))
         .flatMap((valueWithContext: ValueWithContext[util.Collection[AnyRef]], c: Collector[ValueWithContext[AnyRef]]) => {
-          valueWithContext.value.asScala
-            .map(new ValueWithContext[AnyRef](_, valueWithContext.context))
+          valueWithContext.value.asScala.toList.zipWithIndex
+            .map { case (partToRun, index) =>
+              new ValueWithContext[AnyRef](partToRun, valueWithContext.context.copy(id=s"${valueWithContext.context.id}-$index"))
+            }
             .foreach(c.collect)
         }, ctx.valueWithContextInfo.forType[AnyRef](returnType(elements)))
     }, returnType(elements))

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
@@ -23,7 +23,7 @@ object ForEachTransformer extends CustomStreamTransformer {
       stream
         .flatMap(ctx.lazyParameterHelper.lazyMapFunction(elements))
         .flatMap((valueWithContext: ValueWithContext[util.Collection[AnyRef]], c: Collector[ValueWithContext[AnyRef]]) => {
-          valueWithContext.value.asScala.toList.zipWithIndex
+          valueWithContext.value.asScala.zipWithIndex
             .map { case (partToRun, index) =>
               new ValueWithContext[AnyRef](partToRun, valueWithContext.context.copy(id=s"${valueWithContext.context.id}-$index"))
             }


### PR DESCRIPTION
Fix for incorrect contextId assignment in `ForEachTransformer`.

Environment: 1.7.0-staging-2022-10-27-10064, e.g. https://staging.nussknacker.io/visualization/fmc_c1
Steps to reproduce: 
1. run "Test from file" on scenario with for-each component
2. see the values assigned to the output of for-each
3. on "Test case" list it is impossible to switch between individual cases within the same input collection, because all elements have the same Test case id = contenxtId (see attached image)

The "lite" version ForEachTransformer assigns contextId correctly.

![obraz](https://user-images.githubusercontent.com/2381222/199099717-01e45500-ae92-4f44-807b-269ce0d33bf5.png)
