### PR TITLE
Cleanup legacy API in `SubprocessRef::outputVariableNames`

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentDefinitionPreparer.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentDefinitionPreparer.scala
@@ -130,7 +130,7 @@ object ComponentDefinitionPreparer {
             case (id, definition) =>
               val nodes = EvaluatedParameterPreparer.prepareEvaluatedParameter(definition.parameters)
               val outputs = definition.outputParameters.map(name => (name, name)).toMap
-              ComponentTemplate(ComponentType.Fragments, id, SubprocessInput("", SubprocessRef(id, nodes, Some(outputs))), userProcessingTypeCategories.intersect(definition.categories))
+              ComponentTemplate(ComponentType.Fragments, id, SubprocessInput("", SubprocessRef(id, nodes, outputs)), userProcessingTypeCategories.intersect(definition.categories))
           }.toList))
     } else {
       List.empty

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -13,6 +13,7 @@
   to return scenario JSON omitting validation and dictionary resolving.
 * [#3607](https://github.com/TouK/nussknacker/pull/3607) Request-response jsonSchema based encoder.
 * [#3656](https://github.com/TouK/nussknacker/pull/3656) OpenAPI 3.1.0 support + basic support for type references in json schemas
+* [#3680](https://github.com/TouK/nussknacker/pull/3680) Fix: validate multiple same fragments used in a row in legacy scenario jsons (without `outputVariableNames` field in `SubprocessRef`)
 
 1.6.1 (Not released yet)
 * [#3647](https://github.com/TouK/nussknacker/pull/3647) Fix for serving OpenApi definition and SwaggerUI for deployed RequestResponse scenarios in embedded mode

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -19,6 +19,9 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   * ValidationMode moved to package `pl.touk.nussknacker.engine.api.validation` in `nussknacker-components-api`
   * BestEffortJsonSchemaEncoder moved to package `pl.touk.nussknacker.engine.json.encode` in `nussknacker-json-utils`
 
+### Code API changes
+* [#3680](https://github.com/TouK/nussknacker/pull/3680) `SubprocessRef::outputVariableNames` type is changed from `Option[Map[String,String]]` with default None, to `Map[String,String]` with default `Map.empty`
+
 ## In version 1.6.0
 * [#3440](https://github.com/TouK/nussknacker/pull/3440) Feature: allow to define fragment's outputs
   * Right now using fragments in scenario is changed. We have to provide each outputName for outputs defined in fragment.

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeDataValidator.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeDataValidator.scala
@@ -69,8 +69,8 @@ object NodeDataValidator {
           errors => ValidationPerformed(errors.toList, None, None),
           { case InputValidationResponse(params, outputs) =>
             val outputFieldsValidationErrors = outputs.collect { case Output(name, true) => name }.map { output =>
-              val outputName = a.ref.outputVariableNames.map(names =>
-                Validated.fromOption(names.get(output), NonEmptyList.one(UnknownFragmentOutput(output, Set(a.id))))).getOrElse(Valid(output))
+              val maybeOutputName: Option[String] = a.ref.outputVariableNames.get(output)
+              val outputName = Validated.fromOption(maybeOutputName, NonEmptyList.one(UnknownFragmentOutput(output, Set(a.id))))
               outputName.andThen(name => validationContext.withVariable(OutputVar.fragmentOutput(output, name), Unknown))
             }.toList.sequence.swap.toList.flatMap(_.toList)
             val outgoingEdgesErrors = outputs.collect {

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
@@ -244,7 +244,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside {
     val expectedMsg = s"Bad expression type, expected: String, found: ${Typed.fromInstance(145).display}"
     inside(
       validate(SubprocessInput("frInput", SubprocessRef("fragment1", List(Parameter("param1", "145")),
-        Some(Map("out1" -> "test1")))), ValidationContext.empty, outgoingEdges = List(OutgoingEdge("any", Some(SubprocessOutput("out1")))))
+        Map("out1" -> "test1"))), ValidationContext.empty, outgoingEdges = List(OutgoingEdge("any", Some(SubprocessOutput("out1")))))
     ) {
       case ValidationPerformed(List(ExpressionParserCompilationError(expectedMsg, "frInput", Some("param1"), "145")), None, None) =>
     }
@@ -257,7 +257,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside {
     val nodeId = "frInput"
     inside(
       validate(SubprocessInput(nodeId, SubprocessRef("fragment1", List(Parameter("param1", "'someValue'")),
-        Some(Map("out1" -> incorrectVarName)))), ValidationContext.empty, outgoingEdges = List(OutgoingEdge("any", Some(SubprocessOutput("out1")))))
+        Map("out1" -> incorrectVarName))), ValidationContext.empty, outgoingEdges = List(OutgoingEdge("any", Some(SubprocessOutput("out1")))))
     ) {
       case ValidationPerformed(List(InvalidVariableOutputName(incorrectVarName, nodeId, Some(varFieldName))), None, None) =>
     }
@@ -265,7 +265,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside {
     val existingVar = "var1"
     inside(
       validate(SubprocessInput(nodeId, SubprocessRef("fragment1", List(Parameter("param1", "'someValue'")),
-        Some(Map("out1" -> existingVar)))), ValidationContext(Map(existingVar -> Typed[String])), outgoingEdges = List(OutgoingEdge("any", Some(SubprocessOutput("out1")))))
+        Map("out1" -> existingVar))), ValidationContext(Map(existingVar -> Typed[String])), outgoingEdges = List(OutgoingEdge("any", Some(SubprocessOutput("out1")))))
     ) {
       case ValidationPerformed(List(OverwrittenVariable(existingVar, nodeId, Some(varFieldName))), None, None) =>
     }
@@ -275,7 +275,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside {
     val nodeId = "frInput"
     val nodes = Set("aa")
     inside(
-      validate(SubprocessInput(nodeId, SubprocessRef("fragment1", List(Parameter("param1", "'someValue'")), Some(Map("out1" -> "ok")))), ValidationContext.empty)
+      validate(SubprocessInput(nodeId, SubprocessRef("fragment1", List(Parameter("param1", "'someValue'")), Map("out1" -> "ok"))), ValidationContext.empty)
     ) {
       case ValidationPerformed(List(FragmentOutputNotDefined("out1", nodes)), None, None) =>
     }

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/build/GraphBuilder.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/build/GraphBuilder.scala
@@ -38,13 +38,13 @@ trait GraphBuilder[R] {
     build(node => creator(OneOutputSubsequentNode(Processor(id, ServiceRef(svcId, params.map(Parameter.tupled).toList), isDisabled = Some(true)), node)))
 
   def subprocessOneOut(id: String, subProcessId: String, fragmentOutputDefinitionName: String, outputParamName: String, params: (String, Expression)*): GraphBuilder[R] =
-    build(node => creator(SubprocessNode(SubprocessInput(id, SubprocessRef(subProcessId, params.map(Parameter.tupled).toList, Some(Map(fragmentOutputDefinitionName -> outputParamName)))), Map(fragmentOutputDefinitionName -> node))))
+    build(node => creator(SubprocessNode(SubprocessInput(id, SubprocessRef(subProcessId, params.map(Parameter.tupled).toList, Map(fragmentOutputDefinitionName -> outputParamName))), Map(fragmentOutputDefinitionName -> node))))
 
   def subprocess(id: String, subProcessId: String, params: List[(String, Expression)], outputParameters: Map[String, String], outputs: Map[String, SubsequentNode]): R =
-    creator(SubprocessNode(SubprocessInput(id, SubprocessRef(subProcessId, params.map(Parameter.tupled), Some(outputParameters))), outputs))
+    creator(SubprocessNode(SubprocessInput(id, SubprocessRef(subProcessId, params.map(Parameter.tupled), outputParameters)), outputs))
 
   def subprocessEnd(id: String, subProcessId: String, params: (String, Expression)*): R =
-    creator(SubprocessNode(SubprocessInput(id, SubprocessRef(subProcessId, params.map(Parameter.tupled).toList, None)), Map()))
+    creator(SubprocessNode(SubprocessInput(id, SubprocessRef(subProcessId, params.map(Parameter.tupled).toList, Map.empty)), Map()))
 
   def fragmentInput(id: String, params: (String, Class[_])*): GraphBuilder[SourceNode] =
     new SimpleGraphBuilder(SourceNode(SubprocessInputDefinition(id, params.map(kv => SubprocessParameter(kv._1, SubprocessClazzRef(kv._2.getName))).toList), _))

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/graph/subprocess.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/graph/subprocess.scala
@@ -1,11 +1,14 @@
 package pl.touk.nussknacker.engine.graph
 
+import io.circe.Decoder
 import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
 
 object subprocess {
 
-  //TODO: outputVariableNames has to be optional because of backward compatibility (nodes from db are converted to this..), remove optional in next version
-  @JsonCodec case class SubprocessRef(id: String, parameters: List[Parameter], outputVariableNames: Option[Map[String, String]] = None)
+  //we decode absence to empty map because of backwards compatibility (objects in db can contain no `outputVariableNames` field)
+  private implicit val mapWithFallbackToEmptyMapDecoder: Decoder[Map[String, String]] =
+    Decoder.decodeOption[Map[String, String]](Decoder.decodeMap[String, String]).map(_.getOrElse(Map.empty))
 
+  @JsonCodec case class SubprocessRef(id: String, parameters: List[Parameter], outputVariableNames: Map[String, String] = Map.empty)
 }

--- a/scenario-api/src/test/scala/pl/touk/nussknacker/engine/canonicalgraph/CanonicalProcessTest.scala
+++ b/scenario-api/src/test/scala/pl/touk/nussknacker/engine/canonicalgraph/CanonicalProcessTest.scala
@@ -167,7 +167,7 @@ class CanonicalProcessTest extends AnyFunSuite with Matchers {
     Subprocess(
       SubprocessInput(
         "sub1",
-        SubprocessRef("sub1", Nil, None),
+        SubprocessRef("sub1", Nil, Map.empty),
         isDisabled = Some(isDisabled)
       ),
       Map("subOut" -> output)

--- a/scenario-api/src/test/scala/pl/touk/nussknacker/engine/graph/SubprocessRefSerializationSpec.scala
+++ b/scenario-api/src/test/scala/pl/touk/nussknacker/engine/graph/SubprocessRefSerializationSpec.scala
@@ -1,0 +1,18 @@
+package pl.touk.nussknacker.engine.graph
+
+import io.circe.jawn.decode
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.graph.subprocess.SubprocessRef
+
+class SubprocessRefSerializationSpec extends AnyFunSuite with Matchers {
+
+  test("should deserialize SubprocessRef without outputVariableNames [backwards compatibility test]") {
+    decode[SubprocessRef]("""{"id":"1","parameters":[]}""") shouldBe Right(SubprocessRef("1", List()))
+    decode[SubprocessRef]("""{"id":"1","parameters":[],"outputVariableNames":null}""") shouldBe Right(SubprocessRef("1", List()))
+  }
+
+  test("should deserialize SubprocessRef") {
+    decode[SubprocessRef]("""{"id":"1","parameters":[], "outputVariableNames":{"a":"b"}}""") shouldBe Right(SubprocessRef("1", List(), Map("a" -> "b")))
+  }
+}


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
