### PR TITLE
Fix: keep openapi classes in package rather that package object

### DIFF
--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/package.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/package.scala
@@ -10,7 +10,9 @@ package object openapi {
 
   implicit val urlEncoder: Encoder[URL] = Encoder.encodeString.contramap(_.toExternalForm)
   implicit val urlDecoder: Decoder[URL] = Decoder.decodeString.map(new URL(_))
+}
 
+package openapi {
   @JsonCodec sealed trait SwaggerParameter {
 
     def name: String


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
