### PR TITLE
Fixup - deployment of scenarios with warning was failing after clicking deploy

### DIFF
--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/ValidationResults.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/ValidationResults.scala
@@ -16,7 +16,8 @@ object ValidationResults {
 
   //TODO: consider extracting additional DTO class
   @JsonCodec case class ValidationResult(errors: ValidationErrors, warnings: ValidationWarnings, nodeResults: Map[String, NodeTypingData]) {
-    val isOk: Boolean = errors == ValidationErrors.success && warnings == ValidationWarnings.success
+    val hasErrors: Boolean = errors != ValidationErrors.success
+    val hasWarnings: Boolean = warnings != ValidationWarnings.success
     val saveAllowed: Boolean = allErrors.forall(_.errorType == NodeValidationErrorType.SaveAllowed)
 
     def add(other: ValidationResult): ValidationResult = ValidationResult(

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
@@ -133,7 +133,7 @@ class DBProcessService(managerActor: ActorRef,
       .map(_.map(pd => processResolving.validateBeforeUiResolving(pd.json, pd.processCategory))) // validating the same way, as UI does
       .flatMap {
         case l@Left(_) => Future(l.map(_ => ()))
-        case Right(value) if !value.isOk => Future(Left(DeployingInvalidScenarioError))
+        case Right(value) if value.hasErrors => Future(Left(DeployingInvalidScenarioError))
         case _ => callback
       }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrations.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrations.scala
@@ -72,7 +72,7 @@ class TestModelMigrations(migrations: ProcessingTypeDataProvider[ProcessMigratio
 
 @JsonCodec case class TestMigrationResult(converted: ValidatedDisplayableProcess, newErrors: ValidationResult, shouldFailOnNewErrors: Boolean) {
   def shouldFail: Boolean = {
-    shouldFailOnNewErrors && !newErrors.isOk
+    shouldFailOnNewErrors && (newErrors.hasErrors || newErrors.hasWarnings)
   }
 }
 private case class MigratedProcessDetails(newProcess: DisplayableProcess, oldProcessErrors: ValidationResult, shouldFail: Boolean, processCategory: String)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -214,6 +214,20 @@ class ManagementResourcesSpec extends AnyFunSuite with ScalatestRouteTest with F
     }
   }
 
+  test("should allow deployment of scenario with warning") {
+    val processWithDisabledFilter = ScenarioBuilder
+      .streaming("sampleProcess")
+      .parallelism(1)
+      .source("startProcess", "csv-source")
+      .filter("input", "#input != null", Some(true))
+      .emptySink("end", "kafka-string", "topic" -> "'end.topic'", "value" -> "#input")
+
+    saveProcessAndAssertSuccess(SampleProcess.process.id, processWithDisabledFilter)
+    deployProcess(processName.value) ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
   test("should return failure for not validating scenario") {
     val invalidScenario = ScenarioBuilder
       .streaming("sampleProcess")

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrationsSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrationsSpec.scala
@@ -138,8 +138,10 @@ class TestModelMigrationsSpec extends AnyFunSuite with Matchers {
     val results = testMigration.testMigrations(List(validatedToProcess(process)), List(validatedToProcess(subprocess).copy(modelVersion = Some(10))))
 
     val processMigrationResult = results.find(_.converted.id == process.id).get
-    processMigrationResult.newErrors.isOk shouldBe true
-    processMigrationResult.converted.validationResult.isOk shouldBe true
+    processMigrationResult.newErrors.hasErrors shouldBe false
+    processMigrationResult.newErrors.hasWarnings shouldBe false
+    processMigrationResult.converted.validationResult.hasErrors shouldBe false
+    processMigrationResult.converted.validationResult.hasWarnings shouldBe false
   }
 
   private def getFirst[T: ClassTag](result: TestMigrationResult): T =

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/validation/ProcessValidationSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/validation/ProcessValidationSpec.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.ui.validation
 import cats.data.{Validated, ValidatedNel}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.{BeMatcher, MatchResult}
 import pl.touk.nussknacker.engine.api.component.AdditionalPropertyConfig
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{MissingSourceFactory, ScenarioNameValidationError, UnknownSubprocess}
@@ -23,8 +24,8 @@ import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.graph.subprocess.SubprocessRef
 import pl.touk.nussknacker.engine.graph.variable.Field
 import pl.touk.nussknacker.engine.graph.{EdgeType, evaluatedparam}
-import pl.touk.nussknacker.engine.{CustomProcessValidator, spel}
 import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder
+import pl.touk.nussknacker.engine.{CustomProcessValidator, spel}
 import pl.touk.nussknacker.restmodel.displayedgraph.displayablenode.Edge
 import pl.touk.nussknacker.restmodel.displayedgraph.{DisplayableProcess, ProcessProperties}
 import pl.touk.nussknacker.restmodel.process.ProcessingType
@@ -38,6 +39,7 @@ import pl.touk.nussknacker.ui.process.subprocess.{SubprocessDetails, SubprocessR
 import scala.collection.immutable.ListMap
 
 class ProcessValidationSpec extends AnyFunSuite with Matchers {
+
   import ProcessTestData._
   import ProcessValidationSpec._
   import TestCategories._
@@ -87,25 +89,25 @@ class ProcessValidationSpec extends AnyFunSuite with Matchers {
   }
 
   test("check for notunique edges") {
-      val process = createProcess(
-        List(
-          Source("in", SourceRef(existingSourceFactory, List())),
-          SubprocessInput("subIn", SubprocessRef("sub1", List())),
-          Sink("out2", SinkRef(existingSinkFactory, List())),
-        ),
-        List(
-          Edge("in", "subIn", None),
-          Edge("subIn", "out2", Some(EdgeType.SubprocessOutput("out1"))),
-          Edge("subIn", "out2", Some(EdgeType.SubprocessOutput("out2"))),
-        )
+    val process = createProcess(
+      List(
+        Source("in", SourceRef(existingSourceFactory, List())),
+        SubprocessInput("subIn", SubprocessRef("sub1", List())),
+        Sink("out2", SinkRef(existingSinkFactory, List())),
+      ),
+      List(
+        Edge("in", "subIn", None),
+        Edge("subIn", "out2", Some(EdgeType.SubprocessOutput("out1"))),
+        Edge("subIn", "out2", Some(EdgeType.SubprocessOutput("out2"))),
       )
+    )
 
-      val result = validator.validate(process, Category1)
+    val result = validator.validate(process, Category1)
 
-      result.errors.invalidNodes shouldBe Map(
-        "subIn" -> List(PrettyValidationErrors.nonuniqeEdge(validator.uiValidationError, "out2"))
-      )
-    }
+    result.errors.invalidNodes shouldBe Map(
+      "subIn" -> List(PrettyValidationErrors.nonuniqeEdge(validator.uiValidationError, "out2"))
+    )
+  }
 
   test("check for loose nodes") {
     val process = createProcess(
@@ -123,17 +125,17 @@ class ProcessValidationSpec extends AnyFunSuite with Matchers {
   }
 
   test("check for empty ids") {
-      val process = createProcess(
-        List(
-          Source("", SourceRef(existingSourceFactory, List())),
-          Sink("out", SinkRef(existingSinkFactory, List()))
-        ),
-        List(Edge("", "out", None))
-      )
-      val result = validator.validate(process, Category1)
+    val process = createProcess(
+      List(
+        Source("", SourceRef(existingSourceFactory, List())),
+        Sink("out", SinkRef(existingSinkFactory, List()))
+      ),
+      List(Edge("", "out", None))
+    )
+    val result = validator.validate(process, Category1)
 
-      result.errors.globalErrors shouldBe List(PrettyValidationErrors.emptyNodeId(validator.uiValidationError))
-    }
+    result.errors.globalErrors shouldBe List(PrettyValidationErrors.emptyNodeId(validator.uiValidationError))
+  }
 
 
   test("check for duplicated ids") {
@@ -197,9 +199,9 @@ class ProcessValidationSpec extends AnyFunSuite with Matchers {
       ))
     )
 
-    processValidation.validate(validProcessWithFields(Map("field1" -> "a", "field2" -> "b")), Category1) shouldBe 'ok
+    processValidation.validate(validProcessWithFields(Map("field1" -> "a", "field2" -> "b")), Category1) shouldBe withoutErrorsAndWarnings
 
-    processValidation.validate(validProcessWithFields(Map("field1" -> "a")), Category1) shouldBe 'ok
+    processValidation.validate(validProcessWithFields(Map("field1" -> "a")), Category1) shouldBe withoutErrorsAndWarnings
 
     processValidation.validate(validProcessWithFields(Map("field1" -> "", "field2" -> "b")), Category1)
       .errors.processPropertiesErrors should matchPattern {
@@ -222,7 +224,7 @@ class ProcessValidationSpec extends AnyFunSuite with Matchers {
     val process = validProcessWithFields(Map())
     val subprocess = process.copy(properties = process.properties.copy(typeSpecificProperties = FragmentSpecificData()))
 
-    processValidation.validate(subprocess, Category1) shouldBe 'ok
+    processValidation.validate(subprocess, Category1) shouldBe withoutErrorsAndWarnings
 
   }
 
@@ -235,13 +237,13 @@ class ProcessValidationSpec extends AnyFunSuite with Matchers {
       ))
     )
 
-    processValidation.validate(validProcessWithFields(Map("field1" -> "true")), Category1) shouldBe 'ok
-    processValidation.validate(validProcessWithFields(Map("field1" -> "false")), Category1) shouldBe 'ok
-    processValidation.validate(validProcessWithFields(Map("field1" -> "1")), Category1) should not be 'ok
+    processValidation.validate(validProcessWithFields(Map("field1" -> "true")), Category1) shouldBe withoutErrorsAndWarnings
+    processValidation.validate(validProcessWithFields(Map("field1" -> "false")), Category1) shouldBe withoutErrorsAndWarnings
+    processValidation.validate(validProcessWithFields(Map("field1" -> "1")), Category1) should not be withoutErrorsAndWarnings
 
-    processValidation.validate(validProcessWithFields(Map("field2" -> "1")), Category1) shouldBe 'ok
-    processValidation.validate(validProcessWithFields(Map("field2" -> "1.1")), Category1) should not be 'ok
-    processValidation.validate(validProcessWithFields(Map("field2" -> "true")), Category1) should not be 'ok
+    processValidation.validate(validProcessWithFields(Map("field2" -> "1")), Category1) shouldBe withoutErrorsAndWarnings
+    processValidation.validate(validProcessWithFields(Map("field2" -> "1.1")), Category1) should not be withoutErrorsAndWarnings
+    processValidation.validate(validProcessWithFields(Map("field2" -> "true")), Category1) should not be withoutErrorsAndWarnings
   }
 
   test("handle unknown properties validation") {
@@ -574,7 +576,7 @@ private object ProcessValidationSpec {
     mockedProcessValidation
   }
 
-  object SampleCustomProcessValidator extends CustomProcessValidator{
+  object SampleCustomProcessValidator extends CustomProcessValidator {
     val badName = "badName"
 
     val badNameError: ScenarioNameValidationError = ScenarioNameValidationError("BadName", "BadName")
@@ -583,4 +585,17 @@ private object ProcessValidationSpec {
       Validated.condNel(process.id != badName, (), badNameError)
     }
   }
+
+  class WithoutErrorsAndWarnings extends BeMatcher[ValidationResult] {
+    override def apply(left: ValidationResult): MatchResult = {
+      MatchResult(
+        !left.hasErrors && !left.hasWarnings,
+        "ValidationResult should has neither errors nor warnings",
+        "ValidationResult should has either errors or warnings"
+      )
+    }
+  }
+
+  val withoutErrorsAndWarnings: WithoutErrorsAndWarnings = new WithoutErrorsAndWarnings()
+
 }


### PR DESCRIPTION
Rollback to desired behaviour:
* deployment of scenarios with warnings is allowed (without this change it is allowed on UI but fails after clicking "deploy")
* migration of scenarios with warnings is still disabled (can be discussed in the future whether it really should be disabled)