### PR TITLE
Configuration docs cognitive aspects polishing

### DIFF
--- a/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
+++ b/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
@@ -10,12 +10,13 @@ Below you can find a snippet of Deployment Manager configuration.
 deploymentConfig {     
   type: "flinkStreaming"
   restUrl: "http://localhost:8081"
+  
   # additional configuration goes here
 }
 ```
-`type` parameter determines engine to which the scenario is deployed. Currently there are only two values allowed: `flinkStreaming` and `lite-k8s`. The `type` parameter is set in both the minimal working configuration file (Docker image and binary distribution) and Helm chart - you will need to set it on your won. 
+`type` parameter determines engine to which the scenario is deployed.The `type` parameter is set in both the minimal working configuration file (Docker image and binary distribution) and Helm chart - you will not need to set it on your won. 
 
-
+&nbsp;
 ## Kubernetes native Lite engine configuration
                                                                                 
 Please note, that K8s Deployment Manager has to be run with properly configured K8s access. If you install the Designer
@@ -38,7 +39,8 @@ The table below contains configuration options for the Lite engine. If you insta
 | logbackConfigPath         | string                                              | {}                                  | see [below](#configuring-runtime-logging)                                                |
 | commonConfigMapForLogback | string                                              | {}                                  | see [below](#configuring-runtime-logging)                                                |
 | servicePort               | int                                                 | 80                                  | Port of service exposed in request-response processing mode                              |
-                                                 
+
+&nbsp;                                                 
 ### Customizing K8s deployment resource definition
 
 By default, each scenario creates K8s Deployment. By default, Nussknacker will create following deployment:
@@ -143,7 +145,8 @@ spec {
 ```
 This config will be merged into the final K8s deployment resource definition. 
 Please note that you cannot override names or labels configured by Nussknacker. 
-                              
+
+&nbsp;                              
 ### Overriding configuration passed to runtime. 
 
 In most cases, the model configuration values passed to the Lite Engine runtime are the ones from 
@@ -166,23 +169,23 @@ modelConfig {
 }
 ```
 
+&nbsp;
 ### Configuring replicas count
 
-Each scenario has its own, configured parallelism. It describes how many worker threads,
-across all replicas, should be used to process events. With `scalingConfig` one can affect replicas count 
-(each replica receives the same number of worker threads).
-Following options are possible:
-- ```{ fixedReplicasCount: x }```  
-- ```{ tasksPerReplica: y }```
-- by default `tasksPerReplica: 4`
+In the request-response processing mode, the only way to affect parallelism is to set the count of scenario pods (replicas). This is achieved with the `fixedReplicasCount` configuration key; its default setting is 2:
 
-Please note that:
-- it's not possible to set both config options at the same time
-- for `request-response` processing mode only `fixedReplicasCount` is available
-- due to rounding, exact workers count may be different from parallelism 
-  (e.g. for fixedReplicasCount = 3, parallelism = 5, there will be 2 tasks per replica, total workers = 6)  
+`{ fixedReplicasCount: x }`.
 
+​In the  streaming processing mode you can affect scenario parallelism in the following ways:
+- Set scenario parallelism in the scenario properties - this will determine how many parallel tasks are used to process the scenario. The number of replicas in the K8s deployment will be set to the `ceiling(scenarioParallelism / tasksPerReplica)`. In this case, the default value of 4 will be used for `tasksPerReplica`.
+- Modify the default value of `tasksPerReplica` by setting:
+  - `{ tasksPerReplica: t }`
 
+Alternatively, you can set `fixedReplicasCount` to override scenario parallelism set in the scenario properties. You cannot use this setting together with `tasksPerReplica` setting. 
+
+Finally, due to rounding, the number of tasks may be different from scenario parallelism (e.g. for `fixedReplicasCount = 3`, scenario parallelism = 5, there will be 2 tasks per replica, total tasks = 6)
+
+&nbsp;
 ### Nussknacker instance name
 Value of `nussknackerInstanceName` will be passed to scenario runtime pods as a `nussknacker.io/nussknackerInstanceName` Kubernetes label.
 In a standard scenario, its value is taken from Nussknacker's pod `app.kubernetes.io/instance` label which, when installed
@@ -190,15 +193,18 @@ using helm should be set to [helm release name](https://helm.sh/docs/chart_best_
 
 It can be used to identify scenario deployments and its resources bound to a specific Nussknacker helm release.
 
+&nbsp;
 ### Configuring runtime logging
 With `logbackConfigPath` you can provide path to your own logback config file, which will be used by runtime containers. This configuration is optional, if skipped default logging configuration will be used. 
 Please mind, that apart whether you will provide your own logging configuration or use default, you can still modify it in runtime (for each scenario deployment separately*) as described [here](../operations_guide/Lite#logging-level)
 
 *By default, every scenario runtime has its own separate configMap with logback configuration. By setting `commonConfigMapForLogback` you can enforce usage of single configMap (with such name as configured) with logback.xml for all your runtime containers. Take into account, that DeploymentManager relinquishes control over lifecycle of this ConfigMap (with one exception - it will create it, if not exist).
 
+&nbsp;
 ### Configuring Prometheus metrics
 Just like in [Designer installation](./Installation.md#Basic environment variables), you can attach [JMX Exporter for Prometheus](https://github.com/prometheus/jmx_exporter) to your runtime pods. Pass `PROMETHEUS_METRICS_PORT` environment variable to enable agent, and simultaneously define port on which metrics will be exposed. By default, agent is configured to expose basic jvm metrics, but you can provide your own configuration file by setting `PROMETHEUS_AGENT_CONFIG_FILE` environment, which has to point to it.   
 
+&nbsp;
 ## Request-Response embedded
 
 Deployment Manager of type `request-response-embedded` has the following configuration options:

--- a/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
+++ b/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
@@ -179,7 +179,7 @@ In the request-response processing mode, the only way to affect parallelism is t
 ​In the  streaming processing mode you can affect scenario parallelism in the following ways:
 - Set scenario parallelism in the scenario properties - this will determine how many parallel tasks are used to process the scenario. The number of replicas in the K8s deployment will be set to the `ceiling(scenarioParallelism / tasksPerReplica)`. In this case, the default value of 4 will be used for `tasksPerReplica`.
 - Modify the default value of `tasksPerReplica` by setting:
-  - `{ tasksPerReplica: t }`
+  - `{ tasksPerReplica y }`
 
 Alternatively, you can set `fixedReplicasCount` to override scenario parallelism set in the scenario properties. You cannot use this setting together with `tasksPerReplica` setting. 
 

--- a/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
+++ b/docs/installation_configuration_guide/DeploymentManagerConfiguration.md
@@ -3,8 +3,9 @@ sidebar_position: 3
 ---
 # Deployment Manager configuration
 
-Configuration of Deployment Manager, which is component of the Designer that deploys scenario to given Engine (e.g. Lite or Flink). 
-Type of Deployment Manager is defined with `type` parameter, e.g. for running scenarios with Flink streaming job we would configure: 
+Deployment Manager deploys scenarios from the Designer to the engine on which scenarios are processed. Check [configuration areas](./#configuration-areas) to understand where Deployment Manager configuration should be placed in Nussknacker configuration.
+
+Below you can find a snippet of Deployment Manager configuration. 
 ```
 deploymentConfig {     
   type: "flinkStreaming"
@@ -12,12 +13,12 @@ deploymentConfig {
   # additional configuration goes here
 }
 ```
+`type` parameter determines engine to which the scenario is deployed. Currently there are only two values allowed: `flinkStreaming` and `lite-k8s`. The `type` parameter is set in both the minimal working configuration file (Docker image and binary distribution) and Helm chart - you will need to set it on your won. 
 
-Look at [configuration areas](./#configuration-areas) to understand where Deployment Manager configuration should be placed in Nussknacker configuration.
 
 ## Kubernetes native Lite engine configuration
                                                                                 
-Please remember, that K8s Deployment Manager has to be run with properly configured K8s access. If you install the Designer
+Please note, that K8s Deployment Manager has to be run with properly configured K8s access. If you install the Designer
 in K8s cluster (e.g. via Helm chart) this comes out of the box. If you want to run the Designer outside the cluster, you 
 have to configure `.kube/config` properly.
 

--- a/docs/installation_configuration_guide/DesignerConfiguration.md
+++ b/docs/installation_configuration_guide/DesignerConfiguration.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 ---
 # Designer configuration
                              
-Please note that all the default values for Designer configuration are defined in [defaultDesignerConfig.conf](https://github.com/TouK/nussknacker/blob/staging/designer/server/src/main/resources/defaultDesignerConfig.conf).
+The default Designer configuration is defined in [defaultDesignerConfig.conf](https://github.com/TouK/nussknacker/blob/staging/designer/server/src/main/resources/defaultDesignerConfig.conf).
 
 
 ## Web interface configuration

--- a/docs/installation_configuration_guide/ModelConfiguration.md
+++ b/docs/installation_configuration_guide/ModelConfiguration.md
@@ -3,14 +3,14 @@ sidebar_position: 5
 ---
 # Model configuration
 
-This part of configuration defines how to configure Components and certain runtime behaviour (e.g. error handling) for a given scenario type (Lite or Flink engine). 
-It is processed not only at the Designer but also passed to the execution engine (e.g. Flink), that’s why it’s parsed and processed a bit differently: 
+Model definition is part of a scenario type definition. There can be multiple scenario types in one Nussknacker installation, consequently there will also be multiple model definitions in such a case. 
+Check [configuration areas](./#configuration-areas) to understand where Model configuration should be placed in the Nussknacker configuration. If you deploy to K8s using Nussknacker Helm chart, check [here](DeploymentManagerConfiguration.md#overriding-configuration-passed-to-runtime) how to supply additional model configuration.
 
-* Some Components can use a special mechanism which resolves and adds additional configuration during deployment, which is then passed to the execution engine. Such configuration is read and resolved only at the designer. Example: OpenAPI enrichers need to read its definition from external sites - so e.g. Flink cluster does not have to have access to the site with the definition. 
+Model defines how to configure [components](https://nussknacker.io/documentation/about/GLOSSARY#component) and certain runtime behavior (e.g. error handling) for a given scenario type. Model configuration is processed not only at the Designer but also passed to the execution engine (e.g. Flink), that’s why it’s parsed and processed a bit differently: 
+
+* Some Components can use a special mechanism which resolves and adds additional configuration during deployment, which is then passed to the execution engine. Such configuration is read and resolved only at the Designer. Example: OpenAPI enrichers need to read its definition from external sites - so e.g. Flink cluster does not have to have access to the site with the definition. 
 * There is additional set of defaults, taken from `defaultModelConfig.conf` if it exists on the classpath. The standard Nussknacker installation uses the one from [here](https://github.com/TouK/nussknacker/blob/staging/defaultModel/src/main/resources/defaultModelConfig.conf), installations using certain code customizations may use a different one.       
-
-Look at [configuration areas](./#configuration-areas) to understand where Model configuration should be placed in Nussknacker configuration.
-                  
+                 
 ## ClassPath configuration
 
 Nussknacker looks for components and various extensions in jars on the Model classpath, default config [example here](https://github.com/TouK/nussknacker/blob/staging/nussknacker-dist/src/universal/conf/application.conf) to see where classpath can be configured.
@@ -38,12 +38,12 @@ If the given path element in the `classPath` is relative, it should be relative 
 ## Components configuration 
 
 Nussknacker comes with a set of provided components. Some of them (e.g. `filter`, `variable`, aggregations in Flink, `for-each`, `union`) are 
-predefined and accessible by default. Others need additional configuration - the most important ones are enrichers, 
-where you have to set e.g. JDBC URL or external service address.
+predefined and accessible by default. Others need additional configuration - the most important ones are enrichers, where you have to set e.g. JDBC URL or external service address.
 
-Check documentation of available components that you can configure:
-- [OpenAPI](../components/OpenAPI.md) Supports accessing external APIs directly from scenario 
-- [SQL](../components/Sql.md)         Supports access to SQL database engines    
+Check Integration documentation for the details on how to configure the following components:
+- [OpenAPI](./../integration/OpenAPI.md) Supports accessing external APIs directly from scenario 
+- [SQL](./../integration/Sql.md)         Supports access to SQL database engines    
+- [Machine Learning](./../integration/MachineLearning.md)         Infers ML models
 
 
 ### Configuration of component providers


### PR DESCRIPTION
Rewrote the "Configuring replicas count" in R-R processing mode.
+
This PR focuses on the cognitive aspects of the configuration documentation. The purpose is to reduce the cognitive distress of the reader - there is so much to understand and remember that we need to give the reader a hand in the journey through the documentation. 

The typical questions asked when you install Nu and try to understand its configuration:
- will I need to configure anything in this particular area (Designer, Deployment Manager, Model) or is everything set for me?
- If there are incremental changes to be applied, how to apply them in the Docker case and how to apply them in the K8s case?

These questions need to be answered for all three configuration areas.