### PR TITLE
Support testing scenarios with multiple sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -955,7 +955,7 @@ lazy val liteBaseComponentsTests = (project in lite("components/base-tests")).
   settings(commonSettings).
   settings(
     name := "nussknacker-lite-base-components-tests"
-  ).dependsOn(liteComponentsTestkit % Test)
+  ).dependsOn(liteBaseComponents % Test, liteComponentsTestkit % Test)
 
 lazy val liteKafkaComponents: Project = (project in lite("components/kafka")).
   settings(commonSettings).

--- a/build.sbt
+++ b/build.sbt
@@ -951,6 +951,12 @@ lazy val liteBaseComponents = (project in lite("components/base")).
     name := "nussknacker-lite-base-components",
   ).dependsOn(liteComponentsApi % "provided", componentsUtils % Provided, testUtils % "test", liteEngineRuntime % "test")
 
+lazy val liteBaseComponentsTests = (project in lite("components/base-tests")).
+  settings(commonSettings).
+  settings(
+    name := "nussknacker-lite-base-components-tests"
+  ).dependsOn(liteComponentsTestkit % Test)
+
 lazy val liteKafkaComponents: Project = (project in lite("components/kafka")).
   settings(commonSettings).
   settings(assemblyNoScala("liteKafka.jar"): _*).
@@ -1520,7 +1526,7 @@ lazy val modules = List[ProjectReference](
   flinkExecutor, flinkSchemedKafkaComponentsUtils, flinkKafkaComponentsUtils, flinkComponentsUtils, flinkTests, flinkTestUtils, flinkComponentsApi, flinkExtensionsApi, flinkScalaUtils,
   requestResponseComponentsUtils, requestResponseComponentsApi, componentsApi, extensionsApi, security, processReports, httpUtils,
   restmodel, listenerApi, deploymentManagerApi, designer, sqlComponents, schemedKafkaComponentsUtils, flinkBaseComponents, flinkKafkaComponents,
-  liteComponentsApi, liteEngineKafkaComponentsApi, liteEngineRuntime, liteBaseComponents, liteKafkaComponents, liteKafkaComponentsTests, liteEngineKafkaRuntime, liteEngineKafkaIntegrationTest, liteEmbeddedDeploymentManager, liteK8sDeploymentManager,
+  liteComponentsApi, liteEngineKafkaComponentsApi, liteEngineRuntime, liteBaseComponents, liteBaseComponentsTests, liteKafkaComponents, liteKafkaComponentsTests, liteEngineKafkaRuntime, liteEngineKafkaIntegrationTest, liteEmbeddedDeploymentManager, liteK8sDeploymentManager,
   liteRequestResponseComponents, liteRequestResponseComponentsTests, scenarioApi, commonApi, jsonUtils, liteComponentsTestkit, flinkComponentsTestkit, mathUtils
 )
 lazy val modulesWithBom: List[ProjectReference] = bom :: modules

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
@@ -6,16 +6,16 @@ import java.nio.charset.StandardCharsets
 
 sealed trait ScenarioTestData {
   def samplesLimit: Int
-  def forNodeId(id: NodeId): TestData
+  def forSourceId(id: NodeId): TestData
 }
 
 case class SingleSourceScenarioTestData(testData: TestData, samplesLimit: Int) extends ScenarioTestData {
-  override def forNodeId(id: NodeId): TestData = testData
+  override def forSourceId(id: NodeId): TestData = testData
 }
 
 // TODO: string key?
 case class MultipleSourcesScenarioTestData(sourceTestDataMap: Map[String, TestData], samplesLimit: Int) extends ScenarioTestData {
-  override def forNodeId(id: NodeId): TestData = sourceTestDataMap(id.id)
+  override def forSourceId(id: NodeId): TestData = sourceTestDataMap.getOrElse(id.id, throw new IllegalArgumentException(s"Missing test data for: $id"))
 }
 
 object ScenarioTestData {

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
@@ -1,0 +1,24 @@
+package pl.touk.nussknacker.engine.api.test
+
+import pl.touk.nussknacker.engine.api.NodeId
+
+import java.nio.charset.StandardCharsets
+
+sealed trait ScenarioTestData {
+  def samplesLimit: Int
+  def forNodeId(id: NodeId): TestData
+}
+
+case class SingleSourceScenarioTestData(testData: TestData, samplesLimit: Int) extends ScenarioTestData {
+  override def forNodeId(id: NodeId): TestData = testData
+}
+
+// TODO: string key?
+case class MultipleSourcesScenarioTestData(sourceTestDataMap: Map[String, TestData], samplesLimit: Int) extends ScenarioTestData {
+  override def forNodeId(id: NodeId): TestData = sourceTestDataMap(id.id)
+}
+
+object ScenarioTestData {
+  def newLineSeparated(s: String*): ScenarioTestData = SingleSourceScenarioTestData(TestData(s.mkString("\n").getBytes(StandardCharsets.UTF_8)), s.length)
+}
+

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
@@ -13,9 +13,11 @@ case class SingleSourceScenarioTestData(testData: TestData, samplesLimit: Int) e
   override def forSourceId(id: NodeId): TestData = testData
 }
 
-// TODO: string key?
 case class MultipleSourcesScenarioTestData(sourceTestDataMap: Map[String, TestData], samplesLimit: Int) extends ScenarioTestData {
-  override def forSourceId(id: NodeId): TestData = sourceTestDataMap.getOrElse(id.id, throw new IllegalArgumentException(s"Missing test data for: $id"))
+  override def forSourceId(id: NodeId): TestData = {
+    val idValue = id.id
+    sourceTestDataMap.getOrElse(idValue, throw new IllegalArgumentException(s"Missing test data for: $idValue"))
+  }
 }
 
 object ScenarioTestData {

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/TestData.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/TestData.scala
@@ -1,9 +1,27 @@
 package pl.touk.nussknacker.engine.api.test
 
+import pl.touk.nussknacker.engine.api.NodeId
+
 import java.nio.charset.StandardCharsets
 
-case class TestData(testData: Array[Byte], rowLimit: Int)
+// TODO: remove samplesLimit
+// TODO: differentiate raw test data as json, string, bytes, etc.
+case class TestData(testData: Array[Byte], samplesLimit: Int)
+
+trait ScenarioTestData {
+  def samplesLimit: Int
+  def forNodeId(id: NodeId): TestData
+}
+
+case class SingleSourceScenarioTestData(testData: TestData, samplesLimit: Int) extends ScenarioTestData {
+  override def forNodeId(id: NodeId): TestData = testData
+}
+
+// TODO: string key
+case class MultipleSourcesScenarioTestData(sourceTestDataMap: Map[String, TestData], samplesLimit: Int) extends ScenarioTestData {
+  override def forNodeId(id: NodeId): TestData = sourceTestDataMap(id.id)
+}
 
 object TestData {
-  def newLineSeparated(s: String*): TestData = new TestData(s.mkString("\n").getBytes(StandardCharsets.UTF_8), s.length)
+  def newLineSeparated(s: String*): ScenarioTestData = SingleSourceScenarioTestData(TestData(s.mkString("\n").getBytes(StandardCharsets.UTF_8), s.length), s.length)
 }

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/TestData.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/TestData.scala
@@ -1,26 +1,3 @@
 package pl.touk.nussknacker.engine.api.test
 
-import pl.touk.nussknacker.engine.api.NodeId
-
-import java.nio.charset.StandardCharsets
-
-// TODO: differentiate raw test data as json, string, bytes, etc.
 case class TestData(testData: Array[Byte])
-
-sealed trait ScenarioTestData {
-  def samplesLimit: Int
-  def forNodeId(id: NodeId): TestData
-}
-
-case class SingleSourceScenarioTestData(testData: TestData, samplesLimit: Int) extends ScenarioTestData {
-  override def forNodeId(id: NodeId): TestData = testData
-}
-
-// TODO: string key
-case class MultipleSourcesScenarioTestData(sourceTestDataMap: Map[String, TestData], samplesLimit: Int) extends ScenarioTestData {
-  override def forNodeId(id: NodeId): TestData = sourceTestDataMap(id.id)
-}
-
-object TestData {
-  def newLineSeparated(s: String*): ScenarioTestData = SingleSourceScenarioTestData(TestData(s.mkString("\n").getBytes(StandardCharsets.UTF_8)), s.length)
-}

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/TestData.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/test/TestData.scala
@@ -4,11 +4,10 @@ import pl.touk.nussknacker.engine.api.NodeId
 
 import java.nio.charset.StandardCharsets
 
-// TODO: remove samplesLimit
 // TODO: differentiate raw test data as json, string, bytes, etc.
-case class TestData(testData: Array[Byte], samplesLimit: Int)
+case class TestData(testData: Array[Byte])
 
-trait ScenarioTestData {
+sealed trait ScenarioTestData {
   def samplesLimit: Int
   def forNodeId(id: NodeId): TestData
 }
@@ -23,5 +22,5 @@ case class MultipleSourcesScenarioTestData(sourceTestDataMap: Map[String, TestDa
 }
 
 object TestData {
-  def newLineSeparated(s: String*): ScenarioTestData = SingleSourceScenarioTestData(TestData(s.mkString("\n").getBytes(StandardCharsets.UTF_8), s.length), s.length)
+  def newLineSeparated(s: String*): ScenarioTestData = SingleSourceScenarioTestData(TestData(s.mkString("\n").getBytes(StandardCharsets.UTF_8)), s.length)
 }

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
@@ -24,7 +24,7 @@ trait DeploymentManager extends AutoCloseable {
 
   def cancel(name: ProcessName, user: User): Future[Unit]
 
-  def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestResults[T]]
+  def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, scenarioTestData: ScenarioTestData, variableEncoder: Any => T): Future[TestResults[T]]
 
   def findJobStatus(name: ProcessName): Future[Option[ProcessState]]
 

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.api.deployment
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, ExternalDeploymentId, User}
 
@@ -24,7 +24,7 @@ trait DeploymentManager extends AutoCloseable {
 
   def cancel(name: ProcessName, user: User): Future[Unit]
 
-  def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: TestData, variableEncoder: Any => T): Future[TestResults[T]]
+  def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestResults[T]]
 
   def findJobStatus(name: ProcessName): Future[Option[ProcessState]]
 

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleProcessStateDefinitionManager
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.queryablestate.QueryableClient
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.api.{ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, ExternalDeploymentId, User}
@@ -29,7 +29,7 @@ class DeploymentManagerStub extends DeploymentManager {
 
   override def cancel(name: ProcessName, user: User): Future[Unit] = Future.successful(())
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: TestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
 
   override def findJobStatus(name: ProcessName): Future[Option[ProcessState]] = Future.successful(None)
 

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
@@ -29,7 +29,7 @@ class DeploymentManagerStub extends DeploymentManager {
 
   override def cancel(name: ProcessName, user: User): Future[Unit] = Future.successful(())
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, scenarioTestData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
 
   override def findJobStatus(name: ProcessName): Future[Option[ProcessState]] = Future.successful(None)
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -254,7 +254,7 @@ class ManagementResources(processCounter: ProcessCounter,
         val validationResult = processResolving.validateBeforeUiResolving(process, idWithCategory.category)
         val canonical = processResolving.resolveExpressions(process, validationResult.typingInfo)
         // TODO ljd: parse test data.
-        (managementActor ? Test(idWithCategory.processIdWithName, canonical, idWithCategory.category, SingleSourceScenarioTestData(TestData(testData, testDataSettings.maxSamplesCount), testDataSettings.maxSamplesCount), user, ManagementResources.testResultsVariableEncoder)).mapTo[TestResults[Json]].flatMap { results =>
+        (managementActor ? Test(idWithCategory.processIdWithName, canonical, idWithCategory.category, SingleSourceScenarioTestData(TestData(testData), testDataSettings.maxSamplesCount), user, ManagementResources.testResultsVariableEncoder)).mapTo[TestResults[Json]].flatMap { results =>
           assertTestResultsAreNotTooBig(results)
         }.map { results =>
           ResultsWithCounts(ManagementResources.testResultsEncoder(results), computeCounts(canonical, results))

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -19,11 +19,10 @@ import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
 import io.dropwizard.metrics5.MetricRegistry
 import pl.touk.nussknacker.engine.api.DisplayJson
-import pl.touk.nussknacker.engine.api.component.ComponentType.Source
 import pl.touk.nussknacker.engine.api.deployment._
-import pl.touk.nussknacker.engine.api.process.Source
 import pl.touk.nussknacker.engine.api.test.{SingleSourceScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.graph.node.Source
 import pl.touk.nussknacker.engine.testmode.TestProcess._
 import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
@@ -255,7 +254,7 @@ class ManagementResources(processCounter: ProcessCounter,
       case Right(process) =>
         val validationResult = processResolving.validateBeforeUiResolving(process, idWithCategory.category)
         val canonical = processResolving.resolveExpressions(process, validationResult.typingInfo)
-        if (hasSingleSource(canonical)) {
+        if (!hasSingleSource(canonical)) {
           Future.failed(new IllegalArgumentException("Tests mechanism support scenarios with exact one source"))
         } else {
           (managementActor ? Test(idWithCategory.processIdWithName, canonical, idWithCategory.category, SingleSourceScenarioTestData(TestData(testData), testDataSettings.maxSamplesCount), user, ManagementResources.testResultsVariableEncoder)).mapTo[TestResults[Json]].flatMap { results =>

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -253,7 +253,6 @@ class ManagementResources(processCounter: ProcessCounter,
       case Right(process) =>
         val validationResult = processResolving.validateBeforeUiResolving(process, idWithCategory.category)
         val canonical = processResolving.resolveExpressions(process, validationResult.typingInfo)
-        // TODO ljd: parse test data.
         (managementActor ? Test(idWithCategory.processIdWithName, canonical, idWithCategory.category, SingleSourceScenarioTestData(TestData(testData), testDataSettings.maxSamplesCount), user, ManagementResources.testResultsVariableEncoder)).mapTo[TestResults[Json]].flatMap { results =>
           assertTestResultsAreNotTooBig(results)
         }.map { results =>

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -20,7 +20,7 @@ import io.circe.{Decoder, Encoder, Json}
 import io.dropwizard.metrics5.MetricRegistry
 import pl.touk.nussknacker.engine.api.DisplayJson
 import pl.touk.nussknacker.engine.api.deployment._
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{SingleSourceScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.testmode.TestProcess._
 import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
@@ -253,7 +253,8 @@ class ManagementResources(processCounter: ProcessCounter,
       case Right(process) =>
         val validationResult = processResolving.validateBeforeUiResolving(process, idWithCategory.category)
         val canonical = processResolving.resolveExpressions(process, validationResult.typingInfo)
-        (managementActor ? Test(idWithCategory.processIdWithName, canonical, idWithCategory.category, TestData(testData, testDataSettings.maxSamplesCount), user, ManagementResources.testResultsVariableEncoder)).mapTo[TestResults[Json]].flatMap { results =>
+        // TODO ljd: parse test data.
+        (managementActor ? Test(idWithCategory.processIdWithName, canonical, idWithCategory.category, SingleSourceScenarioTestData(TestData(testData, testDataSettings.maxSamplesCount), testDataSettings.maxSamplesCount), user, ManagementResources.testResultsVariableEncoder)).mapTo[TestResults[Json]].flatMap { results =>
           assertTestResultsAreNotTooBig(results)
         }.map { results =>
           ResultsWithCounts(ManagementResources.testResultsEncoder(results), computeCounts(canonical, results))

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestInfoResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestInfoResources.scala
@@ -55,7 +55,6 @@ class TestInfoResources(providers: ProcessingTypeDataProvider[TestInfoProvider],
             canDeploy(processId) {
               val provider = providers.forTypeUnsafe(displayableProcess.processingType)
 
-              // TODO ljd: multiple sources
               val source = displayableProcess.nodes.flatMap(asSource).headOption
               val metadata = displayableProcess.metaData
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestInfoResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestInfoResources.scala
@@ -55,6 +55,7 @@ class TestInfoResources(providers: ProcessingTypeDataProvider[TestInfoProvider],
             canDeploy(processId) {
               val provider = providers.forTypeUnsafe(displayableProcess.processingType)
 
+              // TODO ljd: multiple sources
               val source = displayableProcess.nodes.flatMap(asSource).headOption
               val metadata = displayableProcess.metaData
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ManagementActor.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessAction
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessStateDefinitionManager, SimpleStateStatus}
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId}
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{User => ManagerUser}
 import pl.touk.nussknacker.restmodel.process.ProcessIdWithName
@@ -203,7 +203,7 @@ case class Stop(id: ProcessIdWithName, user: LoggedUser, savepointDir: Option[St
 
 case class CheckStatus(id: ProcessIdWithName, user: LoggedUser)
 
-case class Test[T](id: ProcessIdWithName, canonicalProcess: CanonicalProcess, category: String, test: TestData, user: LoggedUser, variableEncoder: Any => T)
+case class Test[T](id: ProcessIdWithName, canonicalProcess: CanonicalProcess, category: String, test: ScenarioTestData, user: LoggedUser, variableEncoder: Any => T)
 
 case class DeploymentDetails(version: VersionId, deploymentComment: Option[DeploymentComment], deployedAt: Instant, action: ProcessActionType)
 

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentDeploymentManagerProvider.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentDeploymentManagerProvider.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessStateDefinitionManager, SimpleStateStatus}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.queryablestate.QueryableClient
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.api.{ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, ExternalDeploymentId, User}
@@ -112,7 +112,7 @@ class DevelopmentDeploymentManager(actorSystem: ActorSystem) extends DeploymentM
     Future.unit
   }
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: TestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
 
   override def findJobStatus(name: ProcessName): Future[Option[ProcessState]] =
     Future.successful(memory.get(name))

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentDeploymentManagerProvider.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentDeploymentManagerProvider.scala
@@ -112,7 +112,7 @@ class DevelopmentDeploymentManager(actorSystem: ActorSystem) extends DeploymentM
     Future.unit
   }
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, scenarioTestData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
 
   override def findJobStatus(name: ProcessName): Future[Option[ProcessState]] =
     Future.successful(memory.get(name))

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFlinkProcessCompiler.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFlinkProcessCompiler.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import org.apache.flink.api.common.serialization.DeserializationSchema
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{ConnectedStreams, DataStream}
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ContextTransformation
 import pl.touk.nussknacker.engine.api.namespaces.ObjectNaming
 import pl.touk.nussknacker.engine.api.process.{ComponentUseCase, ProcessConfigCreator, ProcessObjectDependencies}
@@ -35,9 +36,9 @@ abstract class StubbedFlinkProcessCompiler(process: CanonicalProcess,
   override protected def definitions(processObjectDependencies: ProcessObjectDependencies): ProcessDefinitionExtractor.ProcessDefinition[ObjectWithMethodDef] = {
     val createdDefinitions = super.definitions(processObjectDependencies)
 
-    val collectedSources = checkSources(process.allStartNodes.map(_.head.data).collect {
+    val collectedSources = process.allStartNodes.map(_.head.data).collect {
       case source: Source => source
-    })
+    }
 
     val usedSourceTypes = collectedSources.map(_.ref.typ)
     val stubbedSources =
@@ -55,18 +56,22 @@ abstract class StubbedFlinkProcessCompiler(process: CanonicalProcess,
         services = stubbedServices)
   }
 
-  protected def checkSources(sources: List[Source]): List[Source] = sources
-
   protected def prepareService(service: ObjectWithMethodDef): ObjectWithMethodDef
 
   protected def prepareSourceFactory(sourceFactory: ObjectWithMethodDef): ObjectWithMethodDef
 
 
-  protected def overrideObjectWithMethod(original: ObjectWithMethodDef, overrideFromOriginalAndType: (Any, TypingResult) => Any): ObjectWithMethodDef =
+  protected def overrideObjectWithMethod(original: ObjectWithMethodDef, overrideFromOriginalAndType: (Any, TypingResult, NodeId) => Any): ObjectWithMethodDef =
     new OverriddenObjectWithMethodDef(original) {
       override def invokeMethod(params: Map[String, Any], outputVariableNameOpt: Option[String], additional: Seq[AnyRef]): Any = {
         //this is needed to be able to handle dynamic types in tests
-        def transform(impl: Any): Any = overrideFromOriginalAndType(impl, impl.cast[ReturningType].map(_.returnType).getOrElse(original.returnType))
+        def transform(impl: Any): Any = {
+          val typingResult = impl.cast[ReturningType].map(_.returnType).getOrElse(original.returnType)
+          val nodeId = additional.collectFirst {
+            case nodeId: NodeId => nodeId
+          }.getOrElse(throw new IllegalArgumentException("Node id is missing in additional parameters"))
+          overrideFromOriginalAndType(impl, typingResult, nodeId)
+        }
 
         val originalValue = original.invokeMethod(params, outputVariableNameOpt, additional)
         originalValue match {

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/TestFlinkProcessCompiler.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/TestFlinkProcessCompiler.scala
@@ -4,14 +4,13 @@ import com.typesafe.config.Config
 import org.apache.flink.api.common.restartstrategy.RestartStrategies
 import pl.touk.nussknacker.engine.api.namespaces.ObjectNaming
 import pl.touk.nussknacker.engine.api.process.{ComponentUseCase, ContextInitializer, ProcessConfigCreator, ProcessObjectDependencies}
-import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, SingleSourceScenarioTestData, TestData}
+import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.api.{MetaData, ProcessListener}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor.ObjectWithMethodDef
 import pl.touk.nussknacker.engine.flink.api.exception.FlinkEspExceptionConsumer
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkIntermediateRawSource, FlinkSourceTestSupport}
 import pl.touk.nussknacker.engine.flink.util.source.CollectionSource
-import pl.touk.nussknacker.engine.graph.node
 import pl.touk.nussknacker.engine.process.exception.FlinkExceptionHandler
 import pl.touk.nussknacker.engine.testmode.{ResultsCollectingListener, TestDataPreparer}
 
@@ -32,7 +31,7 @@ class TestFlinkProcessCompiler(creator: ProcessConfigCreator,
     overrideObjectWithMethod(sourceFactory, (originalSource, returnType, nodeId) => {
       originalSource match {
         case sourceWithTestSupport: FlinkSourceTestSupport[Object@unchecked] =>
-          val parsedTestData = TestDataPreparer.prepareDataForTest(sourceWithTestSupport, scenarioTestData.forNodeId(nodeId))
+          val parsedTestData = TestDataPreparer.prepareDataForTest(sourceWithTestSupport, scenarioTestData, nodeId)
           sourceWithTestSupport match {
             case providerWithTransformation: FlinkIntermediateRawSource[Object@unchecked] =>
               new CollectionSource[Object](parsedTestData.samples, sourceWithTestSupport.timestampAssignerForTest, returnType)(providerWithTransformation.typeInformation) {

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/TestFlinkProcessCompiler.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/TestFlinkProcessCompiler.scala
@@ -19,7 +19,7 @@ class TestFlinkProcessCompiler(creator: ProcessConfigCreator,
                                inputConfigDuringExecution: Config,
                                collectingListener: ResultsCollectingListener,
                                process: CanonicalProcess,
-                               testData: ScenarioTestData,
+                               scenarioTestData: ScenarioTestData,
                                objectNaming: ObjectNaming)
   extends StubbedFlinkProcessCompiler(process, creator, inputConfigDuringExecution, diskStateBackendSupport = false, objectNaming, ComponentUseCase.TestRuntime) {
 
@@ -32,7 +32,7 @@ class TestFlinkProcessCompiler(creator: ProcessConfigCreator,
     overrideObjectWithMethod(sourceFactory, (originalSource, returnType, nodeId) => {
       originalSource match {
         case sourceWithTestSupport: FlinkSourceTestSupport[Object@unchecked] =>
-          val parsedTestData = TestDataPreparer.prepareDataForTest(sourceWithTestSupport, testData.forNodeId(nodeId))
+          val parsedTestData = TestDataPreparer.prepareDataForTest(sourceWithTestSupport, scenarioTestData.forNodeId(nodeId))
           sourceWithTestSupport match {
             case providerWithTransformation: FlinkIntermediateRawSource[Object@unchecked] =>
               new CollectionSource[Object](parsedTestData.samples, sourceWithTestSupport.timestampAssignerForTest, returnType)(providerWithTransformation.typeInformation) {

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/VerificationFlinkProcessCompiler.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/VerificationFlinkProcessCompiler.scala
@@ -18,11 +18,11 @@ class VerificationFlinkProcessCompiler(process: CanonicalProcess,
   override protected def adjustListeners(defaults: List[ProcessListener], processObjectDependencies: ProcessObjectDependencies): List[ProcessListener] = Nil
 
   override protected def prepareService(service: DefinitionExtractor.ObjectWithMethodDef): DefinitionExtractor.ObjectWithMethodDef =
-    overrideObjectWithMethod(service, (_, _) => null)
+    overrideObjectWithMethod(service, (_, _, _) => null)
 
   override protected def prepareSourceFactory(sourceFactory: DefinitionExtractor.ObjectWithMethodDef): DefinitionExtractor.ObjectWithMethodDef =
     overrideObjectWithMethod(
       sourceFactory,
-      (_, returnType) =>  new EmptySource[Object](returnType)(TypeInformation.of(classOf[Object]))
+      (_, returnType, _) =>  new EmptySource[Object](returnType)(TypeInformation.of(classOf[Object]))
     )
 }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMain.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMain.scala
@@ -5,7 +5,7 @@ import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings
 import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.DeploymentData
 import pl.touk.nussknacker.engine.process.ExecutionConfigPreparer
@@ -16,7 +16,7 @@ import pl.touk.nussknacker.engine.testmode.{ResultsCollectingListener, ResultsCo
 
 object FlinkTestMain extends FlinkRunner {
 
-  def run[T](modelData: ModelData, process: CanonicalProcess, testData: TestData, configuration: Configuration, variableEncoder: Any => T): TestResults[T] = {
+  def run[T](modelData: ModelData, process: CanonicalProcess, testData: ScenarioTestData, configuration: Configuration, variableEncoder: Any => T): TestResults[T] = {
     val processVersion = ProcessVersion.empty.copy(processName = ProcessName("snapshot version")) // testing process may be unreleased, so it has no version
     new FlinkTestMain(modelData, process, testData, processVersion, DeploymentData.empty, configuration).runTest(variableEncoder)
   }
@@ -25,7 +25,7 @@ object FlinkTestMain extends FlinkRunner {
 
 class FlinkTestMain(val modelData: ModelData,
                     val process: CanonicalProcess,
-                    testData: TestData,
+                    testData: ScenarioTestData,
                     processVersion: ProcessVersion,
                     deploymentData: DeploymentData,
                     val configuration: Configuration)
@@ -44,7 +44,7 @@ class FlinkTestMain(val modelData: ModelData,
     }
   }
 
-  protected def prepareRegistrar[T](collectingListener: ResultsCollectingListener, testData: TestData): FlinkProcessRegistrar = {
+  protected def prepareRegistrar[T](collectingListener: ResultsCollectingListener, testData: ScenarioTestData): FlinkProcessRegistrar = {
     FlinkProcessRegistrar(new TestFlinkProcessCompiler(
       modelData.configCreator,
       modelData.processConfig,

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMain.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMain.scala
@@ -16,16 +16,16 @@ import pl.touk.nussknacker.engine.testmode.{ResultsCollectingListener, ResultsCo
 
 object FlinkTestMain extends FlinkRunner {
 
-  def run[T](modelData: ModelData, process: CanonicalProcess, testData: ScenarioTestData, configuration: Configuration, variableEncoder: Any => T): TestResults[T] = {
+  def run[T](modelData: ModelData, process: CanonicalProcess, scenarioTestData: ScenarioTestData, configuration: Configuration, variableEncoder: Any => T): TestResults[T] = {
     val processVersion = ProcessVersion.empty.copy(processName = ProcessName("snapshot version")) // testing process may be unreleased, so it has no version
-    new FlinkTestMain(modelData, process, testData, processVersion, DeploymentData.empty, configuration).runTest(variableEncoder)
+    new FlinkTestMain(modelData, process, scenarioTestData, processVersion, DeploymentData.empty, configuration).runTest(variableEncoder)
   }
 
 }
 
 class FlinkTestMain(val modelData: ModelData,
                     val process: CanonicalProcess,
-                    testData: ScenarioTestData,
+                    scenarioTestData: ScenarioTestData,
                     processVersion: ProcessVersion,
                     deploymentData: DeploymentData,
                     val configuration: Configuration)
@@ -35,7 +35,7 @@ class FlinkTestMain(val modelData: ModelData,
     val env = createEnv
     val collectingListener = ResultsCollectingListenerHolder.registerRun(variableEncoder)
     try {
-      val registrar: FlinkProcessRegistrar = prepareRegistrar(collectingListener, testData)
+      val registrar: FlinkProcessRegistrar = prepareRegistrar(collectingListener, scenarioTestData)
       registrar.register(env, process, processVersion, deploymentData, Option(collectingListener.runId))
       execute(env, SavepointRestoreSettings.none())
       collectingListener.results
@@ -44,13 +44,13 @@ class FlinkTestMain(val modelData: ModelData,
     }
   }
 
-  protected def prepareRegistrar[T](collectingListener: ResultsCollectingListener, testData: ScenarioTestData): FlinkProcessRegistrar = {
+  protected def prepareRegistrar[T](collectingListener: ResultsCollectingListener, scenarioTestData: ScenarioTestData): FlinkProcessRegistrar = {
     FlinkProcessRegistrar(new TestFlinkProcessCompiler(
       modelData.configCreator,
       modelData.processConfig,
       collectingListener,
       process,
-      testData,
+      scenarioTestData,
       modelData.objectNaming),
       ExecutionConfigPreparer.defaultChain(modelData))
   }

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFlinkProcessCompilerTest.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFlinkProcessCompilerTest.scala
@@ -57,7 +57,7 @@ class StubbedFlinkProcessCompilerTest extends AnyFunSuite with Matchers {
   }
 
   test("stubbing for test purpose should work for one source") {
-    val testData = SingleSourceScenarioTestData(TestData(Array(1, 2, 3), 3), 3)
+    val testData = SingleSourceScenarioTestData(TestData(Array(1, 2, 3)), 3)
     val compiledProcess = testCompile(scenarioWithSingleSource, testData)
     val sources = compiledProcess.sources.collect {
       case source: SourcePart => source.obj
@@ -70,8 +70,8 @@ class StubbedFlinkProcessCompilerTest extends AnyFunSuite with Matchers {
   test("stubbing for test purpose should work for multiple sources") {
     val testData = MultipleSourcesScenarioTestData(
       Map(
-        "left-source" -> TestData(Array(11, 12, 13), 3),
-        "right-source" -> TestData(Array(21, 22, 23), 3),
+        "left-source" -> TestData(Array(11, 12, 13)),
+        "right-source" -> TestData(Array(21, 22, 23)),
       ),
       samplesLimit = 3
     )

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFlinkProcessCompilerTest.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFlinkProcessCompilerTest.scala
@@ -89,9 +89,9 @@ class StubbedFlinkProcessCompilerTest extends AnyFunSuite with Matchers {
     }
   }
 
-  private def testCompile(scenario: CanonicalProcess, testData: ScenarioTestData) = {
+  private def testCompile(scenario: CanonicalProcess, scenarioTestData: ScenarioTestData) = {
     val testCompiler = new TestFlinkProcessCompiler(SampleConfigCreator, minimalFlinkConfig, ResultsCollectingListenerHolder.registerRun(identity),
-      scenario, testData, DefaultNamespacedObjectNaming)
+      scenario, scenarioTestData, DefaultNamespacedObjectNaming)
     testCompiler.compileProcess(scenario, ProcessVersion.empty, DeploymentData.empty, PreventInvocationCollector)(UsedNodes.empty, getClass.getClassLoader).compileProcessOrFail()
   }
 

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
@@ -244,7 +244,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
         | "id": "3",
         | "field": "33"
         |}
-        |""".stripMargin.getBytes(StandardCharsets.UTF_8), 3), 3)
+        |""".stripMargin.getBytes(StandardCharsets.UTF_8)), 3)
 
     val results = runFlinkTest(process, testJsonData)
 
@@ -417,8 +417,8 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
     val recC = "c|1|2|3|4|5|6"
     val testData = MultipleSourcesScenarioTestData(
       Map(
-        "input1" -> TestData(s"$recA\n$recC".getBytes(StandardCharsets.UTF_8), samplesLimit = 3),
-        "input2" -> TestData(s"$recA\n$recB\n$recC".getBytes(StandardCharsets.UTF_8), samplesLimit = 3),
+        "input1" -> TestData(s"$recA\n$recC".getBytes(StandardCharsets.UTF_8)),
+        "input2" -> TestData(s"$recA\n$recB\n$recC".getBytes(StandardCharsets.UTF_8)),
       ),
       3
     )

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
@@ -49,7 +49,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
     val input = SimpleRecord("0", 1, "2", new Date(3), Some(4), 5, "6")
     val input2 = SimpleRecord("0", 11, "2", new Date(3), Some(4), 5, "6")
 
-    val results = runFlinkTest(process, TestData.newLineSeparated("0|1|2|3|4|5|6", "0|11|2|3|4|5|6"))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated("0|1|2|3|4|5|6", "0|11|2|3|4|5|6"))
 
     val nodeResults = results.nodeResults
 
@@ -85,7 +85,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
           GraphBuilder.emptySink("out2", "monitor")
         )
 
-    val results = runFlinkTest(process, TestData.newLineSeparated("0|1|2|3|4|5|6", "0|11|2|3|4|5|6"))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated("0|1|2|3|4|5|6", "0|11|2|3|4|5|6"))
 
     results.nodeResults("splitId1") shouldBe List(nodeResult(0, "input" ->
         SimpleRecord("0", 1, "2", new Date(3), Some(4), 5, "6")),
@@ -108,7 +108,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
     val aggregate2 = SimpleRecordWithPreviousValue(input2, 1, "s")
 
 
-    val results = runFlinkTest(process, TestData.newLineSeparated("0|1|2|3|4|5|6", "0|11|2|3|4|5|6"))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated("0|1|2|3|4|5|6", "0|11|2|3|4|5|6"))
 
     val nodeResults = results.nodeResults
 
@@ -148,7 +148,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
         .source("id", "input")
         .emptySink("out", "monitor")
 
-    val results = runFlinkTest(process, TestData.newLineSeparated("0|1|2|3|4|5|6", "0|11|2|3|4|5|6", "0|11|2|3|4|5|6", "0|11|2|3|4|5|6", "0|11|2|3|4|5|6"))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated("0|1|2|3|4|5|6", "0|11|2|3|4|5|6", "0|11|2|3|4|5|6", "0|11|2|3|4|5|6", "0|11|2|3|4|5|6"))
 
     val nodeResults = results.nodeResults
 
@@ -165,7 +165,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
         .filter("filter", "1 / #input.value1 >= 0")
         .emptySink("out", "monitor")
 
-    val results = runFlinkTest(process, TestData.newLineSeparated("0|1|2|3|4|5|6", "1|0|2|3|4|5|6", "2|2|2|3|4|5|6", "3|4|2|3|4|5|6"))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated("0|1|2|3|4|5|6", "1|0|2|3|4|5|6", "2|2|2|3|4|5|6", "3|4|2|3|4|5|6"))
 
     val nodeResults = results.nodeResults
 
@@ -196,7 +196,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
 
     val exceptionConsumerId = UUID.randomUUID().toString
     val config = RecordingExceptionConsumerProvider.configWithProvider(ConfigFactory.load(), exceptionConsumerId)
-    val results = runFlinkTest(process, TestData.newLineSeparated("0|1|2|3|4|5|6", "1|0|2|3|4|5|6", "2|2|2|3|4|5|6", "3|4|2|3|4|5|6"), config)
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated("0|1|2|3|4|5|6", "1|0|2|3|4|5|6", "2|2|2|3|4|5|6", "3|4|2|3|4|5|6"), config)
 
     val nodeResults = results.nodeResults
 
@@ -216,7 +216,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
         .emptySink("out", "monitor")
 
     val run = Future {
-      runFlinkTest(process, TestData.newLineSeparated("2|2|2|3|4|5|6"))
+      runFlinkTest(process, ScenarioTestData.newLineSeparated("2|2|2|3|4|5|6"))
     }
 
     intercept[JobExecutionException](Await.result(run, 10 seconds))
@@ -262,7 +262,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
       .streaming("proc1")
       .source("id", "genericSourceWithCustomVariables", "elements" -> "{'abc'}")
       .emptySink("out", "valueMonitor", "value" -> "#additionalOne + '|' + #additionalTwo")
-    val testData = TestData.newLineSeparated("abc")
+    val testData = ScenarioTestData.newLineSeparated("abc")
 
     val results = runFlinkTest(process, testData)
 
@@ -280,7 +280,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
         .source("id", "input")
         .emptySink("out", "sinkForInts", "value" -> "15 / {0, 1}[0]")
 
-    val results = runFlinkTest(process, TestData.newLineSeparated("2|2|2|3|4|5|6"))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated("2|2|2|3|4|5|6"))
 
     results.exceptions should have length 1
     results.exceptions.head.nodeId shouldBe Some("out")
@@ -299,7 +299,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
 
     def recordWithSeconds(duration: FiniteDuration) = s"0|0|0|${duration.toMillis}|0|0|0"
 
-    val results = runFlinkTest(process, TestData.newLineSeparated(
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated(
       recordWithSeconds(1 second),
       recordWithSeconds(2 second),
       recordWithSeconds(5 second),
@@ -320,7 +320,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
         .source("id", "typedJsonInput", "type" -> """{"field1": "String", "field2": "java.lang.String"}""")
         .emptySink("out", "valueMonitor", "value" -> "#input.field1 + #input.field2")
 
-    val results = runFlinkTest(process, TestData.newLineSeparated("""{"field1": "abc", "field2": "def"}"""))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated("""{"field1": "abc", "field2": "def"}"""))
 
     results.invocationResults("out").map(_.value) shouldBe List("abcdef")
   }
@@ -336,7 +336,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
         "definition" -> "{'field1', 'field2'}", "toFill" -> "#input.value1.toString()", "count" -> countToPass)
       .emptySink("out", "valueMonitor", "value" ->  "#parsed.size + ' ' + #parsed[0].field2")
 
-    val results = runFlinkTest(process, TestData.newLineSeparated(s"0|$valueToReturn|2|3|4|5|6"))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated(s"0|$valueToReturn|2|3|4|5|6"))
 
     results.invocationResults("out").map(_.value) shouldBe List(s"$countToPass $valueToReturn")
   }
@@ -358,7 +358,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
     val recordTrue = "ala|1|2|3|4|5|6"
     val recordFalse = "bela|1|2|3|4|5|6"
 
-    val results = runFlinkTest(process, TestData.newLineSeparated(recordTrue, recordFalse))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated(recordTrue, recordFalse))
 
     val invocationResults = results.invocationResults
 
@@ -388,7 +388,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
     val recC = "c|1|2|3|4|5|6"
 
 
-    val results = runFlinkTest(process, TestData.newLineSeparated(recA, recB, recC))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated(recA, recB, recC))
 
     //TODO: currently e.g. invocation results will behave strangely in this test, because we duplicate inputs and this results in duplicate context ids...
     results.externalInvocationResults("proc2").map(_.value.asInstanceOf[String]).sorted shouldBe List("a", "b", "c", "c").map(_ + "-collectedDuringServiceInvocation")
@@ -454,7 +454,7 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
       .customNode("componentUseCaseCustomNode", "componentUseCaseCustomNode", "transformerAddingComponentUseCase")
       .emptySink("out", "valueMonitor", "value" -> "{#componentUseCaseService, #componentUseCaseCustomNode}")
 
-    val results = runFlinkTest(process, TestData.newLineSeparated("0|1|2|3|4|5|6"))
+    val results = runFlinkTest(process, ScenarioTestData.newLineSeparated("0|1|2|3|4|5|6"))
 
     results.invocationResults("out").map(_.value) shouldBe List(List(ComponentUseCase.TestRuntime, ComponentUseCase.TestRuntime).asJava)
   }

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
@@ -459,11 +459,11 @@ class FlinkTestMainSpec extends AnyFunSuite with Matchers with Inside with Befor
     results.invocationResults("out").map(_.value) shouldBe List(List(ComponentUseCase.TestRuntime, ComponentUseCase.TestRuntime).asJava)
   }
 
-  def runFlinkTest(process: CanonicalProcess, testData: ScenarioTestData, config: Config= ConfigFactory.load()): TestResults[Any] = {
+  def runFlinkTest(process: CanonicalProcess, scenarioTestData: ScenarioTestData, config: Config= ConfigFactory.load()): TestResults[Any] = {
     //We need to set context loader to avoid forking in sbt
     val modelData = ModelData(config, ModelClassLoader.empty)
     ThreadUtils.withThisAsContextClassLoader(getClass.getClassLoader) {
-      FlinkTestMain.run(modelData, process, testData, FlinkTestConfiguration.configuration(), identity)
+      FlinkTestMain.run(modelData, process, scenarioTestData, FlinkTestConfiguration.configuration(), identity)
     }
   }
 

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/signal/KafkaSignalInTestSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/signal/KafkaSignalInTestSpec.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.kafka.signal
 import org.scalatest.{BeforeAndAfterEach, Inside}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.flink.test.FlinkTestConfiguration
 import pl.touk.nussknacker.engine.kafka.KafkaSpec
@@ -24,7 +24,7 @@ class KafkaSignalInTestSpec extends AnyFunSuite with Matchers with Inside with B
         .processorEnd("out", "logService", "all" -> "#input")
 
     val modelData = LocalModelData(config, new KafkaSignalsCreator(Nil))
-    val testData = TestData.newLineSeparated("0|1|2|3|4|5|6")
+    val testData = ScenarioTestData.newLineSeparated("0|1|2|3|4|5|6")
 
     val results = ThreadUtils.withThisAsContextClassLoader(getClass.getClassLoader) {
       FlinkTestMain.run(modelData, process, testData, FlinkTestConfiguration.configuration(), identity)

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/KafkaSourceFactorySpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/KafkaSourceFactorySpec.scala
@@ -34,7 +34,7 @@ class KafkaSourceFactorySpec extends AnyFunSuite with Matchers with KafkaSpec wi
   private def readLastMessage(sourceFactory: KafkaSourceFactory[Any, Any], topic: String, numberOfMessages: Int = 1): List[AnyRef] = {
     val source = createSource(sourceFactory, topic)
     val bytes = source.generateTestData(numberOfMessages)
-    source.testDataParser.parseTestData(TestData(bytes, numberOfMessages))
+    source.testDataParser.parseTestData(TestData(bytes))
   }
 
   private def createSource[K, V](sourceFactory: KafkaSourceFactory[K, V], topic: String): Source with TestDataGenerator with FlinkSourceTestSupport[ConsumerRecord[K, V]] with ReturningType = {
@@ -164,7 +164,7 @@ class KafkaSourceFactorySpec extends AnyFunSuite with Matchers with KafkaSpec wi
 
       val data = source.generateTestData(2)
 
-      val parsed = source.testDataParser.parseTestData(TestData(data, 2))
+      val parsed = source.testDataParser.parseTestData(TestData(data))
       parsed.map(_.value())
     }
 

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/TestFromFileSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/TestFromFileSpec.scala
@@ -7,7 +7,7 @@ import io.circe.Json.{Null, fromString, obj}
 import org.apache.kafka.common.record.TimestampType
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.flink.test.FlinkTestConfiguration
@@ -71,7 +71,7 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
     results.nodeResults shouldBe 'nonEmpty
   }
 
-  private def run(process: CanonicalProcess, testData: TestData): TestResults[Any] = {
+  private def run(process: CanonicalProcess, testData: ScenarioTestData): TestResults[Any] = {
     ThreadUtils.withThisAsContextClassLoader(getClass.getClassLoader) {
       FlinkTestMain.run(LocalModelData(config, creator), process, testData,
         FlinkTestConfiguration.configuration(), identity

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/TestFromFileSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/TestFromFileSpec.scala
@@ -71,9 +71,9 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
     results.nodeResults shouldBe 'nonEmpty
   }
 
-  private def run(process: CanonicalProcess, testData: ScenarioTestData): TestResults[Any] = {
+  private def run(process: CanonicalProcess, scenarioTestData: ScenarioTestData): TestResults[Any] = {
     ThreadUtils.withThisAsContextClassLoader(getClass.getClassLoader) {
-      FlinkTestMain.run(LocalModelData(config, creator), process, testData,
+      FlinkTestMain.run(LocalModelData(config, creator), process, scenarioTestData,
         FlinkTestConfiguration.configuration(), identity
       )
     }

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/TestFromFileSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/TestFromFileSpec.scala
@@ -49,7 +49,7 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
       .mapObject(_.add("key", Null)
       .add("value", obj("city" -> fromString("Lublin"), "street" -> fromString("Lipowa"))))
 
-    val results = run(process, TestData.newLineSeparated(consumerRecord.noSpaces))
+    val results = run(process, ScenarioTestData.newLineSeparated(consumerRecord.noSpaces))
 
     val testResultVars = results.nodeResults("end").head.context.variables
     testResultVars.get("extractedTimestamp") shouldBe Some(expectedTimestamp)
@@ -66,7 +66,7 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
       .mapObject(_.add("key", Null)
         .add("value", obj("id" -> fromString("1234"), "field" -> fromString("abcd"))))
 
-    val results = run(process, TestData.newLineSeparated(consumerRecord.noSpaces))
+    val results = run(process, ScenarioTestData.newLineSeparated(consumerRecord.noSpaces))
 
     results.nodeResults shouldBe 'nonEmpty
   }

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -134,8 +134,8 @@ class PeriodicDeploymentManager private[periodic](val delegate: DeploymentManage
     }
   }
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] =
-    delegate.test(name, canonicalProcess, testData, variableEncoder)
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, scenarioTestData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] =
+    delegate.test(name, canonicalProcess, scenarioTestData, variableEncoder)
 
   override def findJobStatus(name: ProcessName): Future[Option[ProcessState]] = {
     def createScheduledProcessState(processDeployment: PeriodicProcessDeployment): ProcessState = {

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, ExternalDeploymentId, User}
 import pl.touk.nussknacker.engine.management.FlinkConfig
@@ -134,7 +134,7 @@ class PeriodicDeploymentManager private[periodic](val delegate: DeploymentManage
     }
   }
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: TestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] =
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] =
     delegate.test(name, canonicalProcess, testData, variableEncoder)
 
   override def findJobStatus(name: ProcessName): Future[Option[ProcessState]] = {

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.management.periodic
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, ExternalDeploymentId, User}
 import pl.touk.nussknacker.engine.testmode.TestProcess
@@ -34,7 +34,7 @@ class DeploymentManagerStub extends BaseDeploymentManager {
 
   override def cancel(name: ProcessName, user: User): Future[Unit] = Future.successful(())
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: TestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
 
   override def findJobStatus(name: ProcessName): Future[Option[ProcessState]] = Future.successful(jobStatus)
 

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
@@ -34,7 +34,7 @@ class DeploymentManagerStub extends BaseDeploymentManager {
 
   override def cancel(name: ProcessName, user: User): Future[Unit] = Future.successful(())
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, scenarioTestData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
 
   override def findJobStatus(name: ProcessName): Future[Option[ProcessState]] = Future.successful(jobStatus)
 

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.testmode.TestProcess.{NodeResult, ResultContext}
 import pl.touk.nussknacker.engine.api.deployment.{ProcessingTypeDeploymentService, ProcessingTypeDeploymentServiceStub}
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.management.FlinkStreamingDeploymentManagerProvider
 import pl.touk.nussknacker.test.{KafkaConfigProperties, VeryPatientScalaFutures}
@@ -41,7 +41,7 @@ class FlinkStreamingProcessTestRunnerSpec extends AnyFlatSpec with Matchers with
 
     val process = SampleProcess.prepareProcess(processId)
 
-    whenReady(deploymentManager.test(ProcessName(processId), process, TestData.newLineSeparated("terefere"), identity)) { r =>
+    whenReady(deploymentManager.test(ProcessName(processId), process, ScenarioTestData.newLineSeparated("terefere"), identity)) { r =>
       r.nodeResults shouldBe Map(
         "startProcess" -> List(NodeResult(ResultContext(s"$processId-startProcess-0-0", Map("input" -> "terefere")))),
         "nightFilter" -> List(NodeResult(ResultContext(s"$processId-startProcess-0-0", Map("input" -> "terefere")))),
@@ -61,7 +61,7 @@ class FlinkStreamingProcessTestRunnerSpec extends AnyFlatSpec with Matchers with
     val deploymentManager = FlinkStreamingDeploymentManagerProvider.defaultDeploymentManager(config)
 
     val caught = intercept[IllegalArgumentException] {
-      Await.result(deploymentManager.test(ProcessName(processId), process, TestData.newLineSeparated("terefere"), _ => null), patienceConfig.timeout)
+      Await.result(deploymentManager.test(ProcessName(processId), process, ScenarioTestData.newLineSeparated("terefere"), _ => null), patienceConfig.timeout)
     }
     caught.getMessage shouldBe "Compilation errors: MissingSinkFactory(sendSmsNotExist,endSend)"
   }

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
@@ -83,8 +83,8 @@ abstract class FlinkDeploymentManager(modelData: BaseModelData, shouldVerifyBefo
     }
   }
 
-  override def test[T](processName: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestResults[T]] = {
-    testRunner.test(processName, canonicalProcess, testData, variableEncoder)
+  override def test[T](processName: ProcessName, canonicalProcess: CanonicalProcess, scenarioTestData: ScenarioTestData, variableEncoder: Any => T): Future[TestResults[T]] = {
+    testRunner.test(processName, canonicalProcess, scenarioTestData, variableEncoder)
   }
 
   override def customActions: List[CustomAction] = List.empty

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
@@ -9,7 +9,7 @@ import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, ExternalDeploymentId, User}
 import pl.touk.nussknacker.engine.management.FlinkDeploymentManager.prepareProgramArgs
@@ -83,7 +83,7 @@ abstract class FlinkDeploymentManager(modelData: BaseModelData, shouldVerifyBefo
     }
   }
 
-  override def test[T](processName: ProcessName, canonicalProcess: CanonicalProcess, testData: TestData, variableEncoder: Any => T): Future[TestResults[T]] = {
+  override def test[T](processName: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestResults[T]] = {
     testRunner.test(processName, canonicalProcess, testData, variableEncoder)
   }
 

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessTestRunner.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessTestRunner.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.management
 import org.apache.flink.configuration.Configuration
 import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 import pl.touk.nussknacker.engine.util.StaticMethodRunner
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 class FlinkProcessTestRunner(modelData: ModelData) extends StaticMethodRunner(modelData.modelClassLoader.classLoader,
   "pl.touk.nussknacker.engine.process.runner.FlinkTestMain", "run") {
 
-  def test[T](processName: ProcessName, canonicalProcess: CanonicalProcess, testData: TestData, variableEncoder: Any => T): Future[TestResults[T]] = {
+  def test[T](processName: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestResults[T]] = {
     Future.successful(tryToInvoke(modelData, canonicalProcess, testData, new Configuration(), variableEncoder).asInstanceOf[TestResults[T]])
   }
 

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessTestRunner.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkProcessTestRunner.scala
@@ -13,8 +13,8 @@ import scala.concurrent.Future
 class FlinkProcessTestRunner(modelData: ModelData) extends StaticMethodRunner(modelData.modelClassLoader.classLoader,
   "pl.touk.nussknacker.engine.process.runner.FlinkTestMain", "run") {
 
-  def test[T](processName: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestResults[T]] = {
-    Future.successful(tryToInvoke(modelData, canonicalProcess, testData, new Configuration(), variableEncoder).asInstanceOf[TestResults[T]])
+  def test[T](processName: ProcessName, canonicalProcess: CanonicalProcess, scenarioTestData: ScenarioTestData, variableEncoder: Any => T): Future[TestResults[T]] = {
+    Future.successful(tryToInvoke(modelData, canonicalProcess, scenarioTestData, new Configuration(), variableEncoder).asInstanceOf[TestResults[T]])
   }
 
 }

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/AvroNodesClassloadingSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/AvroNodesClassloadingSpec.scala
@@ -4,7 +4,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.schemedkafka.KafkaAvroIntegrationMockSchemaRegistry.schemaRegistryMockClient
 import pl.touk.nussknacker.engine.schemedkafka.helpers.SchemaRegistryMixin
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.SchemaVersionOption
@@ -46,7 +46,7 @@ class AvroNodesClassloadingSpec extends AnyFunSuite with Matchers with SchemaReg
         scenario.nodes.head.data.asInstanceOf[Source]) shouldBe TestingCapabilities(canBeTested = false, canGenerateTestData = false)
 
       intercept[IllegalArgumentException] {
-        new TestDataPreparer(modelData).prepareDataForTest(scenario, TestData.newLineSeparated())
+        new TestDataPreparer(modelData).prepareDataForTest(scenario, ScenarioTestData.newLineSeparated())
       }.getMessage.contains("InvalidPropertyFixedValue") shouldBe true
     }
   }

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/AvroNodesClassloadingSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/AvroNodesClassloadingSpec.scala
@@ -44,10 +44,6 @@ class AvroNodesClassloadingSpec extends AnyFunSuite with Matchers with SchemaReg
     withFailingLoader {
       new ModelDataTestInfoProvider(modelData).getTestingCapabilities(scenario.metaData,
         scenario.nodes.head.data.asInstanceOf[Source]) shouldBe TestingCapabilities(canBeTested = false, canGenerateTestData = false)
-
-      intercept[IllegalArgumentException] {
-        new TestDataPreparer(modelData).prepareDataForTest(scenario, ScenarioTestData.newLineSeparated())
-      }.getMessage.contains("InvalidPropertyFixedValue") shouldBe true
     }
   }
 

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/helpers/KafkaAvroSpecMixin.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/helpers/KafkaAvroSpecMixin.scala
@@ -231,7 +231,7 @@ trait KafkaAvroSpecMixin extends AnyFunSuite with KafkaWithSchemaRegistryOperati
       .map(source => {
         val bytes = source.generateTestData(1)
         info("test object: " + new String(bytes, StandardCharsets.UTF_8))
-        val deserializedObj = source.testDataParser.parseTestData(TestData(bytes, 1)).head.asInstanceOf[ConsumerRecord[Any, Any]]
+        val deserializedObj = source.testDataParser.parseTestData(TestData(bytes)).head.asInstanceOf[ConsumerRecord[Any, Any]]
 
         deserializedObj.key() shouldEqual givenKey
         deserializedObj.value() shouldEqual givenValue

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/TestFromFileSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/TestFromFileSpec.scala
@@ -71,9 +71,9 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
     schemaRegistryMockClient.register(subject, parsedSchema)
   }
 
-  private def run(process: CanonicalProcess, testData: ScenarioTestData): TestResults[Any] = {
+  private def run(process: CanonicalProcess, scenarioTestData: ScenarioTestData): TestResults[Any] = {
     ThreadUtils.withThisAsContextClassLoader(getClass.getClassLoader) {
-      FlinkTestMain.run(LocalModelData(config, creator), process, testData,
+      FlinkTestMain.run(LocalModelData(config, creator), process, scenarioTestData,
         FlinkTestConfiguration.configuration(), identity
       )
     }

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/TestFromFileSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/TestFromFileSpec.scala
@@ -7,7 +7,7 @@ import io.circe.Json._
 import org.apache.kafka.common.record.TimestampType
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.flink.test.FlinkTestConfiguration
@@ -71,7 +71,7 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
     schemaRegistryMockClient.register(subject, parsedSchema)
   }
 
-  private def run(process: CanonicalProcess, testData: TestData): TestResults[Any] = {
+  private def run(process: CanonicalProcess, testData: ScenarioTestData): TestResults[Any] = {
     ThreadUtils.withThisAsContextClassLoader(getClass.getClassLoader) {
       FlinkTestMain.run(LocalModelData(config, creator), process, testData,
         FlinkTestConfiguration.configuration(), identity

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/TestFromFileSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/TestFromFileSpec.scala
@@ -58,7 +58,7 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
       .mapObject(_.add("key", Null)
       .add("value", obj("city" -> fromString("Lublin"), "street" -> fromString("Lipowa"))))
 
-    val results = run(process, TestData.newLineSeparated(s"""{"keySchemaId":null,"valueSchemaId":$id,"consumerRecord":${consumerRecord.noSpaces} }"""))
+    val results = run(process, ScenarioTestData.newLineSeparated(s"""{"keySchemaId":null,"valueSchemaId":$id,"consumerRecord":${consumerRecord.noSpaces} }"""))
 
     val testResultVars = results.nodeResults("end").head.context.variables
     testResultVars.get("extractedTimestamp") shouldBe Some(expectedTimestamp)

--- a/engine/lite/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/UnionTestSupportTest.scala
+++ b/engine/lite/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/UnionTestSupportTest.scala
@@ -1,0 +1,80 @@
+package pl.touk.nussknacker.engine.lite.components
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.process._
+import pl.touk.nussknacker.engine.api.test.{MultipleSourcesScenarioTestData, NewLineSplittedTestDataParser, TestData, TestDataParser}
+import pl.touk.nussknacker.engine.api.{Context, MethodToInvoke, NodeId, VariableConstants}
+import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
+import pl.touk.nussknacker.engine.lite.api.utils.sources.BaseLiteSource
+import pl.touk.nussknacker.engine.lite.components.UnionTestSupportTest.SampleConfigCreator
+import pl.touk.nussknacker.engine.lite.util.test.SynchronousLiteInterpreter
+import pl.touk.nussknacker.engine.spel.Implicits._
+import pl.touk.nussknacker.engine.testing.LocalModelData
+import pl.touk.nussknacker.engine.testmode.TestProcess.{NodeResult, ResultContext}
+
+import java.nio.charset.StandardCharsets
+
+class UnionTestSupportTest extends AnyFunSuite with Matchers {
+
+  private val modelData: LocalModelData = LocalModelData(ConfigFactory.empty(), SampleConfigCreator)
+  private val scenarioName = "scenario1"
+
+  test("should test multiple source scenario with union") {
+    val scenario = ScenarioBuilder
+      .streamingLite(scenarioName)
+      .sources(
+        GraphBuilder.source("source1", "source").branchEnd("branch1", "join1"),
+        GraphBuilder.source("source2", "source").branchEnd("branch2", "join1"),
+        GraphBuilder
+          .join("join1", "union", Some("unionOutput"),
+            List(
+              "branch1" -> List("Output expression" -> "#input"),
+              "branch2" -> List("Output expression" -> "#input"))
+          )
+          .emptySink("end", "dead-end")
+      )
+    val testData = MultipleSourcesScenarioTestData(
+      Map(
+        "source1" -> TestData("source1-firstRecord\nsource1-secondRecord".getBytes(StandardCharsets.UTF_8)),
+        "source2" -> TestData("source2-firstRecord".getBytes(StandardCharsets.UTF_8)),
+      ),
+      samplesLimit = 2
+    )
+
+    val results = SynchronousLiteInterpreter.test(modelData, scenario, testData)
+
+    results.nodeResults("end") shouldBe List(unionNodeResult("source1", 0, "source1-firstRecord"),
+      unionNodeResult("source1", 1, "source1-secondRecord"), unionNodeResult("source2", 0, "source2-firstRecord"))
+  }
+
+  private def unionNodeResult(sourceId: String, count: Int, unionValue: String): NodeResult[Any] = {
+    NodeResult(ResultContext[Any](s"$scenarioName-$sourceId-$count", Map("unionOutput" -> unionValue)))
+  }
+
+}
+
+object UnionTestSupportTest {
+
+  object SampleConfigCreator extends EmptyProcessConfigCreator {
+    override def sourceFactories(processObjectDependencies: ProcessObjectDependencies): Map[String, WithCategories[SourceFactory]] =
+      Map("source" -> WithCategories.anyCategory(SampleSourceFactory))
+  }
+
+  object SampleSourceFactory extends SourceFactory {
+
+    @MethodToInvoke
+    def create(implicit implicitNodeId: NodeId): Source = {
+      new BaseLiteSource[String] with SourceTestSupport[String] {
+        override def nodeId: NodeId = implicitNodeId
+
+        override def transform(record: String): Context = Context(contextIdGenerator.nextContextId()).withVariable(VariableConstants.InputVariableName, record)
+
+        override def testDataParser: TestDataParser[String] = new NewLineSplittedTestDataParser[String] {
+          override def parseElement(testElement: String): String = testElement
+        }
+      }
+    }
+  }
+}

--- a/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedDeploymentManager.scala
+++ b/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedDeploymentManager.scala
@@ -9,7 +9,7 @@ import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.component.AdditionalPropertyConfig
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, ExternalDeploymentId, User}
 import pl.touk.nussknacker.engine.embedded.requestresponse.RequestResponseDeploymentStrategy
@@ -163,7 +163,7 @@ class EmbeddedDeploymentManager(modelData: ModelData,
     logger.info("All embedded scenarios successfully closed")
   }
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: TestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = {
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = {
     Future {
       modelData.withThisAsContextClassLoader {
         deploymentStrategy.testRunner.runTest(modelData, testData, canonicalProcess, variableEncoder)

--- a/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedDeploymentManager.scala
+++ b/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedDeploymentManager.scala
@@ -163,10 +163,10 @@ class EmbeddedDeploymentManager(modelData: ModelData,
     logger.info("All embedded scenarios successfully closed")
   }
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = {
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, scenarioTestData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = {
     Future {
       modelData.withThisAsContextClassLoader {
-        deploymentStrategy.testRunner.runTest(modelData, testData, canonicalProcess, variableEncoder)
+        deploymentStrategy.testRunner.runTest(modelData, scenarioTestData, canonicalProcess, variableEncoder)
       }
     }
   }

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.runtimecontext.IncContextIdGenerator
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{SingleSourceScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.definition.ModelDataTestInfoProvider
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, User}
@@ -195,8 +195,8 @@ class StreamingEmbeddedDeploymentManagerTest extends BaseStreamingEmbeddedDeploy
     kafkaClient.sendMessage(inputTopic, message("1")).futureValue
     kafkaClient.sendMessage(inputTopic, message("2")).futureValue
 
-    val testData = TestData(new ModelDataTestInfoProvider(modelData).generateTestData(scenario.metaData,
-        scenario.nodes.head.data.asInstanceOf[Source], 2).get, 2)
+    val testData = SingleSourceScenarioTestData(TestData(new ModelDataTestInfoProvider(modelData).generateTestData(scenario.metaData,
+        scenario.nodes.head.data.asInstanceOf[Source], 2).get, 2), 2)
 
     val results = wrapInFailingLoader {
       manager.test(name, scenario, testData, identity[Any]).futureValue

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
@@ -196,7 +196,7 @@ class StreamingEmbeddedDeploymentManagerTest extends BaseStreamingEmbeddedDeploy
     kafkaClient.sendMessage(inputTopic, message("2")).futureValue
 
     val testData = SingleSourceScenarioTestData(TestData(new ModelDataTestInfoProvider(modelData).generateTestData(scenario.metaData,
-        scenario.nodes.head.data.asInstanceOf[Source], 2).get, 2), 2)
+        scenario.nodes.head.data.asInstanceOf[Source], 2).get), 2)
 
     val results = wrapInFailingLoader {
       manager.test(name, scenario, testData, identity[Any]).futureValue

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
@@ -10,7 +10,7 @@ import pl.touk.nussknacker.engine.ModelData.BaseModelDataExt
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName}
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, ExternalDeploymentId, User}
 import pl.touk.nussknacker.engine.lite.kafka.KafkaTransactionalScenarioInterpreter
@@ -175,7 +175,7 @@ class K8sDeploymentManager(modelData: BaseModelData, config: K8sDeploymentManage
     }
   }
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: TestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = {
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = {
     Future {
       modelData.asInvokableModelData.withThisAsContextClassLoader {
         KafkaTransactionalScenarioInterpreter.testRunner.runTest(modelData.asInvokableModelData, testData, canonicalProcess, variableEncoder)

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
@@ -175,10 +175,10 @@ class K8sDeploymentManager(modelData: BaseModelData, config: K8sDeploymentManage
     }
   }
 
-  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, testData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = {
+  override def test[T](name: ProcessName, canonicalProcess: CanonicalProcess, scenarioTestData: ScenarioTestData, variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = {
     Future {
       modelData.asInvokableModelData.withThisAsContextClassLoader {
-        KafkaTransactionalScenarioInterpreter.testRunner.runTest(modelData.asInvokableModelData, testData, canonicalProcess, variableEncoder)
+        KafkaTransactionalScenarioInterpreter.testRunner.runTest(modelData.asInvokableModelData, scenarioTestData, canonicalProcess, variableEncoder)
       }
     }
   }

--- a/engine/lite/request-response/components-utils/src/test/scala/pl/touk/nussknacker/engine/requestresponse/utils/QueryStringTestDataParserSpec.scala
+++ b/engine/lite/request-response/components-utils/src/test/scala/pl/touk/nussknacker/engine/requestresponse/utils/QueryStringTestDataParserSpec.scala
@@ -12,7 +12,7 @@ class QueryStringTestDataParserSpec extends AnyFunSuite with Matchers {
   test("should parse query") {
     val parser = new QueryStringTestDataParser
 
-    parser.parseTestData(TestData("no=12&id=123&id=155&mode=test\nno=15&id=555&mode=prod".getBytes(StandardCharsets.UTF_8), 2)) shouldBe List(
+    parser.parseTestData(TestData("no=12&id=123&id=155&mode=test\nno=15&id=555&mode=prod".getBytes(StandardCharsets.UTF_8))) shouldBe List(
       TypedMap(Map("no" -> "12", "id" -> util.Arrays.asList("123", "155"), "mode" -> "test")),
       TypedMap(Map("no" -> "15", "id" -> "555", "mode" -> "prod"))
     )

--- a/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
+++ b/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
@@ -37,7 +37,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = FutureBasedRequestResponseScenarioInterpreter.testRunner.runTest(
       process = process,
       modelData = modelData,
-      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8)), 10), variableEncoder = identity)
+      scenarioTestData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8)), 10), variableEncoder = identity)
 
     val contextIds = firstIdForFirstSource(process)
     val firstId = contextIds.nextContextId()
@@ -82,7 +82,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = FutureBasedRequestResponseScenarioInterpreter.testRunner.runTest(
       process = process,
       modelData = modelData,
-      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8)), 10), variableEncoder = identity)
+      scenarioTestData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8)), 10), variableEncoder = identity)
 
     results.invocationResults("occasionallyThrowFilter").toSet shouldBe Set(ExpressionInvocationResult(secondId, "expression", true))
     results.exceptions should have size 1
@@ -106,7 +106,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = FutureBasedRequestResponseScenarioInterpreter.testRunner.runTest(
       process = process,
       modelData = modelData,
-      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8)), 10), variableEncoder = identity)
+      scenarioTestData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8)), 10), variableEncoder = identity)
 
     results.nodeResults("endNodeIID").toSet shouldBe Set(
       NodeResult(ResultContext(firstId, Map("input" -> Request1("a","b"))))

--- a/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
+++ b/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
@@ -37,7 +37,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = FutureBasedRequestResponseScenarioInterpreter.testRunner.runTest(
       process = process,
       modelData = modelData,
-      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8), 10), 10), variableEncoder = identity)
+      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8)), 10), variableEncoder = identity)
 
     val contextIds = firstIdForFirstSource(process)
     val firstId = contextIds.nextContextId()
@@ -82,7 +82,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = FutureBasedRequestResponseScenarioInterpreter.testRunner.runTest(
       process = process,
       modelData = modelData,
-      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8), 10), 10), variableEncoder = identity)
+      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8)), 10), variableEncoder = identity)
 
     results.invocationResults("occasionallyThrowFilter").toSet shouldBe Set(ExpressionInvocationResult(secondId, "expression", true))
     results.exceptions should have size 1
@@ -106,7 +106,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = FutureBasedRequestResponseScenarioInterpreter.testRunner.runTest(
       process = process,
       modelData = modelData,
-      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8), 10), 10), variableEncoder = identity)
+      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8)), 10), variableEncoder = identity)
 
     results.nodeResults("endNodeIID").toSet shouldBe Set(
       NodeResult(ResultContext(firstId, Map("input" -> Request1("a","b"))))

--- a/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
+++ b/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.runtimecontext.IncContextIdGenerator
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{SingleSourceScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.requestresponse.{FutureBasedRequestResponseScenarioInterpreter, Request1, RequestResponseConfigCreator, Response}
@@ -37,7 +37,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = FutureBasedRequestResponseScenarioInterpreter.testRunner.runTest(
       process = process,
       modelData = modelData,
-      testData = new TestData(input.getBytes(StandardCharsets.UTF_8), 10), variableEncoder = identity)
+      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8), 10), 10), variableEncoder = identity)
 
     val contextIds = firstIdForFirstSource(process)
     val firstId = contextIds.nextContextId()
@@ -82,7 +82,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = FutureBasedRequestResponseScenarioInterpreter.testRunner.runTest(
       process = process,
       modelData = modelData,
-      testData = new TestData(input.getBytes(StandardCharsets.UTF_8), 10), variableEncoder = identity)
+      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8), 10), 10), variableEncoder = identity)
 
     results.invocationResults("occasionallyThrowFilter").toSet shouldBe Set(ExpressionInvocationResult(secondId, "expression", true))
     results.exceptions should have size 1
@@ -106,7 +106,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = FutureBasedRequestResponseScenarioInterpreter.testRunner.runTest(
       process = process,
       modelData = modelData,
-      testData = new TestData(input.getBytes(StandardCharsets.UTF_8), 10), variableEncoder = identity)
+      testData = SingleSourceScenarioTestData(TestData(input.getBytes(StandardCharsets.UTF_8), 10), 10), variableEncoder = identity)
 
     results.nodeResults("endNodeIID").toSet shouldBe Set(
       NodeResult(ResultContext(firstId, Map("input" -> Request1("a","b"))))

--- a/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/TestRunner.scala
+++ b/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/TestRunner.scala
@@ -24,7 +24,7 @@ import scala.language.higherKinds
 
 trait TestRunner {
   def runTest[T](modelData: ModelData,
-                 testData: ScenarioTestData,
+                 scenarioTestData: ScenarioTestData,
                  process: CanonicalProcess,
                  variableEncoder: Any => T): TestResults[T]
 }
@@ -33,13 +33,13 @@ trait TestRunner {
 class InterpreterTestRunner[F[_] : InterpreterShape : CapabilityTransformer : EffectUnwrapper, Input, Res <: AnyRef] extends TestRunner {
 
   def runTest[T](modelData: ModelData,
-                 testData: ScenarioTestData,
+                 scenarioTestData: ScenarioTestData,
                  process: CanonicalProcess,
                  variableEncoder: Any => T): TestResults[T] = {
 
     //TODO: probably we don't need statics here, we don't serialize stuff like in Flink
     val collectingListener = ResultsCollectingListenerHolder.registerRun(variableEncoder)
-    val parsedTestData = new TestDataPreparer(modelData).prepareDataForTest[Input](process, testData)
+    val parsedTestData = new TestDataPreparer(modelData).prepareDataForTest[Input](process, scenarioTestData)
 
     //in tests we don't send metrics anywhere
     val testContext = LiteEngineRuntimeContextPreparer.noOp.prepare(testJobData(process))

--- a/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/TestRunner.scala
+++ b/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/TestRunner.scala
@@ -6,7 +6,7 @@ import pl.touk.nussknacker.engine.Interpreter.InterpreterShape
 import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 import pl.touk.nussknacker.engine.api.process.{ComponentUseCase, ProcessName}
-import pl.touk.nussknacker.engine.api.test.TestData
+import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, TestData}
 import pl.touk.nussknacker.engine.api.{JobData, ProcessVersion}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.DeploymentData
@@ -24,7 +24,7 @@ import scala.language.higherKinds
 
 trait TestRunner {
   def runTest[T](modelData: ModelData,
-                 testData: TestData,
+                 testData: ScenarioTestData,
                  process: CanonicalProcess,
                  variableEncoder: Any => T): TestResults[T]
 }
@@ -33,7 +33,7 @@ trait TestRunner {
 class InterpreterTestRunner[F[_] : InterpreterShape : CapabilityTransformer : EffectUnwrapper, Input, Res <: AnyRef] extends TestRunner {
 
   def runTest[T](modelData: ModelData,
-                 testData: TestData,
+                 testData: ScenarioTestData,
                  process: CanonicalProcess,
                  variableEncoder: Any => T): TestResults[T] = {
 

--- a/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/InterpreterTestRunnerTest.scala
+++ b/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/InterpreterTestRunnerTest.scala
@@ -1,0 +1,61 @@
+package pl.touk.nussknacker.engine.lite
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.test.{MultipleSourcesScenarioTestData, ScenarioTestData, TestData}
+import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
+import pl.touk.nussknacker.engine.spel.Implicits._
+import pl.touk.nussknacker.engine.testmode.TestProcess.{ExpressionInvocationResult, ExternalInvocationResult, NodeResult, ResultContext}
+
+import java.nio.charset.StandardCharsets
+
+class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
+
+  test("should test single source scenario") {
+    val scenario = ScenarioBuilder
+      .streamingLite("scenario1")
+      .source("start", "start")
+      .enricher("failOnNumber1", "out1", "failOnNumber1", "value" -> "#input")
+      .customNode("sum", "sum", "sum", "name" -> "'test'", "value" -> "#input")
+      .emptySink("end", "end", "value" -> "#input + ':' + #sum")
+    val testData = ScenarioTestData.newLineSeparated("A|2", "B|1", "C|3")
+
+    val results = sample.test(scenario, testData)
+
+    results.nodeResults("start") shouldBe List(NodeResult(ResultContext("A", Map("input" -> 2))),
+      NodeResult(ResultContext("B", Map("input" -> 1))), NodeResult(ResultContext("C", Map("input" -> 3))))
+    results.nodeResults("sum") shouldBe List(NodeResult(ResultContext("A", Map("input" -> 2, "out1" -> 2))),
+      NodeResult(ResultContext("C", Map("input" -> 3, "out1" -> 3))))
+    results.nodeResults("end") shouldBe List(NodeResult(ResultContext("A", Map("input" -> 2, "out1" -> 2, "sum" -> 2))),
+      NodeResult(ResultContext("C", Map("input" -> 3, "out1" -> 3, "sum" -> 5))))
+
+    results.invocationResults("sum") shouldBe List(ExpressionInvocationResult("A", "value", 2), ExpressionInvocationResult("C", "value", 3))
+
+    results.externalInvocationResults("end") shouldBe List(ExternalInvocationResult("A", "end", "2:2.0"), ExternalInvocationResult("C", "end","3:5.0"))
+  }
+
+  test("should test multiple source scenario") {
+    val scenario = ScenarioBuilder
+      .streamingLite("scenario1")
+      .sources(
+        GraphBuilder.source("source1", "start").emptySink("end1", "end", "value" -> "#input"),
+        GraphBuilder.source("source2", "start").emptySink("end2", "end", "value" -> "#input")
+      )
+    val testData = MultipleSourcesScenarioTestData(
+      Map(
+        "source1" -> TestData("A|1\nB|2".getBytes(StandardCharsets.UTF_8)),
+        "source2" -> TestData("C|3".getBytes(StandardCharsets.UTF_8)),
+      ),
+      samplesLimit = 2
+    )
+
+    val results = sample.test(scenario, testData)
+
+    results.nodeResults("source1") shouldBe List(NodeResult(ResultContext("A", Map("input" -> 1))), NodeResult(ResultContext("B", Map("input" -> 2))))
+    results.nodeResults("source2") shouldBe List(NodeResult(ResultContext("C", Map("input" -> 3))))
+
+    results.externalInvocationResults("end1") shouldBe List(ExternalInvocationResult("A", "end1", 1), ExternalInvocationResult("B", "end1", 2))
+    results.externalInvocationResults("end2") shouldBe List(ExternalInvocationResult("C", "end2", 3))
+  }
+
+}

--- a/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/StateEngineTest.scala
+++ b/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/StateEngineTest.scala
@@ -9,7 +9,6 @@ import pl.touk.nussknacker.engine.lite.api.interpreterTypes.{ScenarioInputBatch,
 import pl.touk.nussknacker.engine.lite.sample.{SampleInput, SourceFailure}
 import pl.touk.nussknacker.engine.spel.Implicits._
 
-//TODO: test for test-from-file
 class StateEngineTest extends AnyFunSuite with Matchers with OptionValues {
 
   test("run scenario with sum aggregation") {

--- a/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/sample.scala
+++ b/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/sample.scala
@@ -9,7 +9,9 @@ import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.component.{ComponentType, NodeComponentInfo}
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 import pl.touk.nussknacker.engine.api.process._
+import pl.touk.nussknacker.engine.api.test.{NewLineSplittedTestDataParser, ScenarioTestData, TestDataParser}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.lite.TestRunner.EffectUnwrapper
 import pl.touk.nussknacker.engine.lite.api.commonTypes.{ErrorType, ResultType}
 import pl.touk.nussknacker.engine.lite.api.customComponentTypes.{CapabilityTransformer, CustomComponentContext, LiteSource}
 import pl.touk.nussknacker.engine.lite.api.interpreterTypes.{EndResult, ScenarioInputBatch}
@@ -19,6 +21,7 @@ import pl.touk.nussknacker.engine.lite.api.utils.transformers.ContextMappingComp
 import pl.touk.nussknacker.engine.lite.capabilities.FixedCapabilityTransformer
 import pl.touk.nussknacker.engine.resultcollector.ProductionServiceInvocationCollector
 import pl.touk.nussknacker.engine.testing.LocalModelData
+import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext.ctx
 
 import scala.concurrent.duration.DurationInt
@@ -59,6 +62,14 @@ object sample {
     val interpreterResult = interpreter.invoke(data)
     val resultWithInitialState = interpreterResult.runA(initialState).value
     resultWithInitialState
+  }
+
+  def test(scenario: CanonicalProcess, scenarioTestData: ScenarioTestData): TestResults[Any] = {
+    implicit val effectUnwrapper: EffectUnwrapper[StateType] = new EffectUnwrapper[StateType] {
+      override def apply[A](fa: StateType[A]): A = fa.runA(Map.empty).value
+    }
+    val testRunner = new InterpreterTestRunner[StateType, SampleInput, AnyRef]
+    testRunner.runTest(modelData, scenarioTestData, scenario, identity)
   }
 
   class SumTransformer(name: String, outputVar: String, value: LazyParameter[java.lang.Double]) extends ContextMappingComponent {
@@ -117,9 +128,16 @@ object sample {
   object SimpleSourceFactory extends SourceFactory {
 
     @MethodToInvoke
-    def create(): Source = new LiteSource[SampleInput] {
+    def create(): Source = new LiteSource[SampleInput] with SourceTestSupport[SampleInput] {
       override def createTransformation[F[_] : Monad](evaluateLazyParameter: CustomComponentContext[F]): SampleInput => ValidatedNel[ErrorType, Context] =
         input => Valid(Context(input.contextId, Map("input" -> input.value), None))
+
+      override def testDataParser: TestDataParser[SampleInput] = new NewLineSplittedTestDataParser[SampleInput] {
+        override def parseElement(testElement: String): SampleInput = {
+          val fields = testElement.split("\\|")
+          SampleInput(fields(0), fields(1).toInt)
+        }
+      }
     }
   }
 

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/testmode/TestDataPreparer.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/testmode/TestDataPreparer.scala
@@ -27,9 +27,6 @@ object TestDataPreparer {
   def prepareDataForTest[T](sourceTestSupport: SourceTestSupport[T], testData: TestData): ParsedTestData[T] = {
     val testParserForSource = sourceTestSupport.testDataParser
     val testSamples = testParserForSource.parseTestData(testData)
-    if (testSamples.size > testData.samplesLimit) {
-      throw new IllegalArgumentException(s"Too many samples: ${testSamples.size}, limit is: ${testData.samplesLimit}")
-    }
     ParsedTestData(testSamples)
   }
 

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/testmode/TestDataPreparer.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/testmode/TestDataPreparer.scala
@@ -1,67 +1,21 @@
 package pl.touk.nussknacker.engine.testmode
 
-import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.api.NodeId
-import pl.touk.nussknacker.engine.api.process.{ComponentUseCase, SourceTestSupport}
-import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, SingleSourceScenarioTestData, TestData}
-import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.compile.ExpressionCompiler
-import pl.touk.nussknacker.engine.compile.nodecompilation.NodeCompiler
-import pl.touk.nussknacker.engine.graph.node.SourceNodeData
-import pl.touk.nussknacker.engine.resultcollector.PreventInvocationCollector
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser
+import pl.touk.nussknacker.engine.api.process.SourceTestSupport
+import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 
 case class ParsedTestData[T](samples: List[T])
 
 object TestDataPreparer {
 
-  def prepareDataForTest[T](sourceTestSupport: SourceTestSupport[T], scenarioTestData: SingleSourceScenarioTestData): ParsedTestData[T] = {
+  def prepareDataForTest[T](sourceTestSupport: SourceTestSupport[T], scenarioTestData: ScenarioTestData, sourceId: NodeId): ParsedTestData[T] = {
+    val testData = scenarioTestData.forSourceId(sourceId)
     val testParserForSource = sourceTestSupport.testDataParser
-    val testSamples = testParserForSource.parseTestData(scenarioTestData.testData)
+    val testSamples = testParserForSource.parseTestData(testData)
     if (testSamples.size > scenarioTestData.samplesLimit) {
       throw new IllegalArgumentException(s"Too many samples: ${testSamples.size}, limit is: ${scenarioTestData.samplesLimit}")
     }
     ParsedTestData(testSamples)
   }
 
-  def prepareDataForTest[T](sourceTestSupport: SourceTestSupport[T], testData: TestData): ParsedTestData[T] = {
-    val testParserForSource = sourceTestSupport.testDataParser
-    val testSamples = testParserForSource.parseTestData(testData)
-    ParsedTestData(testSamples)
-  }
-
 }
-
-class TestDataPreparer(modelData: ModelData) {
-
-  private val nodeCompiler = {
-    val expressionCompiler = ExpressionCompiler.withoutOptimization(modelData).withExpressionParsers {
-      case spel: SpelExpressionParser => spel.typingDictLabels
-    }
-    new NodeCompiler(modelData.processWithObjectsDefinition,
-      expressionCompiler, modelData.modelClassLoader.classLoader, PreventInvocationCollector, ComponentUseCase.TestDataGeneration)
-  }
-
-  def prepareDataForTest[T](scenario: CanonicalProcess, scenarioTestData: ScenarioTestData): ParsedTestData[T] = {
-    prepareDataForTest(scenario, scenarioTestData.asInstanceOf[SingleSourceScenarioTestData].testData)
-  }
-
-  def prepareDataForTest[T](scenario: CanonicalProcess, testData: TestData): ParsedTestData[T] = modelData.withThisAsContextClassLoader {
-    // TODO ljd: first
-    val sourceTestSupport = (scenario.allStartNodes.map(_.head.data).collect {
-      case e: SourceNodeData => e
-    } match {
-      case one :: Nil =>
-        nodeCompiler.compileSource(one)(scenario.metaData, NodeId(one.id)).compiledObject
-          .fold(a => throw new IllegalArgumentException(s"Failed to compile source: ${a.toList.mkString(", ")}"), identity)
-      case _ =>
-        throw new IllegalArgumentException("Currently only one source can be handled")
-    }) match {
-      case e: SourceTestSupport[T@unchecked] => e
-      case other => throw new IllegalArgumentException(s"Source ${other.getClass} cannot be stubbed - it doesn't provide test data parser")
-    }
-    TestDataPreparer.prepareDataForTest(sourceTestSupport, testData)
-  }
-
-}
-

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/testmode/TestDataPreparer.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/testmode/TestDataPreparer.scala
@@ -42,8 +42,8 @@ class TestDataPreparer(modelData: ModelData) {
       expressionCompiler, modelData.modelClassLoader.classLoader, PreventInvocationCollector, ComponentUseCase.TestDataGeneration)
   }
 
-  def prepareDataForTest[T](scenario: CanonicalProcess, testData: ScenarioTestData): ParsedTestData[T] = {
-    prepareDataForTest(scenario, testData.asInstanceOf[SingleSourceScenarioTestData].testData)
+  def prepareDataForTest[T](scenario: CanonicalProcess, scenarioTestData: ScenarioTestData): ParsedTestData[T] = {
+    prepareDataForTest(scenario, scenarioTestData.asInstanceOf[SingleSourceScenarioTestData].testData)
   }
 
   def prepareDataForTest[T](scenario: CanonicalProcess, testData: TestData): ParsedTestData[T] = modelData.withThisAsContextClassLoader {


### PR DESCRIPTION
For now the support is added to the engines. Designer is still capable of testing only single source scenarios.

* `TestData` holds only raw data for a single source.
* New `ScenarioTestData` holds test data for a scenario.