### PR TITLE
Fixup to NotBlankParameterValidator

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
@@ -50,7 +50,7 @@ case object MandatoryParameterValidator extends ParameterValidator {
 
 case object NotBlankParameterValidator extends ParameterValidator {
 
-  private final lazy val blankStringLiteralPattern: Pattern = Pattern.compile("'\\s*'")
+  private final lazy val blankStringLiteralPattern: Pattern = Pattern.compile("['\"]\\s*['\"]")
 
   // TODO: for now we correctly detect only literal expression with blank string - on this level (not evaluated expression) it is the only thing that we can do
   override def isValid(paramName: String, expression: String, label: Option[String])(implicit nodeId: NodeId): Validated[PartSubGraphCompilationError, Unit] =

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidatorSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidatorSpec.scala
@@ -1,0 +1,26 @@
+package pl.touk.nussknacker.engine.api.definition
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import pl.touk.nussknacker.engine.api.NodeId
+
+class ParameterValidatorSpec extends AnyFunSuite with TableDrivenPropertyChecks with Matchers {
+
+  test("NotBlankParameterValidator") {
+    forAll(Table(
+      ("inputExpression", "isValid"),
+      ("''", false),
+      (" '' ", false),
+      ("\"\"", false),
+      (" \"\" ", false),
+      ("'someString' ", true),
+      ("\"someString\" ", true),
+      ("\"someString\" + \"\"", true)
+    )) { (expression, expected) =>
+      val nodeId = NodeId("someNode")
+      NotBlankParameterValidator.isValid("dummy", expression, None)(nodeId).isValid shouldBe expected
+    }
+  }
+
+}

--- a/designer/client/components/graph/node-modal/editors/Validators.ts
+++ b/designer/client/components/graph/node-modal/editors/Validators.ts
@@ -91,7 +91,7 @@ export const fixedValueValidator = (possibleValues: Array<PossibleValue>): Valid
 const literalRegExpPattern = (pattern: string) => new RegExp(pattern)
 
 export const notBlankValueValidator: Validator = {
-  isValid: value => !literalRegExpPattern("'\\s*'").test(value.trim()),
+  isValid: value => !literalRegExpPattern("^['\"]\\s*['\"]$").test(value.trim()),
   message: () => i18next.t("notBlankValueValidator.message", "This field value is required and can not be blank"),
   description: () => i18next.t("validator.notBlank.description", "Please fill field value for this parameter"),
   handledErrorType: HandledErrorType.BlankParameter,

--- a/designer/client/test/Validators-test.tsx
+++ b/designer/client/test/Validators-test.tsx
@@ -1,0 +1,18 @@
+import {notBlankValueValidator} from "../components/graph/node-modal/editors/Validators"
+import {it, describe, expect} from '@jest/globals';
+
+describe("Validator", () => {
+    describe("notBlankValueValidator", () => {
+        it.each([
+            ["''", false],
+            [" '' ", false],
+            ['""', false],
+            [' "" ', false],
+            ["'someString' ", true],
+            ['"someString" ', true],
+            ['"someString" + ""', true],
+        ])('for expression: [%s] isValid should be %s', (expression: string, expected: boolean) => {
+            return expect(notBlankValueValidator.isValid(expression)).toEqual(expected)
+        })
+    })
+})


### PR DESCRIPTION
Fixup to NotBlankParameterValidator:
* not empty expressions containing somewhere '' were treated as errors by FE validator
* spel string literals created using "" weren't checked
* test on be/fe added