### PR TITLE
Remove unneeded setAccessible calls

### DIFF
--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/Serializers.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/Serializers.scala
@@ -50,7 +50,6 @@ object Serializers extends LazyLogging {
         fields.take(constructorParamsCount).foreach(field => {
           field.setAccessible(true)
           kryo.writeClassAndObject(output, field.get(obj))
-          field.setAccessible(false)
         })
       }
 

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/AvroStringSettingsInTests.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/AvroStringSettingsInTests.scala
@@ -21,6 +21,5 @@ object AvroStringSettingsInTests {
     val field = Class.forName("pl.touk.nussknacker.engine.schemedkafka.schema.AvroStringSettings$").getDeclaredField("forceUsingStringForStringSchema")
     field.setAccessible(true)
     field.setBoolean(AvroStringSettings, value)
-    field.setAccessible(false)
   }
 }


### PR DESCRIPTION
`setAccessible(true)` modifies only locally kept flag, there's no need to reset it