### PR TITLE
Added diagnostics for flaky K8sDeploymentManagerReqRespTest + avoid i…

### DIFF
--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sTestUtils.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sTestUtils.scala
@@ -119,11 +119,13 @@ class K8sTestUtils(k8s: KubernetesClient) extends K8sUtils(k8s) with Matchers wi
         reverseProxyConfConfigMapName, Volume.ConfigMapVolumeSource(reverseProxyConfConfigMapName)
       ))
     ))
+    // We setup keepalive_timeout to 0 to make sure that nginx won't keep any idle connection to terminating pods
     val configMap = ConfigMap(metadata = ObjectMeta(reverseProxyConfConfigMapName), data = Map("nginx.conf" ->
       s"""server {
          |  listen $reverseProxyPodRemotePort;
          |  location / {
          |    proxy_pass $targetUrl;
+         |    keepalive_timeout 0;
          |  }
          |}""".stripMargin))
     cleanupReverseProxyPod()

--- a/engine/lite/runtime-app/src/main/scala/pl/touk/nussknacker/engine/lite/app/NuRuntimeApp.scala
+++ b/engine/lite/runtime-app/src/main/scala/pl/touk/nussknacker/engine/lite/app/NuRuntimeApp.scala
@@ -36,6 +36,8 @@ object NuRuntimeApp extends App with LazyLogging {
 
   import system.dispatcher
 
+  private val akkaHttpCloseTimeout = 10 seconds
+
   // Because actor system creates non-daemon threads, all exceptions from current thread will be suppressed and process
   // will be still alive even if something fail (like scenarioInterpreter creation)
   val exitCode = try {
@@ -49,8 +51,6 @@ object NuRuntimeApp extends App with LazyLogging {
     Await.result(system.terminate(), 5.seconds)
   }
   System.exit(exitCode)
-
-  private val akkaHttpCloseTimeout = 10 seconds
 
   private def runAfterActorSystemCreation(): Unit = {
     val scenarioInterpreter = RunnableScenarioInterpreterFactory.prepareScenarioInterpreter(scenario, runtimeConfig, deploymentConfig, system)


### PR DESCRIPTION
…dle connections to make sure that nginx doesn't talk with terminating instances

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
