### PR TITLE
Bumps: jwks 0.19.0 -> 0.21.3, jackson: 2.11.3 -> 2.13.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -277,8 +277,7 @@ val logbackV = "1.2.11"
 val logbackJsonV = "0.1.5"
 val circeV = "0.14.3"
 val jwtCirceV = "9.1.2"
-//TODO: upgrade to 2.13.x
-val jacksonV = "2.11.3"
+val jacksonV = "2.13.4"
 val catsV = "2.6.1"
 val scalaParsersV = "1.0.4"
 val everitSchemaV = "1.14.1"
@@ -1251,7 +1250,7 @@ lazy val security = (project in file("security")).
       "io.circe" %% "circe-core" % circeV,
       "com.github.jwt-scala" %% "jwt-circe" % jwtCirceV,
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,
-      "com.auth0" % "jwks-rsa" % "0.19.0", // a tool library for reading a remote JWK store, not an Auth0 service dependency
+      "com.auth0" % "jwks-rsa" % "0.21.3", // a tool library for reading a remote JWK store, not an Auth0 service dependency
       "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % sttpV % "it,test",
       "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaV % "it,test",
       "com.github.dasniko" % "testcontainers-keycloak" % "1.6.0" % "it,test"

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11,6 +11,7 @@
 * [#3869](https://github.com/TouK/nussknacker/pull/3869) cross-compile - scala 2.12 & 2.13
 * [#3874](https://github.com/TouK/nussknacker/pull/3874) Tumbling window with OnEvent trigger saves context
 * [#3853](https://github.com/TouK/nussknacker/pull/3853) Support of patternProperties in sink with JSON Schema
+* [#3922](https://github.com/TouK/nussknacker/pull/3922) Bumps: jwks 0.19.0 -> 0.21.3, jackson: 2.11.3 -> 2.13.4 
 
 
 1.7.0 (19 Dec 2022)

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -17,6 +17,7 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   * `TestData.newLineSeparated` helper was removed. Scenario test records have to be created explicitly. Each scenario test record has assigned source
   * `DeploymentManager#test` takes `ScenarioTestData` instead of `TestData`
   * Designer configuration `testDataSettings.testDataMaxBytes` renamed to `testDataMaxLength`
+* [#3922](https://github.com/TouK/nussknacker/pull/3922) Bumps: jwks: 0.19.0 -> 0.21.3, jackson: 2.11.3 -> 2.13.4
 
 ## In version 1.7.0 
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
