### PR TITLE
Runtime probes tune

### DIFF
--- a/engine/lite/k8sDeploymentManager/src/main/resources/defaultMinimalDeployment.conf
+++ b/engine/lite/k8sDeploymentManager/src/main/resources/defaultMinimalDeployment.conf
@@ -5,7 +5,7 @@
   },
   "spec": {
     # we set minReadySeconds default
-    "minReadySeconds": 10,
+    "minReadySeconds": 0,
     "selector": {
     },
     "template": {

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
@@ -97,7 +97,7 @@ class DeploymentPreparer(config: K8sDeploymentManagerConfig) extends LazyLogging
         Volume.Mount(name = "runtime-conf", mountPath = RuntimeConfigMountPath),
       ),
       // used standard AkkaManagement see HealthCheckServerRunner for details
-      startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = defaultTimeoutSeconds)),
+      startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = defaultTimeoutSeconds)),
       readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = defaultTimeoutSeconds)),
       livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = defaultTimeoutSeconds))
     )

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
@@ -78,7 +78,7 @@ class DeploymentPreparer(config: K8sDeploymentManagerConfig) extends LazyLogging
 
   private def modifyContainers(containers: List[Container]): List[Container] = {
     val image = s"${config.dockerImageName}:${config.dockerImageTag}"
-    val defaultTimeoutSeconds = 3
+    val defaultTimeoutSeconds = 5
     val runtimeContainer = Container(
       name = "runtime",
       image = image,
@@ -97,14 +97,15 @@ class DeploymentPreparer(config: K8sDeploymentManagerConfig) extends LazyLogging
         Volume.Mount(name = "runtime-conf", mountPath = RuntimeConfigMountPath),
       ),
       // used standard AkkaManagement see HealthCheckServerRunner for details
-      // TODO we should tune failureThreshold to some lower value
-      readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = defaultTimeoutSeconds)),
+      startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = defaultTimeoutSeconds)),
+      readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = defaultTimeoutSeconds)),
       livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = defaultTimeoutSeconds))
     )
 
     def modifyRuntimeContainer(value: Container): Container = {
       val containerLens = GenLens[Container](_.env).modify(_ ++ runtimeContainer.env) andThen
         GenLens[Container](_.volumeMounts).modify(_ ++ runtimeContainer.volumeMounts) andThen
+        GenLens[Container](_.startupProbe).modify(_.orElse(runtimeContainer.startupProbe)) andThen
         GenLens[Container](_.readinessProbe).modify(_.orElse(runtimeContainer.readinessProbe)) andThen
         GenLens[Container](_.livenessProbe).modify(_.orElse(runtimeContainer.livenessProbe)) andThen
         GenLens[Container](_.image).modify { configuredImage =>

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
@@ -78,6 +78,7 @@ class DeploymentPreparer(config: K8sDeploymentManagerConfig) extends LazyLogging
 
   private def modifyContainers(containers: List[Container]): List[Container] = {
     val image = s"${config.dockerImageName}:${config.dockerImageTag}"
+    val defaultTimeoutSeconds = 3
     val runtimeContainer = Container(
       name = "runtime",
       image = image,
@@ -97,8 +98,8 @@ class DeploymentPreparer(config: K8sDeploymentManagerConfig) extends LazyLogging
       ),
       // used standard AkkaManagement see HealthCheckServerRunner for details
       // TODO we should tune failureThreshold to some lower value
-      readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60))),
-      livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive")))
+      readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = defaultTimeoutSeconds)),
+      livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = defaultTimeoutSeconds))
     )
 
     def modifyRuntimeContainer(value: Container): Container = {

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerReqRespTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerReqRespTest.scala
@@ -105,7 +105,7 @@ class K8sDeploymentManagerReqRespTest extends BaseK8sDeploymentManagerTest with 
     val givenScenarioName = "reqresp-redeploy"
     val firstVersion = 1
     val f = createReqRespFixture(givenScenarioName, firstVersion,
-      extraDeployConfig = ConfigFactory.empty().withValue("scalingConfig.fixedReplicasCount", fromAnyRef(1)))
+      extraDeployConfig = ConfigFactory.empty().withValue("scalingConfig.fixedReplicasCount", fromAnyRef(2)))
 
     f.withRunningScenario {
       k8sTestUtils.withForwardedProxyPod(s"http://$givenScenarioName:$givenServicePort") { proxyLocalPort =>

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerReqRespTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerReqRespTest.scala
@@ -5,7 +5,9 @@ import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser
 import org.scalatest.OptionValues
+import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.tags.Network
+import org.scalatest.time.{Seconds, Span}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.component.ComponentProvider
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
@@ -55,7 +57,8 @@ class K8sDeploymentManagerReqRespTest extends BaseK8sDeploymentManagerTest with 
         val pingMessage = s"""{"ping":"$pingContent"}"""
         val instanceIds = (1 to 10).map { _ =>
           val request = basicRequest.post(uri"http://localhost".port(proxyLocalPort))
-          val jsonResponse = parser.parse(request.body(pingMessage).send().body.rightValue).rightValue
+          val response = request.body(pingMessage).send().body.rightValue
+          val jsonResponse = parser.parse(response).rightValue
           jsonResponse.hcursor.downField("pong").as[String].rightValue shouldEqual pingContent
           jsonResponse.hcursor.downField("instanceId").as[String].rightValue
         }.toSet
@@ -77,13 +80,16 @@ class K8sDeploymentManagerReqRespTest extends BaseK8sDeploymentManagerTest with 
       val pingContent = """Nussknacker!"""
       val pingMessage = s"""{"ping":"$pingContent"}"""
       val request = basicRequest.post(uri"http://localhost".port(8081).path(givenScenarioName))
-      val jsonResponse = parser.parse(request.body(pingMessage).send().body.rightValue).rightValue
+      val response = eventually(PatienceConfiguration.Timeout(Span(10, Seconds))) { // nginx returns 503 even if service is ready
+        request.body(pingMessage).send().body.rightValue
+      }
+      val jsonResponse = parser.parse(response).rightValue
       jsonResponse.hcursor.downField("pong").as[String].rightValue shouldEqual pingContent
     }
   }
 
   test("deployment of secured req-resp") {
-    val givenScenarioName = "reqresp-ingress"
+    val givenScenarioName = "reqresp-secured"
     val config = ConfigFactory.empty()
       .withValue("ingress.enabled", fromAnyRef(true))
       .withValue("configExecutionOverrides.request-response.security.basicAuth.user", fromAnyRef("publisher"))
@@ -96,7 +102,10 @@ class K8sDeploymentManagerReqRespTest extends BaseK8sDeploymentManagerTest with 
       val pingContent = """Nussknacker!"""
       val pingMessage = s"""{"ping":"$pingContent"}"""
       val request = basicRequest.auth.basic("publisher", "rrPassword").post(uri"http://localhost".port(8081).path(givenScenarioName))
-      val jsonResponse = parser.parse(request.body(pingMessage).send().body.rightValue).rightValue
+      val response = eventually(PatienceConfiguration.Timeout(Span(10, Seconds))) { // nginx returns 503 even if service is ready
+        request.body(pingMessage).send().body.rightValue
+      }
+      val jsonResponse = parser.parse(response).rightValue
       jsonResponse.hcursor.downField("pong").as[String].rightValue shouldEqual pingContent
     }
   }
@@ -114,7 +123,10 @@ class K8sDeploymentManagerReqRespTest extends BaseK8sDeploymentManagerTest with 
 
         def checkVersions() = (1 to 10).map { _ =>
           val request = basicRequest.post(uri"http://localhost".port(proxyLocalPort))
-          val jsonResponse = parser.parse(request.body(pingMessage).send().body.rightValue).rightValue
+          val response = eventually(PatienceConfiguration.Timeout(Span(10, Seconds))) { // nginx returns 503 even if service is ready
+            request.body(pingMessage).send().body.rightValue
+          }
+          val jsonResponse = parser.parse(response).rightValue
           jsonResponse.hcursor.downField("version").as[Int].rightValue
         }.toSet
 

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparerTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparerTest.scala
@@ -79,7 +79,7 @@ class DeploymentPreparerTest extends AnyFunSuite {
                   Volume.Mount(name = "runtime-conf", mountPath = "/runtime-config")
                 ),
                 // used standard AkkaManagement see HealthCheckServerRunner for details
-                startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 5)),
+                startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 5)),
                 readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5)),
                 livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5))
               )),
@@ -169,7 +169,7 @@ class DeploymentPreparerTest extends AnyFunSuite {
                   Volume.Mount(name = "runtime-conf", mountPath = "/runtime-config")
                 ),
                 // used standard AkkaManagement see HealthCheckServerRunner for details
-                startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 5)),
+                startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 5)),
                 readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5)),
                 livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5)),
                 resources = Some(
@@ -253,7 +253,7 @@ class DeploymentPreparerTest extends AnyFunSuite {
                   Volume.Mount(name = "runtime-conf", mountPath = "/runtime-config")
                 ),
                 // used standard AkkaManagement see HealthCheckServerRunner for details
-                startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 5)),
+                startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 5)),
                 readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5)),
                 livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5))
               )),

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparerTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparerTest.scala
@@ -79,8 +79,9 @@ class DeploymentPreparerTest extends AnyFunSuite {
                   Volume.Mount(name = "runtime-conf", mountPath = "/runtime-config")
                 ),
                 // used standard AkkaManagement see HealthCheckServerRunner for details
-                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 3)),
-                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 3))
+                startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 5)),
+                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5)),
+                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5))
               )),
               volumes = List(
                 Volume("common-conf", Volume.ConfigMapVolumeSource(configMapId)),
@@ -168,8 +169,9 @@ class DeploymentPreparerTest extends AnyFunSuite {
                   Volume.Mount(name = "runtime-conf", mountPath = "/runtime-config")
                 ),
                 // used standard AkkaManagement see HealthCheckServerRunner for details
-                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 3)),
-                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 3)),
+                startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 5)),
+                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5)),
+                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5)),
                 resources = Some(
                   skuber.Resource.Requirements(
                     limits = Map("cpu" -> Quantity("20m"), "memory" -> Quantity("256Mi")),
@@ -251,8 +253,9 @@ class DeploymentPreparerTest extends AnyFunSuite {
                   Volume.Mount(name = "runtime-conf", mountPath = "/runtime-config")
                 ),
                 // used standard AkkaManagement see HealthCheckServerRunner for details
-                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 3)),
-                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 3))
+                startupProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 5)),
+                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5)),
+                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 5))
               )),
               volumes = List(
                 Volume("common-conf", Volume.ConfigMapVolumeSource(configMapId)),

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparerTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparerTest.scala
@@ -54,7 +54,7 @@ class DeploymentPreparerTest extends AnyFunSuite {
         //here we use id to avoid sanitization problems
         selector = LabelSelector(LabelSelector.IsEqualRequirement(K8sDeploymentManager.scenarioIdLabel, "1")),
         progressDeadlineSeconds = None,
-        minReadySeconds = 10,
+        minReadySeconds = 0,
         template = Pod.Template.Spec(
           metadata = ObjectMeta(
             name = "scenario-1-x",
@@ -79,8 +79,8 @@ class DeploymentPreparerTest extends AnyFunSuite {
                   Volume.Mount(name = "runtime-conf", mountPath = "/runtime-config")
                 ),
                 // used standard AkkaManagement see HealthCheckServerRunner for details
-                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60))),
-                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive")))
+                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 3)),
+                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 3))
               )),
               volumes = List(
                 Volume("common-conf", Volume.ConfigMapVolumeSource(configMapId)),
@@ -168,8 +168,8 @@ class DeploymentPreparerTest extends AnyFunSuite {
                   Volume.Mount(name = "runtime-conf", mountPath = "/runtime-config")
                 ),
                 // used standard AkkaManagement see HealthCheckServerRunner for details
-                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60))),
-                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"))),
+                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 3)),
+                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 3)),
                 resources = Some(
                   skuber.Resource.Requirements(
                     limits = Map("cpu" -> Quantity("20m"), "memory" -> Quantity("256Mi")),
@@ -225,7 +225,7 @@ class DeploymentPreparerTest extends AnyFunSuite {
         //here we use id to avoid sanitization problems
         selector = LabelSelector(LabelSelector.IsEqualRequirement(K8sDeploymentManager.scenarioIdLabel, "1")),
         progressDeadlineSeconds = None,
-        minReadySeconds = 10,
+        minReadySeconds = 0,
         template = Pod.Template.Spec(
           metadata = ObjectMeta(
             name = "scenario-1-x",
@@ -251,8 +251,8 @@ class DeploymentPreparerTest extends AnyFunSuite {
                   Volume.Mount(name = "runtime-conf", mountPath = "/runtime-config")
                 ),
                 // used standard AkkaManagement see HealthCheckServerRunner for details
-                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60))),
-                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive")))
+                readinessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/ready"), periodSeconds = Some(1), failureThreshold = Some(60), timeoutSeconds = 3)),
+                livenessProbe = Some(Probe(new HTTPGetAction(Left(8080), path = "/alive"), periodSeconds = Some(5), failureThreshold = Some(3), timeoutSeconds = 3))
               )),
               volumes = List(
                 Volume("common-conf", Volume.ConfigMapVolumeSource(configMapId)),


### PR DESCRIPTION
- added startupProbe
- timeout seconds increased from default 1 sec to 5 secs (in case of e.g. full GC) 
 - liveness period: 10 sec -> 5 sec for faster unavailability detection 
 - minReadySeconds: 10 -> 0 (default value) to make runtime containers ready as soon as they are ready