### PR TITLE
additional logging in case of k8 deployment failure in tests

### DIFF
--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/BaseK8sDeploymentManagerTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/BaseK8sDeploymentManagerTest.scala
@@ -83,9 +83,8 @@ class BaseK8sDeploymentManagerTest extends AnyFunSuite with Matchers with Extrem
 
     def withRunningScenario(action: => Unit): Unit = {
       manager.deploy(version, DeploymentData.empty, scenario, None).futureValue
-      waitForRunning(version)
-
       try {
+        waitForRunning(version)
         action
       } catch {
         case NonFatal(ex) =>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
