### PR TITLE
unique name for test components providers

### DIFF
--- a/engine/flink/tests/src/test/resources/application.conf
+++ b/engine/flink/tests/src/test/resources/application.conf
@@ -7,4 +7,5 @@ asyncExecutionConfig {
   workers: 8
 }
 
-components.mockKafka.disabled: true
+components.mockKafkaFlink.disabled: true
+components.mockKafkaLite.disabled: true

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/FlinkWithKafkaSuite.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/FlinkWithKafkaSuite.scala
@@ -61,18 +61,19 @@ abstract class FlinkWithKafkaSuite extends AnyFunSuite with FlinkSpec with Kafka
   protected def avroAsJsonSerialization = false
 
   override lazy val config: Config = ConfigFactory.load()
-    .withValue(KafkaConfigProperties.bootstrapServersProperty("components.mockKafka.config"), fromAnyRef(kafkaServer.kafkaAddress))
-    .withValue(KafkaConfigProperties.property("components.mockKafka.config", "schema.registry.url"), fromAnyRef("not_used"))
-    .withValue(KafkaConfigProperties.property("components.mockKafka.config", "auto.offset.reset"), fromAnyRef("earliest"))
-    .withValue("components.mockKafka.config.lowLevelComponentsEnabled", fromAnyRef(false))
+    .withValue(KafkaConfigProperties.bootstrapServersProperty("components.mockKafkaFlink.config"), fromAnyRef(kafkaServer.kafkaAddress))
+    .withValue(KafkaConfigProperties.property("components.mockKafkaFlink.config", "schema.registry.url"), fromAnyRef("not_used"))
+    .withValue(KafkaConfigProperties.property("components.mockKafkaFlink.config", "auto.offset.reset"), fromAnyRef("earliest"))
+    .withValue("components.mockKafkaFlink.config.lowLevelComponentsEnabled", fromAnyRef(false))
     .withValue("components.kafka.disabled", fromAnyRef(true))
-    .withValue("components.mockKafka.disabled", fromAnyRef(false))
+    .withValue("components.mockKafkaLite.disabled", fromAnyRef(true))
+    .withValue("components.mockKafkaFlink.disabled", fromAnyRef(false))
     //For tests we want to read from the beginning...
-    .withValue("components.mockKafka.config.avroAsJsonSerialization", fromAnyRef(avroAsJsonSerialization))
+    .withValue("components.mockKafkaFlink.config.avroAsJsonSerialization", fromAnyRef(avroAsJsonSerialization))
     // we turn off auto registration to do it on our own passing mocked schema registry client
-    .withValue(s"components.mockKafka.config.kafkaEspProperties.${AvroSerializersRegistrar.autoRegisterRecordSchemaIdSerializationProperty}", fromAnyRef(false))
+    .withValue(s"components.mockKafkaFlink.config.kafkaEspProperties.${AvroSerializersRegistrar.autoRegisterRecordSchemaIdSerializationProperty}", fromAnyRef(false))
 
-  lazy val kafkaConfig: KafkaConfig = KafkaConfig.parseConfig(config, "components.mockKafka.config")
+  lazy val kafkaConfig: KafkaConfig = KafkaConfig.parseConfig(config, "components.mockKafkaFlink.config")
   protected val avroEncoder: BestEffortAvroEncoder = BestEffortAvroEncoder(ValidationMode.strict)
 
   protected val givenNotMatchingAvroObj = avroEncoder.encodeRecordOrError(

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/MockFlinkKafkaComponentProvider.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/MockFlinkKafkaComponentProvider.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.MockSche
 
 class MockFlinkKafkaComponentProvider extends FlinkKafkaComponentProvider {
 
-  override def providerName: String = "mockKafka"
+  override def providerName: String = "mockKafkaFlink"
 
   override protected def schemaRegistryClientFactory: SchemaRegistryClientFactory = MockSchemaRegistryClientFactory.confluentBased(schemaRegistryMockClient)
 

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/BaseStreamingEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/BaseStreamingEmbeddedDeploymentManagerTest.scala
@@ -71,9 +71,10 @@ trait BaseStreamingEmbeddedDeploymentManagerTest extends AnyFunSuite with Schema
       .withValue("exceptionHandlingConfig.topic", fromAnyRef("errors"))
       .withValue("components.kafka.enabled", fromAnyRef(false))
       .withValue("components.kafka.disabled", fromAnyRef(true))
-      .withValue("components.mockKafka.disabled", fromAnyRef(false))
+      .withValue("components.mockKafkaFlink.disabled", fromAnyRef(true))
+      .withValue("components.mockKafkaLite.disabled", fromAnyRef(false))
       .withValue("kafka.lowLevelComponentsEnabled", fromAnyRef(false))
-      .withValue("components.mockKafka.kafkaProperties", fromMap(Map[String, Any](
+      .withValue("components.mockKafkaFlink.kafkaProperties", fromMap(Map[String, Any](
         //        This timeout controls how long the kafka producer initialization in pl.touk.nussknacker.engine.lite.kafka.KafkaSingleScenarioTaskRun.init.
         //        So it has to be set to a reasonably low value for the restarting test to finish before ScalaFutures patience runs out.
         "max.block.ms" -> 2000,

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/MockLiteKafkaComponentProvider.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/MockLiteKafkaComponentProvider.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.streaming.embedded.MockSchemaRegistry.schemaRegistryM
 
 class MockLiteKafkaComponentProvider extends LiteKafkaComponentProvider(MockSchemaRegistryClientFactory.confluentBased(schemaRegistryMockClient)) {
 
-  override def providerName: String = "mockKafka"
+  override def providerName: String = "mockKafkaLite"
 
 }
 

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/RequestResponseEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/RequestResponseEmbeddedDeploymentManagerTest.scala
@@ -31,7 +31,8 @@ class RequestResponseEmbeddedDeploymentManagerTest extends AnyFunSuite with Matc
 
     val modelData = LocalModelData(ConfigFactory.empty()
       .withValue("components.kafka.disabled", fromAnyRef(true))
-      .withValue("components.mockKafka.disabled", fromAnyRef(true)), new EmptyProcessConfigCreator)
+      .withValue("components.mockKafkaLite.disabled", fromAnyRef(true))
+      .withValue("components.mockKafkaFlink.disabled", fromAnyRef(true)), new EmptyProcessConfigCreator)
     implicit val deploymentService: ProcessingTypeDeploymentServiceStub = new ProcessingTypeDeploymentServiceStub(initiallyDeployedScenarios)
     implicit val as: ActorSystem = ActorSystem(getClass.getSimpleName)
     implicit val dummyBackend: SttpBackend[Future, Any] = null


### PR DESCRIPTION
 work around to bug in intelliJ which causes that wrong classpath is provided when runining tests from intelliJ