### PR TITLE
Use ProcessStateStatus to detect alerting scenarios in healthcheck

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppResources.scala
@@ -77,9 +77,9 @@ class AppResources(config: Config,
               if (set.isEmpty) {
                 createHealthCheckHttpResponse(OK)
               } else {
-                logger.warn(s"Alerting scenarios: ${set.keys}")
-                logger.debug(s"Alerting scenarios: $set")
-                createHealthCheckHttpResponse(ERROR, Some("Alerting scenarios"), Some(set.keys.toSet))
+                logger.warn(s"Scenarios with status PROBLEM: ${set.keys}")
+                logger.debug(s"Scenarios with status PROBLEM: $set")
+                createHealthCheckHttpResponse(ERROR, Some("Scenarios with status PROBLEM"), Some(set.keys.toSet))
               }
             }.recover[Future[HttpResponse]] {
               case NonFatal(e) =>

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -26,7 +26,7 @@
 * [#4127](https://github.com/TouK/nussknacker/pull/4127) ResourceLoader and bumps commons io 2.4 -> to 2.6
 * [#4122](https://github.com/TouK/nussknacker/pull/4122) 
   * Add state definitions to `ProcessStateDefinitionManager`
-  * Add `ProcessResources` endpoint that returns state definitions with default state properties (such as displayable name, icon and description), 
+  * Add `StatusResources` endpoint `/statusDefinitions` that returns state definitions with default state properties (such as displayable name, icon and description), 
     to allow filtering by state in UI.
 * [#4100](https://github.com/TouK/nussknacker/pull/4100)[#4104](https://github.com/TouK/nussknacker/pull/4104)
   Before the change, the scenario list presented "local" states - based only on Nussknacker's actions log.
@@ -35,7 +35,8 @@
 * [#4131](https://github.com/TouK/nussknacker/pull/4131) Support for components using other languages than SpEL, added basic support for SpEL in template mode
 * [#4132](https://github.com/TouK/nussknacker/pull/4132) Combine statuses Failing, Failed, Error, Warning, FailedToGet and MulipleJobsRunning into one status that represents a "Problem".
   Status "Unknown" is removed.
-
+* [#4143](https://github.com/TouK/nussknacker/pull/4143) Use `ProcessStateStatus` to detect alerting scenarios in healthcheck `/healthCheck/process/deployment`.
+  After this change healthcheck alerts all types of deployment problems based on `ProcessStateStatus`, including "deployed and not running".
 
 1.8.1 (28 Feb 2023)
 ------------------------

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -32,6 +32,13 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   which provide the same interface as the previous one, with only method name changed.
   Especially, when you use 'PeriodicDeploymentManagerProvider', `delegate` should already return `DeploymentManager` wrapped by caching mechanism.
 * [#4131](https://github.com/TouK/nussknacker/pull/4131) `Parameter.defaultValue` now holds `Option[Expression]` instead of `Option[String]`. You have to wrap a `String` with `Expression.spel()`
+* [#4132](https://github.com/TouK/nussknacker/pull/4132) 
+  * Within the base set of statuses used in Embedded, Flink, K8 and Periodic mode (`SimpleStateStatus`), statuses `Failing`, `Failed`, `Error`, `Warning`, `FailedToGet` and `MulipleJobsRunning`
+    are replaced by one `ProblemStateStatus` which is parametrized by specific message. `ProblemStateStatus` provides several builder methods, one for each corresponding removed state.
+    Those builders allow to preserve the exact moments when each state appears in the scenario lifecycle. 
+  * Displayed tooltip and description of `ProblemStateStatus` have the same value. 
+  * Removed `SimpleStateStatus.Undefined`
+  * Parameter `delegate` in `OverridingProcessStateDefinitionManager` now has no default value. For clarity it should be provided explicitly.
 
 
 ### Other changes

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -32,13 +32,7 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   which provide the same interface as the previous one, with only method name changed.
   Especially, when you use 'PeriodicDeploymentManagerProvider', `delegate` should already return `DeploymentManager` wrapped by caching mechanism.
 * [#4131](https://github.com/TouK/nussknacker/pull/4131) `Parameter.defaultValue` now holds `Option[Expression]` instead of `Option[String]`. You have to wrap a `String` with `Expression.spel()`
-* [#4132](https://github.com/TouK/nussknacker/pull/4132) 
-  * Within the base set of statuses used in Embedded, Flink, K8 and Periodic mode (`SimpleStateStatus`), statuses `Failing`, `Failed`, `Error`, `Warning`, `FailedToGet` and `MulipleJobsRunning`
-    are replaced by one `ProblemStateStatus` which is parametrized by specific message. `ProblemStateStatus` provides several builder methods, one for each corresponding removed state.
-    Those builders allow to preserve the exact moments when each state appears in the scenario lifecycle. 
-  * Displayed tooltip and description of `ProblemStateStatus` have the same value. 
-  * Removed `SimpleStateStatus.Undefined`
-  * Parameter `delegate` in `OverridingProcessStateDefinitionManager` now has no default value. For clarity it should be provided explicitly.
+
 
 
 ### Other changes


### PR DESCRIPTION
Before

Healthcheck alerts when there is a scenario deployed-not-running.

After

Helathcheck alerts when there is scenario with any instance of ProblemStateStatus (including deployed-not-running)