### PR TITLE
Bump dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -253,14 +253,27 @@ lazy val commonSettings =
 
         "io.netty" % "netty-handler" % nettyV,
         "io.netty" % "netty-codec" % nettyV,
+        "io.netty" % "netty-codec-http" % nettyV,
+        "io.netty" % "netty-codec-socks" % nettyV,
+        "io.netty" % "netty-handler-proxy" % nettyV,
         "io.netty" % "netty-transport-native-epoll" % nettyV,
 
-        // Jackson is used by openapi and jwks-rsa
+        // For async-http-client
+        "com.typesafe.netty" % "netty-reactive-streams" % nettyReactiveStreamsV,
+
+        // Jackson is used by: openapi, jwks-rsa, kafka-json-schema-provider
         "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV,
         "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
         "com.fasterxml.jackson.core" % "jackson-databind" % jacksonV,
+        "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonV,
+        "com.fasterxml.jackson.dataformat" % "jackson-dataformat-toml" % jacksonV,
         "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonV,
+        "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonV,
+        "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonV,
+        "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonV,
         "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonV,
+        "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonV,
+        "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonV,
 
         "io.dropwizard.metrics5" % "metrics-core" % dropWizardV,
         "io.dropwizard.metrics5" % "metrics-json" % dropWizardV,
@@ -302,6 +315,7 @@ val dropWizardV = "5.0.0-rc15"
 val scalaCollectionsCompatV = "2.9.0"
 val testcontainersScalaV = "0.40.14"
 val nettyV = "4.1.90.Final"
+val nettyReactiveStreamsV = "2.0.8"
 
 val akkaV = "2.6.20"
 val akkaHttpV = "10.2.10"

--- a/build.sbt
+++ b/build.sbt
@@ -1386,8 +1386,8 @@ lazy val sqlComponents = (project in component("sql")).
     libraryDependencies ++= Seq(
       "com.zaxxer" % "HikariCP" % hikariCpV,
       //      It won't run on Java 16 as Hikari will fail while trying to load IgniteJdbcThinDriver https://issues.apache.org/jira/browse/IGNITE-14888
-      "org.apache.ignite" % "ignite-core" % "2.14.0" % Provided,
-      "org.apache.ignite" % "ignite-indexing" % "2.14.0" % Provided,
+      "org.apache.ignite" % "ignite-core" % "2.10.0" % Provided,
+      "org.apache.ignite" % "ignite-indexing" % "2.10.0" % Provided,
       "org.scalatest" %% "scalatest" % scalaTestV % "it,test",
       "org.hsqldb" % "hsqldb" % hsqldbV % "it,test",
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -673,7 +673,7 @@ lazy val interpreter = (project in file("interpreter")).
     name := "nussknacker-interpreter",
     libraryDependencies ++= {
       Seq(
-        "org.typelevel" %% "cats-effect" % "2.5.3",
+        "org.typelevel" %% "cats-effect" % "2.5.5",
         "org.scala-lang.modules" %% "scala-java8-compat" % scalaCompatV,
         "org.apache.avro" % "avro" % avroV % "test",
         "org.scalacheck" %% "scalacheck" % scalaCheckV % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -231,7 +231,7 @@ lazy val commonSettings =
         "commons-io" % "commons-io" % commonsIOV,
         //we stick to version in Flink to avoid nasty bugs in process runtime...
         //NOTE: commons-text (in api) uses 3.9...
-        "org.apache.commons" % "commons-lang3" % commonsLangV,
+        "org.apache.commons" % "commons-lang3" % commonsLang3V,
 
         "io.circe" %% "circe-core" % circeV,
         "io.circe" %% "circe-parser" % circeV,
@@ -270,37 +270,38 @@ lazy val commonSettings =
     )
 
 val flinkV = "1.16.1"
-val avroV = "1.11.0"
+val avroV = "1.11.1"
 //we should use max(version used by confluent, version acceptable by flink), https://docs.confluent.io/platform/current/installation/versions-interoperability.html - confluent version reference
 val kafkaV = "3.3.1"
 //TODO: Spring 5.3 has some problem with handling our PrimitiveOrWrappersPropertyAccessor
-val springV = "5.2.21.RELEASE"
+val springV = "5.2.23.RELEASE"
 val scalaTestV = "3.2.15"
 val scalaCheckV = "1.17.0"
 val scalaCheckVshort = scalaCheckV.take(4).replace(".","-")
 val scalaTestPlusV = "3.2.15.0" //has to match scalatest and scalacheck versions, see https://github.com/scalatest/scalatestplus-scalacheck/releases
 val logbackV = "1.2.11"
 val logbackJsonV = "0.1.5"
-val circeV = "0.14.3"
-val jwtCirceV = "9.1.2"
-val jacksonV = "2.13.4"
+val circeV = "0.14.5"
+val circeGenericExtrasV = "0.14.3"
+val jwtCirceV = "9.2.0"
+val jacksonV = "2.14.2"
 val catsV = "2.8.0"
-val scalaParsersV = "1.0.4"
-val everitSchemaV = "1.14.1"
+val everitSchemaV = "1.14.2"
 val slf4jV = "1.7.36"
 val scalaLoggingV = "3.9.5"
 val scalaCompatV = "1.0.2"
 val ficusV = "1.4.7"
 val configV = "1.4.2"
-val commonsLangV = "3.3.2"
-val commonsTextV = "1.8"
-val commonsIOV = "2.6"
+val commonsLang3V = "3.12.0"
+val commonsTextV = "1.10.0"
+val commonsIOV = "2.11.0"
 //we want to use 5.x for lite metrics to have tags, however dropwizard development kind of freezed. Maybe we should consider micrometer?
 //In Flink metrics we use bundled dropwizard metrics v. 3.x
-val dropWizardV = "5.0.0-rc11"
+// rc16+ depend on slf4j 2.x
+val dropWizardV = "5.0.0-rc15"
 val scalaCollectionsCompatV = "2.9.0"
 val testcontainersScalaV = "0.40.10"
-val nettyV = "4.1.48.Final"
+val nettyV = "4.1.90.Final"
 
 val akkaV = "2.6.20"
 val akkaHttpV = "10.2.10"
@@ -309,17 +310,17 @@ val akkaHttpCirceV = "1.39.2"
 val slickV = "3.4.1"
 val hikariCpV = "5.0.1"
 val hsqldbV = "2.7.1"
-val postgresV = "42.5.1"
-val flywayV = "6.3.3"
-val confluentV = "7.3.0"
-val azureKafkaSchemaRegistryV = "1.0.0-beta.9"
-val azureSchemaRegistryV = "1.3.1"
-val azureIdentityV = "1.7.3"
+val postgresV = "42.6.0"
+val flywayV = "9.16.1"
+val confluentV = "7.3.2"
+val azureKafkaSchemaRegistryV = "1.1.0-beta.1"
+val azureSchemaRegistryV = "1.3.4"
+val azureIdentityV = "1.8.1"
 val bcryptV = "0.10.2"
 val cronParserV = "9.1.6" // 9.1.7+ requires JDK 16+
 val javaxValidationApiV = "2.0.1.Final"
-val caffeineCacheV = "3.1.2"
-val sttpV = "3.8.11"
+val caffeineCacheV = "3.1.5"
+val sttpV = "3.8.13"
 //we use legacy version because this one supports Scala 2.12
 val monocleV = "2.1.0"
 val jmxPrometheusJavaagentV = "0.16.1"
@@ -1257,7 +1258,7 @@ lazy val commonApi = (project in file("common-api")).
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionsCompatV,
       "io.circe" %% "circe-parser" % circeV,
       "io.circe" %% "circe-generic" % circeV,
-      "io.circe" %% "circe-generic-extras" % circeV
+      "io.circe" %% "circe-generic-extras" % circeGenericExtrasV
     )
   )
 
@@ -1266,7 +1267,7 @@ lazy val scenarioApi = (project in file("scenario-api")).
   settings(
     name := "nussknacker-scenario-api",
     libraryDependencies ++= Seq(
-      "org.apache.commons" % "commons-lang3" % commonsLangV,
+      "org.apache.commons" % "commons-lang3" % commonsLang3V,
     )
   ).dependsOn(commonApi, testUtils % "test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -285,7 +285,7 @@ val circeV = "0.14.5"
 val circeGenericExtrasV = "0.14.3"
 val jwtCirceV = "9.2.0"
 val jacksonV = "2.14.2"
-val catsV = "2.8.0"
+val catsV = "2.9.0"
 val everitSchemaV = "1.14.2"
 val slf4jV = "1.7.36"
 val scalaLoggingV = "3.9.5"
@@ -300,7 +300,7 @@ val commonsIOV = "2.11.0"
 // rc16+ depend on slf4j 2.x
 val dropWizardV = "5.0.0-rc15"
 val scalaCollectionsCompatV = "2.9.0"
-val testcontainersScalaV = "0.40.10"
+val testcontainersScalaV = "0.40.14"
 val nettyV = "4.1.90.Final"
 
 val akkaV = "2.6.20"
@@ -323,7 +323,7 @@ val caffeineCacheV = "3.1.5"
 val sttpV = "3.8.13"
 //we use legacy version because this one supports Scala 2.12
 val monocleV = "2.1.0"
-val jmxPrometheusJavaagentV = "0.16.1"
+val jmxPrometheusJavaagentV = "0.18.0"
 val wireMockV = "2.35.0"
 
 lazy val commonDockerSettings = {
@@ -1292,7 +1292,7 @@ lazy val security = (project in file("security")).
       "com.auth0" % "jwks-rsa" % "0.21.3", // a tool library for reading a remote JWK store, not an Auth0 service dependency
       "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % sttpV % "it,test",
       "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaV % "it,test",
-      "com.github.dasniko" % "testcontainers-keycloak" % "2.0.0" % "it,test"
+      "com.github.dasniko" % "testcontainers-keycloak" % "2.5.0" % "it,test"
     )
   )
   .dependsOn(utilsInternal, httpUtils, testUtils % "it,test")
@@ -1332,7 +1332,7 @@ lazy val processReports = (project in file("designer/processReports")).
         "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % sttpV % "it,test",
         "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaV % "it,test",
         "com.dimafeng" %% "testcontainers-scala-influxdb" % testcontainersScalaV % "it,test",
-        "org.influxdb" % "influxdb-java" % "2.21" % "it,test"
+        "org.influxdb" % "influxdb-java" % "2.23" % "it,test"
       )
     }
   ).dependsOn(httpUtils, commonUtils, testUtils % "it,test")
@@ -1350,8 +1350,8 @@ lazy val httpUtils = (project in utils("http-utils")).
     }
   ).dependsOn(componentsApi % Provided, testUtils % "test")
 
-val swaggerParserV = "2.1.1"
-val swaggerIntegrationV = "2.2.1"
+val swaggerParserV = "2.1.12"
+val swaggerIntegrationV = "2.2.8"
 
 lazy val openapiComponents = (project in component("openapi")).
   configs(IntegrationTest).
@@ -1386,8 +1386,8 @@ lazy val sqlComponents = (project in component("sql")).
     libraryDependencies ++= Seq(
       "com.zaxxer" % "HikariCP" % hikariCpV,
       //      It won't run on Java 16 as Hikari will fail while trying to load IgniteJdbcThinDriver https://issues.apache.org/jira/browse/IGNITE-14888
-      "org.apache.ignite" % "ignite-core" % "2.10.0" % Provided,
-      "org.apache.ignite" % "ignite-indexing" % "2.10.0" % Provided,
+      "org.apache.ignite" % "ignite-core" % "2.14.0" % Provided,
+      "org.apache.ignite" % "ignite-indexing" % "2.14.0" % Provided,
       "org.scalatest" %% "scalatest" % scalaTestV % "it,test",
       "org.hsqldb" % "hsqldb" % hsqldbV % "it,test",
     ),
@@ -1514,7 +1514,7 @@ lazy val designer = (project in file("designer/server"))
         "org.hsqldb" % "hsqldb" % hsqldbV,
         "org.postgresql" % "postgresql" % postgresV,
         "org.flywaydb" % "flyway-core" % flywayV,
-        "org.apache.xmlgraphics" % "fop" % "2.3",
+        "org.apache.xmlgraphics" % "fop" % "2.8",
 
 
         "com.typesafe.slick" %% "slick-testkit" % slickV % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -1292,7 +1292,7 @@ lazy val security = (project in file("security")).
       "com.auth0" % "jwks-rsa" % "0.21.3", // a tool library for reading a remote JWK store, not an Auth0 service dependency
       "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % sttpV % "it,test",
       "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaV % "it,test",
-      "com.github.dasniko" % "testcontainers-keycloak" % "2.5.0" % "it,test"
+      "com.github.dasniko" % "testcontainers-keycloak" % "2.0.0" % "it,test"
     )
   )
   .dependsOn(utilsInternal, httpUtils, testUtils % "it,test")
@@ -1351,7 +1351,7 @@ lazy val httpUtils = (project in utils("http-utils")).
   ).dependsOn(componentsApi % Provided, testUtils % "test")
 
 val swaggerParserV = "2.1.12"
-val swaggerIntegrationV = "2.2.8"
+val swaggerIntegrationV = "2.2.9"
 
 lazy val openapiComponents = (project in component("openapi")).
   configs(IntegrationTest).

--- a/build.sbt
+++ b/build.sbt
@@ -272,7 +272,7 @@ lazy val commonSettings =
 val flinkV = "1.16.1"
 val avroV = "1.11.1"
 //we should use max(version used by confluent, version acceptable by flink), https://docs.confluent.io/platform/current/installation/versions-interoperability.html - confluent version reference
-val kafkaV = "3.3.1"
+val kafkaV = "3.3.2"
 //TODO: Spring 5.3 has some problem with handling our PrimitiveOrWrappersPropertyAccessor
 val springV = "5.2.23.RELEASE"
 val scalaTestV = "3.2.15"

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterEditor.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterEditor.scala
@@ -9,7 +9,6 @@ import pl.touk.nussknacker.engine.api.CirceUtil._
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.JsonCodec
 import io.circe.Json
-import org.apache.commons.lang3.StringUtils
 
 import scala.util.Try
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -39,6 +39,7 @@
   After this change healthcheck alerts all types of deployment problems based on `ProcessStateStatus`, including "deployed and not running".
 * [#4160](https://github.com/TouK/nussknacker/pull/4160) Testing using events from file accepts simplified test record format. 
   SourceId and timestamp fields can be omitted from the test record and record field can be inlined. The simplified format works only for scenarios with only one source.
+* [#4161](https://github.com/TouK/nussknacker/pull/4161) Update most dependencies to latest versions  
 
 1.8.1 (28 Feb 2023)
 ------------------------

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/DbInitializer.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/DbInitializer.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import net.ceedubs.ficus.readers.ValueReader
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.configuration.FluentConfiguration
-import org.flywaydb.core.internal.jdbc.DriverDataSource.DriverType
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLDatabaseType
 import slick.jdbc.{HsqldbProfile, JdbcBackend, JdbcProfile, PostgresProfile}
 
 object DbInitializer extends LazyLogging {
@@ -30,7 +30,7 @@ object DbInitializer extends LazyLogging {
         ( profile match {
           case HsqldbProfile => Array("db/batch_periodic/migration/hsql", "db/batch_periodic/migration/common")
           case PostgresProfile => Array("db/batch_periodic/migration/postgres", "db/batch_periodic/migration/common")
-          case _ => throw new IllegalArgumentException(s"Unsuported database url: $url . Use either PostgreSQL or HSQLDB.")
+          case _ => throw new IllegalArgumentException(s"Unsupported database url: $url. Use either PostgreSQL or HSQLDB.")
         }): _*
       )
       .dataSource(url, configDb.as[String]("user"), configDb.as[String]("password"))
@@ -44,7 +44,7 @@ object DbInitializer extends LazyLogging {
 
   private def chooseDbProfile(dbUrl: String): JdbcProfile = {
     dbUrl match {
-      case url if DriverType.POSTGRESQL.matches(url) => PostgresProfile
+      case url if (new PostgreSQLDatabaseType).handlesJDBCUrl(url) => PostgresProfile
       case _ => HsqldbProfile
     }
   }

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/TypeDefinitionSet.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/TypeDefinitionSet.scala
@@ -2,7 +2,6 @@ package pl.touk.nussknacker.engine
 
 import cats.data.{NonEmptyList, Validated}
 import cats.data.Validated.{Invalid, Valid}
-import org.apache.commons.lang3.ClassUtils
 import org.springframework.expression.{EvaluationContext, EvaluationException}
 import org.springframework.expression.spel.ExpressionState
 import org.springframework.expression.spel.ast.TypeReference

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.8.2

--- a/security/src/it/scala/pl/touk/nussknacker/ui/security/oauth2/GenericOidcServiceSpec.scala
+++ b/security/src/it/scala/pl/touk/nussknacker/ui/security/oauth2/GenericOidcServiceSpec.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.ui.security.oauth2
 
 import com.dimafeng.testcontainers.{ForAllTestContainer, SingleContainer}
 import dasniko.testcontainers.keycloak.KeycloakContainer
-import org.apache.commons.lang3.StringEscapeUtils
+import org.apache.commons.text.StringEscapeUtils
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext._

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/swagger/SwaggerTyped.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/swagger/SwaggerTyped.scala
@@ -230,11 +230,8 @@ object SwaggerObject {
 
     val additionalProperties = schema.getAdditionalProperties match {
       case null => AdditionalPropertiesEnabled(SwaggerAny)
-      case additionalPropertyEnabled if additionalPropertyEnabled == true => AdditionalPropertiesEnabled(SwaggerAny)
-      case additionalPropertyEnabled if additionalPropertyEnabled == false => AdditionalPropertiesDisabled
-      case additionalPropertySchema: Schema[_] =>
-        val typed = AdditionalPropertiesEnabled(SwaggerTyped(additionalPropertySchema, swaggerRefSchemas, usedRefs))
-        typed
+      case schema: Schema[_] if schema.getBooleanSchemaValue == false => AdditionalPropertiesDisabled
+      case schema: Schema[_] => AdditionalPropertiesEnabled(SwaggerTyped(schema, swaggerRefSchemas, usedRefs))
     }
     SwaggerObject(properties, additionalProperties, patternProperties)
   }

--- a/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/EmbeddedKafkaServer.scala
+++ b/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/EmbeddedKafkaServer.scala
@@ -67,7 +67,7 @@ object EmbeddedKafkaServer {
 
   private def prepareRaftStorage(logDir: File, kafkaConfig: server.KafkaConfig) = {
     val uuid = Uuid.randomUuid()
-    StorageTool.formatCommand(new PrintStream(new NullOutputStream), Seq(logDir.getAbsolutePath),
+    StorageTool.formatCommand(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM), Seq(logDir.getAbsolutePath),
       StorageTool.buildMetadataProperties(uuid.toString, kafkaConfig), MetadataVersion.IBP_3_3_IV3, ignoreFormatted = false)
   }
 


### PR DESCRIPTION
Mostly safe upgrades, except:
* some commons dependencies were outdated when they were originally added to Nu, but there was no comment explaining that this was required - so I updated them
* netty is upgraded from 4.1.48.Final to 4.1.90.Final - we're already running model with 4.1.60, and AsyncHttpClient seems to work fine with 4.1.87: https://github.com/AsyncHttpClient/async-http-client/commits/main/pom.xml

Not updated:
* cats-effect left at 2.x
* testcontainers-keycloak - newer version fails in CI due to some JUnit dependency mismatch
* ignite - newer version fails in CI on some data type conversion error, I couldn't quickly find out why

Also, I added version overrides for various netty and Jackson libraries pulled as transitive dependencies - we were missing some of them, resulting in a mix of various versions.