### PR TITLE
Changes in basic editor button hints

### DIFF
--- a/designer/client/components/graph/node-modal/editors/expression/FixedValuesEditor.tsx
+++ b/designer/client/components/graph/node-modal/editors/expression/FixedValuesEditor.tsx
@@ -36,7 +36,7 @@ export default class FixedValuesEditor extends React.Component<Props> {
 
   public static switchableTo = (expressionObj: ExpressionObj, editorConfig) => editorConfig.possibleValues.map(v => v.expression).includes(expressionObj.expression) || isEmpty(expressionObj.expression)
   public static switchableToHint = () => "Switch to basic mode"
-  public static notSwitchableToHint = () => "Expression must be one of the expression possible values to switch basic mode"
+  public static notSwitchableToHint = () => "Expression must be one of the predefined values to switch to basic mode"
 
   currentOption(expressionObj: ExpressionObj, options: Option[]): Option {
     return expressionObj && options.find((option) => option.value === expressionObj.expression) ||  // current value with label taken from options

--- a/designer/client/components/graph/node-modal/editors/expression/SqlEditor.tsx
+++ b/designer/client/components/graph/node-modal/editors/expression/SqlEditor.tsx
@@ -110,7 +110,7 @@ SqlEditor.switchableTo = (expressionObj) => parseable(expressionObj)
 SqlEditor.switchableToHint = () => i18next.t("editors.textarea.switchableToHint", "Switch to basic mode")
 SqlEditor.notSwitchableToHint = () => i18next.t(
   "editors.textarea.notSwitchableToHint",
-  "Expression must be a simple string literal i.e. text surrounded by single or double quotation marks to switch to basic mode",
+  "Expression must be a string literal i.e. text surrounded by quotation marks to switch to basic mode",
 )
 
 export default SqlEditor

--- a/designer/client/components/graph/node-modal/editors/expression/StringEditor.tsx
+++ b/designer/client/components/graph/node-modal/editors/expression/StringEditor.tsx
@@ -37,6 +37,6 @@ const parseable = (expressionObj) => {
 
 StringEditor.switchableTo = (expressionObj) => parseable(expressionObj)
 StringEditor.switchableToHint = () => i18next.t("editors.string.switchableToHint", "Switch to basic mode")
-StringEditor.notSwitchableToHint = () => i18next.t("editors.string.notSwitchableToHint", "Expression must be a simple string literal i.e. text surrounded by single or double quotation marks to switch to basic mode")
+StringEditor.notSwitchableToHint = () => i18next.t("editors.string.notSwitchableToHint", "Expression must be a string literal i.e. text surrounded by quotation marks to switch to basic mode")
 
 export default StringEditor

--- a/designer/client/components/graph/node-modal/editors/expression/TextareaEditor.tsx
+++ b/designer/client/components/graph/node-modal/editors/expression/TextareaEditor.tsx
@@ -40,6 +40,6 @@ const parseable = (expressionObj) => {
 
 TextareaEditor.switchableTo = (expressionObj) => parseable(expressionObj)
 TextareaEditor.switchableToHint = () => i18next.t("editors.textarea.switchableToHint", "Switch to basic mode")
-TextareaEditor.notSwitchableToHint = () => i18next.t("editors.textarea.notSwitchableToHint", "Expression must be a simple string literal i.e. text surrounded by single or double quotation marks to switch to basic mode")
+TextareaEditor.notSwitchableToHint = () => i18next.t("editors.textarea.notSwitchableToHint", "Expression must be a string literal i.e. text surrounded by quotation marks to switch to basic mode")
 
 export default TextareaEditor


### PR DESCRIPTION
Improved button hints when conversion from SpEL editor to basic editor is not possible and the button is disabled.