### PR TITLE
Fix scenario properties form types

### DIFF
--- a/designer/client/components/graph/node-modal/NodeField.tsx
+++ b/designer/client/components/graph/node-modal/NodeField.tsx
@@ -1,9 +1,14 @@
 import Field, {FieldType} from "./editors/field/Field"
 import {allValid, Validator} from "./editors/Validators"
 import {get} from "lodash"
-import React from "react"
+import React, {useCallback, useMemo} from "react"
 import {useDiffMark} from "./PathsToMark"
 import {NodeType} from "../../../types"
+
+export enum FieldInputType {
+  STRING,
+  INTEGER,
+}
 
 type NodeFieldProps<N extends string, V> = {
   autoFocus?: boolean,
@@ -12,10 +17,12 @@ type NodeFieldProps<N extends string, V> = {
   fieldProperty: N,
   fieldType: FieldType,
   isEditMode?: boolean,
+  placeholder?: string
   node: NodeType,
   readonly?: boolean,
   renderFieldLabel: (paramName: string) => JSX.Element,
   setProperty: <K extends keyof NodeType>(property: K, newValue: NodeType[K], defaultValue?: NodeType[K]) => void,
+  inputType?: FieldInputType,
   showValidation?: boolean,
   validators?: Validator[],
 }
@@ -27,17 +34,42 @@ export function NodeField<N extends string, V>({
   fieldProperty,
   fieldType,
   isEditMode,
+  placeholder,
   node,
   readonly,
   renderFieldLabel,
   setProperty,
+  inputType,
   showValidation,
   validators = [],
 }: NodeFieldProps<N, V>): JSX.Element {
   const readOnly = !isEditMode || readonly
   const value = get(node, fieldProperty, null) ?? defaultValue
   const className = !showValidation || allValid(validators, [value]) ? "node-input" : "node-input node-input-with-error"
-  const onChange = (newValue) => setProperty(fieldProperty, newValue, defaultValue)
+
+  const defaultOnChange = (newValue) =>
+    setProperty(fieldProperty, newValue, defaultValue)
+
+  const integerOnChange = (newValue) => {
+    if (!newValue) {
+      setProperty(fieldProperty, defaultValue, defaultValue)
+      return
+    }
+    const pattern = new RegExp("^[0-9]*$")
+    if (pattern.test(newValue)) {
+      const valueWithoutLeadingZeros = parseInt(newValue)
+      setProperty(fieldProperty, valueWithoutLeadingZeros, defaultValue)
+    }
+  }
+
+  const onChange = useMemo(() => {
+    if (inputType === FieldInputType.INTEGER) {
+      return integerOnChange
+    } else {
+      return defaultOnChange
+    }
+  }, [inputType])
+
   const [isMarked] = useDiffMark()
 
   return (
@@ -45,6 +77,7 @@ export function NodeField<N extends string, V>({
       type={fieldType}
       isMarked={isMarked(`${fieldProperty}`)}
       readOnly={readOnly}
+      placeholder={placeholder}
       showValidation={showValidation}
       autoFocus={autoFocus}
       className={className}

--- a/designer/client/components/graph/node-modal/NodeField.tsx
+++ b/designer/client/components/graph/node-modal/NodeField.tsx
@@ -4,6 +4,7 @@ import {get} from "lodash"
 import React, {useMemo} from "react"
 import {useDiffMark} from "./PathsToMark"
 import {NodeType} from "../../../types"
+import {Option} from "./editors/field/Select"
 
 export enum FieldInputType {
   STRING,
@@ -17,12 +18,13 @@ type NodeFieldProps<N extends string, V> = {
   fieldProperty: N,
   fieldType: FieldType,
   isEditMode?: boolean,
-  placeholder?: string
+  placeholder?: string,
   node: NodeType,
   readonly?: boolean,
   renderFieldLabel: (paramName: string) => JSX.Element,
   setProperty: <K extends keyof NodeType>(property: K, newValue: NodeType[K], defaultValue?: NodeType[K]) => void,
   inputType?: FieldInputType,
+  options?: Option[],
   showValidation?: boolean,
   validators?: Validator[],
 }
@@ -40,6 +42,7 @@ export function NodeField<N extends string, V>({
   renderFieldLabel,
   setProperty,
   inputType,
+  options,
   showValidation,
   validators = [],
 }: NodeFieldProps<N, V>): JSX.Element {
@@ -47,8 +50,7 @@ export function NodeField<N extends string, V>({
   const value = get(node, fieldProperty, null) ?? defaultValue
   const className = !showValidation || allValid(validators, [value]) ? "node-input" : "node-input node-input-with-error"
 
-  const defaultOnChange = (newValue) =>
-    setProperty(fieldProperty, newValue, defaultValue)
+  const defaultOnChange = (newValue) => setProperty(fieldProperty, newValue, defaultValue)
 
   const integerOnChange = (newValue) => {
     if (!newValue) {
@@ -83,6 +85,7 @@ export function NodeField<N extends string, V>({
       className={className}
       validators={validators}
       value={value}
+      options={options}
       onChange={onChange}
     >
       {renderFieldLabel(fieldLabel)}

--- a/designer/client/components/graph/node-modal/NodeField.tsx
+++ b/designer/client/components/graph/node-modal/NodeField.tsx
@@ -1,7 +1,7 @@
 import Field, {FieldType} from "./editors/field/Field"
 import {allValid, Validator} from "./editors/Validators"
 import {get} from "lodash"
-import React, {useCallback, useMemo} from "react"
+import React, {useMemo} from "react"
 import {useDiffMark} from "./PathsToMark"
 import {NodeType} from "../../../types"
 

--- a/designer/client/components/graph/node-modal/editors/field/Field.tsx
+++ b/designer/client/components/graph/node-modal/editors/field/Field.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren} from "react"
+import React, {PropsWithChildren, useCallback} from "react"
 import Checkbox from "./Checkbox"
 import Input from "./Input"
 import LabeledInput from "./LabeledInput"
@@ -16,6 +16,7 @@ export enum FieldType {
 interface FieldProps {
   isMarked: boolean,
   readOnly: boolean,
+  placeholder?: string,
   showValidation: boolean,
   autoFocus: boolean,
   className: string,
@@ -32,6 +33,7 @@ export default function Field({type, children, ...props}: PropsWithChildren<Fiel
         <LabeledInput
           {...props}
           value={props.value?.toString() || ""}
+          placeholder={props.placeholder}
           onChange={({target}) => props.onChange(target.value)}
         >
           {children}

--- a/designer/client/components/graph/node-modal/editors/field/Field.tsx
+++ b/designer/client/components/graph/node-modal/editors/field/Field.tsx
@@ -5,12 +5,14 @@ import LabeledInput from "./LabeledInput"
 import LabeledTextarea from "./LabeledTextarea"
 import UnknownField from "./UnknownField"
 import {Validator} from "../Validators"
+import Select, {Option} from "./Select"
 
 export enum FieldType {
   input = "input",
   unlabeledInput = "unlabeled-input",
   checkbox = "checkbox",
   plainTextarea = "plain-textarea",
+  select = "select"
 }
 
 interface FieldProps {
@@ -22,8 +24,17 @@ interface FieldProps {
   className: string,
   validators: Validator[],
   type: FieldType,
+  options?: Option[],
   value: string | boolean,
-  onChange: (value: string | boolean) => void,
+  onChange: (value: string | boolean | Option) => void,
+}
+
+function getCurrentBooleanOption(options: Option[], value: boolean | string): Option {
+  return options.find(x => {
+    const optionIsTrueFalse = x.value === value
+    const optionIsNull = x.value === null && value === undefined
+    return optionIsTrueFalse || optionIsNull
+  })
 }
 
 export default function Field({type, children, ...props}: PropsWithChildren<FieldProps>): JSX.Element {
@@ -66,6 +77,17 @@ export default function Field({type, children, ...props}: PropsWithChildren<Fiel
         >
           {children}
         </LabeledTextarea>
+      )
+    case FieldType.select:
+      return (
+        <Select
+          {...props}
+          options={props.options}
+          value={getCurrentBooleanOption(props.options, props.value) || null}
+          onChange={(option) => {props.onChange(option.value)}}
+        >
+          {children}
+        </Select>
       )
     default:
       return (<UnknownField/>)

--- a/designer/client/components/graph/node-modal/editors/field/Field.tsx
+++ b/designer/client/components/graph/node-modal/editors/field/Field.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren, useCallback} from "react"
+import React, {PropsWithChildren} from "react"
 import Checkbox from "./Checkbox"
 import Input from "./Input"
 import LabeledInput from "./LabeledInput"

--- a/designer/client/components/graph/node-modal/editors/field/Select.tsx
+++ b/designer/client/components/graph/node-modal/editors/field/Select.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import ReactSelect from "react-select"
+import styles from "../../../../../stylesheets/select.styl"
+import {LabeledInputProps} from "./LabeledInput"
+
+export interface Option {
+  label: string,
+  value: boolean,
+}
+
+export interface LabeledSelectProps extends Pick<LabeledInputProps, "children" | "autoFocus" | "isMarked" | "onChange" | "readOnly"> {
+  value: Option,
+  onChange: (Option) => void,
+  options: Option[],
+}
+
+export default function Select(props: LabeledSelectProps): JSX.Element {
+  const {children, autoFocus, value, options, isMarked, readOnly, onChange} = props
+
+  return (
+    <div className="node-row">
+      {children}
+      <div className={`node-value${isMarked ? " marked" : ""}`}>
+        <ReactSelect
+          classNamePrefix={styles.nodeValueSelect}
+          onChange={onChange}
+          value={value}
+          options={options}
+          autoFocus={autoFocus}
+          isDisabled={readOnly}
+        />
+      </div>
+    </div>
+  )
+}

--- a/designer/client/components/graph/node-modal/properties.tsx
+++ b/designer/client/components/graph/node-modal/properties.tsx
@@ -5,7 +5,7 @@ import React, {useMemo} from "react"
 import {sortBy} from "lodash"
 import {NodeTableBody} from "./NodeDetailsContent/NodeTable"
 import {IdField} from "./IdField"
-import {NodeField} from "./NodeField"
+import {FieldInputType, NodeField} from "./NodeField"
 import {FieldType} from "./editors/field/Field"
 import {errorValidator, literalIntegerValueValidator} from "./editors/Validators"
 import AdditionalProperty from "./AdditionalProperty"
@@ -45,7 +45,6 @@ export function Properties({
         renderFieldLabel={renderFieldLabel}
         setProperty={setProperty}
         additionalValidators={[errorValidator(fieldErrors || [], "id")]}
-        
       />
       {node.isSubprocess ?
         (
@@ -67,11 +66,13 @@ export function Properties({
             <>
               <NodeField
                 isEditMode={isEditMode}
+                placeholder={'Server default'}
                 showValidation={showValidation}
                 node={node}
                 renderFieldLabel={renderFieldLabel}
                 setProperty={setProperty}
                 fieldType={FieldType.input}
+                inputType={FieldInputType.INTEGER}
                 fieldLabel={"Parallelism"}
                 fieldProperty={"typeSpecificProperties.parallelism"}
                 validators={[literalIntegerValueValidator, errorValidator(fieldErrors || [], "parallelism")]}
@@ -79,11 +80,13 @@ export function Properties({
               />
               <NodeField
                 isEditMode={isEditMode}
+                placeholder={'Server default'}
                 showValidation={showValidation}
                 node={node}
                 renderFieldLabel={renderFieldLabel}
                 setProperty={setProperty}
                 fieldType={FieldType.input}
+                inputType={FieldInputType.INTEGER}
                 fieldLabel={"Checkpoint interval in seconds"}
                 fieldProperty={"typeSpecificProperties.checkpointIntervalInSeconds"}
                 validators={[literalIntegerValueValidator, errorValidator(fieldErrors || [], "checkpointIntervalInSeconds")]}
@@ -117,11 +120,13 @@ export function Properties({
             (
               <NodeField
                 isEditMode={isEditMode}
+                placeholder={'Server default'}
                 showValidation={showValidation}
                 node={node}
                 renderFieldLabel={renderFieldLabel}
                 setProperty={setProperty}
                 fieldType={FieldType.input}
+                inputType={FieldInputType.INTEGER}
                 fieldLabel={"Parallelism"}
                 fieldProperty={"typeSpecificProperties.parallelism"}
                 validators={[literalIntegerValueValidator, errorValidator(fieldErrors || [], "parallelism")]}

--- a/designer/client/components/graph/node-modal/properties.tsx
+++ b/designer/client/components/graph/node-modal/properties.tsx
@@ -66,7 +66,7 @@ export function Properties({
             <>
               <NodeField
                 isEditMode={isEditMode}
-                placeholder={'Server default'}
+                placeholder={"Server default"}
                 showValidation={showValidation}
                 node={node}
                 renderFieldLabel={renderFieldLabel}
@@ -80,7 +80,7 @@ export function Properties({
               />
               <NodeField
                 isEditMode={isEditMode}
-                placeholder={'Server default'}
+                placeholder={"Server default"}
                 showValidation={showValidation}
                 node={node}
                 renderFieldLabel={renderFieldLabel}
@@ -97,10 +97,15 @@ export function Properties({
                 node={node}
                 renderFieldLabel={renderFieldLabel}
                 setProperty={setProperty}
-                fieldType={FieldType.checkbox}
-                fieldLabel={"Spill state to disk"}
-                fieldProperty={"typeSpecificProperties.spillStateToDisk"}
-                validators={[errorValidator(fieldErrors || [], "spillStateToDisk")]}
+                fieldType={FieldType.select}
+                fieldLabel={"I/O mode"}
+                options={[
+                  {label: "Server default", value: null},
+                  {label: "Synchronous", value: true},
+                  {label: "Asynchronous", value: false},
+                ]}
+                fieldProperty={"typeSpecificProperties.useAsyncInterpretation"}
+                validators={[errorValidator(fieldErrors || [], "useAsyncInterpretation")]}
               />
               <NodeField
                 isEditMode={isEditMode}
@@ -109,10 +114,9 @@ export function Properties({
                 renderFieldLabel={renderFieldLabel}
                 setProperty={setProperty}
                 fieldType={FieldType.checkbox}
-                fieldLabel={"Should use async interpretation"}
-                fieldProperty={"typeSpecificProperties.useAsyncInterpretation"}
-                validators={[errorValidator(fieldErrors || [], "useAsyncInterpretation")]}
-                defaultValue={processDefinitionData?.defaultAsyncInterpretation}
+                fieldLabel={"Spill state to disk"}
+                fieldProperty={"typeSpecificProperties.spillStateToDisk"}
+                validators={[errorValidator(fieldErrors || [], "spillStateToDisk")]}
               />
             </>
           ) :
@@ -120,7 +124,7 @@ export function Properties({
             (
               <NodeField
                 isEditMode={isEditMode}
-                placeholder={'Server default'}
+                placeholder={"Server default"}
                 showValidation={showValidation}
                 node={node}
                 renderFieldLabel={renderFieldLabel}

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -46,6 +46,7 @@
 * [#4117](https://github.com/TouK/nussknacker/pull/4117)[#4202](https://github.com/TouK/nussknacker/pull/4202) Fragment parameters definition is now computed based on config. Thanks to that you can use `componentsUiConfig` setting to provide
   additional settings like parameter's validators or editors to fragments.
 * [#4201](https://github.com/TouK/nussknacker/pull/4201) Fix for: Dynamic nodes (GenericNodeTransformation) has now initial parameters inferred based on definition instead empty List
+* [#4210](https://github.com/TouK/nussknacker/pull/4210) Fix scenario properties form types (limit inputs to integers to match backend api)
 
 1.8.1 (28 Feb 2023)
 ------------------------


### PR DESCRIPTION
Typing a non-integer value in the parallelism or checkpoint interval properties resulted in an ugly looking backend unmarshalling error since backend expects an integer/long in these fields. There doesn't seem to be a way to get types and default values of type specific scenario properties without modifying the backend api. The simplest solution is to prevent the user from typing non-integers.

The form with new placeholders looks like this:
![properties-flink-defaults](https://user-images.githubusercontent.com/92804917/230083798-50237159-696a-454e-8d73-d7c722ee6a93.png)


There is no feedback to the user when he tries to type a non-integer, but that is still preferable than throwing an ugly error.