### PR TITLE
Draft: Lock cancel button when there are unsaved changes

### DIFF
--- a/designer/client/components/toolbars/status/buttons/CancelDeployButton.tsx
+++ b/designer/client/components/toolbars/status/buttons/CancelDeployButton.tsx
@@ -4,7 +4,7 @@ import {useDispatch, useSelector} from "react-redux"
 import {loadProcessState} from "../../../../actions/nk"
 import {ReactComponent as Icon} from "../../../../assets/img/toolbarButtons/stop.svg"
 import HttpService from "../../../../http/HttpService"
-import {getProcessId, isCancelPossible} from "../../../../reducers/selectors/graph"
+import {getProcessId, isCancelPossible, isSaveDisabled} from "../../../../reducers/selectors/graph"
 import {getCapabilities} from "../../../../reducers/selectors/other"
 import {useWindows} from "../../../../windowManager"
 import {WindowKind} from "../../../../windowManager/WindowKind"
@@ -17,19 +17,23 @@ export default function CancelDeployButton(props: ToolbarButtonProps) {
   const dispatch = useDispatch()
   const {disabled} = props
   const cancelPossible = useSelector(isCancelPossible)
+  const saveDisabled = useSelector(isSaveDisabled)
   const processId = useSelector(getProcessId)
   const capabilities = useSelector(getCapabilities)
   const available = !disabled && cancelPossible && capabilities.deploy
 
+  const cancelToolTip = !saveDisabled ? t("panels.actions.deploy-cancel.tooltips.unsaved", "You have unsaved changes.") : null
+
   const {open} = useWindows()
   const action = (p, c) => HttpService.cancel(p, c).finally(() => dispatch(loadProcessState(processId)))
-  const message = t("panels.actions.deploy-canel.dialog", "Cancel scenario {{name}}", {name: processId})
+  const message = t("panels.actions.deploy-cancel.dialog", "Cancel scenario {{name}}", {name: processId})
 
   return (
     <ToolbarButton
-      name={t("panels.actions.deploy-canel.button", "cancel")}
+      name={t("panels.actions.deploy-cancel.button", "cancel")}
       disabled={!available}
       icon={<Icon/>}
+      title={cancelToolTip}
       onClick={() => open<ToggleProcessActionModalData>({
         title: message,
         kind: WindowKind.deployProcess,

--- a/designer/client/reducers/selectors/graph.ts
+++ b/designer/client/reducers/selectors/graph.ts
@@ -6,7 +6,7 @@ import ProcessStateUtils from "../../components/Process/ProcessStateUtils"
 import {Process} from "../../types"
 import {ProcessCounts} from "../graph"
 import {RootState} from "../index"
-import {getProcessState, isProcessStateLoaded} from "./scenarioState";
+import {getProcessState, isProcessStateLoaded} from "./scenarioState"
 
 export const getGraph = (state: RootState): RootState["graphReducer"] => state.graphReducer
 
@@ -56,7 +56,10 @@ export const isMigrationPossible = createSelector(
   [isSaveDisabled, hasError, getFetchedProcessState],
   (saveDisabled, error, state) => saveDisabled && !error && ProcessStateUtils.canDeploy(state),
 )
-export const isCancelPossible = createSelector(getFetchedProcessState, state => ProcessStateUtils.canCancel(state))
+export const isCancelPossible = createSelector(
+  [isSaveDisabled, getFetchedProcessState],
+  (saveDisabled, state) => saveDisabled && ProcessStateUtils.canCancel(state)
+)
 export const isArchivePossible = createSelector(getFetchedProcessState, state => ProcessStateUtils.canArchive(state))
 export const getTestCapabilities = createSelector(getGraph, g => g.testCapabilities || {})
 export const getTestResults = createSelector(getGraph, g => g.testResults)


### PR DESCRIPTION
While a scenario is deployed, when a user makes changes and cancels the deployment he loses the unsaved changes without any previous prompt. This change locks the cancel button when there are unsaved changes (same as deploy button). The user gets feedback in the form of a tooltip.

![cancel-blocked](https://user-images.githubusercontent.com/92804917/230126854-cc69f12b-5f9c-46d8-bfec-153eb6ed388a.png)
