### PR TITLE
 Components are aware of processing data reload

### DIFF
--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/component/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/component/package.scala
@@ -13,6 +13,8 @@ package object component {
 
   import pl.touk.nussknacker.restmodel.codecs.URICodecs._
 
+  type NodeId = String
+
   object ComponentLink {
     val DocumentationId = "documentation"
     val DocumentationTile: String = "Documentation"
@@ -30,10 +32,17 @@ package object component {
   }
 
   @JsonCodec
-  final case class ComponentListElement(id: ComponentId, name: String, icon: String, componentType: ComponentType, componentGroupName: ComponentGroupName, categories: List[String], links: List[ComponentLink], usageCount: Long)
+  final case class ComponentListElement(id: ComponentId,
+                                        name: String,
+                                        icon: String,
+                                        componentType: ComponentType,
+                                        componentGroupName: ComponentGroupName,
+                                        categories: List[String],
+                                        links: List[ComponentLink],
+                                        usageCount: Long)
 
   object ComponentUsagesInScenario {
-    def apply(process: BaseProcessDetails[_], nodesId: List[String]): ComponentUsagesInScenario = ComponentUsagesInScenario(
+    def apply(process: BaseProcessDetails[_], nodesId: List[NodeId]): ComponentUsagesInScenario = ComponentUsagesInScenario(
       id = process.id, //Right now we assume that scenario id is name..
       name = process.idWithName.name,
       processId = process.processId,
@@ -50,6 +59,17 @@ package object component {
   }
 
   @JsonCodec
-  final case class ComponentUsagesInScenario(id: String, name: ProcessName, processId: ProcessId, nodesId: List[String], isSubprocess: Boolean, processCategory: String, modificationDate: Instant, modifiedAt: Instant, modifiedBy: String, createdAt: Instant, createdBy: String, lastAction: Option[ProcessAction])
+  final case class ComponentUsagesInScenario(id: String,
+                                             name: ProcessName,
+                                             processId: ProcessId,
+                                             nodesId: List[NodeId],
+                                             isSubprocess: Boolean,
+                                             processCategory: String,
+                                             modificationDate: Instant,
+                                             modifiedAt: Instant,
+                                             modifiedBy: String,
+                                             createdAt: Instant,
+                                             createdBy: String,
+                                             lastAction: Option[ProcessAction])
 
 }

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
@@ -77,7 +77,11 @@ package object definition {
       ComponentTemplate(`type`, `type`.toString, node, categories, branchParametersTemplate)
   }
 
-  @JsonCodec(encodeOnly = true) case class ComponentTemplate(`type`: ComponentType, label: String, node: NodeData, categories: List[String], branchParametersTemplate: List[evaluatedparam.Parameter] = List.empty)
+  @JsonCodec(encodeOnly = true) case class ComponentTemplate(`type`: ComponentType,
+                                                             label: String,
+                                                             node: NodeData,
+                                                             categories: List[String],
+                                                             branchParametersTemplate: List[evaluatedparam.Parameter] = List.empty)
 
   @JsonCodec(encodeOnly = true) case class ComponentGroup(name: ComponentGroupName, components: List[ComponentTemplate])
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/engine/CombinedProcessingTypeData.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/engine/CombinedProcessingTypeData.scala
@@ -1,17 +1,21 @@
 package pl.touk.nussknacker.engine
 
 import pl.touk.nussknacker.restmodel.process.ProcessingType
-import pl.touk.nussknacker.ui.process.ProcessStateDefinitionService
+import pl.touk.nussknacker.ui.component.{ComponentIdProvider, DefaultComponentIdProvider}
+import pl.touk.nussknacker.ui.process.{ProcessCategoryService, ProcessStateDefinitionService}
 import pl.touk.nussknacker.ui.process.ProcessStateDefinitionService.StatusNameToStateDefinitionsMapping
 
 case class CombinedProcessingTypeData(statusNameToStateDefinitionsMapping: StatusNameToStateDefinitionsMapping,
+                                      componentIdProvider: ComponentIdProvider,
                                      )
 
 object CombinedProcessingTypeData {
 
-  def create(processingTypes: Map[ProcessingType, ProcessingTypeData]): CombinedProcessingTypeData = {
+  def create(processingTypes: Map[ProcessingType, ProcessingTypeData],
+             categoryService: ProcessCategoryService): CombinedProcessingTypeData = {
     CombinedProcessingTypeData(
       statusNameToStateDefinitionsMapping = ProcessStateDefinitionService.createDefinitionsMappingUnsafe(processingTypes),
+      componentIdProvider = DefaultComponentIdProvider.createUnsafe(processingTypes, categoryService)
     )
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/engine/CombinedProcessingTypeData.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/engine/CombinedProcessingTypeData.scala
@@ -15,6 +15,8 @@ object CombinedProcessingTypeData {
              categoryService: ProcessCategoryService): CombinedProcessingTypeData = {
     CombinedProcessingTypeData(
       statusNameToStateDefinitionsMapping = ProcessStateDefinitionService.createDefinitionsMappingUnsafe(processingTypes),
+      // While creation of component id provider, we validate all component ids but fragments.
+      // We assume that fragments cannot have overridden component id thus are not merged/deduplicated across processing types.
       componentIdProvider = DefaultComponentIdProvider.createUnsafe(processingTypes, categoryService)
     )
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -22,7 +22,7 @@ import pl.touk.nussknacker.processCounts.influxdb.InfluxCountsReporterCreator
 import pl.touk.nussknacker.processCounts.{CountsReporter, CountsReporterCreator}
 import pl.touk.nussknacker.ui.api._
 import pl.touk.nussknacker.ui.component.DefaultComponentService
-import pl.touk.nussknacker.ui.config.{AnalyticsConfig, AttachmentsConfig, DesignerConfigLoader, FeatureTogglesConfig, UsageStatisticsReportsConfig}
+import pl.touk.nussknacker.ui.config.{AnalyticsConfig, AttachmentsConfig, ComponentLinksConfigExtractor, DesignerConfigLoader, FeatureTogglesConfig, UsageStatisticsReportsConfig}
 import pl.touk.nussknacker.ui.db.{DatabaseInitializer, DbConfig}
 import pl.touk.nussknacker.ui.initialization.Initialization
 import pl.touk.nussknacker.ui.listener.ProcessChangeListenerLoader
@@ -175,7 +175,7 @@ trait NusskanckerDefaultAppRouter extends NusskanckerAppRouter {
 
     val countsReporter = featureTogglesConfig.counts.flatMap(prepareCountsReporter(environment, _))
 
-    val componentService = DefaultComponentService(resolvedConfig, typeToConfig, processService, processCategoryService)
+    val componentService = DefaultComponentService(ComponentLinksConfigExtractor.extract(resolvedConfig), typeToConfig.mapCombined(_.componentIdProvider), processService, processCategoryService)
 
     val notificationService = new NotificationServiceImpl(actionRepository, dbioRunner, notificationsConfig)
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentDefinitionPreparer.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentDefinitionPreparer.scala
@@ -21,6 +21,7 @@ import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
 import pl.touk.nussknacker.ui.process.subprocess.SubprocessDetails
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
+import pl.touk.nussknacker.restmodel.process.ProcessingType
 
 import scala.collection.immutable.ListMap
 
@@ -38,7 +39,7 @@ object ComponentDefinitionPreparer {
                                  componentsGroupMapping: Map[ComponentGroupName, Option[ComponentGroupName]],
                                  processCategoryService: ProcessCategoryService,
                                  customTransformerAdditionalData: Map[String, CustomTransformerAdditionalData],
-                                 processingType: String
+                                 processingType: ProcessingType
                                 ): List[ComponentGroup] = {
     val userCategories = processCategoryService.getUserCategories(user)
     val processingTypeCategories = processCategoryService.getProcessingTypeCategories(processingType)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentIdProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentIdProvider.scala
@@ -40,7 +40,7 @@ class DefaultComponentIdProvider(configs: Map[ProcessingType, ComponentsUiConfig
 
     //We assume that base and currently fragment component's id can't be overridden
     if (defaultComponentId != overriddenComponentId && (ComponentType.isBaseComponent(componentType) || componentType == ComponentType.Fragments)) {
-      throw new IllegalArgumentException(s"Component: '$name' can't be overridden for component type: '$componentType'.")
+      throw new IllegalArgumentException(s"Component id can't be overridden for: '$name' with component type: '$componentType'.")
     }
 
     overriddenComponentId

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentIdProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentIdProvider.scala
@@ -40,7 +40,7 @@ class DefaultComponentIdProvider(configs: Map[ProcessingType, ComponentsUiConfig
 
     //We assume that base and currently fragment component's id can't be overridden
     if (defaultComponentId != overriddenComponentId && (ComponentType.isBaseComponent(componentType) || componentType == ComponentType.Fragments)) {
-      throw new IllegalArgumentException(s"ComponentId can't be overridden for component type: '$componentType'.")
+      throw new IllegalArgumentException(s"Component: '$name' can't be overridden for component type: '$componentType'.")
     }
 
     overriddenComponentId

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentIdProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentIdProvider.scala
@@ -35,7 +35,7 @@ class DefaultComponentIdProvider(configs: Map[ProcessingType, ComponentsUiConfig
       })
 
   private def getOverriddenComponentId(processingType: ProcessingType, componentName: String, defaultComponentId: ComponentId): ComponentId = {
-    def getComponentId(namespace: String) = configs.get(processingType).flatMap(_.get(namespace)).flatMap(_.componentId)
+    def getComponentId(name: String): Option[ComponentId] = configs.get(processingType).flatMap(_.get(name)).flatMap(_.componentId)
 
     val componentId = getComponentId(componentName)
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentIdProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentIdProvider.scala
@@ -24,7 +24,7 @@ object DefaultComponentIdProvider extends LazyLogging {
 
     val componentObjectsService = new ComponentObjectsService(categoryService)
     val componentObjectsMap = processingTypeDataMap.transform(componentObjectsService.prepareWithoutFragments)
-    val componentIdProvider = new DefaultComponentIdProvider(componentObjectsMap.view.mapValues(_.config).toMap)
+    val componentIdProvider = new DefaultComponentIdProvider(componentObjectsMap.transform { case (_, componentsObjects) => componentsObjects.config })
 
     ComponentsValidator.checkUnsafe(componentObjectsMap, componentIdProvider)
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentObjects.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentObjects.scala
@@ -34,7 +34,7 @@ private[component] class ComponentObjectsService(categoryService: ProcessCategor
       processingType,
       processingTypeData,
       user = NussknackerInternalUser, // We need admin user to receive all components info
-      subprocesses = Set.empty, // We don't check fragments, because these are dynamic components
+      subprocesses = Set.empty,
     )
     ComponentObjects(uiProcessObjects)
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentObjects.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentObjects.scala
@@ -29,36 +29,39 @@ private[component] object ComponentObjects {
  */
 private[component] class ComponentObjectsService(categoryService: ProcessCategoryService) {
 
-  def prepareWithoutFragments(processingTypeData: ProcessingTypeData,
-                              processingType: ProcessingType): ComponentObjects = {
-    val uiProcessObjects = UIProcessObjectsFactory.prepareUIProcessObjects(
-      processingTypeData.modelData,
-      processingTypeData.deploymentManager,
-      user = NussknackerInternalUser, // We need admin user to received all components info
-      subprocessesDetails = Set.empty, // We don't check subprocesses, because these are dynamic components
-      isSubprocess = false, // It excludes fragment's components: input / output
-      categoryService,
-      processingTypeData.additionalPropertiesConfig,
-      processingType
+  def prepareWithoutFragments(processingType: ProcessingType, processingTypeData: ProcessingTypeData): ComponentObjects = {
+    val uiProcessObjects = createUIProcessObjects(
+      processingType,
+      processingTypeData,
+      user = NussknackerInternalUser, // We need admin user to receive all components info
+      subprocesses = Set.empty, // We don't check fragments, because these are dynamic components
     )
     ComponentObjects(uiProcessObjects)
   }
 
-  def prepare(processingTypeData: ProcessingTypeData,
-              processingType: ProcessingType,
+  def prepare(processingType: ProcessingType,
+              processingTypeData: ProcessingTypeData,
               user: LoggedUser,
               subprocesses: Set[SubprocessDetails]): ComponentObjects = {
-    val uiProcessObjects = UIProcessObjectsFactory.prepareUIProcessObjects(
-      processingTypeData.modelData,
-      processingTypeData.deploymentManager,
-      user,
-      subprocesses,
-      isSubprocess = false, //It excludes fragment's components: input / output
-      categoryService,
-      processingTypeData.additionalPropertiesConfig,
-      processingType
-    )
+    val uiProcessObjects = createUIProcessObjects(processingType, processingTypeData, user, subprocesses)
     ComponentObjects(uiProcessObjects)
+  }
+
+  private def createUIProcessObjects(processingType: ProcessingType,
+                                     processingTypeData: ProcessingTypeData,
+                                     user: LoggedUser,
+                                     subprocesses: Set[SubprocessDetails]): UIProcessObjects = {
+    UIProcessObjectsFactory.prepareUIProcessObjects(
+      modelDataForType = processingTypeData.modelData,
+      deploymentManager = processingTypeData.deploymentManager,
+      typeSpecificInitialData = processingTypeData.typeSpecificInitialData,
+      user = user,
+      subprocessesDetails = subprocesses,
+      isSubprocess = false, //It excludes fragment's components: input / output
+      processCategoryService = categoryService,
+      additionalPropertiesConfig = processingTypeData.additionalPropertiesConfig,
+      processingType = processingType
+    )
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentObjects.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentObjects.scala
@@ -1,0 +1,64 @@
+package pl.touk.nussknacker.ui.component
+
+import pl.touk.nussknacker.engine.ProcessingTypeData
+import pl.touk.nussknacker.engine.api.component.ComponentGroupName
+import pl.touk.nussknacker.engine.component.ComponentsUiConfigExtractor.ComponentsUiConfig
+import pl.touk.nussknacker.restmodel.definition.{ComponentTemplate, UIProcessObjects}
+import pl.touk.nussknacker.restmodel.process.ProcessingType
+import pl.touk.nussknacker.ui.definition.UIProcessObjectsFactory
+import pl.touk.nussknacker.ui.process.ProcessCategoryService
+import pl.touk.nussknacker.ui.process.subprocess.SubprocessDetails
+import pl.touk.nussknacker.ui.security.api.{LoggedUser, NussknackerInternalUser}
+
+private[component] case class ComponentObjects(templates: List[(ComponentGroupName, ComponentTemplate)],
+                                               config: ComponentsUiConfig)
+
+private[component] object ComponentObjects {
+
+  def apply(uIProcessObjects: UIProcessObjects): ComponentObjects = {
+    val templates = uIProcessObjects.componentGroups.flatMap(group => group.components.map(component => (group.name, component)))
+    ComponentObjects(templates, uIProcessObjects.componentsConfig)
+  }
+
+}
+
+/**
+ * TODO: Right now we use UIProcessObjectsFactory for extract components data, because there is assigned logic
+ * responsible for: hiding, mapping group name, etc.. We should move this logic to another place, because
+ * UIProcessObjectsFactory does many other things, things that we don't need here..
+ */
+private[component] class ComponentObjectsService(categoryService: ProcessCategoryService) {
+
+  def prepareWithoutFragments(processingTypeData: ProcessingTypeData,
+                              processingType: ProcessingType): ComponentObjects = {
+    val uiProcessObjects = UIProcessObjectsFactory.prepareUIProcessObjects(
+      processingTypeData.modelData,
+      processingTypeData.deploymentManager,
+      user = NussknackerInternalUser, // We need admin user to received all components info
+      subprocessesDetails = Set.empty, // We don't check subprocesses, because these are dynamic components
+      isSubprocess = false, // It excludes fragment's components: input / output
+      categoryService,
+      processingTypeData.additionalPropertiesConfig,
+      processingType
+    )
+    ComponentObjects(uiProcessObjects)
+  }
+
+  def prepare(processingTypeData: ProcessingTypeData,
+              processingType: ProcessingType,
+              user: LoggedUser,
+              subprocesses: Set[SubprocessDetails]): ComponentObjects = {
+    val uiProcessObjects = UIProcessObjectsFactory.prepareUIProcessObjects(
+      processingTypeData.modelData,
+      processingTypeData.deploymentManager,
+      user,
+      subprocesses,
+      isSubprocess = false, //It excludes fragment's components: input / output
+      categoryService,
+      processingTypeData.additionalPropertiesConfig,
+      processingType
+    )
+    ComponentObjects(uiProcessObjects)
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentService.scala
@@ -111,6 +111,7 @@ class DefaultComponentService private(componentLinksConfig: ComponentLinksConfig
     processService
       .getSubProcesses(processingTypes = Some(List(processingType)))(user)
       .map { subprocesses =>
+        // We assume that fragments have unique component ids ($processing-type-fragment-$name) thus we do not need to validate them.
         val componentObjects = componentObjectsService.prepare(processingType, processingTypeData, user, subprocesses)
         createComponents(componentObjects, componentUsages, processingType, componentIdProvider)
       }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentService.scala
@@ -1,29 +1,23 @@
 package pl.touk.nussknacker.ui.component
 
-import cats.data.Validated
-import cats.data.Validated.{Invalid, Valid}
 import com.typesafe.config.Config
 import pl.touk.nussknacker.engine.ProcessingTypeData
-import pl.touk.nussknacker.engine.api.component.ComponentType.ComponentType
 import pl.touk.nussknacker.engine.api.component.{ComponentGroupName, ComponentId, SingleComponentConfig}
 import pl.touk.nussknacker.engine.component.ComponentsUiConfigExtractor.ComponentsUiConfig
-import pl.touk.nussknacker.restmodel.component.{ComponentListElement, ComponentUsagesInScenario}
+import pl.touk.nussknacker.restmodel.component.{ComponentLink, ComponentListElement, ComponentUsagesInScenario}
 import pl.touk.nussknacker.restmodel.definition.ComponentTemplate
 import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
 import pl.touk.nussknacker.restmodel.process.ProcessingType
 import pl.touk.nussknacker.ui.EspError.XError
 import pl.touk.nussknacker.ui.NotFoundError
 import pl.touk.nussknacker.ui.component.DefaultComponentService.{getComponentDoc, getComponentIcon}
-import pl.touk.nussknacker.ui.component.WrongConfigurationAttribute.WrongConfigurationAttribute
 import pl.touk.nussknacker.ui.config.ComponentLinksConfigExtractor
-import pl.touk.nussknacker.ui.definition.UIProcessObjectsFactory
 import pl.touk.nussknacker.ui.process.ProcessCategoryService.Category
 import pl.touk.nussknacker.ui.process.processingtypedata.ProcessingTypeDataProvider
-import pl.touk.nussknacker.ui.process.{ProcessCategoryService, ProcessObjectsFinder, ProcessService}
-import pl.touk.nussknacker.ui.security.api.{LoggedUser, NussknackerInternalUser}
+import pl.touk.nussknacker.ui.process.{ProcessCategoryService, ProcessService}
+import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.{ExecutionContext, Future}
-import pl.touk.nussknacker.restmodel.component.ComponentLink
 
 trait ComponentService {
   def getComponentsList(user: LoggedUser): Future[List[ComponentListElement]]
@@ -33,115 +27,35 @@ trait ComponentService {
 
 object DefaultComponentService {
 
-  import WrongConfigurationAttribute._
-
-  type ComponentIdProviderWithError = Validated[List[ComponentWrongConfiguration[_]], ComponentIdProvider]
+  def checkUnsafe(processingTypeDataMap: Map[ProcessingType, ProcessingTypeData], categoryService: ProcessCategoryService): Unit =
+    ComponentsValidator.checkUnsafe(processingTypeDataMap, categoryService)
 
   def apply(config: Config,
             processingTypeDataProvider: ProcessingTypeDataProvider[ProcessingTypeData, _],
             processService: ProcessService,
             categoryService: ProcessCategoryService)(implicit ec: ExecutionContext): DefaultComponentService = {
-    val componentIdProvider = prepareComponentProvider(processingTypeDataProvider, categoryService)
-
-    componentIdProvider
-      .map(new DefaultComponentService(config, processingTypeDataProvider, processService, categoryService, _))
-      .valueOr(wrongConfigurations => throw ComponentConfigurationException(s"Wrong configured components were found.", wrongConfigurations))
+    new DefaultComponentService(config, processingTypeDataProvider, processService, categoryService)
   }
 
-  private def prepareComponentProvider(processingTypeDataProvider: ProcessingTypeDataProvider[ProcessingTypeData, _], categoryService: ProcessCategoryService)(implicit ec: ExecutionContext): ComponentIdProviderWithError = {
-    val data = processingTypeDataProvider.all.toList.map {
-      case (processingType, processingTypeData) =>
-        extractFromProcessingType(processingTypeData, processingType, categoryService)
-    }
-
-    val wrongComponents = data
-      .flatMap(_.components)
-      .groupBy(_.id)
-      .flatMap {
-        case (_, _ :: Nil) => Nil
-        case (componentId, components) => computeWrongConfigurations(componentId, components)
-      }
-      .toList
-
-    if (wrongComponents.nonEmpty)
-      Invalid(wrongComponents)
-    else
-      Valid(new DefaultComponentIdProvider(data.map(d => d.processingType -> d.componentsUiConfig).toMap))
-
-  }
-
-  //TODO: right now we don't support hidden components, see how works UIProcessObjectsFactory.prepareUIProcessObjects
-  private def extractFromProcessingType(processingTypeData: ProcessingTypeData,
-                                        processingType: ProcessingType,
-                                        categoryService: ProcessCategoryService)(implicit ec: ExecutionContext) = {
-      val uiProcessObjects = UIProcessObjectsFactory.prepareUIProcessObjects(
-        processingTypeData.modelData,
-        processingTypeData.deploymentManager,
-        processingTypeData.typeSpecificInitialData,
-        user = NussknackerInternalUser, // We need admin user to received all components info
-        subprocessesDetails = Set.empty, // We don't check subprocesses, because these are dynamic components
-        isSubprocess = false, // It excludes fragment's components: input / output
-        categoryService,
-        processingTypeData.additionalPropertiesConfig,
-        processingType
-      )
-
-      val componentsUiConfig = uiProcessObjects.componentsConfig
-      val componentIdProvider = new DefaultComponentIdProvider(Map(processingType -> componentsUiConfig))
-
-      val components = uiProcessObjects
-        .componentGroups
-        .flatMap(group => group.components.map(com => {
-          val componentId = componentIdProvider.createComponentId(processingType, com.label, com.`type`)
-          val icon = getComponentIcon(componentsUiConfig, com)
-
-          Component(
-            id = componentId,
-            name = com.label,
-            icon = icon,
-            componentType = com.`type`,
-            componentGroupName = group.name,
-          )
-        }))
-
-      ExtractedData(processingType, componentsUiConfig, components)
-  }
-
-  private def getComponentIcon(componentsUiConfig: ComponentsUiConfig, com: ComponentTemplate) =
+  private[component] def getComponentIcon(componentsUiConfig: ComponentsUiConfig, com: ComponentTemplate): String =
     componentConfig(componentsUiConfig, com).flatMap(_.icon).getOrElse(DefaultsComponentIcon.fromComponentType(com.`type`))
 
-  private def getComponentDoc(componentsUiConfig: ComponentsUiConfig, com: ComponentTemplate) =
+  private def getComponentDoc(componentsUiConfig: ComponentsUiConfig, com: ComponentTemplate): Option[String] =
     componentConfig(componentsUiConfig, com).flatMap(_.docsUrl)
 
   private def componentConfig(componentsUiConfig: ComponentsUiConfig, com: ComponentTemplate): Option[SingleComponentConfig] =
     componentsUiConfig.get(com.label)
 
-  private def computeWrongConfigurations(componentId: ComponentId, components: Iterable[Component]): List[ComponentWrongConfiguration[_]] = {
-    def discoverWrongConfiguration[T](attribute: WrongConfigurationAttribute, elements: Iterable[T]): Option[ComponentWrongConfiguration[T]] =
-      elements.toList.distinct match {
-        case _ :: Nil => None
-        case elements => Some(ComponentWrongConfiguration(componentId, attribute, elements))
-      }
-
-    val wrongConfiguredNames = discoverWrongConfiguration(NameAttribute, components.map(_.name))
-    val wrongConfiguredIcons = discoverWrongConfiguration(IconAttribute, components.map(_.icon))
-    val wrongConfiguredGroups = discoverWrongConfiguration(ComponentGroupNameAttribute, components.map(_.componentGroupName))
-    val wrongConfiguredTypes = discoverWrongConfiguration(ComponentTypeAttribute, components.map(_.componentType))
-    val wrongConfigurations = wrongConfiguredNames ++ wrongConfiguredTypes ++ wrongConfiguredGroups ++ wrongConfiguredIcons
-    wrongConfigurations.toList
-  }
-
-  private final case class ExtractedData(processingType: String, componentsUiConfig: ComponentsUiConfig, components: List[Component])
 }
 
 class DefaultComponentService private(config: Config,
                                       processingTypeDataProvider: ProcessingTypeDataProvider[ProcessingTypeData, _],
                                       processService: ProcessService,
-                                      categoryService: ProcessCategoryService,
-                                      componentIdProvider: ComponentIdProvider)(implicit ec: ExecutionContext) extends ComponentService {
+                                      categoryService: ProcessCategoryService)(implicit ec: ExecutionContext) extends ComponentService {
 
   import cats.syntax.traverse._
 
+  private val componentObjectsService = new ComponentObjectsService(categoryService)
   lazy private val componentLinksConfig = ComponentLinksConfigExtractor.extract(config)
 
   override def getComponentsList(user: LoggedUser): Future[List[ComponentListElement]] = {
@@ -162,7 +76,7 @@ class DefaultComponentService private(config: Config,
     processService
       .getProcesses[DisplayableProcess](user)
       .map(processes => {
-        val componentsUsage = ProcessObjectsFinder.computeComponentsUsage(componentIdProvider, processes)
+        val componentsUsage = ComponentsUsageHelper.computeComponentsUsage(componentIdProvider, processes)
 
         componentsUsage
           .get(componentId)
@@ -172,12 +86,12 @@ class DefaultComponentService private(config: Config,
 
   private def extractComponentsFromProcessingType(processingTypeData: ProcessingTypeData,
                                                   processingType: ProcessingType,
-                                                  user: LoggedUser) = {
+                                                  user: LoggedUser): Future[List[ComponentListElement]] = {
     val userCategories = categoryService.getUserCategories(user)
     val processingTypeCategories = categoryService.getProcessingTypeCategories(processingType)
     val userProcessingTypeCategories = userCategories.intersect(processingTypeCategories)
 
-    //When user hasn't access to model then is no sens to extract data
+    // When user has no access to the model then it makes no sense to extract data.
     userProcessingTypeCategories match {
       case Nil => Future(List.empty)
       case _ => getComponentUsages(userProcessingTypeCategories)(user, ec).flatMap { componentUsages =>
@@ -186,72 +100,66 @@ class DefaultComponentService private(config: Config,
     }
   }
 
-  private def extractUserComponentsFromProcessingType(processingTypeData: ProcessingTypeData,
-                                                      processingType: String,
-                                                      user: LoggedUser,
-                                                      componentUsages: Map[ComponentId, Long]): Future[List[ComponentListElement]] = {
-    processService
-      .getSubProcesses(processingTypes = Some(List(processingType)))(user)
-      .map(subprocesses => {
-        /**
-          * TODO: Right now we use UIProcessObjectsFactory for extract components data, because there is assigned logic
-          * responsible for: hiding, mapping group name, etc.. We should move this logic to another place, because
-          * UIProcessObjectsFactory does many other things, things that we don't need here..
-          */
-        val uiProcessObjects = UIProcessObjectsFactory.prepareUIProcessObjects(
-          processingTypeData.modelData,
-          processingTypeData.deploymentManager,
-          processingTypeData.typeSpecificInitialData,
-          user,
-          subprocesses,
-          isSubprocess = false, //It excludes fragment's components: input / output
-          categoryService,
-          processingTypeData.additionalPropertiesConfig,
-          processingType
-        )
-
-        def createLinks(componentId: ComponentId, component: ComponentTemplate): List[ComponentLink] = {
-          val componentLinks = componentLinksConfig
-            .filter(_.isAvailable(component.`type`))
-            .map(_.toComponentLink(componentId, component.label))
-
-          //If component configuration contains documentation link then we add base link
-          getComponentDoc(uiProcessObjects.componentsConfig, component)
-            .map(ComponentLink.createDocumentationLink)
-            .map(doc => List(doc) ++ componentLinks)
-            .getOrElse(componentLinks)
-        }
-
-        uiProcessObjects
-          .componentGroups
-          .flatMap(group => group.components.map(com => {
-            val componentId = componentIdProvider.createComponentId(processingType, com.label, com.`type`)
-            val icon = getComponentIcon(uiProcessObjects.componentsConfig, com)
-            val links = createLinks(componentId, com)
-            val usageCount = componentUsages.getOrElse(componentId, 0L)
-
-            ComponentListElement(
-              id = componentId,
-              name = com.label,
-              icon = icon,
-              componentType = com.`type`,
-              componentGroupName = group.name,
-              categories = com.categories,
-              links = links,
-              usageCount = usageCount
-            )
-          }))
-      })
-  }
-
   private def getComponentUsages(categories: List[Category])(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Map[ComponentId, Long]] = {
     processService
       .getProcesses[DisplayableProcess](loggedUser)
       .map(_.filter(p => categories.contains(p.processCategory))) //TODO: move it to service?
-      .map(processes => ProcessObjectsFinder.computeComponentsUsageCount(componentIdProvider, processes))
+      .map(processes => ComponentsUsageHelper.computeComponentsUsageCount(componentIdProvider, processes))
   }
 
-  private def deduplication(components: Iterable[ComponentListElement]) = {
+  private def extractUserComponentsFromProcessingType(processingTypeData: ProcessingTypeData,
+                                                      processingType: ProcessingType,
+                                                      user: LoggedUser,
+                                                      componentUsages: Map[ComponentId, Long]): Future[List[ComponentListElement]] = {
+    processService
+      .getSubProcesses(processingTypes = Some(List(processingType)))(user)
+      .map { subprocesses =>
+        val componentObjects = componentObjectsService.prepare(processingTypeData, processingType, user, subprocesses)
+        val componentIdProvider = new DefaultComponentIdProvider(Map(processingType -> componentObjects.config))
+        createComponents(componentObjects.templates, componentObjects.config, componentUsages, processingType, componentIdProvider)
+      }
+  }
+
+  private def createComponents(componentTemplates: List[(ComponentGroupName, ComponentTemplate)],
+                               componentsConfig: ComponentsUiConfig,
+                               componentUsages: Map[ComponentId, Long],
+                               processingType: ProcessingType,
+                               componentIdProvider: ComponentIdProvider): List[ComponentListElement] = {
+    componentTemplates
+      .map { case (groupName, com) =>
+        val componentId = componentIdProvider.createComponentId(processingType, com.label, com.`type`)
+        val icon = getComponentIcon(componentsConfig, com)
+        val links = createComponentLinks(componentId, com, componentsConfig)
+        val usageCount = componentUsages.getOrElse(componentId, 0L)
+
+        ComponentListElement(
+          id = componentId,
+          name = com.label,
+          icon = icon,
+          componentType = com.`type`,
+          componentGroupName = groupName,
+          categories = com.categories,
+          links = links,
+          usageCount = usageCount
+        )
+      }
+  }
+
+  private def createComponentLinks(componentId: ComponentId,
+                                   component: ComponentTemplate,
+                                   componentsConfig: ComponentsUiConfig): List[ComponentLink] = {
+    val componentLinks = componentLinksConfig
+      .filter(_.isAvailable(component.`type`))
+      .map(_.toComponentLink(componentId, component.label))
+
+    //If component configuration contains documentation link then we add base link
+    getComponentDoc(componentsConfig, component)
+      .map(ComponentLink.createDocumentationLink)
+      .map(doc => List(doc) ++ componentLinks)
+      .getOrElse(componentLinks)
+  }
+
+  private def deduplication(components: Iterable[ComponentListElement]): List[ComponentListElement] = {
     val groupedComponents = components.groupBy(_.id)
     groupedComponents
       .map { case (_, components) => components match {
@@ -266,20 +174,4 @@ class DefaultComponentService private(config: Config,
   }
 }
 
-private[component] final case class Component(id: ComponentId, name: String, icon: String, componentType: ComponentType, componentGroupName: ComponentGroupName)
-
-private[component] final case class ComponentWrongConfiguration[T](id: ComponentId, attribute: WrongConfigurationAttribute, duplications: List[T])
-
-private[component] object WrongConfigurationAttribute extends Enumeration {
-  type WrongConfigurationAttribute = Value
-
-  val NameAttribute = Value("name")
-  val IconAttribute = Value("icon")
-  val ComponentTypeAttribute = Value("componentType")
-  val ComponentGroupNameAttribute = Value("componentGroupName")
-}
-
-private[component] case class ComponentConfigurationException(message: String, wrongConfigurations: List[ComponentWrongConfiguration[_]])
-  extends RuntimeException(s"$message Wrong configurations: ${wrongConfigurations.groupBy(_.id)}.")
-
-private[component] case class ComponentNotFoundError(componentId: ComponentId) extends Exception(s"Component $componentId not exist.") with NotFoundError
+private case class ComponentNotFoundError(componentId: ComponentId) extends Exception(s"Component $componentId not exist.") with NotFoundError

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentService.scala
@@ -112,7 +112,6 @@ class DefaultComponentService private(componentLinksConfig: ComponentLinksConfig
       .getSubProcesses(processingTypes = Some(List(processingType)))(user)
       .map { subprocesses =>
         val componentObjects = componentObjectsService.prepare(processingType, processingTypeData, user, subprocesses)
-        val componentIdProvider = new DefaultComponentIdProvider(Map(processingType -> componentObjects.config))
         createComponents(componentObjects, componentUsages, processingType, componentIdProvider)
       }
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentsUsageHelper.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentsUsageHelper.scala
@@ -1,0 +1,50 @@
+package pl.touk.nussknacker.ui.component
+
+import pl.touk.nussknacker.engine.api.component.ComponentId
+import pl.touk.nussknacker.restmodel.component.NodeId
+import pl.touk.nussknacker.restmodel.processdetails.ProcessDetails
+
+private[component] object ComponentsUsageHelper {
+
+  import pl.touk.nussknacker.engine.util.Implicits._
+
+  def computeComponentsUsageCount(componentIdProvider: ComponentIdProvider, processes: List[ProcessDetails]): Map[ComponentId, Long] =
+    processes
+      .flatMap(processDetails => extractComponentIds(componentIdProvider, processDetails))
+      .groupBy(identity)
+      .mapValuesNow(_.size)
+
+  def computeComponentsUsage(componentIdProvider: ComponentIdProvider, processes: List[ProcessDetails]): Map[ComponentId, List[(ProcessDetails, List[NodeId])]] =
+    processes
+      .flatMap(processDetails => extractComponentIdsWithProcessAndNodeId(componentIdProvider, processDetails))
+      .groupBy { case (componentId, _, _) => componentId }
+      .map { case (componentId, groupedByComponentId) =>
+        val processAndNodeList = groupedByComponentId.map { case (_, processDetails, nodeId) => (processDetails, nodeId) }
+        val groupedByProcess = groupByProcess(processAndNodeList)
+        (componentId, groupedByProcess)
+      }
+
+  private def extractComponentIds(componentIdProvider: ComponentIdProvider, processDetails: ProcessDetails): List[ComponentId] = {
+    processDetails.json.nodes.flatMap(componentIdProvider.nodeToComponentId(processDetails.processingType, _))
+  }
+
+  private def extractComponentIdsWithProcessAndNodeId(componentIdProvider: ComponentIdProvider, processDetails: ProcessDetails): List[(ComponentId, ProcessDetails, NodeId)] = {
+    processDetails.json.nodes.flatMap(node =>
+      componentIdProvider.nodeToComponentId(processDetails.processingType, node)
+        .map((_, processDetails, node.id))
+    )
+  }
+
+  private def groupByProcess(processAndNodeList: List[(ProcessDetails, NodeId)]): List[(ProcessDetails, List[NodeId])] = {
+    processAndNodeList
+      .groupBy { case (processDetails, _) => processDetails }
+      .toList
+      .map {
+        case (processDetails, groupedByProcess) =>
+          val nodeIds = groupedByProcess.map { case (_, nodeId) => nodeId }.sorted
+          (processDetails, nodeIds)
+      }
+      .sortBy { case (processDetails, _) => processDetails.name }
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentsValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentsValidator.scala
@@ -1,0 +1,90 @@
+package pl.touk.nussknacker.ui.component
+
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import pl.touk.nussknacker.engine.ProcessingTypeData
+import pl.touk.nussknacker.engine.api.component.ComponentType.ComponentType
+import pl.touk.nussknacker.engine.api.component.{ComponentGroupName, ComponentId}
+import pl.touk.nussknacker.restmodel.process.ProcessingType
+import pl.touk.nussknacker.ui.component.DefaultComponentService.getComponentIcon
+import pl.touk.nussknacker.ui.component.WrongConfigurationAttribute.{ComponentGroupNameAttribute, ComponentTypeAttribute, IconAttribute, NameAttribute, WrongConfigurationAttribute}
+import pl.touk.nussknacker.ui.process.ProcessCategoryService
+
+private[component] object ComponentsValidator {
+
+  def checkUnsafe(processingTypeDataMap: Map[ProcessingType, ProcessingTypeData], categoryService: ProcessCategoryService): Unit = {
+    val componentObjectsService = new ComponentObjectsService(categoryService)
+
+    val components = processingTypeDataMap.toList.flatMap {
+      case (processingType, processingTypeData) =>
+        val componentObjects = componentObjectsService.prepareWithoutFragments(processingTypeData, processingType)
+        val componentIdProvider = new DefaultComponentIdProvider(Map(processingType -> componentObjects.config))
+        extractComponents(processingType, componentObjects, componentIdProvider)
+    }
+    validateComponents(components)
+      .valueOr(wrongConfigurations => throw ComponentConfigurationException(s"Wrong configured components were found.", wrongConfigurations))
+  }
+
+  //TODO: right now we don't support hidden components, see how works UIProcessObjectsFactory.prepareUIProcessObjects
+  private def extractComponents(processingType: ProcessingType,
+                                componentObjects: ComponentObjects,
+                                componentIdProvider: ComponentIdProvider): List[ComponentValidationData]  = {
+    componentObjects
+      .templates
+      .map { case (groupName, com) =>
+        val componentId = componentIdProvider.createComponentId(processingType, com.label, com.`type`)
+        val icon = getComponentIcon(componentObjects.config, com)
+
+        ComponentValidationData(
+          id = componentId,
+          name = com.label,
+          icon = icon,
+          componentType = com.`type`,
+          componentGroupName = groupName
+        )
+      }
+  }
+
+  private def validateComponents(components: List[ComponentValidationData]): ValidatedNel[ComponentWrongConfiguration[_], Unit] = {
+    val wrongComponents = components
+      .groupBy(_.id)
+      .flatMap {
+        case (_, _ :: Nil) => Nil
+        case (componentId, components) => computeWrongConfigurations(componentId, components)
+      }
+      .toList
+    NonEmptyList.fromList(wrongComponents)
+      .fold(Validated.valid(()))(Validated.invalid(_))
+  }
+
+  private def computeWrongConfigurations(componentId: ComponentId, components: Iterable[ComponentValidationData]): List[ComponentWrongConfiguration[_]] = {
+    def checkUniqueAttributeValue[T](attribute: WrongConfigurationAttribute, values: Iterable[T]): Option[ComponentWrongConfiguration[T]] =
+      values.toList.distinct match {
+        case _ :: Nil => None
+        case elements => Some(ComponentWrongConfiguration(componentId, attribute, elements))
+      }
+
+    val wrongConfiguredNames = checkUniqueAttributeValue(NameAttribute, components.map(_.name))
+    val wrongConfiguredIcons = checkUniqueAttributeValue(IconAttribute, components.map(_.icon))
+    val wrongConfiguredGroups = checkUniqueAttributeValue(ComponentGroupNameAttribute, components.map(_.componentGroupName))
+    val wrongConfiguredTypes = checkUniqueAttributeValue(ComponentTypeAttribute, components.map(_.componentType))
+    val wrongConfigurations = wrongConfiguredNames ++ wrongConfiguredTypes ++ wrongConfiguredGroups ++ wrongConfiguredIcons
+    wrongConfigurations.toList
+  }
+
+}
+
+private final case class ComponentValidationData(id: ComponentId, name: String, icon: String, componentType: ComponentType, componentGroupName: ComponentGroupName)
+
+private final case class ComponentWrongConfiguration[T](id: ComponentId, attribute: WrongConfigurationAttribute, duplications: List[T])
+
+private object WrongConfigurationAttribute extends Enumeration {
+  type WrongConfigurationAttribute = Value
+
+  val NameAttribute = Value("name")
+  val IconAttribute = Value("icon")
+  val ComponentTypeAttribute = Value("componentType")
+  val ComponentGroupNameAttribute = Value("componentGroupName")
+}
+
+private case class ComponentConfigurationException(message: String, wrongConfigurations: NonEmptyList[ComponentWrongConfiguration[_]])
+  extends RuntimeException(s"$message Wrong configurations: ${wrongConfigurations.groupBy(_.id.value)}.")

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/DefaultsComponentGroupName.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/DefaultsComponentGroupName.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.ui.component
 
 import pl.touk.nussknacker.engine.api.component.ComponentGroupName
 
-object DefaultsComponentGroupName {
+private[component] object DefaultsComponentGroupName {
   val BaseGroupName: ComponentGroupName = ComponentGroupName("base")
   val ServicesGroupName: ComponentGroupName = ComponentGroupName("services")
   val EnrichersGroupName: ComponentGroupName = ComponentGroupName("enrichers")

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/DefaultsComponentIcon.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/DefaultsComponentIcon.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.ui.component
 import pl.touk.nussknacker.engine.api.component.ComponentType
 import ComponentType.ComponentType
 
-object DefaultsComponentIcon {
+private[component] object DefaultsComponentIcon {
   val FilterIcon = "/assets/components/Filter.svg"
   val SplitIcon = "/assets/components/Split.svg"
   val SwitchIcon = "/assets/components/Switch.svg"

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactory.scala
@@ -16,6 +16,7 @@ import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.{ModelData, TypeSpecificInitialData}
 import pl.touk.nussknacker.restmodel.definition._
+import pl.touk.nussknacker.restmodel.process.ProcessingType
 import pl.touk.nussknacker.ui.component.ComponentDefinitionPreparer
 import pl.touk.nussknacker.ui.config.ComponentsGroupMappingConfigExtractor
 import pl.touk.nussknacker.ui.definition.additionalproperty.{AdditionalPropertyValidatorDeterminerChain, UiAdditionalPropertyEditorDeterminer}
@@ -35,7 +36,7 @@ object UIProcessObjectsFactory {
                               isSubprocess: Boolean,
                               processCategoryService: ProcessCategoryService,
                               additionalPropertiesConfig: Map[String, AdditionalPropertyConfig],
-                              processingType: String): UIProcessObjects = {
+                              processingType: ProcessingType): UIProcessObjects = {
     val processConfig = modelDataForType.processConfig
 
     val toStaticObjectDefinitionTransformer = new ToStaticObjectDefinitionTransformer(

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessObjectsFinder.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessObjectsFinder.scala
@@ -1,79 +1,14 @@
 package pl.touk.nussknacker.ui.process
 
-import io.circe.generic.JsonCodec
-import pl.touk.nussknacker.engine.api.component.ComponentId
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.ProcessDefinition
-import pl.touk.nussknacker.engine.graph
-import pl.touk.nussknacker.engine.graph.node._
-import pl.touk.nussknacker.restmodel.displayedgraph.DisplayableProcess
-import pl.touk.nussknacker.restmodel.processdetails.ProcessDetails
-import pl.touk.nussknacker.ui.component.ComponentIdProvider
 
 object ProcessObjectsFinder {
 
-  import pl.touk.nussknacker.engine.util.Implicits._
-
-  def computeComponentsUsageCount(componentIdProvider: ComponentIdProvider, processes: List[ProcessDetails]): Map[ComponentId, Long] =
-    extractProcesses(processes.map(_.json))
-      .allProcesses
-      .flatMap(process => process.nodes.flatMap(componentIdProvider.nodeToComponentId(process.processingType, _)))
-      .groupBy(identity)
-      .mapValuesNow(_.size)
-
-  def computeComponentsUsage(componentIdProvider: ComponentIdProvider, processes: List[ProcessDetails]): Map[ComponentId, List[(ProcessDetails, List[String])]] =
-    processes.flatMap(processDetails =>
-      processDetails.json.nodes.flatMap(node =>
-        componentIdProvider.nodeToComponentId(processDetails.processingType, node)
-          .map((_, node.id, processDetails))
-      ))
-      .groupBy(_._1)
-      .map{case(componentId, groupedByComponentId) =>
-        (
-          componentId,
-          groupedByComponentId
-            .groupBy(_._3)
-            .toList
-            .map{
-              case (process, groupedByProcess) => (process, groupedByProcess.map(_._2).sorted)
-            }
-            .sortBy(_._1.name)
-        )
-      }
+  import pl.touk.nussknacker.engine.util.Implicits.RichStringList
 
   def componentIds(processDefinitions: List[ProcessDefinition[_]], subprocessIds: List[String]): List[String] = {
     val ids = processDefinitions.flatMap(_.componentIds)
     (ids ++ subprocessIds).distinct.sortCaseInsensitive
   }
 
-  //TODO it will work for single depth subprocesses only - i.e it won't find for transformer inside subprocess that is inside subprocess
-  private def findProcessesWithTransformers(processList: List[ProcessDetails], transformers: Set[String]): List[String] = {
-    val extracted = extractProcesses(processList.map(_.json))
-    val processesWithTransformers = extracted.processesOnly.filter(processContainsData(nodeIsSignalTransformer(transformers)))
-    val subprocessesWithTransformers = extracted.subprocessesOnly.filter(processContainsData(nodeIsSignalTransformer(transformers))).map(_.id)
-    val processesThatContainsSubprocessWithTransformer = extracted.allProcesses.filter { proc =>
-      processContainsData(node => graph.node.asSubprocessInput(node).exists(sub => subprocessesWithTransformers.contains(sub.componentId)))(proc)
-    }
-    (processesWithTransformers ++ processesThatContainsSubprocessWithTransformer).map(_.id).distinct.sortCaseInsensitive
-  }
-
-  private def nodeIsSignalTransformer(transformers: Set[String])(node: NodeData): Boolean = {
-    def isCustomNodeFromList = (c: CustomNode) => transformers.contains(c.nodeType)
-
-    graph.node.asCustomNode(node).exists(isCustomNodeFromList)
-  }
-
-  private def processContainsData(predicate: NodeData => Boolean)(process: DisplayableProcess): Boolean = {
-    process.nodes.exists(predicate)
-  }
-
-  private def extractProcesses(displayableProcesses: List[DisplayableProcess]): ExtractedProcesses = {
-    ExtractedProcesses(displayableProcesses)
-  }
-
-  private case class ExtractedProcesses(allProcesses: List[DisplayableProcess]) {
-    val processesOnly = allProcesses.filter(!_.properties.isSubprocess)
-    val subprocessesOnly = allProcesses.filter(_.properties.isSubprocess)
-  }
 }
-
-@JsonCodec case class ProcessComponent(processName: String, nodeId: String, processCategory: String, isDeployed: Boolean)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataProvider.scala
@@ -43,7 +43,7 @@ trait ProcessingTypeDataProvider[+T, +C] {
 
   }
 
-  def mapCombined[CC](fun: C => CC): ProcessingTypeDataProvider[T, CC] = {
+  def mapCombined[CC](fun: (=> C) => CC): ProcessingTypeDataProvider[T, CC] = {
 
     new ProcessingTypeDataProvider[T, CC] {
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataReader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataReader.scala
@@ -7,6 +7,7 @@ import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
 import pl.touk.nussknacker.engine.{CombinedProcessingTypeData, ConfigWithUnresolvedVersion, DeploymentManagerProvider, ProcessingTypeConfig, ProcessingTypeData}
 import pl.touk.nussknacker.restmodel.process.ProcessingType
+import pl.touk.nussknacker.ui.component.{ComponentsValidator, DefaultComponentService}
 import pl.touk.nussknacker.ui.process.{ProcessCategoryService, ProcessStateDefinitionService}
 import pl.touk.nussknacker.ui.process.deployment.DeploymentService
 import sttp.client3.SttpBackend

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataReader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataReader.scala
@@ -17,6 +17,7 @@ object ProcessingTypeDataReader extends ProcessingTypeDataReader
 
 trait ProcessingTypeDataReader extends LazyLogging {
 
+
   def loadProcessingTypeData(config: ConfigWithUnresolvedVersion)(implicit ec: ExecutionContext, actorSystem: ActorSystem,
                                                                   sttpBackend: SttpBackend[Future, Any],
                                                                   deploymentService: DeploymentService,
@@ -31,7 +32,7 @@ trait ProcessingTypeDataReader extends LazyLogging {
 
     // Here all processing types are loaded and we are ready to perform additional configuration validations
     // to assert the loaded configuration is correct (fail-fast approach).
-    val combinedData = CombinedProcessingTypeData.create(valueMap, categoryService)
+    val combinedData = createCombinedData(valueMap, categoryService)
 
     new MapBasedProcessingTypeDataProvider[ProcessingTypeData, CombinedProcessingTypeData](valueMap, combinedData)
   }
@@ -45,4 +46,9 @@ trait ProcessingTypeDataReader extends LazyLogging {
     implicit val processTypeDeploymentService: ProcessingTypeDeploymentService = new DefaultProcessingTypeDeploymentService(name, deploymentService)
     ProcessingTypeData.createProcessingTypeData(managerProvider, typeConfig)
   }
+
+  protected def createCombinedData(valueMap: Map[ProcessingType, ProcessingTypeData], categoryService: ProcessCategoryService): CombinedProcessingTypeData = {
+    CombinedProcessingTypeData.create(valueMap, categoryService)
+  }
+
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataReader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataReader.scala
@@ -5,11 +5,11 @@ import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.deployment.ProcessingTypeDeploymentService
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
-import pl.touk.nussknacker.engine._
+import pl.touk.nussknacker.engine.{CombinedProcessingTypeData, ConfigWithUnresolvedVersion, DeploymentManagerProvider, ProcessingTypeConfig, ProcessingTypeData}
 import pl.touk.nussknacker.restmodel.process.ProcessingType
 import pl.touk.nussknacker.ui.process.ProcessCategoryService
 import pl.touk.nussknacker.ui.process.deployment.DeploymentService
-import _root_.sttp.client3.SttpBackend
+import sttp.client3.SttpBackend
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/util/LocalNussknackerWithSingleModel.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/util/LocalNussknackerWithSingleModel.scala
@@ -31,7 +31,7 @@ object LocalNussknackerWithSingleModel  {
     val router = new NusskanckerDefaultAppRouter {
       override protected def prepareProcessingTypeData(config: ConfigWithUnresolvedVersion,
                                                        getDeploymentService: () => DeploymentService,
-                                                       categoriesService: ProcessCategoryService)
+                                                       categoryService: ProcessCategoryService)
                                                       (implicit ec: ExecutionContext, actorSystem: ActorSystem,
                                                        sttpBackend: SttpBackend[Future, Any]): (ProcessingTypeDataProvider[ProcessingTypeData, CombinedProcessingTypeData], ProcessingTypeDataReload with Initialization) = {
         //TODO: figure out how to perform e.g. hotswap
@@ -40,7 +40,7 @@ object LocalNussknackerWithSingleModel  {
           implicit val processTypeDeploymentService: ProcessingTypeDeploymentService = new DefaultProcessingTypeDeploymentService(typeName, deploymentService)
           val data = ProcessingTypeData.createProcessingTypeData(deploymentManagerProvider, modelData, managerConfig)
           val processingTypes = Map(typeName -> data)
-          val combinedData = CombinedProcessingTypeData.create(processingTypes)
+          val combinedData = CombinedProcessingTypeData.create(processingTypes, categoryService)
           new MapBasedProcessingTypeDataProvider(processingTypes, combinedData)
         })
       }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ComponentResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ComponentResourcesSpec.scala
@@ -13,14 +13,19 @@ import pl.touk.nussknacker.restmodel.component.{ComponentListElement, ComponentU
 import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.ui.api.helpers.{EspItTest, TestCategories, TestProcessingTypes}
 import pl.touk.nussknacker.ui.component.{ComponentIdProvider, DefaultComponentIdProvider, DefaultComponentService}
+import pl.touk.nussknacker.ui.config.ComponentLinksConfigExtractor
 
 class ComponentResourcesSpec extends AnyFunSpec with ScalatestRouteTest with FailFastCirceSupport
   with Matchers with PatientScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with EspItTest {
 
   //These should be defined as lazy val's because of racing, there are some missing tables in db..
-  private lazy val componentService = DefaultComponentService(testConfig, testProcessingTypeDataProvider, processService, processCategoryService)
-  private lazy val componentRoute = new ComponentResource(componentService)
   private val defaultComponentIdProvider: ComponentIdProvider = new DefaultComponentIdProvider(Map.empty)
+  private lazy val componentService = DefaultComponentService(
+    ComponentLinksConfigExtractor.extract(config),
+    testProcessingTypeDataProvider.mapCombined(_ => defaultComponentIdProvider),
+    processService,
+    processCategoryService)
+  private lazy val componentRoute = new ComponentResource(componentService)
 
   //Here we test only response, logic is tested in DefaultComponentServiceSpec
   it("should return users(test, admin) components list") {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/ComponentsUsageHelperTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/ComponentsUsageHelperTest.scala
@@ -1,4 +1,4 @@
-package pl.touk.nussknacker.ui.process
+package pl.touk.nussknacker.ui.component
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -18,12 +18,11 @@ import pl.touk.nussknacker.ui.api.helpers.ProcessTestData._
 import pl.touk.nussknacker.ui.api.helpers.TestProcessUtil._
 import pl.touk.nussknacker.ui.api.helpers.TestProcessingTypes._
 import pl.touk.nussknacker.ui.api.helpers.{TestCategories, TestProcessUtil, TestProcessingTypes}
-import pl.touk.nussknacker.ui.component.DefaultComponentIdProvider
 import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
 
 import java.time.Instant
 
-class ProcessObjectsFinderTest extends AnyFunSuite with Matchers with TableDrivenPropertyChecks {
+class ComponentsUsageHelperTest extends AnyFunSuite with Matchers with TableDrivenPropertyChecks {
 
   import pl.touk.nussknacker.engine.spel.Implicits._
 
@@ -50,19 +49,6 @@ class ProcessObjectsFinderTest extends AnyFunSuite with Matchers with TableDrive
       .streaming("fooProcess2")
       .source("source", existingSourceFactory)
       .customNode("custom", "out1", otherExistingStreamTransformer)
-      .emptySink("sink", existingSinkFactory)))
-
-  private val process3 = displayableToProcess(TestProcessUtil.toDisplayable(
-    ScenarioBuilder
-      .streaming("fooProcess3")
-      .source("source", existingSourceFactory)
-      .emptySink("sink", existingSinkFactory)))
-
-  private val process4 = displayableToProcess(TestProcessUtil.toDisplayable(
-    ScenarioBuilder
-      .streaming("fooProcess4")
-      .source("source", existingSourceFactory)
-      .subprocessOneOut("sub", "subProcess1", "output", "fragmentResult", "ala" -> "'makota'")
       .emptySink("sink", existingSinkFactory)))
 
   private val processWithSomeBasesStreaming = displayableToProcess(TestProcessUtil.toDisplayable(
@@ -140,7 +126,7 @@ class ProcessObjectsFinderTest extends AnyFunSuite with Matchers with TableDrive
     )
 
     forAll(table) { (processes, expectedData) =>
-      val result = ProcessObjectsFinder.computeComponentsUsageCount(defaultComponentIdProvider, processes)
+      val result = ComponentsUsageHelper.computeComponentsUsageCount(defaultComponentIdProvider, processes)
       result shouldBe expectedData
     }
   }
@@ -182,7 +168,7 @@ class ProcessObjectsFinderTest extends AnyFunSuite with Matchers with TableDrive
     )
 
     forAll(table) { (process, expected) =>
-      val result = ProcessObjectsFinder.computeComponentsUsage(defaultComponentIdProvider, process)
+      val result = ComponentsUsageHelper.computeComponentsUsage(defaultComponentIdProvider, process)
       result shouldBe expected
     }
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/DefaultComponentIdProviderSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/DefaultComponentIdProviderSpec.scala
@@ -60,9 +60,10 @@ class DefaultComponentIdProviderSpec extends AnyFlatSpec with Matchers with Pati
     ))
 
     badComponentsType.foreach(componentType => {
+      val name = componentType.toString
       intercept[IllegalArgumentException]{
-        provider.createComponentId(processingType, componentType.toString, componentType)
-      }.getMessage shouldBe s"ComponentId can't be overridden for component type: '$componentType'."
+        provider.createComponentId(processingType, name, componentType)
+      }.getMessage shouldBe s"Component id can't be overridden for: '$name' with component type: '$componentType'."
     })
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/DefaultComponentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/DefaultComponentServiceSpec.scala
@@ -448,7 +448,7 @@ class DefaultComponentServiceSpec extends AnyFlatSpec with Matchers with Patient
     }
     val componentObjectsService = new ComponentObjectsService(categoryService)
     val componentObjectsMap = badProcessingTypeDataMap.transform(componentObjectsService.prepareWithoutFragments)
-    val componentIdProvider = new DefaultComponentIdProvider(componentObjectsMap.view.mapValues(_.config).toMap)
+    val componentIdProvider = new DefaultComponentIdProvider(componentObjectsMap.transform { case (_, componentsObjects) => componentsObjects.config })
 
     val expectedWrongConfigurations = List(
       ComponentWrongConfiguration(sharedSourceComponentId, NameAttribute, List(SharedSourceName, SharedSourceV2Name)),

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/DefaultComponentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/DefaultComponentServiceSpec.scala
@@ -362,14 +362,14 @@ class DefaultComponentServiceSpec extends AnyFlatSpec with Matchers with Patient
   private val processingTypeDataMap: Map[Category, ProcessingTypeData] = Map(
     Streaming -> LocalModelData(streamingConfig, ComponentMarketingTestConfigCreator),
     Fraud -> LocalModelData(fraudConfig, ComponentFraudTestConfigCreator),
-  ).view.mapValues { modelData =>
+  ).transform { case (_, modelData) =>
     ProcessingTypeData(new MockDeploymentManager,
       modelData,
       MockManagerProvider.typeSpecificInitialData(ConfigFactory.empty()),
       Map.empty,
       Nil,
       ProcessingTypeUsageStatistics(None, None))
-  }.toMap
+  }
   private val processingTypeDataProvider = new MapBasedProcessingTypeDataProvider(processingTypeDataMap, DefaultComponentIdProvider.createUnsafe(processingTypeDataMap, categoryService))
 
   it should "return components for each user" in {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataReaderSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtypedata/ProcessingTypeDataReaderSpec.scala
@@ -4,9 +4,10 @@ import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.{ConfigWithUnresolvedVersion, ProcessingTypeConfig, ProcessingTypeData}
+import pl.touk.nussknacker.engine.{CombinedProcessingTypeData, ConfigWithUnresolvedVersion, ProcessingTypeConfig, ProcessingTypeData}
 import pl.touk.nussknacker.restmodel.process.ProcessingType
 import pl.touk.nussknacker.ui.api.helpers.MockDeploymentManager
+import pl.touk.nussknacker.ui.component.DefaultComponentIdProvider
 import pl.touk.nussknacker.ui.process.deployment.DeploymentService
 import pl.touk.nussknacker.ui.process.{ConfigProcessCategoryService, ProcessCategoryService}
 import pl.touk.nussknacker.ui.statistics.ProcessingTypeUsageStatistics
@@ -58,6 +59,13 @@ class ProcessingTypeDataReaderSpec extends AnyFunSuite with Matchers {
                                                     sttpBackend: SttpBackend[Future, Any],
                                                     deploymentService: DeploymentService): ProcessingTypeData = {
       ProcessingTypeData(new MockDeploymentManager, null, null, Map.empty, Nil, ProcessingTypeUsageStatistics(None, None))
+    }
+
+    override protected def createCombinedData(valueMap: Map[ProcessingType, ProcessingTypeData], categoryService: ProcessCategoryService): CombinedProcessingTypeData = {
+      CombinedProcessingTypeData(
+        statusNameToStateDefinitionsMapping = Map.empty,
+        componentIdProvider = new DefaultComponentIdProvider(Map.empty),
+      )
     }
   }
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,7 +5,7 @@
 1.10.0 (not released yet)
 -------------------------
 * [#4204](https://github.com/TouK/nussknacker/pull/4204) ProcessingTypeDataProvider has combined data being a result of all processing types
-* [#4215](https://github.com/TouK/nussknacker/pull/4215) Components are aware of processing data reload
+* [#4219](https://github.com/TouK/nussknacker/pull/4219) Components are aware of processing data reload
 
 1.9.0 (not released yet)
 ------------------------

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,6 +5,7 @@
 1.10.0 (not released yet)
 -------------------------
 * [#4204](https://github.com/TouK/nussknacker/pull/4204) ProcessingTypeDataProvider has combined data being a result of all processing types
+* [#4215](https://github.com/TouK/nussknacker/pull/4215) Components are aware of processing data reload
 
 1.9.0 (not released yet)
 ------------------------


### PR DESCRIPTION
* `ComponentIdProvider` is not longer created eagerly during Nussknacker start up since it depends on components which can be reloaded. Component id provider is created once during processing data creation as a combined data of all processing types.
* Extracted `ComponentsValidator` which validates components configuration during processing data creation.
* Internal `ComponentObjectsService` extracted to hide complexity of `UIProcessObjects`.
* Extracted `ComponentsUsageHelper` from `ProcessObjectsFinder`.