### PR TITLE
Ignore error message and description when comparing errors lists in model migration tests

### DIFF
--- a/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/BaseOpenAPITest.scala
+++ b/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/BaseOpenAPITest.scala
@@ -12,6 +12,7 @@ import pl.touk.nussknacker.openapi.parser.{ServiceParseError, SwaggerParser}
 import sttp.client3.testing.SttpBackendStub
 
 import java.net.URL
+import java.nio.charset.StandardCharsets
 import scala.concurrent.{ExecutionContext, Future}
 
 trait BaseOpenAPITest {
@@ -35,7 +36,7 @@ trait BaseOpenAPITest {
   }
 
   protected def parseResource(name: String): String =
-    IOUtils.toString(getClass.getResourceAsStream(s"/swagger/$name"), "UTF-8")
+    IOUtils.toString(getClass.getResourceAsStream(s"/swagger/$name"), StandardCharsets.UTF_8)
 
   protected def parseToEnrichers(resource: String, backend: SttpBackendStub[Future, Any], config: OpenAPIServicesConfig = baseConfig): Map[ServiceName, EagerServiceWithStaticParametersAndReturnType] = {
     val services = parseServicesFromResourceUnsafe(resource, config)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -166,7 +166,7 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
       HttpMethods.GET,
       "processesDetails" :: Nil,
       Query(
-        ("names", names.map(ns => URLEncoder.encode(ns.value, StandardCharsets.UTF_8.displayName())).mkString(",")),
+        ("names", names.map(ns => URLEncoder.encode(ns.value, StandardCharsets.UTF_8)).mkString(",")),
         ("isArchived", "false"),
       )
     )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -130,7 +130,7 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
     (for {
       allBasicProcesses <- EitherT(fetchProcesses)
       basicProcesses = allBasicProcesses.filterNot(_.isSubprocess).filter(processToInclude)
-      basicSubProcesses = allBasicProcesses.filter(_.isSubprocess)
+      basicSubProcesses = allBasicProcesses.filter(_.isSubprocess).filter(processToInclude)
       processes <- fetchGroupByGroup(basicProcesses)
       subProcesses <- fetchGroupByGroup(basicSubProcesses)
     } yield testModelMigrations.testMigrations(processes, subProcesses)).value

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
@@ -35,6 +35,7 @@ import pl.touk.nussknacker.ui.util.{ConfigWithScalaVersion, CorsSupport, Multipa
 import pl.touk.nussknacker.ui.{NusskanckerDefaultAppRouter, NussknackerAppInitializer}
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 import scala.concurrent.duration._
 import scala.util.Properties
@@ -297,7 +298,7 @@ class BaseFlowTest extends AnyFunSuite with ScalatestRouteTest with FailFastCirc
 
     //we generate random parameter
     val parameterUUID = UUID.randomUUID().toString
-    FileUtils.writeStringToFile(dynamicServiceFile, parameterUUID, "UTF-8")
+    FileUtils.writeStringToFile(dynamicServiceFile, parameterUUID, StandardCharsets.UTF_8)
 
     dynamicServiceParametersBeforeReload.exists(_.contains(parameterUUID)) shouldBe false
     dynamicServiceParameters shouldBe dynamicServiceParametersBeforeReload

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,7 @@
 -------------------------
 * [#4204](https://github.com/TouK/nussknacker/pull/4204) ProcessingTypeDataProvider has combined data being a result of all processing types
 * [#4219](https://github.com/TouK/nussknacker/pull/4219) Components are aware of processing data reload
+* [#4256](https://github.com/TouK/nussknacker/pull/4256) Ignore error message and description when comparing errors lists in model migration tests
 
 1.9.0 (not released yet)
 ------------------------

--- a/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/deployment/ProcessRepository.scala
+++ b/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/deployment/ProcessRepository.scala
@@ -45,7 +45,7 @@ class FileProcessRepository(path: File) extends ProcessRepository {
 
   override def add(id: ProcessName, deploymentData: RequestResponseDeploymentData): Unit = {
     val outFile = new File(path, id.value)
-    Using.resource(new PrintWriter(outFile, StandardCharsets.UTF_8.name())) { writer =>
+    Using.resource(new PrintWriter(outFile, StandardCharsets.UTF_8)) { writer =>
       writer.write(deploymentData.asJson.spaces2)
     }
   }

--- a/security/src/test/scala/pl/touk/nussknacker/ui/security/api/SecurityApiSpec.scala
+++ b/security/src/test/scala/pl/touk/nussknacker/ui/security/api/SecurityApiSpec.scala
@@ -24,7 +24,7 @@ class SecurityApiSpec extends org.scalatest.flatspec.AnyFlatSpec with Matchers w
     Get("/secured") ~> route(basic) ~> check {
       status shouldEqual StatusCodes.Unauthorized
       responseAs[String] shouldEqual "The resource requires authentication, which was not supplied with the request"
-      header[`WWW-Authenticate`].get.challenges.head shouldEqual HttpChallenge("Basic", "nussknacker", Map("charset" -> StandardCharsets.UTF_8.toString))
+      header[`WWW-Authenticate`].get.challenges.head shouldEqual HttpChallenge("Basic", "nussknacker", Map("charset" -> StandardCharsets.UTF_8.name))
     }
   }
   it should "support basic auth" in {

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/formatter/AvroMessageFormatter.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/formatter/AvroMessageFormatter.scala
@@ -17,7 +17,7 @@ private[schemaregistry] object AvroMessageFormatter extends DatumReaderWriterMix
   def asJson(obj: Any): Json = {
     val schema = AvroUtils.getSchema(obj)
     val bos = new ByteArrayOutputStream()
-    val output = new PrintStream(bos, true, StandardCharsets.UTF_8.toString)
+    val output = new PrintStream(bos, true, StandardCharsets.UTF_8)
 
     try {
       //pretty = false is important, as we rely on the fact that there are no new lines in message parsing

--- a/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/UriUtils.scala
+++ b/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/UriUtils.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.util
 
 import java.net.{URLDecoder, URLEncoder}
+import java.nio.charset.StandardCharsets
 
 /**
   * Utility class for JavaScript compatible UTF-8 encoding and decoding.
@@ -9,15 +10,13 @@ import java.net.{URLDecoder, URLEncoder}
   */
 object UriUtils {
 
-  private final val Charset = "UTF-8"
-
   /**
     * Decodes the passed UTF-8 String using an algorithm that's compatible with
     * JavaScript's <code>decodeURIComponent</code> function. Returns
     * <code>null</code> if the String is <code>null</code>.
     */
   def decodeURIComponent(value: String): String =
-    URLDecoder.decode(value, Charset)
+    URLDecoder.decode(value, StandardCharsets.UTF_8)
 
   /**
     * Encodes the passed String as UTF-8 using an algorithm that's compatible
@@ -25,7 +24,7 @@ object UriUtils {
     * <code>null</code> if the String is <code>null</code>.
     */
   def encodeURIComponent(value: String): String =
-    URLEncoder.encode(value, Charset)
+    URLEncoder.encode(value, StandardCharsets.UTF_8)
       .replaceAll("\\+", "%20")
       .replaceAll("\\!", "%21")
       .replaceAll("\\'", "%27")


### PR DESCRIPTION
Sometimes error messages and descriptions may differ, and then they are reported as new ones in migration tests, even though they are not "new" (caused by migration):
* when description or message in Nu changes
* when locale between local and remote environment differs
* when error message or description depends on runtime environment's settings