### PR TITLE
Removing -target jvm opts from scala 2.13 build because is depreated …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -199,8 +199,7 @@ lazy val commonSettings =
           "-target:jvm-1.8",
         ),
         (2, 13) -> Seq(
-          "-Ymacro-annotations",
-          "-target:jvm-11",
+          "-Ymacro-annotations"
         )
       ),
       javacOptions := Seq(


### PR DESCRIPTION
…in java17 (we use -release instead)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
