### PR TITLE
Description added

### DIFF
--- a/docs/installation_configuration_guide/model/Flink.md
+++ b/docs/installation_configuration_guide/model/Flink.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: "Flink"
+description: Flink specific model configuration
 ---
 
 # Flink specific model configuration


### PR DESCRIPTION
Added short page summary in the 'description' parameter, which should be visible on the card in the list auto-generated on category page ('Model' page in this case).