### PR TITLE
Replace regex matching in expression compilation with string matching

### DIFF
--- a/benchmarks/Readme.md
+++ b/benchmarks/Readme.md
@@ -16,4 +16,7 @@ https://github.com/sbt/sbt-jmh
 
 Running in sbt:
 ---------------
+```
 benchmarks/Jmh/run -i 8 -wi 3 -f1 -t2 .*SampleSpelBenchmark.*
+benchmarks/Jmh/run -i 8 -wi 3 -f1 -t2 -prof jfr:stackDepth=512 .*SampleSpelBenchmark.*
+```

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -13,6 +13,7 @@
 * [#4264](https://github.com/TouK/nussknacker/pull/4264) Add Unknown type as valid fragment input
 * [#4278](https://github.com/TouK/nussknacker/pull/4278) Expression compilation speedup: reusage of type definitions extracted for code suggestions purpose + 
   added completions for some missing types like `TimestampType` (`#inputMeta.timestampType`) 
+* [#4290](https://github.com/TouK/nussknacker/pull/4290) Expression compilation speedup: replace most regular expression matching with plain string matching
 
 1.9.1 (24 Apr 2023)
 ------------------------

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -10,6 +10,9 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   types extracted based on model. Before the change types in compiler were lazily extracted. Because of this change, some expressions
   can stop to compile. You may need to add `WithExplicitTypesToExtract` to some of yours `SourceFactory` implementations.
   See extending classes for examples on how to implement it.
+* [#4290](https://github.com/TouK/nussknacker/pull/4290) Renamed predicates used in `ClassExtractionSettings`:
+  * `ClassMemberPatternPredicate` renamed to `MemberNamePatternPredicate`
+  * `AllMethodNamesPredicate` renamed to AllMembersPredicate
 
 ## In version 1.9.0
 

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassMemberPredicate.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassMemberPredicate.scala
@@ -38,29 +38,42 @@ case class ReturnMemberPredicate(returnClassPredicate: ClassPredicate, classPred
 }
 
 /**
-  * Simple implementation of ClassMemberPredicate based on class member's name pattern
+  * Simple implementation of ClassMemberPredicate based on class member's name
   * @param classPredicate - class predicate
-  * @param classMemberPattern - class member's name pattern
+  * @param memberNames - class member names
   */
-case class ClassMemberPatternPredicate(classPredicate: ClassPredicate, classMemberPattern: Pattern) extends ClassMemberPredicate {
+case class MemberNamePredicate(classPredicate: ClassPredicate, memberNames: Set[String]) extends ClassMemberPredicate {
 
   override def matchesClass(clazz: Class[_]): Boolean = classPredicate.matches(clazz)
 
-  override def matchesMember(member: Member): Boolean = classMemberPattern.matcher(member.getName).matches()
+  override def matchesMember(member: Member): Boolean = memberNames.contains(member.getName)
+
+}
+
+/**
+  * Simple implementation of ClassMemberPredicate based on class member's name pattern
+  * @param classPredicate - class predicate
+  * @param memberNamePattern - class member's name pattern
+  */
+case class MemberNamePatternPredicate(classPredicate: ClassPredicate, memberNamePattern: Pattern) extends ClassMemberPredicate {
+
+  override def matchesClass(clazz: Class[_]): Boolean = classPredicate.matches(clazz)
+
+  override def matchesMember(member: Member): Boolean = memberNamePattern.matcher(member.getName).matches()
 
 }
 
 /**
  * Implementation of ClassMemberPredicate matching all methods that has the same name as methods in given class
  * @param clazz - class which method names will match predicate
- * @param exceptMethodNames - method names that will be excluded from matching
+ * @param exceptNames - method names that will be excluded from matching
  */
-case class AllMethodNamesPredicate(clazz: Class[_], exceptMethodNames: Set[String] = Set.empty) extends ClassMemberPredicate {
+case class AllMembersPredicate(clazz: Class[_], exceptNames: Set[String] = Set.empty) extends ClassMemberPredicate {
 
-  private val matchingMethodNames = clazz.getMethods.map(_.getName).toSet -- exceptMethodNames
+  private val matchingMethodNames = clazz.getMethods.map(_.getName).toSet -- exceptNames
 
   override def matchesClass(clazz: Class[_]): Boolean = true
 
-  override def matchesMember(member: Member): Boolean =matchingMethodNames.contains(member.getName)
+  override def matchesMember(member: Member): Boolean = matchingMethodNames.contains(member.getName)
 
 }

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/types/EspTypeUtilsSpec.scala
@@ -116,9 +116,9 @@ class EspTypeUtilsSpec extends AnyFunSuite with Matchers with OptionValues {
       forAll(testClassPatterns) { classPattern =>
         val infos = clazzAndItsChildrenDefinition(List(clazz))(ClassExtractionSettings.Default.copy(excludeClassMemberPredicates =
           ClassExtractionSettings.DefaultExcludedMembers ++ Seq(
-          ClassMemberPatternPredicate(SuperClassPredicate(ClassPatternPredicate(Pattern.compile(classPattern))), Pattern.compile("ba.*")),
-          ClassMemberPatternPredicate(SuperClassPredicate(ClassPatternPredicate(Pattern.compile(classPattern))), Pattern.compile("get.*")),
-          ClassMemberPatternPredicate(SuperClassPredicate(ClassPatternPredicate(Pattern.compile(classPattern))), Pattern.compile("is.*")),
+          MemberNamePatternPredicate(SuperClassPredicate(ClassPatternPredicate(Pattern.compile(classPattern))), Pattern.compile("ba.*")),
+          MemberNamePatternPredicate(SuperClassPredicate(ClassPatternPredicate(Pattern.compile(classPattern))), Pattern.compile("get.*")),
+          MemberNamePatternPredicate(SuperClassPredicate(ClassPatternPredicate(Pattern.compile(classPattern))), Pattern.compile("is.*")),
           ReturnMemberPredicate(ExactClassPredicate[Context], BasePackagePredicate("pl.touk.nussknacker.engine.types"))
         )))
         val sampleClassInfo = infos.find(_.getClazz.getName.contains(clazzName)).get


### PR DESCRIPTION
Regex matching accounts for 5-6% of time spent when validating scenario migrations. Recent changes from #4278 should help a lot here, but this was easy to change and made code a bit easier to read, so I went ahead and refactored these predicates.

Benchmark:
```scala
  @Benchmark
  @BenchmarkMode(Array(Mode.AverageTime))
  @OutputTimeUnit(TimeUnit.MICROSECONDS)
  def benchmarkScala(): AnyRef = {
    EspTypeUtils.clazzDefinition(classOf[util.ArrayList[_]])(ClassExtractionSettings.Default)
    EspTypeUtils.clazzDefinition(classOf[util.Set[_]])(ClassExtractionSettings.Default)
    EspTypeUtils.clazzDefinition(functions.conversion.getClass)(ClassExtractionSettings.Default)
    EspTypeUtils.clazzDefinition(functions.numeric.getClass)(ClassExtractionSettings.Default)
    EspTypeUtils.clazzDefinition(functions.date.getClass)(ClassExtractionSettings.Default)
    EspTypeUtils.clazzDefinition(functions.dateFormat.getClass)(ClassExtractionSettings.Default)
  }
```

Before:
```
[info] Benchmark                       Mode  Cnt     Score    Error   Units
[info] SpelSetupSpeed.benchmarkScala   avgt    8  1410,738 ± 58,575   us/op
```

After:
```
[info] Benchmark                      Mode  Cnt     Score    Error  Units
[info] SpelSetupSpeed.benchmarkScala  avgt    8  1128,063 ± 41,772  us/op
```
