### PR TITLE
Refactor: MethodDefinition moved from StandardObjectWithMethodDef into ComponentImplementationInvoker

### DIFF
--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
@@ -7,12 +7,11 @@ import pl.touk.nussknacker.engine.api.context.transformation._
 import pl.touk.nussknacker.engine.api.definition.{OutputVariableNameDependency, Parameter, TypedNodeDependency, WithExplicitTypesToExtract}
 import pl.touk.nussknacker.engine.api.process.{ClassExtractionSettings, WithCategories}
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
-import pl.touk.nussknacker.engine.api.util.ReflectUtils
 import pl.touk.nussknacker.engine.definition.DefinitionExtractor._
 import pl.touk.nussknacker.engine.definition.MethodDefinitionExtractor.MethodDefinition
 import pl.touk.nussknacker.engine.types.TypesInformationExtractor
 
-import java.lang.reflect.{InvocationTargetException, Method}
+import java.lang.reflect.Method
 import scala.runtime.BoxedUnit
 
 class DefinitionExtractor[T](methodDefinitionExtractor: MethodDefinitionExtractor[T]) {
@@ -24,11 +23,12 @@ class DefinitionExtractor[T](methodDefinitionExtractor: MethodDefinitionExtracto
       // TODO: Use ContextTransformation API to check if custom node is adding some output variable
       def notReturnAnything(typ: TypingResult) = Set[TypingResult](Typed[Void], Typed[Unit], Typed[BoxedUnit]).contains(typ)
       val objectDefinition = ObjectDefinition(
-        methodDef.orderedDependencies.definedParameters,
+        methodDef.definedParameters,
         Option(methodDef.returnType).filterNot(notReturnAnything),
         objWithCategories.categories,
         mergedComponentConfig)
-      StandardObjectWithMethodDef(obj, methodDef, objectDefinition)
+      val implementationInvoker = new MethodBasedComponentImplementationInvoker(obj, methodDef)
+      StandardObjectWithMethodDef(implementationInvoker, obj, objectDefinition, methodDef.runtimeClass)
     }
 
     (obj match {
@@ -81,13 +81,24 @@ object DefinitionExtractor {
 
   }
 
-  trait ComponentImplementationInvoker {
+  trait ComponentImplementationInvoker extends Serializable {
 
     def invokeMethod(params: Map[String, Any],
                      outputVariableNameOpt: Option[String],
                      additional: Seq[AnyRef]): Any
 
   }
+
+  object ComponentImplementationInvoker {
+
+    val nullImplementationInvoker: ComponentImplementationInvoker = new ComponentImplementationInvoker {
+      override def invokeMethod(params: Map[String, Any],
+                                outputVariableNameOpt: Option[String],
+                                additional: Seq[AnyRef]): Any = null
+    }
+
+  }
+
 
   case class GenericNodeTransformationMethodDef(override val implementationInvoker: ComponentImplementationInvoker,
                                                 obj: GenericNodeTransformation[_],
@@ -129,15 +140,14 @@ object DefinitionExtractor {
 
   case class FinalStateValue(value: Option[Any])
 
-  // TOOD: rename to StaticComponentWithImplementation
+  // TOOD: rename to MethodBasedComponentWithImplementation
   case class StandardObjectWithMethodDef(implementationInvoker: ComponentImplementationInvoker,
                                          obj: Any,
-                                         methodDef: MethodDefinition,
-                                         objectDefinition: ObjectDefinition) extends ObjectWithMethodDef {
+                                         objectDefinition: ObjectDefinition,
+                                         // TODO: it should be removed - instead implementationInvoker should be transformed
+                                         runtimeClass: Class[_]) extends ObjectWithMethodDef {
     override def withImplementationInvoker(implementationInvoker: ComponentImplementationInvoker): ObjectWithMethodDef =
       copy(implementationInvoker = implementationInvoker)
-
-    def runtimeClass: Class[_] = methodDef.runtimeClass
 
     def parameters: List[Parameter] = objectDefinition.parameters
 
@@ -149,35 +159,12 @@ object DefinitionExtractor {
 
   }
 
-  object StandardObjectWithMethodDef extends LazyLogging {
+  private[definition] class MethodBasedComponentImplementationInvoker(obj: Any, private[definition] val methodDef: MethodDefinition)
+    extends ComponentImplementationInvoker with LazyLogging {
 
-    def apply(obj: Any,
-              methodDef: MethodDefinition,
-              objectDefinition: ObjectDefinition): StandardObjectWithMethodDef = {
-      val implementationInvoker = new ComponentImplementationInvoker {
-        override def invokeMethod(params: Map[String, Any], outputVariableNameOpt: Option[String], additional: Seq[AnyRef]): Any = {
-          val values = methodDef.orderedDependencies.prepareValues(params, outputVariableNameOpt, additional)
-          try {
-            methodDef.invocation(obj, values)
-          } catch {
-            case ex: IllegalArgumentException =>
-              //this usually indicates that parameters do not match or argument list is incorrect
-              logger.debug(s"Failed to invoke method: ${methodDef.name}, with params: $values", ex)
-
-              def className(obj: Any) = Option(obj).map(o => ReflectUtils.simpleNameWithoutSuffix(o.getClass)).getOrElse("null")
-
-              val parameterValues = methodDef.orderedDependencies.definedParameters.map(_.name).map(params)
-              throw new IllegalArgumentException(
-                s"""Failed to invoke "${methodDef.name}" on ${className(obj)} with parameter types: ${parameterValues.map(className)}: ${ex.getMessage}""", ex)
-            //this is somehow an edge case - normally service returns failed future for exceptions
-            case ex: InvocationTargetException =>
-              throw ex.getTargetException
-          }
-        }
-      }
-      new StandardObjectWithMethodDef(implementationInvoker, obj, methodDef, objectDefinition)
+    override def invokeMethod(params: Map[String, Any], outputVariableNameOpt: Option[String], additional: Seq[AnyRef]): Any = {
+      methodDef.invoke(obj, params, outputVariableNameOpt, additional)
     }
-
   }
 
   // TODO: rename to ComponentStaticDefinition

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
@@ -63,6 +63,7 @@ object DefinitionExtractor {
   // TODO: rename to ComponentDefinitionWithImplementation
   sealed trait ObjectWithMethodDef {
 
+    // TODO: It should be exposed only for components - not for global variables
     def implementationInvoker: ComponentImplementationInvoker
 
     // For purpose of transforming (e.g.) stubbing of the implementation

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/GlobalVariableDefinitionExtractor.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/GlobalVariableDefinitionExtractor.scala
@@ -25,6 +25,8 @@ object GlobalVariableDefinitionExtractor {
       componentConfig = varWithCategories.componentConfig
     )
     StandardObjectWithMethodDef(
+      // Global variables are always accessed by StandardObjectWithMethodDef.obj - see GlobalVariablesPreparer
+      // and comment in ObjectWithMethodDef.implementationInvoker
       ComponentImplementationInvoker.nullImplementationInvoker,
       varWithCategories.value,
       objectDef,

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/testing/ProcessDefinitionBuilder.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/testing/ProcessDefinitionBuilder.scala
@@ -5,8 +5,7 @@ import pl.touk.nussknacker.engine.api.component.SingleComponentConfig
 import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.process.{ClassExtractionSettings, LanguageConfiguration}
 import pl.touk.nussknacker.engine.api.typed.typing.{TypingResult, Unknown}
-import pl.touk.nussknacker.engine.definition.DefinitionExtractor.{ObjectDefinition, ObjectWithMethodDef, StandardObjectWithMethodDef}
-import pl.touk.nussknacker.engine.definition.MethodDefinitionExtractor.{MethodDefinition, OrderedDependencies}
+import pl.touk.nussknacker.engine.definition.DefinitionExtractor.{ComponentImplementationInvoker, ObjectDefinition, ObjectWithMethodDef, StandardObjectWithMethodDef}
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.{CustomTransformerAdditionalData, ExpressionDefinition, ProcessDefinition}
 import pl.touk.nussknacker.engine.util.Implicits._
 
@@ -53,8 +52,7 @@ object ProcessDefinitionBuilder {
       expressionConfig.customConversionsProviders)
 
   private def makeDummyDefinition(objectDefinition: ObjectDefinition, realType: Class[_] = classOf[Any]): ObjectWithMethodDef =
-    StandardObjectWithMethodDef(null, MethodDefinition("", (_, _) => null, new OrderedDependencies(objectDefinition.parameters),
-      Unknown, realType, List()), objectDefinition)
+    StandardObjectWithMethodDef(ComponentImplementationInvoker.nullImplementationInvoker,  null, objectDefinition, realType)
 
   implicit class ObjectProcessDefinition(definition: ProcessDefinition[ObjectDefinition]) {
     def withService(id: String, returnType: Option[TypingResult], params: Parameter*): ProcessDefinition[ObjectDefinition] =

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractorSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/definition/ProcessDefinitionExtractorSpec.scala
@@ -13,7 +13,7 @@ import pl.touk.nussknacker.engine.api.test.InvocationCollectors
 import pl.touk.nussknacker.engine.api.typed.TypedGlobalVariable
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 import pl.touk.nussknacker.engine.api._
-import pl.touk.nussknacker.engine.definition.DefinitionExtractor.{GenericNodeTransformationMethodDef, StandardObjectWithMethodDef}
+import pl.touk.nussknacker.engine.definition.DefinitionExtractor.{GenericNodeTransformationMethodDef, MethodBasedComponentImplementationInvoker, StandardObjectWithMethodDef}
 import pl.touk.nussknacker.engine.definition.ProcessDefinitionExtractor.ModelDefinitionWithTypes
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.util.namespaces.ObjectNamingProvider
@@ -32,8 +32,11 @@ class ProcessDefinitionExtractorSpec extends AnyFunSuite with Matchers with Opti
   private val definitionWithTypes = ModelDefinitionWithTypes(processDefinition)
 
   test("extract additional variables info from annotation") {
-    val methodDef = processDefinition.customStreamTransformers("transformer1")._1.asInstanceOf[StandardObjectWithMethodDef].methodDef
-    val additionalVars = methodDef.orderedDependencies.definedParameters.head.additionalVariables
+    val methodDef = processDefinition.customStreamTransformers("transformer1")._1
+      .asInstanceOf[StandardObjectWithMethodDef]
+      .implementationInvoker.asInstanceOf[MethodBasedComponentImplementationInvoker]
+      .methodDef
+    val additionalVars = methodDef.definedParameters.head.additionalVariables
     additionalVars("var1") shouldBe AdditionalVariableProvidedInRuntime[OnlyUsedInAdditionalVariable]
   }
 

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/variables/GlobalVariablesPreparerTest.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/variables/GlobalVariablesPreparerTest.scala
@@ -2,19 +2,18 @@ package pl.touk.nussknacker.engine.variables
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
+import pl.touk.nussknacker.engine.api.process.WithCategories
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 import pl.touk.nussknacker.engine.api.typed.{TypedGlobalVariable, typing}
 import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
-import pl.touk.nussknacker.engine.definition.DefinitionExtractor.{ObjectDefinition, StandardObjectWithMethodDef}
-import pl.touk.nussknacker.engine.definition.MethodDefinitionExtractor.{MethodDefinition, OrderedDependencies}
-import pl.touk.nussknacker.engine.testing.ProcessDefinitionBuilder.objectDefinition
+import pl.touk.nussknacker.engine.definition.GlobalVariableDefinitionExtractor
 
 class GlobalVariablesPreparerTest extends AnyFunSuite with Matchers {
 
   test("should resolve real value and return type for typed variable") {
     val metaData = MetaData("test", StreamMetaData())
-    val unusedMethodDef = MethodDefinition(name = "test", invocation = (_, _) => ???, orderedDependencies = new OrderedDependencies(Nil), returnType = Unknown, runtimeClass = classOf[Any], annotations = Nil)
-    val varsWithMethodDef = Map("typedVar" -> StandardObjectWithMethodDef(TestTypedGlobalVariable, methodDef = unusedMethodDef, objectDefinition = objectDefinition(List.empty, Some(Unknown))))
+    val varsWithMethodDef = Map("typedVar" ->
+      GlobalVariableDefinitionExtractor.extractDefinition(WithCategories.anyCategory(TestTypedGlobalVariable)))
 
     val varsWithType = new GlobalVariablesPreparer(varsWithMethodDef, hideMetaVariable = true).prepareGlobalVariables(metaData)
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
