### PR TITLE
Expose more methods for use in expressions

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -14,6 +14,12 @@
 * [#4278](https://github.com/TouK/nussknacker/pull/4278) Expression compilation speedup: reusage of type definitions extracted for code suggestions purpose + 
   added completions for some missing types like `TimestampType` (`#inputMeta.timestampType`) 
 * [#4290](https://github.com/TouK/nussknacker/pull/4290) Expression compilation speedup: replace most regular expression matching with plain string matching
+* [#4292](https://github.com/TouK/nussknacker/pull/4292) Expose more methods for use in expressions:
+  * `java.lang.CharSequence`: `replace`
+  * `java.util.Collection`: `lastIndexOf`
+  * `java.util.Optional`: `isEmpty`
+  * `scala.Option`, `scala.collection.Iterable`: `head`, `nonEmpty`, `orNull`, `tail`
+  * `io.circe.*` (deserialized raw JSON objects): `noSpacesSortKeys`, `spaces2SortKeys`, `spaces4SortKeys`
 
 1.9.1 (24 Apr 2023)
 ------------------------

--- a/engine/flink/management/dev-model/src/test/resources/extractedTypes/devCreator.json
+++ b/engine/flink/management/dev-model/src/test/resources/extractedTypes/devCreator.json
@@ -447,6 +447,15 @@
           }
         }
       ],
+      "noSpacesSortKeys": [
+        {
+          "name": "noSpacesSortKeys",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"refClazzName": "java.lang.String"}
+          }
+        }
+      ],
       "spaces2": [
         {
           "name": "spaces2",
@@ -456,9 +465,27 @@
           }
         }
       ],
+      "spaces2SortKeys": [
+        {
+          "name": "spaces2SortKeys",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"refClazzName": "java.lang.String"}
+          }
+        }
+      ],
       "spaces4": [
         {
           "name": "spaces4",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"refClazzName": "java.lang.String"}
+          }
+        }
+      ],
+      "spaces4SortKeys": [
+        {
+          "name": "spaces4SortKeys",
           "signature": {
             "noVarArgs": [],
             "result": {"refClazzName": "java.lang.String"}
@@ -3346,6 +3373,28 @@
               {"name": "arg0", "refClazz": {"refClazzName": "java.lang.String"}}
             ],
             "result": {"refClazzName": "java.lang.Boolean"}
+          }
+        }
+      ],
+      "replace": [
+        {
+          "name": "replace",
+          "signature": {
+            "noVarArgs": [
+              {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Character"}},
+              {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Character"}}
+            ],
+            "result": {"refClazzName": "java.lang.String"}
+          }
+        },
+        {
+          "name": "replace",
+          "signature": {
+            "noVarArgs": [
+              {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+              {"name": "arg1", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
+            ],
+            "result": {"refClazzName": "java.lang.String"}
           }
         }
       ],
@@ -11297,6 +11346,17 @@
           "signature": {
             "noVarArgs": [],
             "result": {"refClazzName": "java.lang.Boolean"}
+          }
+        }
+      ],
+      "lastIndexOf": [
+        {
+          "name": "lastIndexOf",
+          "signature": {
+            "noVarArgs": [
+              {"name": "arg0", "refClazz": {"type": "Unknown"}}
+            ],
+            "result": {"refClazzName": "java.lang.Integer"}
           }
         }
       ],

--- a/engine/flink/tests/src/test/resources/extractedTypes/defaultModel.json
+++ b/engine/flink/tests/src/test/resources/extractedTypes/defaultModel.json
@@ -2896,6 +2896,28 @@
           }
         }
       ],
+      "replace": [
+        {
+          "name": "replace",
+          "signature": {
+            "noVarArgs": [
+              {"name": "arg0", "refClazz": {"refClazzName": "java.lang.Character"}},
+              {"name": "arg1", "refClazz": {"refClazzName": "java.lang.Character"}}
+            ],
+            "result": {"refClazzName": "java.lang.String"}
+          }
+        },
+        {
+          "name": "replace",
+          "signature": {
+            "noVarArgs": [
+              {"name": "arg0", "refClazz": {"refClazzName": "java.lang.CharSequence"}},
+              {"name": "arg1", "refClazz": {"refClazzName": "java.lang.CharSequence"}}
+            ],
+            "result": {"refClazzName": "java.lang.String"}
+          }
+        }
+      ],
       "replaceAll": [
         {
           "name": "replaceAll",
@@ -11592,6 +11614,17 @@
           "signature": {
             "noVarArgs": [],
             "result": {"refClazzName": "java.lang.Boolean"}
+          }
+        }
+      ],
+      "lastIndexOf": [
+        {
+          "name": "lastIndexOf",
+          "signature": {
+            "noVarArgs": [
+              {"name": "arg0", "refClazz": {"type": "Unknown"}}
+            ],
+            "result": {"refClazzName": "java.lang.Integer"}
           }
         }
       ],

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassExtractionSettings.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassExtractionSettings.scala
@@ -150,7 +150,7 @@ object ClassExtractionSettings {
         case m: Member with AccessibleObject => m.getAnnotation(classOf[Hidden]) != null
       }),
       ClassMemberPredicate(ClassPredicate { case cl => classOf[HideToString].isAssignableFrom(cl) }, {
-        case m: Method => m.getName == "toString" && m.getParameterCount == 0
+        case m: Method => m.getName == ToStringMethod && m.getParameterCount == 0
       }),
       ClassMemberPredicate(ClassPredicate { case cl => cl.isEnum }, {
         case m: Method => List("declaringClass", "getDeclaringClass").contains(m.getName)
@@ -208,25 +208,25 @@ object ClassExtractionSettings {
       MemberNamePatternPredicate(
         SuperClassPredicate(ExactClassPredicate[CharSequence]),
         Pattern.compile(s"charAt|compareTo.*|concat|contains|endsWith|equalsIgnoreCase|format|indexOf|isBlank|isEmpty|join|lastIndexOf|length|matches|" +
-          s"replaceAll|replaceFirst|split|startsWith|strip.*|substring|toLowerCase|toUpperCase|trim|$ToStringMethod")),
+          s"replace|replaceAll|replaceFirst|split|startsWith|strip.*|substring|toLowerCase|toUpperCase|trim|$ToStringMethod")),
       MemberNamePatternPredicate(
         SuperClassPredicate(ExactClassPredicate[NumberFormat]),
         Pattern.compile(s"get.*Instance|format|parse")),
       MemberNamePredicate(
         SuperClassPredicate(ExactClassPredicate[util.Collection[_]]),
-        Set("contains", "containsAll", "get", "getOrDefault", "indexOf", "isEmpty", "size")),
+        Set("contains", "containsAll", "get", "getOrDefault", "indexOf", "isEmpty", "lastIndexOf", "size")),
       MemberNamePredicate(
         SuperClassPredicate(ExactClassPredicate[util.Map[_, _]]),
         Set("containsKey", "containsValue", "get", "getOrDefault", "isEmpty", "size", "values", "keySet")),
       MemberNamePredicate(
         SuperClassPredicate(ExactClassPredicate[Optional[_]]),
-        Set("get", "isPresent", "orElse")),
+        Set("get", "isEmpty", "isPresent", "orElse")),
       MemberNamePredicate(
         SuperClassPredicate(ExactClassPredicate[UUID]),
         Set("clockSequence", "randomUUID", "fromString", "getLeastSignificantBits", "getMostSignificantBits", "node", "timestamp", ToStringMethod, "variant", "version")),
       MemberNamePredicate(
         SuperClassPredicate(ExactClassPredicate(classOf[Iterable[_]], classOf[Option[_]])),
-        Set("apply", "applyOrElse", "contains", "get", "getOrDefault", "indexOf", "isDefined", "isEmpty", "size", "values", "keys", "diff"))
+        Set("apply", "applyOrElse", "contains", "get", "getOrDefault", "head", "indexOf", "isDefined", "isEmpty", "nonEmpty", "orNull", "size", "tail", "values", "keys", "diff"))
     )
 
   lazy val IncludedSerializableMembers: List[ClassMemberPredicate] =
@@ -236,10 +236,7 @@ object ClassExtractionSettings {
         Set(ToStringMethod)),
       MemberNamePredicate(
         ClassNamePrefixPredicate("io.circe."),
-        Set("noSpaces", "nospaces", "spaces2", "spaces4", ToStringMethod)),
-      MemberNamePredicate(
-        ClassNamePrefixPredicate("argonaut."),
-        Set("noSpaces", "nospaces", "spaces2", "spaces4", ToStringMethod)),
+        Set("noSpaces", "noSpacesSortKeys", "spaces2", "spaces2SortKeys", "spaces4", "spaces4SortKeys", ToStringMethod)),
     )
 
   private case class DumpCaseClass()


### PR DESCRIPTION
Expose more methods for use in expressions:
  * `java.lang.CharSequence`: `replace`
  * `java.util.Collection`: `lastIndexOf`
  * `java.util.Optional`: `isEmpty`
  * `scala.Option`, `scala.collection.Iterable`: `head`, `nonEmpty`, `orNull`, `tail`
  * `io.circe.*` (deserialized raw JSON objects): `noSpacesSortKeys`, `spaces2SortKeys`, `spaces4SortKeys`

I'm also removing detection of Argonaut classes, as we got rid of them over three years ago (thanks to @jedrz for noticing it).