### PR TITLE
Support arrays in BestEffortJsonEncoder

### DIFF
--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/extractor/ServiceRequest.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/extractor/ServiceRequest.scala
@@ -48,7 +48,7 @@ private class ServiceRequest(rootUrl: URL, swaggerService: SwaggerService, input
   }
 
   def apply: SwaggerRequestType = {
-    val encoder = BestEffortJsonEncoder(failOnUnkown = false, getClass.getClassLoader)
+    val encoder = BestEffortJsonEncoder(failOnUnknown = false, getClass.getClassLoader)
 
     //FIXME: lepsza obsluga (rozpoznawanie multi headers, itp...)
     val headers: List[Header] = swaggerService.parameters.collect { case paramDef@HeaderParameter(value, _) =>

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -68,7 +68,7 @@ object ManagementResources {
         case Some(original) => Json.obj("original" -> safeString(original), "pretty" -> displayableJson)
       }
     case null => Json.Null
-    case a => Json.obj("pretty" -> BestEffortJsonEncoder(failOnUnkown = false, a.getClass.getClassLoader).circeEncoder.apply(a))
+    case a => Json.obj("pretty" -> BestEffortJsonEncoder(failOnUnknown = false, a.getClass.getClassLoader).circeEncoder.apply(a))
   }
 
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -20,6 +20,7 @@
   * `java.util.Optional`: `isEmpty`
   * `scala.Option`, `scala.collection.Iterable`: `head`, `nonEmpty`, `orNull`, `tail`
   * `io.circe.*` (deserialized raw JSON objects): `noSpacesSortKeys`, `spaces2SortKeys`, `spaces4SortKeys`
+* [#4298](https://github.com/TouK/nussknacker/pull/4298) Support arrays in `BestEffortJsonEncoder`
 
 1.9.1 (24 Apr 2023)
 ------------------------

--- a/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/DefaultResponseEncoder.scala
+++ b/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/DefaultResponseEncoder.scala
@@ -6,7 +6,7 @@ import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
 
 object DefaultResponseEncoder extends ResponseEncoder[Any] {
 
-  private val bestEffortEncoder = BestEffortJsonEncoder(failOnUnkown = true, getClass.getClassLoader)
+  private val bestEffortEncoder = BestEffortJsonEncoder(failOnUnknown = true, getClass.getClassLoader)
 
   override def toJsonResponse(input: Any, result: List[Any]): Json = bestEffortEncoder.encode(result)
 

--- a/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/openapi/RequestResponseOpenApiGenerator.scala
+++ b/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/openapi/RequestResponseOpenApiGenerator.scala
@@ -27,7 +27,7 @@ class RequestResponseOpenApiGenerator(oApiVersion: String, oApiInfo: OApiInfo) {
 
 object RequestResponseOpenApiGenerator {
 
-  private val jsonEncoder = BestEffortJsonEncoder(failOnUnkown = true, getClass.getClassLoader)
+  private val jsonEncoder = BestEffortJsonEncoder(failOnUnknown = true, getClass.getClassLoader)
 
   private[requestresponse] def generateScenarioDefinition(operationId: String,
                                                           summary: String,

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/encode/BestEffortJsonSchemaEncoder.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/encode/BestEffortJsonSchemaEncoder.scala
@@ -18,7 +18,7 @@ object BestEffortJsonSchemaEncoder {
   import pl.touk.nussknacker.engine.util.json.JsonSchemaImplicits._
 
   private val classLoader = this.getClass.getClassLoader
-  private val jsonEncoder = BestEffortJsonEncoder(failOnUnkown = false, this.getClass.getClassLoader)
+  private val jsonEncoder = BestEffortJsonEncoder(failOnUnknown = false, this.getClass.getClassLoader)
 
   private val optionalEncoders = ServiceLoader.load(classOf[ToJsonBasedOnSchemaEncoder], classLoader).asScala.map(_.encoder(this.encodeBasedOnSchema))
   private val highPriority: PartialFunction[EncodeInput, EncodeOutput] = Map()

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/swagger/SwaggerTyped.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/swagger/SwaggerTyped.scala
@@ -56,7 +56,7 @@ case class SwaggerUnion(types: List[SwaggerTyped]) extends SwaggerTyped
 @JsonCodec case class SwaggerEnum private (values: List[Any]) extends SwaggerTyped
 
 object SwaggerEnum {
-  private val bestEffortJsonEncoder = BestEffortJsonEncoder(failOnUnkown = true, getClass.getClassLoader)
+  private val bestEffortJsonEncoder = BestEffortJsonEncoder(failOnUnknown = true, getClass.getClassLoader)
   private implicit val decoder: Decoder[List[Any]] = Decoder[Json].map(_.asArray.map(_.toList.map(jsonToAny)).getOrElse(List.empty))
   private implicit val encoder: Encoder[List[Any]] = Encoder.instance[List[Any]](bestEffortJsonEncoder.encode)
   private lazy val om = new ObjectMapper()

--- a/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/serialization/schemas.scala
+++ b/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/serialization/schemas.scala
@@ -75,7 +75,7 @@ object schemas {
 
   import scala.jdk.CollectionConverters._
 
-  private implicit val mapEncoder: Encoder[java.util.Map[_, _]] = BestEffortJsonEncoder(failOnUnkown = false, getClass.getClassLoader).circeEncoder.contramap(identity)
+  private implicit val mapEncoder: Encoder[java.util.Map[_, _]] = BestEffortJsonEncoder(failOnUnknown = false, getClass.getClassLoader).circeEncoder.contramap(identity)
 
   private implicit val mapDecoder: Decoder[java.util.Map[_, _]] = Decoder[Json].map(deserializeToMap)
 

--- a/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/sink/GenericJsonSerialization.scala
+++ b/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/sink/GenericJsonSerialization.scala
@@ -15,6 +15,6 @@ case class GenericJsonSerialization(topic: String) extends SimpleSerializationSc
 
 object GenericJsonSerialization {
 
-  private val encoder = BestEffortJsonEncoder(failOnUnkown = false, getClass.getClassLoader)
+  private val encoder = BestEffortJsonEncoder(failOnUnknown = false, getClass.getClassLoader)
 
 }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/RecordFormatterSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/RecordFormatterSupport.scala
@@ -29,7 +29,7 @@ trait RecordFormatterSupport {
 }
 
 object JsonPayloadRecordFormatterSupport extends RecordFormatterSupport {
-  override def formatMessage(data: Any): Json = BestEffortJsonEncoder(failOnUnkown = false, classLoader = getClass.getClassLoader).encode(data)
+  override def formatMessage(data: Any): Json = BestEffortJsonEncoder(failOnUnknown = false, classLoader = getClass.getClassLoader).encode(data)
 
   override def readKeyMessage(topic: String, schemaOpt: Option[ParsedSchema], jsonObj: Json): Array[Byte] = readMessage(topic, schemaOpt, jsonObj)
 

--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/BestEffortJsonEncoder.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/BestEffortJsonEncoder.scala
@@ -16,11 +16,11 @@ import scala.jdk.CollectionConverters._
 
 object BestEffortJsonEncoder {
 
-  val defaultForTests: BestEffortJsonEncoder = BestEffortJsonEncoder(failOnUnkown = true, getClass.getClassLoader)
+  val defaultForTests: BestEffortJsonEncoder = BestEffortJsonEncoder(failOnUnknown = true, getClass.getClassLoader)
 
 }
 
-case class BestEffortJsonEncoder(failOnUnkown: Boolean, classLoader: ClassLoader, highPriority: PartialFunction[Any, Json] = Map()) {
+case class BestEffortJsonEncoder(failOnUnknown: Boolean, classLoader: ClassLoader, highPriority: PartialFunction[Any, Json] = Map()) {
 
   private val safeString = safeJson[String](fromString)
   private val safeLong = safeJson[Long](fromLong)
@@ -63,10 +63,11 @@ case class BestEffortJsonEncoder(failOnUnkown: Boolean, classLoader: ClassLoader
       case a: DisplayJson => a.asJson
       case a: scala.collection.Map[String@unchecked, _] => encodeMap(a.toMap)
       case a: java.util.Map[String@unchecked, _] => encodeMap(a.asScala.toMap)
-      case a: Iterable[_] => fromValues(a.map(encode).toList)
+      case a: Iterable[_] => fromValues(a.map(encode))
       case a: Enum[_] => safeString(a.toString)
-      case a: java.util.Collection[_] => fromValues(a.asScala.map(encode).toList)
-      case _ if !failOnUnkown => safeString(any.toString)
+      case a: java.util.Collection[_] => fromValues(a.asScala.map(encode))
+      case a: Array[_] => fromValues(a.map(encode))
+      case _ if !failOnUnknown => safeString(any.toString)
       case a => throw new IllegalArgumentException(s"Invalid type: ${a.getClass}")
     })
 

--- a/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/json/BestEffortJsonEncoderSpec.scala
+++ b/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/json/BestEffortJsonEncoderSpec.scala
@@ -73,11 +73,17 @@ class BestEffortJsonEncoderSpec extends AnyFunSpec with Matchers {
     encoder.encode(map) shouldEqual obj("key1" -> fromLong(1), "key2" -> fromString("value"))
   }
 
+  it("should encode arrays as a json") {
+    encoder.encode(Array(1, 2, 3)) shouldEqual arr(fromLong(1), fromLong(2), fromLong(3))
+    encoder.encode(Seq(Array(1, 2, 3))) shouldEqual arr(arr(fromLong(1), fromLong(2), fromLong(3)))
+    encoder.encode(Array(1, "value")) shouldEqual arr(fromLong(1), fromString("value"))
+  }
+
   it("should use custom encoders from classloader") {
 
     ClassLoaderWithServices.withCustomServices(List(classOf[ToJsonEncoder] -> classOf[CustomJsonEncoder1],
       classOf[ToJsonEncoder] -> classOf[CustomJsonEncoder2])) { classLoader =>
-      val encoder = BestEffortJsonEncoder(failOnUnkown = true, classLoader)
+      val encoder = BestEffortJsonEncoder(failOnUnknown = true, classLoader)
 
       encoder.encode(Map("custom1" ->
         CustomClassToEncode(Map("custom2" -> new NestedClassToEncode)))) shouldBe obj("custom1" ->


### PR DESCRIPTION
Without this we can't preview arrays in SpEL Interactive:
![obraz](https://github.com/TouK/nussknacker/assets/1409807/ec0921b0-3171-461f-a2b8-fed08edad643)
