### PR TITLE
Identify and serialize state status by name

### DIFF
--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleStateStatus.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleStateStatus.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.engine.api.deployment.simple
 
+import pl.touk.nussknacker.engine.api.deployment
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
 import pl.touk.nussknacker.engine.api.deployment.StateStatus.StatusName
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus.ProblemStateStatus.defaultActions
@@ -15,17 +16,18 @@ object SimpleStateStatus {
     override def name: StatusName = ProblemStateStatus.name
     override def isFailed: Boolean = true
   }
-  case object ProblemStateStatus {
+
+  object ProblemStateStatus {
     val name: String = "PROBLEM"
     val icon: URI = URI.create("/assets/states/error.svg")
     val defaultDescription = "There are some problems with scenario."
-    val defaultActions = List(ProcessActionType.Deploy, ProcessActionType.Cancel)
+    val defaultActions: List[deployment.ProcessActionType.Value] = List(ProcessActionType.Deploy, ProcessActionType.Cancel)
 
     // Problem factory methods
 
-    def failed: ProblemStateStatus = ProblemStateStatus(defaultDescription)
+    val failed: ProblemStateStatus = ProblemStateStatus(defaultDescription)
 
-    def failedToGet: ProblemStateStatus =
+    val failedToGet: ProblemStateStatus =
       ProblemStateStatus(s"Failed to get a state of the scenario.")
 
     def shouldBeRunning(deployedVersionId: VersionId, user: String): ProblemStateStatus =
@@ -43,10 +45,10 @@ object SimpleStateStatus {
     def missingDeployedVersion(exceptedVersionId: VersionId, user: String): ProblemStateStatus =
       ProblemStateStatus(s"Scenario deployed without version by $user, expected version $exceptedVersionId.")
 
-    def processWithoutAction: ProblemStateStatus =
+    val processWithoutAction: ProblemStateStatus =
       ProblemStateStatus("Scenario state error - no actions found.")
 
-    def multipleJobsRunning: ProblemStateStatus =
+    val multipleJobsRunning: ProblemStateStatus =
       ProblemStateStatus("More than one deployment is running.", List(ProcessActionType.Cancel))
 
   }

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleStateStatus.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleStateStatus.scala
@@ -51,30 +51,13 @@ object SimpleStateStatus {
 
   }
 
-  val NotDeployed: StateStatus = new StateStatus {
-    override def name: StatusName = "NOT_DEPLOYED"
-  }
-  val DuringDeploy: StateStatus = new StateStatus {
-    override def name: StatusName = "DURING_DEPLOY"
-    override def isDuringDeploy: Boolean = true
-  }
-  val Running: StateStatus = new StateStatus {
-    override def name: StatusName = "RUNNING"
-    override def isRunning: Boolean = true
-  }
-  val Finished: StateStatus = new StateStatus {
-    override def name: StatusName = "FINISHED"
-    override def isFinished: Boolean = true
-  }
-  val Restarting: StateStatus = new StateStatus {
-    override def name: StatusName = "RESTARTING"
-  }
-  val DuringCancel: StateStatus = new StateStatus {
-    override def name: StatusName = "DURING_CANCEL"
-  }
-  val Canceled: StateStatus = new StateStatus {
-    override def name: StatusName = "CANCELED"
-  }
+  val NotDeployed: StateStatus = StateStatus("NOT_DEPLOYED")
+  val DuringDeploy: StateStatus = StateStatus.duringDeploy("DURING_DEPLOY")
+  val Running: StateStatus = StateStatus.running("RUNNING")
+  val Finished: StateStatus = StateStatus.finished("FINISHED")
+  val Restarting: StateStatus = StateStatus("RESTARTING")
+  val DuringCancel: StateStatus = StateStatus("DURING_CANCEL")
+  val Canceled: StateStatus = StateStatus("CANCELED")
 
   val statusActionsPF: PartialFunction[StateStatus, List[ProcessActionType]] = {
     case SimpleStateStatus.NotDeployed => List(ProcessActionType.Deploy, ProcessActionType.Archive)

--- a/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/OverridingProcessStateDefinitionManagerTest.scala
+++ b/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/OverridingProcessStateDefinitionManagerTest.scala
@@ -8,19 +8,11 @@ import pl.touk.nussknacker.engine.api.deployment.StateStatus.StatusName
 
 class OverridingProcessStateDefinitionManagerTest extends AnyFunSuite with Matchers {
 
-  case object DefaultState extends StateStatus {
-    override def name: StatusName = "DEFAULT_STATE"
-  }
-  case object DefaultStateToOverride extends StateStatus {
-    override def name: StatusName = "OVERRIDE_THIS_STATE"
-  }
+  val DefaultState: StateStatus = StateStatus("DEFAULT_STATE")
+  val DefaultStateToOverride: StateStatus = StateStatus("OVERRIDE_THIS_STATE")
 
-  case object CustomState extends StateStatus {
-    override def name: StatusName = "CUSTOM_STATE"
-  }
-  case object CustomStateThatOverrides extends StateStatus {
-    override def name: StatusName = "OVERRIDE_THIS_STATE"
-  }
+  val CustomState: StateStatus = StateStatus("CUSTOM_STATE")
+  val CustomStateThatOverrides: StateStatus = StateStatus("OVERRIDE_THIS_STATE")
 
   private val icon = UnknownIcon
 

--- a/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/OverridingProcessStateDefinitionManagerTest.scala
+++ b/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/OverridingProcessStateDefinitionManagerTest.scala
@@ -8,11 +8,19 @@ import pl.touk.nussknacker.engine.api.deployment.StateStatus.StatusName
 
 class OverridingProcessStateDefinitionManagerTest extends AnyFunSuite with Matchers {
 
-  case object DefaultState extends CustomStateStatus("DEFAULT_STATE")
-  case object DefaultStateToOverride extends CustomStateStatus("OVERRIDE_THIS_STATE")
+  case object DefaultState extends StateStatus {
+    override def name: StatusName = "DEFAULT_STATE"
+  }
+  case object DefaultStateToOverride extends StateStatus {
+    override def name: StatusName = "OVERRIDE_THIS_STATE"
+  }
 
-  case object CustomState extends CustomStateStatus("CUSTOM_STATE")
-  case object CustomStateThatOverrides extends CustomStateStatus("OVERRIDE_THIS_STATE")
+  case object CustomState extends StateStatus {
+    override def name: StatusName = "CUSTOM_STATE"
+  }
+  case object CustomStateThatOverrides extends StateStatus {
+    override def name: StatusName = "OVERRIDE_THIS_STATE"
+  }
 
   private val icon = UnknownIcon
 

--- a/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/StateStatusCodingSpec.scala
+++ b/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/StateStatusCodingSpec.scala
@@ -34,7 +34,8 @@ class StateStatusCodingSpec extends AnyFunSuite with Matchers with EitherValuesD
     decodedStatus should not equal givenStatus
   }
 
-  case class MyCustomStateStatus(someField: String) extends CustomStateStatus("CUSTOM") {
+  case class MyCustomStateStatus(someField: String) extends StateStatus {
+    override def name: StatusName = "CUSTOM"
     override def isRunning: Boolean = true
   }
 

--- a/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/StateStatusCodingSpec.scala
+++ b/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/StateStatusCodingSpec.scala
@@ -5,6 +5,7 @@ import io.circe.syntax._
 import org.scalatest.OptionValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.deployment.StateStatus.StatusName
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
 
@@ -13,31 +14,23 @@ class StateStatusCodingSpec extends AnyFunSuite with Matchers with EitherValuesD
   test("simple status coding") {
     val givenStatus: StateStatus = SimpleStateStatus.Running
     val statusJson = givenStatus.asJson
-    statusJson.hcursor.get[String]("type").rightValue shouldEqual "RunningStateStatus"
-    statusJson.hcursor.get[String]("name").rightValue shouldEqual "RUNNING"
+    statusJson shouldEqual Json.fromString("RUNNING")
 
-    val decodedStatus = Json.obj(
-      "type" -> Json.fromString("RunningStateStatus"),
-      "name" -> Json.fromString("RUNNING")
-    ).as[StateStatus].rightValue
-    decodedStatus shouldEqual givenStatus
+    val decodedStatus = Json.fromString("RUNNING").as[StateStatus].rightValue
+    decodedStatus.name shouldEqual givenStatus.name
   }
 
   test("custom status coding") {
     val givenStatus: StateStatus = MyCustomStateStatus("fooBar")
 
     val statusJson = givenStatus.asJson
-    statusJson.hcursor.get[String]("type").rightValue shouldEqual "CustomStateStatus"
-    statusJson.hcursor.get[String]("name").rightValue shouldEqual "CUSTOM"
+    statusJson shouldEqual Json.fromString("CUSTOM")
     // we don't encode custom state statuses fields be design
-    statusJson.hcursor.get[String]("someField").toOption shouldBe empty
 
-    val decodedStatus = Json.obj(
-      "type" -> Json.fromString("CustomStateStatus"),
-      "name" -> Json.fromString("CUSTOM")
-    ).as[StateStatus].rightValue
+    val decodedStatus = Json.fromString("CUSTOM").as[StateStatus].rightValue
     // we don't decode correctly custom statuses be design - their role is to encapsulate business status of process which will be
     // then presented by ProcessStateDefinitionManager
+    decodedStatus.name shouldEqual givenStatus.name
     decodedStatus should not equal givenStatus
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -242,7 +242,7 @@ class ManagementResourcesSpec extends AnyFunSuite with ScalatestRouteTest with F
         status shouldBe StatusCodes.Conflict
       }
       getProcess(ProcessName(invalidScenario.id)) ~> check {
-        decodeDetails.state.value.status shouldEqual SimpleStateStatus.NotDeployed
+        decodeDetails.state.value.status.name shouldEqual SimpleStateStatus.NotDeployed.name
       }
     }
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -845,7 +845,6 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
         status shouldEqual StatusCodes.OK
         val stateStatusResponse = parseStateResponse(responseAs[Json])
         stateStatusResponse.name shouldBe SimpleStateStatus.Running.name
-        stateStatusResponse.`type` shouldBe SimpleStateStatus.Running.getClass.getSimpleName
       }
     }
   }
@@ -878,20 +877,14 @@ class ProcessesResourcesSpec extends AnyFunSuite with ScalatestRouteTest with Ma
     }
   }
 
-  case class StateStatusResponse(name: String, `type`: String)
+  case class StateStatusResponse(name: String)
 
   private def parseStateResponse(stateResponse: Json): StateStatusResponse = {
     val name = stateResponse.hcursor
       .downField("status")
-      .downField("name")
       .as[String].toOption.get
 
-    val statusType = stateResponse.hcursor
-      .downField("status")
-      .downField("type")
-      .as[String].toOption.get
-
-    StateStatusResponse(name, statusType)
+    StateStatusResponse(name)
   }
 
   private def checkSampleProcessRootIdEquals(expected: String): Assertion = {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/EspItTest.scala
@@ -389,8 +389,9 @@ trait EspItTest extends LazyLogging with WithHsqlDbTesting with TestPermissions 
     } yield id).futureValue
   }
 
-  protected def parseResponseToListJsonProcess(response: String): List[ProcessJson] =
+  protected def parseResponseToListJsonProcess(response: String): List[ProcessJson] = {
     parser.decode[List[Json]](response).toOption.get.map(j => ProcessJson(j))
+  }
 
   private def decodeJsonProcess(response: String): ProcessJson =
     ProcessJson(parser.decode[Json](response).toOption.get)
@@ -414,7 +415,7 @@ object ProcessJson extends OptionValues {
       process.hcursor.downField("processId").as[Long].toOption.value,
       lastAction.map(_.hcursor.downField("processVersionId").as[Long].toOption.value),
       lastAction.map(_.hcursor.downField("action").as[String].toOption.value),
-      process.hcursor.downField("state").downField("status").downField("name").as[String].toOption.value,
+      process.hcursor.downField("state").downField("status").as[String].toOption.value,  // StateStatus is temporarily serialized as string
       process.hcursor.downField("state").downField("icon").as[String].toOption.map(URI.create).value,
       process.hcursor.downField("state").downField("tooltip").as[String].toOption.value,
       process.hcursor.downField("state").downField("description").as[String].toOption.value,

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -30,6 +30,7 @@
   Components usages by a scenario are stored in the processes version table. It allows to speed up fetching components usages across all scenarios,
   especially for a big number of scenarios and each with a lot of nodes.
 * [#4254](https://github.com/TouK/nussknacker/pull/4254) Add simple spel expression suggestions endpoint to BE
+* [#4299](https://github.com/TouK/nussknacker/pull/4299) `StateStatus` is identified by its name. `ProcessState` serialization uses this name as serialized state value.
 
 1.9.1 (24 Apr 2023)
 ------------------------

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -15,6 +15,9 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 * [#4290](https://github.com/TouK/nussknacker/pull/4290) Renamed predicates used in `ClassExtractionSettings`:
   * `ClassMemberPatternPredicate` renamed to `MemberNamePatternPredicate`
   * `AllMethodNamesPredicate` renamed to AllMembersPredicate
+* [#4299](https://github.com/TouK/nussknacker/pull/4299) `StateStatus` is identified by its name. `ProcessState` serialization uses this name as serialized state value.  
+  Sealed trait `StateStatus` is unsealed, all members are replaced by corresponding `SimpleStateStatus` state definitions,
+  custom statuses are defined within each `ProcessStateDefinitionManager`.
 
 ### Configuration changes
 * [#4283](https://github.com/TouK/nussknacker/pull/4283) For OIDC provider, `accessTokenIsJwt` config property is introduced, with default values `false`.

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentProcessStateDefinitionManager.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentProcessStateDefinitionManager.scala
@@ -13,6 +13,10 @@ class DevelopmentProcessStateDefinitionManager(delegate: ProcessStateDefinitionM
 
 object DevelopmentStateStatus {
 
+  val AfterRunningStatus: StateStatus = StateStatus.running("AFTER")
+  val PreparingResourcesStatus: StateStatus = StateStatus("PREPARING")
+  val TestStatus: StateStatus = StateStatus("TEST")
+
   val statusActionsPF: PartialFunction[StateStatus, List[ProcessActionType]] = {
     case DevelopmentStateStatus.AfterRunningStatus => List(ProcessActionType.Cancel)
     case DevelopmentStateStatus.PreparingResourcesStatus => List(ProcessActionType.Deploy)
@@ -39,18 +43,5 @@ object DevelopmentStateStatus {
       description = "Preparing external resources."
     ),
   )
-
-  case object AfterRunningStatus extends StateStatus {
-    override def name: StatusName = "AFTER"
-    override def isRunning: Boolean = true
-  }
-
-  case object PreparingResourcesStatus extends StateStatus {
-    override def name: StatusName = "PREPARING"
-  }
-
-  case object TestStatus extends StateStatus {
-    override def name: StatusName = "TEST"
-  }
 
 }

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentProcessStateDefinitionManager.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentProcessStateDefinitionManager.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.development.manager
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
 import pl.touk.nussknacker.engine.api.deployment.StateDefinitionDetails.UnknownIcon
 import pl.touk.nussknacker.engine.api.deployment.StateStatus.StatusName
-import pl.touk.nussknacker.engine.api.deployment.{CustomStateStatus, OverridingProcessStateDefinitionManager, ProcessActionType, ProcessStateDefinitionManager, StateDefinitionDetails, StateStatus}
+import pl.touk.nussknacker.engine.api.deployment.{OverridingProcessStateDefinitionManager, ProcessActionType, ProcessStateDefinitionManager, StateDefinitionDetails, StateStatus}
 
 class DevelopmentProcessStateDefinitionManager(delegate: ProcessStateDefinitionManager) extends OverridingProcessStateDefinitionManager(
   statusActionsPF = DevelopmentStateStatus.statusActionsPF,
@@ -40,12 +40,17 @@ object DevelopmentStateStatus {
     ),
   )
 
-  case object AfterRunningStatus extends CustomStateStatus("AFTER") {
+  case object AfterRunningStatus extends StateStatus {
+    override def name: StatusName = "AFTER"
     override def isRunning: Boolean = true
   }
 
-  case object PreparingResourcesStatus extends CustomStateStatus("PREPARING")
+  case object PreparingResourcesStatus extends StateStatus {
+    override def name: StatusName = "PREPARING"
+  }
 
-  case object TestStatus extends CustomStateStatus("TEST")
+  case object TestStatus extends StateStatus {
+    override def name: StatusName = "TEST"
+  }
 
 }

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicStateStatus.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicStateStatus.scala
@@ -19,6 +19,17 @@ object PeriodicStateStatus {
     def pretty: String = ldt.format(Format)
   }
 
+  case class ScheduledStatus(nextRunAt: LocalDateTime) extends StateStatus {
+    override def name: StatusName = ScheduledStatus.name
+    override def isRunning: Boolean = true
+  }
+
+  case object ScheduledStatus {
+    val name = "SCHEDULED"
+  }
+
+  val WaitingForScheduleStatus: StateStatus = StateStatus.running("WAITING_FOR_SCHEDULE")
+
   val statusActionsPF: PartialFunction[StateStatus, List[ProcessActionType]] = {
     case s: StateStatus if s.name == SimpleStateStatus.Running.name => List(ProcessActionType.Cancel) //periodic processes cannot be redeployed from GUI
     case _: ScheduledStatus => List(ProcessActionType.Cancel, ProcessActionType.Deploy)
@@ -49,17 +60,4 @@ object PeriodicStateStatus {
     ),
   )
 
-  case class ScheduledStatus(nextRunAt: LocalDateTime) extends StateStatus {
-    override def name: StatusName = ScheduledStatus.name
-    override def isRunning: Boolean = true
-  }
-
-  case object ScheduledStatus {
-    val name = "SCHEDULED"
-  }
-
-  case object WaitingForScheduleStatus extends StateStatus {
-    override def name: StatusName = "WAITING_FOR_SCHEDULE"
-    override def isRunning: Boolean = true
-  }
 }

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicStateStatus.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicStateStatus.scala
@@ -2,8 +2,9 @@ package pl.touk.nussknacker.engine.management.periodic
 
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
 import pl.touk.nussknacker.engine.api.deployment.StateStatus.StatusName
+import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus.ProblemStateStatus
-import pl.touk.nussknacker.engine.api.deployment.{CustomStateStatus, ProcessActionType, RunningStateStatus, StateDefinitionDetails, StateStatus}
+import pl.touk.nussknacker.engine.api.deployment.{ProcessActionType, StateDefinitionDetails, StateStatus}
 
 import java.net.URI
 import java.time.LocalDateTime
@@ -19,7 +20,7 @@ object PeriodicStateStatus {
   }
 
   val statusActionsPF: PartialFunction[StateStatus, List[ProcessActionType]] = {
-    case _: RunningStateStatus => List(ProcessActionType.Cancel) //periodic processes cannot be redeployed from GUI
+    case s: StateStatus if s.name == SimpleStateStatus.Running.name => List(ProcessActionType.Cancel) //periodic processes cannot be redeployed from GUI
     case _: ScheduledStatus => List(ProcessActionType.Cancel, ProcessActionType.Deploy)
     case WaitingForScheduleStatus => List(ProcessActionType.Cancel) //or maybe should it be empty??
     case _: ProblemStateStatus => List(ProcessActionType.Cancel) //redeploy is not allowed
@@ -48,7 +49,8 @@ object PeriodicStateStatus {
     ),
   )
 
-  case class ScheduledStatus(nextRunAt: LocalDateTime) extends CustomStateStatus(ScheduledStatus.name) {
+  case class ScheduledStatus(nextRunAt: LocalDateTime) extends StateStatus {
+    override def name: StatusName = ScheduledStatus.name
     override def isRunning: Boolean = true
   }
 
@@ -56,7 +58,8 @@ object PeriodicStateStatus {
     val name = "SCHEDULED"
   }
 
-  case object WaitingForScheduleStatus extends CustomStateStatus("WAITING_FOR_SCHEDULE") {
+  case object WaitingForScheduleStatus extends StateStatus {
+    override def name: StatusName = "WAITING_FOR_SCHEDULE"
     override def isRunning: Boolean = true
   }
 }

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
@@ -10,8 +10,8 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.OptionValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus.ProblemStateStatus
-import pl.touk.nussknacker.engine.api.deployment.{FinishedStateStatus, RunningStateStatus}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.{MetaData, ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -113,7 +113,7 @@ class PeriodicProcessServiceIntegrationTest extends AnyFunSuite
     processDeployed.state shouldBe PeriodicProcessDeploymentState(Some(LocalDateTime.now(fixedClock(timeToTriggerCheck))), None, PeriodicProcessDeploymentStatus.Deployed)
     processDeployed.runAt shouldBe localTime(expectedScheduleTime)
 
-    f.delegateDeploymentManagerStub.setStateStatus(FinishedStateStatus("finished"))
+    f.delegateDeploymentManagerStub.setStateStatus(SimpleStateStatus.Finished)
     service.handleFinished.futureValue
 
     val toDeployAfterFinish = service.findToBeDeployed.futureValue
@@ -207,12 +207,12 @@ class PeriodicProcessServiceIntegrationTest extends AnyFunSuite
     toDeploy should have length 2
 
     service.deploy(toDeploy.head)
-    f.delegateDeploymentManagerStub.setStateStatus(RunningStateStatus("running"))
+    f.delegateDeploymentManagerStub.setStateStatus(SimpleStateStatus.Running)
 
     val toDeployAfterDeploy = service.findToBeDeployed.futureValue
     toDeployAfterDeploy should have length 0
 
-    f.delegateDeploymentManagerStub.setStateStatus(FinishedStateStatus("finished"))
+    f.delegateDeploymentManagerStub.setStateStatus(SimpleStateStatus.Finished)
     service.handleFinished.futureValue
 
     val toDeployAfterFinish = service.findToBeDeployed.futureValue
@@ -291,7 +291,7 @@ class PeriodicProcessServiceIntegrationTest extends AnyFunSuite
     val toDeploy = service.findToBeDeployed.futureValue
     toDeploy should have length 1
     service.deploy(toDeploy.head).futureValue
-    f.delegateDeploymentManagerStub.setStateStatus(FinishedStateStatus("running"))
+    f.delegateDeploymentManagerStub.setStateStatus(SimpleStateStatus.Finished)
 
     tryWithFailedListener {
       () => service.deactivate(processName)

--- a/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedStateStatus.scala
+++ b/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedStateStatus.scala
@@ -1,12 +1,14 @@
 package pl.touk.nussknacker.engine.embedded
 
+import pl.touk.nussknacker.engine.api.deployment.StateStatus.StatusName
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus.ProblemStateStatus
 
 object EmbeddedStateStatus  {
   def failed(ex: Throwable): StateStatus = DetailedFailedStateStatus(ex.getMessage)
 
-  case class DetailedFailedStateStatus(message: String) extends CustomStateStatus(ProblemStateStatus.name) {
+  case class DetailedFailedStateStatus(message: String) extends StateStatus {
+    override def name: StatusName = ProblemStateStatus.name
     override def isFailed: Boolean = true
   }
 }

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
@@ -93,9 +93,15 @@ object StateStatus {
     .default
     .withDefaults
     .withDiscriminator("type")
+
+  // Temporary encoder/decoder
+  implicit val statusEncoder: Encoder[StateStatus] = Encoder.encodeString.contramap(_.name)
+  implicit val statusDecoder: Decoder[StateStatus] = Decoder.decodeString.map(statusName => new StateStatus {
+    override def name: StatusName = statusName
+  })
 }
 
-@ConfiguredJsonCodec sealed trait StateStatus {
+sealed trait StateStatus {
   //used for filtering processes (e.g. shouldBeRunning)
   def isDuringDeploy: Boolean = false
   //used for handling finished

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
@@ -90,7 +90,9 @@ object ProcessActionState extends Enumeration {
 object StateStatus {
   type StatusName = String
 
-  // Temporary encoder/decoder
+  // StateStatus has to have Decoder defined because it is decoded along with ProcessState in the migration process
+  // (see StandardRemoteEnvironment class).
+  // In all cases (this one and for FE purposes) only info about the status name is essential.
   implicit val statusEncoder: Encoder[StateStatus] = Encoder.encodeString.contramap(_.name)
   implicit val statusDecoder: Decoder[StateStatus] = Decoder.decodeString.map(statusName => new StateStatus {
     override def name: StatusName = statusName

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
@@ -95,6 +95,25 @@ object StateStatus {
   implicit val statusDecoder: Decoder[StateStatus] = Decoder.decodeString.map(statusName => new StateStatus {
     override def name: StatusName = statusName
   })
+
+  // Temporary methods to simplify status creation
+  def apply(statusName: StatusName): StateStatus = new StateStatus {
+    override def name: StatusName = statusName
+  }
+  def duringDeploy(statusName: StatusName): StateStatus = new StateStatus {
+    override def name: StatusName = statusName
+    override def isDuringDeploy: Boolean = true
+  }
+
+  def running(statusName: StatusName): StateStatus = new StateStatus {
+    override def name: StatusName = statusName
+    override def isRunning: Boolean = true
+  }
+
+  def finished(statusName: StatusName): StateStatus = new StateStatus {
+    override def name: StatusName = statusName
+    override def isFinished: Boolean = true
+  }
 }
 
 trait StateStatus {

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessState.scala
@@ -89,10 +89,6 @@ object ProcessActionState extends Enumeration {
 
 object StateStatus {
   type StatusName = String
-  implicit val configuration: Configuration = Configuration
-    .default
-    .withDefaults
-    .withDiscriminator("type")
 
   // Temporary encoder/decoder
   implicit val statusEncoder: Encoder[StateStatus] = Encoder.encodeString.contramap(_.name)
@@ -101,7 +97,7 @@ object StateStatus {
   })
 }
 
-sealed trait StateStatus {
+trait StateStatus {
   //used for filtering processes (e.g. shouldBeRunning)
   def isDuringDeploy: Boolean = false
   //used for handling finished
@@ -114,27 +110,6 @@ sealed trait StateStatus {
   def name: StatusName
 
 }
-
-final case class AllowDeployStateStatus(name: StatusName) extends StateStatus
-
-final case class NotEstablishedStateStatus(name: StatusName) extends StateStatus
-
-final case class DuringDeployStateStatus(name: StatusName) extends StateStatus {
-  override def isDuringDeploy: Boolean = true
-}
-
-final case class FinishedStateStatus(name: StatusName) extends StateStatus {
-  override def isFinished: Boolean = true
-}
-
-final case class RunningStateStatus(name: StatusName) extends StateStatus {
-  override def isRunning: Boolean = true
-}
-
-// This status class is a walk around for fact that StateStatus is encoded and decoded. It causes that there is no easy option
-// to add own status with some specific fields without passing Encoders and Decoders to many places in application.
-// TODO: we should find places where StateStatuses are encoded and decoded and replace them with some DTOs for this purpose
-class CustomStateStatus(val name: StatusName) extends StateStatus
 
 /**
   * It is used to specify:


### PR DESCRIPTION
This is the first change related to statuses refactor. The general concept of this refactor:
1. make pluggable deployment manager responsible for state management
2. move Flink specific status handling (e.g. `ObsoleteStatusDetector` or `DeploymentServiceImpl.handleFinishedProcess`) to proper deployment manager
3. deployment manager should know what each state means and should be responsible for state recognition and 

The steps:
1. identify and serialize StateStatus by name (https://github.com/TouK/nussknacker/pull/4299)
2. some class renames (https://github.com/TouK/nussknacker/pull/4300)
3. move state inconsistency detection and resolution to deployment manager (https://github.com/TouK/nussknacker/pull/4302)