### PR TITLE
Update flink-scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -342,7 +342,7 @@ val wireMockV = "2.35.0"
 // depending on scala version one of this jar lays in Flink lib dir
 def flinkLibScalaDeps(scalaVersion: String, configurations: Option[String] = None) = forScalaVersion(scalaVersion, Seq(),
   (2, 12) -> Seq("org.apache.flink" %% "flink-scala" % flinkV), // we basically need only `org.apache.flink.runtime.types.FlinkScalaKryoInstantiator` from it...
-  (2, 13) -> Seq("pl.touk" %% "flink-scala-2-13" % "1.0.0") // our tiny custom module with scala 2.13 `org.apache.flink.runtime.types.FlinkScalaKryoInstantiator` impl
+  (2, 13) -> Seq("pl.touk" %% "flink-scala-2-13" % "1.1.0") // our tiny custom module with scala 2.13 `org.apache.flink.runtime.types.FlinkScalaKryoInstantiator` impl
 ).map(m => configurations.map(m % _).getOrElse(m)).map(_ exclude("com.esotericsoftware", "kryo-shaded"))
 
 lazy val commonDockerSettings = {

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -4,10 +4,10 @@
 To see the biggest differences please consult the [changelog](Changelog.md).
 
 ## In version 1.10.0
-* [#4294](https://github.com/TouK/nussknacker/pull/4294) `HttpRemoteEnvironmentConfig` allows you to pass flag `passUsernameInMigration` - (default true).
-  When set to true, migration attaches username in the form of `Remote[userName]` while migrating to secondary environment. To use the old migration endpoint, set to false.
 
 ### Code API changes
+* [#4294](https://github.com/TouK/nussknacker/pull/4294) `HttpRemoteEnvironmentConfig` allows you to pass flag `passUsernameInMigration` - (default true).
+  When set to true, migration attaches username in the form of `Remote[userName]` while migrating to secondary environment. To use the old migration endpoint, set to false.
 * [#4278](https://github.com/TouK/nussknacker/pull/4278) Now expression compiler and code suggestions mechanism are reusing the same
   types extracted based on model. Before the change types in compiler were lazily extracted. Because of this change, some expressions
   can stop to compile. You may need to add `WithExplicitTypesToExtract` to some of yours `SourceFactory` implementations.
@@ -15,6 +15,12 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 * [#4290](https://github.com/TouK/nussknacker/pull/4290) Renamed predicates used in `ClassExtractionSettings`:
   * `ClassMemberPatternPredicate` renamed to `MemberNamePatternPredicate`
   * `AllMethodNamesPredicate` renamed to AllMembersPredicate
+
+### Other changes
+* [#4305](https://github.com/TouK/nussknacker/pull/4305) `scala-compiler` and `scala-reflect` are now included in `flink-scala`,
+  so you can simplify your deployment by removing them and updating to new
+  ([`flink-scala` JAR](https://repo1.maven.org/maven2/pl/touk/flink-scala-2-13_2.13/1.1.0/flink-scala-2-13_2.13-1.1.0-assembly.jar))
+  (this doesn't introduce any functional changes)
 
 ## In version 1.9.0
 

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/DockerTest.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/DockerTest.scala
@@ -4,7 +4,6 @@ import com.dimafeng.testcontainers._
 import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import com.typesafe.scalalogging.Logger
-import org.apache.commons.io.IOUtils
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import org.slf4j
 import org.slf4j.LoggerFactory
@@ -54,15 +53,10 @@ trait DockerTest extends BeforeAndAfterAll with ForAllTestContainer with Extreme
       val flinkLibTweakCommand = ScalaMajorVersionConfig.scalaMajorVersion match {
         case "2.12" => ""
         case "2.13" =>
-          val scalaV = util.Properties.versionNumberString
           s"""
             |RUN rm $$FLINK_HOME/lib/flink-scala*.jar
-            |RUN wget https://repo1.maven.org/maven2/org/scala-lang/scala-library/$scalaV/scala-library-$scalaV.jar -O $$FLINK_HOME/lib/scala-library-$scalaV.jar
-            |RUN wget https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/$scalaV/scala-reflect-$scalaV.jar -O $$FLINK_HOME/lib/scala-reflect-$scalaV.jar
-            |RUN wget https://repo1.maven.org/maven2/pl/touk/flink-scala-2-13_2.13/1.0.0/flink-scala-2-13_2.13-1.0.0-assembly.jar -O $$FLINK_HOME/lib/flink-scala-2-13_2.13-1.0.0-assembly.jar
-            |RUN chown flink $$FLINK_HOME/lib/flink-scala-2-13_2.13-1.0.0-assembly.jar
-            |RUN chown flink $$FLINK_HOME/lib/scala-library-$scalaV.jar
-            |RUN chown flink $$FLINK_HOME/lib/scala-reflect-$scalaV.jar
+            |RUN wget https://repo1.maven.org/maven2/pl/touk/flink-scala-2-13_2.13/1.1.0/flink-scala-2-13_2.13-1.1.0-assembly.jar -O $$FLINK_HOME/lib/flink-scala-2-13_2.13-1.1.0-assembly.jar
+            |RUN chown flink $$FLINK_HOME/lib/flink-scala-2-13_2.13-1.1.0-assembly.jar
             |""".stripMargin
         case v => throw new IllegalStateException(s"unsupported scala version: $v")
       }


### PR DESCRIPTION
Simplify Flink deployment: `scala-compiler` and `scala-reflect` are now included in `flink-scala` (https://github.com/TouK/flink-scala-2.13/pull/2)