### PR TITLE
Fix for spel validations: Typing type reference with class starting from lower case caused nasty error

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -45,6 +45,7 @@
 * [#4346](https://github.com/TouK/nussknacker/pull/4346) Improvement: Don't fetch process state for fragment
 * [#4342](https://github.com/TouK/nussknacker/pull/4342) Improvement: Don't run custom action on archived scenario and fragment
 * [#4302](https://github.com/TouK/nussknacker/pull/4302) State inconsistency detection was moved from designer to DeploymentManager.
+* [#4360](https://github.com/TouK/nussknacker/pull/4360) Fix for spel validations: Typing type reference with class starting from lower case e.g. T(foo) caused nasty error
 
 1.9.1 (24 Apr 2023)
 ------------------------

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -210,7 +210,13 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   test("evaluate static method call on non-existing class") {
     inside(parse[Any]("T(java.lang.NonExistingClass).method()")) {
       case Invalid(NonEmptyList(error: UnknownClassError, _)) =>
-        error.message shouldBe "Class T(java.lang.NonExistingClass) does not exist"
+        error.message shouldBe "Class java.lang.NonExistingClass does not exist"
+    }
+  }
+
+  test("not throw an exception when is used lower case type") {
+    parse[Any]("T(foo).bar", ctx) should matchPattern {
+      case Invalid(NonEmptyList(UnknownClassError("foo"), _)) =>
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
