### PR TITLE
Replace img with inlined svg for CustomAction buttons.

### DIFF
--- a/designer/client/src/components/toolbars/status/buttons/CustomActionButton.tsx
+++ b/designer/client/src/components/toolbars/status/buttons/CustomActionButton.tsx
@@ -8,6 +8,7 @@ import { WindowKind } from "../../../../windowManager/WindowKind";
 import { StatusType } from "../../../Process/types";
 import ToolbarButton from "../../../toolbarComponents/ToolbarButton";
 import { ToolbarButtonProps } from "../../types";
+import UrlIcon from "../../../UrlIcon";
 
 type CustomActionProps = {
     action: CustomAction;
@@ -21,7 +22,7 @@ export default function CustomActionButton(props: CustomActionProps) {
     const dispatch = useDispatch();
     const { t } = useTranslation();
 
-    const icon = action.icon ? <img alt={`custom-action-${action.name}`} src={action.icon} /> : <DefaultIcon />;
+    const icon = action.icon ? <UrlIcon src={action.icon} FallbackComponent={DefaultIcon} /> : <DefaultIcon />;
 
     const statusName = processStatus?.name;
     const available = !disabled && action.allowedStateStatusNames.includes(statusName);

--- a/engine/development/deploymentManager/src/main/resources/web/static/assets/buttons/test_deploy.svg
+++ b/engine/development/deploymentManager/src/main/resources/web/static/assets/buttons/test_deploy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 35 35"><path d="M10.11 10v15a1.46 1.46 0 0 0 2.25 1.22l11.85-7.54a1.46 1.46 0 0 0 0-2.46L12.36 8.74A1.46 1.46 0 0 0 10.11 10z" fill="currentColor"/></svg>

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentDeploymentManagerProvider.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentDeploymentManagerProvider.scala
@@ -17,6 +17,7 @@ import pl.touk.nussknacker.engine.testmode.TestProcess
 import pl.touk.nussknacker.engine.{BaseModelData, DeploymentManagerProvider, MetaDataInitializer}
 import sttp.client3.SttpBackend
 
+import java.net.URI
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.collection.concurrent.TrieMap
@@ -39,7 +40,7 @@ class DevelopmentDeploymentManager(actorSystem: ActorSystem)
 
   private val customActionAfterRunning = CustomAction(AfterRunningStatus.name, List(Running.name))
   private val customActionPreparingResources = CustomAction(PreparingResourcesStatus.name, List(NotDeployed.name, Canceled.name))
-  private val customActionTest = CustomAction(TestStatus.name, Nil)
+  private val customActionTest = CustomAction(TestStatus.name, Nil, icon = Some(URI.create("/assets/buttons/test_deploy.svg")))
 
   private val customActionStatusMapping = Map(
     customActionAfterRunning -> AfterRunningStatus,


### PR DESCRIPTION
Custom action icons, when defined in config file, are rendered as inline `<svg>somefile content</svg>`. When custom action is defined in `DeploymentManager.customActions: List[CustomAction]` icon is rendered as `<img src="somefile.svg" />`. 

Example - double arrow is permanently black (black..ish ?), but color of the text below the icon is set correctly :
![image](https://github.com/TouK/nussknacker/assets/2381222/90580497-3fd9-4fb2-9f79-3c64e95e5d81)

![image](https://github.com/TouK/nussknacker/assets/2381222/e2a0bfea-d2ac-4f66-b42d-7f2290d0dc9d)


