### PR TITLE
Publish assembly artifact for nussknacker-flink-manager

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -546,6 +546,7 @@ lazy val flinkDeploymentManager = (project in flink("management")).
   settings(commonSettings).
   settings(itSettings()).
   settings(assemblyNoScala("nussknacker-flink-manager.jar"): _*).
+  settings(publishAssemblySettings: _*).
   settings(
     name := "nussknacker-flink-manager",
     IntegrationTest / Keys.test := (IntegrationTest / Keys.test).dependsOn(
@@ -573,7 +574,9 @@ lazy val flinkDeploymentManager = (project in flink("management")).
         "com.dimafeng" %% "testcontainers-scala-kafka" % testcontainersScalaV % "it,test",
         "com.github.tomakehurst" % "wiremock-jre8" % wireMockV % Test
       ) ++ flinkLibScalaDeps(scalaVersion.value, Some(flinkScope))
-    }
+    },
+    // override scala-collection-compat from com.softwaremill.retry:retry
+    dependencyOverrides += "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionsCompatV
   ).dependsOn(deploymentManagerApi % "provided",
   interpreter % "provided",
   componentsApi % "provided",


### PR DESCRIPTION
I tried to deploy Nussknacker with Flink executor using the recommended method:

* application classpath: `nussknacker-designer:assembly` + `nussknacker-flink-manager`
* model: `nussknacker-flink-executor:assembly` + components  (`nussknacker-flink-base-components:assembly` + `nussknacker-flink-kafka-components:assembly` + `nussknacker-sql:assembly`)

This failed on startup with:
```
java.lang.NoClassDefFoundError: org/apache/flink/streaming/api/datastream/DataStream
        at pl.touk.nussknacker.engine.flink.util.transformer.FlinkBaseComponentProvider.create(FlinkBaseComponentProvider.scala:27)
```

The issue is that nothing provides Flink runtime, which is required by model.

This fix adds building `assembly` version of `nussknacker-flink-manager`, and corrects version of `scala-collection-compat`, because `com.softwaremill.retry:retry` depends on an older version than our runtime.