### PR TITLE
DisplayableProcess legacy decoder fix - typeSpecificProperties instead of typeSpecificData

### DIFF
--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/displayedgraph/DisplayableProcess.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/displayedgraph/DisplayableProcess.scala
@@ -98,7 +98,7 @@ object ProcessProperties {
 
       (c: HCursor) =>
         for {
-          typeSpecificData <- c.downField("typeSpecificData").as[TypeSpecificData]
+          typeSpecificData <- c.downField("typeSpecificProperties").as[TypeSpecificData]
           additionalFields <- c.downField("additionalFields")
             .as[Option[ProcessAdditionalFields]](
               io.circe.Decoder.decodeOption(

--- a/designer/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/NodeDataCodecSpec.scala
+++ b/designer/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/NodeDataCodecSpec.scala
@@ -46,7 +46,7 @@ class NodeDataCodecSpec extends AnyFunSuite with Matchers with EitherValuesDetai
       s"""{
          |  "id" : "$givenProcessName",
          |  "properties" : {
-         |    "typeSpecificData" : {
+         |    "typeSpecificProperties" : {
          |      "parallelism" : $givenParallelism,
          |      "type" : "${StreamMetaData.typeName}"
          |    },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
