### PR TITLE
Fix: resolve references in Swagger 2.0

### DIFF
--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/parser/SwaggerParser.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/parser/SwaggerParser.scala
@@ -2,9 +2,8 @@ package pl.touk.nussknacker.openapi.parser
 
 import cats.data.Validated
 import com.typesafe.scalalogging.LazyLogging
+import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.oas.models.OpenAPI
-import io.swagger.v3.parser.OpenAPIV3Parser
-import io.swagger.v3.parser.converter.SwaggerConverter
 import io.swagger.v3.parser.core.models.ParseOptions
 import pl.touk.nussknacker.engine.util.ResourceLoader
 import pl.touk.nussknacker.openapi.{OpenAPIServicesConfig, SwaggerService}
@@ -22,15 +21,11 @@ object SwaggerParser extends LazyLogging {
     parse(ResourceLoader.load(path), openAPIsConfig)
 
   private[parser] def parseToSwagger(rawSwagger: String): OpenAPI = {
-    val swagger30 = new OpenAPIV3Parser().readContents(rawSwagger)
-    Option(swagger30.getOpenAPI)
-      .getOrElse {
-        val swagger20 = new SwaggerConverter().readContents(rawSwagger, Collections.emptyList(), new ParseOptions)
-        if (swagger20.getOpenAPI != null) {
-          swagger20.getOpenAPI
-        } else throw new IllegalArgumentException(s"Failed to parse with swagger 3.0: ${swagger30.getMessages} and 2.0 ${swagger20.getMessages}")
-      }
+    val parserConfig = new ParseOptions()
+    parserConfig.setResolve(true)
+
+    val parserResult = new OpenAPIParser().readContents(rawSwagger, Collections.emptyList(), parserConfig)
+    Option(parserResult.getOpenAPI).getOrElse(throw new IllegalArgumentException(s"Failed to parse OpenAPI specification: ${parserResult.getMessages}"))
   }
 
 }
-

--- a/components/openapi/src/test/resources/swagger/swagger-2.0-refs.yml
+++ b/components/openapi/src/test/resources/swagger/swagger-2.0-refs.yml
@@ -1,0 +1,28 @@
+swagger: "2.0"
+info:
+  title: "-"
+  version: "1.0.0"
+paths:
+  /someService:
+    get:
+      description: "-"
+      parameters:
+        - $ref: "#/parameters/queryParam"
+      responses:
+        200:
+          description: "-"
+          schema:
+            $ref: "#/definitions/SomeResponse"
+
+parameters:
+  queryParam:
+    name: queryParam
+    in: query
+    type: string
+
+definitions:
+  SomeResponse:
+    type: object
+    properties:
+      message:
+        type: string

--- a/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/parser/SwaggerParserTest.scala
+++ b/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/parser/SwaggerParserTest.scala
@@ -132,4 +132,20 @@ class SwaggerParserTest extends AnyFunSuite with BaseOpenAPITest with Matchers {
       )
     }
   }
+
+  test("handles local references in swagger 2.0") {
+    val openApi = parseServicesFromResource("swagger-2.0-refs.yml")
+    val openApiService = openApi.headOption match {
+      case Some(Valid(openApiService)) => openApiService
+      case _ => fail("Failed to parse Swagger service")
+    }
+    openApiService.responseSwaggerType shouldBe Some(
+      SwaggerObject(Map(
+        "message" -> SwaggerString,
+      ))
+    )
+    openApiService.parameters shouldBe List(
+      QueryParameter("queryParam", SwaggerString)
+    )
+  }
 }

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,7 +5,8 @@
 1.11.0 (not released yet)
 -------------------------
 * [#4400](https://github.com/TouK/nussknacker/pull/4400) Improvement: Avoid long waits for closing job on test Flink minicluster
-* 
+* [#4435](https://github.com/TouK/nussknacker/pull/4435) Fix: handle resolving refs when parsing Swagger 2.0 schema in openapi enricher
+
 1.10.0 (not released yet)
 -------------------------
 * [#4275](https://github.com/TouK/nussknacker/pull/4275) Add helper methods for use in expressions:


### PR DESCRIPTION
In SwaggerParser when we get a Swagger 2.0 definition which has references which we are using later (such as in parameters or response body), we are not able to properly parse it and convert to SwaggerService. This is because we are passing empty parser config to a dedicated Swagger 2.0 parser which has reference resolving turned off. This problem is not seen in OpenApi 3.0, because we are not passing any config, and it default to resolving refs.

I propose using a unified OpenAPIParser, since it is a higher level interface which parses Swagger 2.0 and Openapi definitions. It gets the same parser config with resolution turned on.