### PR TITLE
Fix stopping processes with `/api/adminProcessManagement/stop/{processName}` endpoint on recent Flink versions

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11,6 +11,7 @@
 * [#4469](https://github.com/TouK/nussknacker/pull/4469) Faster loading of components tab: Component's usages fetched once instead of fetching for each processing type
 * [#4469](https://github.com/TouK/nussknacker/pull/4469) Faster loading of components tab: Don't fetch last actions
 * [#4353](https://github.com/TouK/nussknacker/pull/4353) Removed isCancelled/isDeployed flags based on `ProcessAction`, `ProcessAction.action` renamed to actionType. Trait `Process` is removed.
+* [#4488](https://github.com/TouK/nussknacker/pull/4488) Fix stopping processes with `/api/adminProcessManagement/stop/{processName}` endpoint on recent Flink versions
 
 1.10.0 (29 Jun 2023)
 -------------------------

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
@@ -143,7 +143,7 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
       val savepointPath = deploymentManager.stop(ProcessName(processId), savepointDir = None, user = userToAct).map(_.path)
       eventually {
         val status = deploymentManager.getProcessStates(ProcessName(processId)).futureValue
-        status.value.map(_.status) shouldBe List(SimpleStateStatus.Finished)
+        status.value.map(_.status) shouldBe List(SimpleStateStatus.Canceled)
       }
 
       deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processId), Some(savepointPath.futureValue))


### PR DESCRIPTION
Change caused by https://issues.apache.org/jira/browse/FLINK-28758