### PR TITLE
Replace AkkaHttpBackend with AsyncHttpClientFutureBackend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1387,6 +1387,9 @@ lazy val httpUtils = (project in utils("http-utils")).
         "com.softwaremill.sttp.client3" %% "core" % sttpV,
         "com.softwaremill.sttp.client3" %% "json-common" % sttpV,
         "com.softwaremill.sttp.client3" %% "circe" % sttpV,
+        "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % sttpV excludeAll (
+          ExclusionRule(organization = "com.sun.activation", name = "javax.activation"),
+          ),
       )
     }
   ).dependsOn(componentsApi % Provided, testUtils % "test")

--- a/components/openapi/src/it/scala/pl/touk/nussknacker/openapi/functional/OpenAPIServiceSpec.scala
+++ b/components/openapi/src/it/scala/pl/touk/nussknacker/openapi/functional/OpenAPIServiceSpec.scala
@@ -13,8 +13,8 @@ import pl.touk.nussknacker.engine.api.typed.TypedMap
 import pl.touk.nussknacker.engine.util.ResourceLoader
 import pl.touk.nussknacker.engine.util.runtimecontext.TestEngineRuntimeContext
 import pl.touk.nussknacker.engine.util.service.EagerServiceWithStaticParametersAndReturnType
+import pl.touk.nussknacker.http.backend.FixedAsyncHttpClientBackendProvider
 import pl.touk.nussknacker.openapi.enrichers.{SwaggerEnricherCreator, SwaggerEnrichers}
-import pl.touk.nussknacker.openapi.http.backend.FixedAsyncHttpClientBackendProvider
 import pl.touk.nussknacker.openapi.parser.SwaggerParser
 import pl.touk.nussknacker.openapi.{ApiKeyConfig, OpenAPIServicesConfig}
 import pl.touk.nussknacker.test.PatientScalaFutures

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/OpenAPIsConfig.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/OpenAPIsConfig.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.openapi
 import com.typesafe.config.Config
 import io.swagger.v3.oas.models.PathItem.HttpMethod
 import net.ceedubs.ficus.readers.{ArbitraryTypeReader, ValueReader}
-import pl.touk.nussknacker.openapi.http.backend.{DefaultHttpClientConfig, HttpClientConfig}
+import pl.touk.nussknacker.http.backend.{DefaultHttpClientConfig, HttpClientConfig}
 import sttp.model.StatusCode
 
 import java.net.URL

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/discovery/SwaggerOpenApiDefinitionDiscovery.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/discovery/SwaggerOpenApiDefinitionDiscovery.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.FileUtils
 import org.asynchttpclient.DefaultAsyncHttpClient
 import pl.touk.nussknacker.engine.util.ResourceLoader
-import pl.touk.nussknacker.openapi.http.backend.HttpClientConfig
+import pl.touk.nussknacker.http.backend.HttpClientConfig
 import pl.touk.nussknacker.openapi.parser.{ServiceParseError, SwaggerParser}
 import pl.touk.nussknacker.openapi.{OpenAPIServicesConfig, SwaggerService}
 import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/enrichers/SwaggerEnricher.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/enrichers/SwaggerEnricher.scala
@@ -9,11 +9,12 @@ import pl.touk.nussknacker.engine.api.typed.typing
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
 import pl.touk.nussknacker.engine.api.{ContextId, MetaData}
 import pl.touk.nussknacker.engine.util.service.{EagerServiceWithStaticParametersAndReturnType, TimeMeasuringService}
+import pl.touk.nussknacker.http.backend.{FixedAsyncHttpClientBackendProvider, HttpBackendProvider, HttpClientConfig, LoggingAndCollectingSttpBackend}
 import pl.touk.nussknacker.openapi.SwaggerService
 import pl.touk.nussknacker.openapi.enrichers.SwaggerEnricherCreator.determineInvocationBaseUrl
 import pl.touk.nussknacker.openapi.extractor.ParametersExtractor
 import pl.touk.nussknacker.openapi.http.SwaggerSttpService
-import pl.touk.nussknacker.openapi.http.backend._
+import pl.touk.nussknacker.openapi.http.backend.SharedHttpClientBackendProvider
 import sttp.client3.SttpBackend
 import sttp.model.StatusCode
 

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/http/backend/SharedHttpClient.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/http/backend/SharedHttpClient.scala
@@ -4,6 +4,7 @@ import org.asynchttpclient.{AsyncHttpClient, DefaultAsyncHttpClient}
 import pl.touk.nussknacker.engine.api.MetaData
 import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
 import pl.touk.nussknacker.engine.util.sharedservice.{SharedService, SharedServiceHolder}
+import pl.touk.nussknacker.http.backend.{HttpBackendProvider, HttpClientConfig}
 import sttp.client3.SttpBackend
 import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -12,12 +12,14 @@ import fr.davit.akka.http.metrics.dropwizard.{DropwizardRegistry, DropwizardSett
 import io.dropwizard.metrics5.MetricRegistry
 import io.dropwizard.metrics5.jmx.JmxReporter
 import net.ceedubs.ficus.readers.ArbitraryTypeReader.arbitraryTypeValueReader
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
 import pl.touk.nussknacker.engine.dict.ProcessDictSubstitutor
 import pl.touk.nussknacker.engine.util.config.ConfigFactoryExt
 import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
 import pl.touk.nussknacker.engine.util.multiplicity.{Empty, Many, Multiplicity, One}
 import pl.touk.nussknacker.engine.util.{JavaClassVersionChecker, SLF4JBridgeHandlerRegistrar}
 import pl.touk.nussknacker.engine.{CombinedProcessingTypeData, ConfigWithUnresolvedVersion, ProcessingTypeData}
+import pl.touk.nussknacker.http.backend.FixedAsyncHttpClientBackendProvider
 import pl.touk.nussknacker.processCounts.influxdb.InfluxCountsReporterCreator
 import pl.touk.nussknacker.processCounts.{CountsReporter, CountsReporterCreator}
 import pl.touk.nussknacker.ui.api._
@@ -46,7 +48,7 @@ import pl.touk.nussknacker.ui.util.{CorsSupport, OptionsMethodSupport, SecurityH
 import pl.touk.nussknacker.ui.validation.ProcessValidation
 import slick.jdbc.{HsqldbProfile, JdbcBackend, JdbcProfile, PostgresProfile}
 import sttp.client3.SttpBackend
-import sttp.client3.akkahttp.AkkaHttpBackend
+import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -86,7 +88,7 @@ trait NusskanckerDefaultAppRouter extends NusskanckerAppRouter {
   override def create(designerConfig: ConfigWithUnresolvedVersion, dbConfig: DbConfig, metricsRegistry: MetricRegistry)(implicit system: ActorSystem, materializer: Materializer): (Route, Iterable[AutoCloseable]) = {
     import system.dispatcher
 
-    implicit val sttpBackend: SttpBackend[Future, Any] = AkkaHttpBackend.usingActorSystem(system)
+    implicit val sttpBackend: SttpBackend[Future, Any] = AsyncHttpClientFutureBackend.usingConfig(new DefaultAsyncHttpClientConfig.Builder().build())
 
     val resolvedConfig = designerConfig.resolved
     val environment = resolvedConfig.getString("environment")

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -24,6 +24,10 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   * `isSubprocess` query parameter is renamed to `isFragment`. `isSubprocess` will be removed in 1.12.0
 * [#4462](https://github.com/TouK/nussknacker/pull/4462) Process state API returns `externalDeploymentId` instead of `deploymentId`.
 
+### Other changes
+* [#4514](https://github.com/TouK/nussknacker/pull/4514) `AkkaHttpBackend` in designer is replaced by `AsyncHttpClientFutureBackend`.
+  To use custom http client configuration use `ahc.properties` file and make sure it is available in the classpath.
+
 ## In version 1.10.0
 
 ### Code API changes

--- a/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/HttpBackendProvider.scala
+++ b/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/HttpBackendProvider.scala
@@ -1,4 +1,4 @@
-package pl.touk.nussknacker.openapi.http.backend
+package pl.touk.nussknacker.http.backend
 
 import org.asynchttpclient.AsyncHttpClient
 import pl.touk.nussknacker.engine.api.Lifecycle

--- a/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/HttpClientConfig.scala
+++ b/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/HttpClientConfig.scala
@@ -1,8 +1,8 @@
-package pl.touk.nussknacker.openapi.http.backend
+package pl.touk.nussknacker.http.backend
 
 import net.ceedubs.ficus.readers.ValueReader
 import org.asynchttpclient.DefaultAsyncHttpClientConfig
-import pl.touk.nussknacker.openapi.http.backend.HttpClientConfig.EffectiveHttpClientConfig
+import pl.touk.nussknacker.http.backend.HttpClientConfig.EffectiveHttpClientConfig
 import sttp.client3.SttpBackendOptions
 
 import scala.concurrent.duration._

--- a/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/LoggingAndCollectingSttpBackend.scala
+++ b/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/LoggingAndCollectingSttpBackend.scala
@@ -1,4 +1,4 @@
-package pl.touk.nussknacker.openapi.http.backend
+package pl.touk.nussknacker.http.backend
 
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory

--- a/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/RequestResponseLog.scala
+++ b/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/RequestResponseLog.scala
@@ -1,7 +1,6 @@
-package pl.touk.nussknacker.openapi.http.backend
+package pl.touk.nussknacker.http.backend
 
 import io.circe.generic.JsonCodec
-import pl.touk.nussknacker.engine.api.DisplayJsonWithEncoder
 import sttp.client3.{Request, Response, StringBody}
 import sttp.model.Header
 
@@ -10,7 +9,7 @@ case class RequestResponseLog(url: String,
                               method: Option[String],
                               headers: Map[String, List[String]],
                               body: Option[String],
-                              statusCode: Option[Int]) extends DisplayJsonWithEncoder[RequestResponseLog] {
+                              statusCode: Option[Int]) {
   def pretty: String = {
     Map(
       "url" -> url,


### PR DESCRIPTION
In https://github.com/TouK/nussknacker/commit/5205163169f5e11c7170d5df91ea8587cbe6e063  we added `readTimeout` to `HttpFlinkClient.findJobsByName`.
Akka does not support such setting and sttp uses idleTimeout as readTimeout, see sttp.client3.akkahttp.AkkaHttpBackend :
```
  private def connectionSettings(r: Request[_, _]): ConnectionPoolSettings = {
    //...
    connectionPoolSettingsWithProxy
    .withUpdatedConnectionSettings(_.withIdleTimeout(r.options.readTimeout))
  } 
```
And that idle/readTimeout means that after timeout connection is killed via RST (see also https://github.com/akka/akka-http/issues/3346).
Therefore, to avoid broken sessions of findJobsByName, when HttpFlinkClient is created we should replace use AsyncHttpClientFutureBackend instead of AkkaHttpBackend.
