### PR TITLE
Fix for flaky cypress test: Components list should filter usages

### DIFF
--- a/designer/client/cypress/e2e/components.cy.ts
+++ b/designer/client/cypress/e2e/components.cy.ts
@@ -158,7 +158,7 @@ describe("Components list", () => {
         cy.createTestProcess(`${seed}_xxx`, "testProcess2");
 
         cy.visit("/components/usages/filter");
-
+        cy.get("[data-testid=OpenInNewIcon]").should("have.length.greaterThan", 1);
         cy.get("input[type=text]").type("8 xxx");
         cy.matchQuery("?TEXT=8+xxx");
         cy.contains(/^filter 8$/).should("be.visible");


### PR DESCRIPTION
Waiting for table render befor submit filtering

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please make sure that you added appropriate entry in docs/Changelog.md and docs/MigrationGuide.md

You can learn more about contributing to Nussknacker here: https://github.com/TouK/nussknacker/blob/staging/CONTRIBUTING.md

Happy contributing!

-->
