### PR TITLE
Fix: Allow to pass to sttp client default options, e.g. http proxy

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/NussknackerApp.scala
@@ -88,7 +88,7 @@ trait NusskanckerDefaultAppRouter extends NusskanckerAppRouter {
   override def create(designerConfig: ConfigWithUnresolvedVersion, dbConfig: DbConfig, metricsRegistry: MetricRegistry)(implicit system: ActorSystem, materializer: Materializer): (Route, Iterable[AutoCloseable]) = {
     import system.dispatcher
 
-    implicit val sttpBackend: SttpBackend[Future, Any] = AsyncHttpClientFutureBackend.usingConfig(new DefaultAsyncHttpClientConfig.Builder().build())
+    implicit val sttpBackend: SttpBackend[Future, Any] = AsyncHttpClientFutureBackend.usingConfigBuilder(identity)
 
     val resolvedConfig = designerConfig.resolved
     val environment = resolvedConfig.getString("environment")


### PR DESCRIPTION
Allow to pass http proxy properties to sttp in Nussknacker by:

```
java11 -Dhttps.proxyHost=your-proxy.domain -Dhttps.proxyPort=8080 -cp nussknacker-designer.jar pl.touk.nussknacker.ui.NussknackerApp
```