### PR TITLE
Fix warnings message

### DIFF
--- a/designer/client/src/components/tips/Warnings.js
+++ b/designer/client/src/components/tips/Warnings.js
@@ -15,16 +15,16 @@ export default class Warnings extends React.Component {
 
     render() {
         const { warnings, showDetails, currentProcess } = this.props;
-        const groupedByMessage = groupBy(warnings, (warning) => warning.error.message);
+        const groupedByType = groupBy(warnings, (warning) => warning.error.typ);
         const separator = ", ";
 
         return (
             <div key={uuid4()}>
                 {warnings.length > 0 && <TipsWarning className={"icon"} />}
                 <div>
-                    {Object.entries(groupedByMessage).map(([message, warnings]) => (
+                    {Object.entries(groupedByType).map(([warningType, warnings]) => (
                         <div key={uuid4()} className={"warning-tips"} title={warnings.description}>
-                            <span>{headerMessageByWarningMessage.get(message)}</span>
+                            <span>{headerMessageByWarningType.get(warningType)}</span>
                             <div className={"warning-links"}>
                                 {warnings.map((warning, index) => (
                                     <Link
@@ -46,4 +46,4 @@ export default class Warnings extends React.Component {
     }
 }
 
-const headerMessageByWarningMessage = new Map([["Node is disabled", "Node disabled: "]]);
+const headerMessageByWarningType = new Map([["DisabledNode", "Nodes disabled: "]]);


### PR DESCRIPTION
Scenario warnings are displayed without a header message. This is caused by incorrectly mapping warning message to header message on the FE.

Now:
![warnings-before](https://github.com/TouK/nussknacker/assets/92804917/d18b54e8-698f-43ed-bf35-130e8327183d)
After this change:
![warnings-after](https://github.com/TouK/nussknacker/assets/92804917/6093b662-81a5-48ef-a9f7-74f46b62f85e)
