### PR TITLE
NU-980: Error on page open

### DIFF
--- a/designer/client/src/i18n.ts
+++ b/designer/client/src/i18n.ts
@@ -25,6 +25,9 @@ i18n.init({
             return value;
         },
     },
+    react: {
+        useSuspense: false,
+    },
 });
 
 export default i18n;

--- a/designer/submodules/packages/components/src/settings/i18n.ts
+++ b/designer/submodules/packages/components/src/settings/i18n.ts
@@ -32,6 +32,9 @@ i18n.init({
     defaultNS: "main",
     fallbackLng: "en",
     supportedLngs: ["en"],
+    react: {
+        useSuspense: false,
+    },
 });
 
 i18n.services.formatter.add("relativeDate", (value, lng, options) => {

--- a/designer/submodules/packages/legacy_scenarios/src/i18n.ts
+++ b/designer/submodules/packages/legacy_scenarios/src/i18n.ts
@@ -39,6 +39,9 @@ i18n.init({
             return value;
         },
     },
+    react: {
+        useSuspense: false,
+    },
 });
 
 export default i18n;


### PR DESCRIPTION
- The issue was caused by i18n built-in suspense which was sometimes fired since we have lazy loading and fallback loaders, there is no reason to declare root suspense (in theory it should also resolve this issue, but didn't check it), so we can just remove the built-in  i18n suspense
- The issue is only reproducible on specific environments (we cannot reproduce it locally), I was able to reproduce it and fix it, on the Nu cloud instance by the replacing Nu image with this one https://hub.docker.com/layers/touk/nussknacker/preview_NU-980-error-on-page-open-latest/images/sha256-ac5876187a9aacc35f1506ae4eb7d9a969fa2df0857247143e8849f2f178cff5?context=explore


https://github.com/TouK/nussknacker/assets/9945753/b9842207-cfc1-4018-9bf1-d21aba7f93fd



