### PR TITLE
NU-977 stop server calls when connection error

### DIFF
--- a/designer/client/cypress/e2e/connectionError.cy.ts
+++ b/designer/client/cypress/e2e/connectionError.cy.ts
@@ -71,8 +71,49 @@ describe("Connection error", () => {
             cy.contains(/Backend connection issue/).should("not.exist");
         };
 
+        const verifyNoBackendAccessAndRequestCanceling = () => {
+            const visibleStatusToastMessageBeforeConnectionError = () => {
+                cy.intercept("/api/processes/*/status", { statusCode: 502 });
+
+                // Check if the status toast message is not visible after the backend connection issue. We need to speed up interval to not wait 12s for a request
+                cy.contains(/Cannot fetch status/).should("be.visible");
+
+                cy.intercept("/api/processes/*/status", (req) => {
+                    req.continue();
+                });
+            };
+            const notVisibleStatusToastMessageWhenConnectionError = () => {
+                cy.contains(/Cannot fetch status/).should("not.exist");
+            };
+
+            cy.clock();
+            cy.log("verify no backend access when scenario edit modal opens");
+            cy.visitNewProcess(NAME, "filter");
+
+            cy.contains("svg", /filter/i).dblclick();
+
+            cy.tick(12000);
+
+            visibleStatusToastMessageBeforeConnectionError();
+
+            cy.tick(1000);
+
+            cy.intercept("/api/notifications", { statusCode: 502 });
+
+            cy.tick(12000);
+
+            notVisibleStatusToastMessageWhenConnectionError();
+
+            cy.intercept("/api/notifications", (req) => {
+                req.continue();
+            });
+
+            cy.clock().invoke("restore");
+        };
+
         verifyNoNetworkAccess();
         verifyNoBackendAccess();
         verifyNoBackendAccessWhenScenarioEditNodeModalOpens();
+        verifyNoBackendAccessAndRequestCanceling();
     });
 });

--- a/designer/client/src/containers/connectionErrorProvider/ConnectionErrorProvider.tsx
+++ b/designer/client/src/containers/connectionErrorProvider/ConnectionErrorProvider.tsx
@@ -1,12 +1,13 @@
-import React, { createContext, FC, PropsWithChildren, useContext, useMemo, useState } from "react";
+import React, { createContext, FC, PropsWithChildren, useContext, useEffect, useMemo, useState } from "react";
 import { Dialog } from "@mui/material";
 import { ConnectionErrorContent } from "./ConnectionErrorContent";
 import { CloudOff, WifiOff } from "@mui/icons-material";
 import i18next from "i18next";
+import { useCancelRequestsIfConnectionProblem } from "./useCancelRequestsIfConnectionProblem";
 
 const ConnectionErrorContext = createContext<{ handleChangeConnectionError: (connectionError: ConnectionError) => void | null }>(null);
 
-type ConnectionError = "NO_NETWORK_ACCESS" | "NO_BACKEND_ACCESS";
+export type ConnectionError = "NO_NETWORK_ACCESS" | "NO_BACKEND_ACCESS";
 
 export const ConnectionErrorProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const [connectionError, setConnectionError] = useState<ConnectionError | null>(null);
@@ -14,6 +15,8 @@ export const ConnectionErrorProvider: FC<PropsWithChildren<unknown>> = ({ childr
     const handleChangeConnectionError = (newConnectionError: ConnectionError) => {
         setConnectionError(newConnectionError);
     };
+
+    useCancelRequestsIfConnectionProblem(connectionError);
 
     const connectionErrorComponent = useMemo(() => {
         switch (connectionError) {

--- a/designer/client/src/containers/connectionErrorProvider/useCancelRequestsIfConnectionProblem.ts
+++ b/designer/client/src/containers/connectionErrorProvider/useCancelRequestsIfConnectionProblem.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import api from "../../api";
+import { ConnectionError } from "./ConnectionErrorProvider";
+
+export const useCancelRequestsIfConnectionProblem = (connectionError: ConnectionError) => {
+    useEffect(() => {
+        const interceptorRequestId = api.interceptors.request.use(
+            (config) => {
+                const controller = new AbortController();
+
+                if (connectionError && !config.url.includes("/notifications")) {
+                    controller.abort();
+                }
+
+                return { ...config, signal: controller.signal };
+            },
+            function (error) {
+                return Promise.reject(error);
+            },
+        );
+
+        return () => {
+            api.interceptors.request.eject(interceptorRequestId);
+        };
+    }, [connectionError]);
+};

--- a/designer/client/src/http/HttpService.ts
+++ b/designer/client/src/http/HttpService.ts
@@ -651,6 +651,11 @@ class HttpService {
 
     async #addError(message: string, error?: AxiosError<unknown>, showErrorText = false) {
         console.warn(message, error);
+
+        if (this.#requestCanceled(error)) {
+            return;
+        }
+
         const errorResponseData = error?.response?.data || error.message;
         const errorMessage =
             errorResponseData instanceof Blob
@@ -668,6 +673,10 @@ class HttpService {
             //don't send empty edges
             withoutHackOfEmptyEdges(process);
         return { id, nodes, edges, properties, processingType, category };
+    }
+
+    #requestCanceled(error: AxiosError<unknown>) {
+        return error.message === "canceled";
     }
 }
 


### PR DESCRIPTION
- All server calls will be cancelled when connection error detected (which means, that we won't display bottom left toast message in this case
