### PR TITLE
Customize search and replace ace editor styles

### DIFF
--- a/designer/client/src/brace/theme/nussknacker.css
+++ b/designer/client/src/brace/theme/nussknacker.css
@@ -16,7 +16,7 @@
 }
 
 .ace-nussknacker .ace_search_field {
-    color: #a8ce91;
+    color: #ccc;
 }
 
 .ace-nussknacker {

--- a/designer/client/src/brace/theme/nussknacker.css
+++ b/designer/client/src/brace/theme/nussknacker.css
@@ -10,6 +10,15 @@
     width: 1px;
     background: #555651
 }
+
+.ace-nussknacker .ace_search {
+    background: #818181;
+}
+
+.ace-nussknacker .ace_search_field {
+    color: #a8ce91;
+}
+
 .ace-nussknacker {
     background-color: #333;
     color: #F8F8F2


### PR DESCRIPTION
Currently text input color inside Search & Replace Ace Editor's  is very unfriendly. Here I propose new colours 

====== BEFORE ======
![image](https://github.com/TouK/nussknacker/assets/8947632/fbefd92f-ed20-491c-9f9c-449fb9836170)


====== AFTER ======
![Screenshot Capture - 2023-08-21 - 15-27-58](https://github.com/TouK/nussknacker/assets/8947632/a28ac41a-6d74-41c7-b7e9-9b427ba16a18)
