### PR TITLE
[bugfix] interpreters fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ target.tgz
 .k3d/k3s_manifests/local-storage.yaml
 .k3d/k3s_manifests/rolebindings.yaml
 .eslintcache
+.java-version

--- a/benchmarks/src/test/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
+++ b/benchmarks/src/test/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
@@ -26,13 +26,13 @@ class ManyParamsInterpreterBenchmark {
     .enricher("e1", "out", "service", (1 to 20).map(i => s"p$i" -> ("''": Expression)): _*)
     .emptySink("sink", "sink")
 
-  private def prepareInterpreter(executionContext: ExecutionContext) = {
+  private def prepareIoInterpreter(executionContext: ExecutionContext) = {
     val setup = new InterpreterSetup[String].sourceInterpretation[IO](process, Map("service" -> new ManyParamsService(executionContext)), Nil)
     (ctx: Context) => setup(ctx, executionContext)
   }
 
-  private val interpreterSyncIO = prepareInterpreter(SynchronousExecutionContext.ctx)
-  private val interpreterAsyncIO = prepareInterpreter(ExecutionContext.Implicits.global)
+  private val interpreterSyncIO = prepareIoInterpreter(SynchronousExecutionContext.ctx)
+  private val interpreterAsyncIO = prepareIoInterpreter(ExecutionContext.Implicits.global)
 
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmarks/src/test/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
+++ b/benchmarks/src/test/scala/pl/touk/nussknacker/engine/benchmarks/interpreter/ManyParamsInterpreterBenchmark.scala
@@ -31,14 +31,14 @@ class ManyParamsInterpreterBenchmark {
     (ctx: Context) => setup(ctx, executionContext)
   }
 
-  private val interpreterSync = prepareInterpreter(SynchronousExecutionContext.create())
-  private val interpreterAsync = prepareInterpreter(ExecutionContext.Implicits.global)
+  private val interpreterSyncIO = prepareInterpreter(SynchronousExecutionContext.ctx)
+  private val interpreterAsyncIO = prepareInterpreter(ExecutionContext.Implicits.global)
 
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
   def benchmarkSync(): AnyRef = {
-    interpreterSync(Context("")).unsafeRunSync()
+    interpreterSyncIO(Context("")).unsafeRunSync()
   }
 
 
@@ -46,7 +46,7 @@ class ManyParamsInterpreterBenchmark {
   @BenchmarkMode(Array(Mode.Throughput))
   @OutputTimeUnit(TimeUnit.SECONDS)
   def benchmarkAsync(): AnyRef = {
-    interpreterAsync(Context("")).unsafeRunSync()
+    interpreterAsyncIO(Context("")).unsafeRunSync()
   }
 
 }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
@@ -6,10 +6,10 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.async.{ResultFuture, RichAsyncFunction}
 import pl.touk.nussknacker.engine.InterpretationResult
 import pl.touk.nussknacker.engine.Interpreter.FutureShape
+import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 import pl.touk.nussknacker.engine.api.process.AsyncExecutionContextPreparer
-import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.graph.node.NodeData
 import pl.touk.nussknacker.engine.process.ProcessPartFunction
 import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
@@ -18,7 +18,6 @@ import pl.touk.nussknacker.engine.splittedgraph.splittednode.SplittedNode
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success}
 
 private[registrar] class AsyncInterpretationFunction(val compiledProcessWithDepsProvider: ClassLoader => FlinkProcessCompilerData,
                                                      val node: SplittedNode[_<:NodeData], validationContext: ValidationContext,
@@ -65,7 +64,7 @@ private[registrar] class AsyncInterpretationFunction(val compiledProcessWithDeps
       interpreter.interpret[IO](compiledNode, metaData, input).unsafeRunAsync(callback)
     } else {
       implicit val future: FutureShape = new FutureShape()
-      interpreter.interpret[Future](compiledNode, metaData, input).onComplete(_.toEither)
+      interpreter.interpret[Future](compiledNode, metaData, input).onComplete(result => callback(result.toEither))
     }
   }
 

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
@@ -13,6 +13,7 @@ import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
 import pl.touk.nussknacker.engine.splittedgraph.splittednode.SplittedNode
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
 
+import java.util.concurrent.TimeoutException
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.control.NonFatal
 
@@ -42,7 +43,10 @@ private[registrar] class SyncInterpretationFunction(val compiledProcessWithDepsP
   private def runInterpreter(input: Context): List[Either[InterpretationResult, NuExceptionInfo[_ <: Throwable]]] = {
     //we leave switch to be able to return to Future if IO has some flaws...
     if (useIOMonad) {
-      interpreter.interpret(compiledNode, metaData, input).unsafeRunSync()
+      interpreter.interpret(compiledNode, metaData, input).unsafeRunTimed(processTimeout) match {
+        case Some(result) => result
+        case None => throw new TimeoutException(s"Interpreter is running too long (timeout: $processTimeout)")
+      }
     } else {
       implicit val futureShape: FutureShape = new FutureShape()
       Await.result(interpreter.interpret[Future](compiledNode, metaData, input), processTimeout)

--- a/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/sample.scala
+++ b/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/sample.scala
@@ -50,8 +50,8 @@ object sample {
 
     override def monad: Monad[StateType] = implicitly[Monad[StateType]]
 
-    override def fromFuture[T](implicit ec: ExecutionContext): Future[T] => StateType[Either[T, Throwable]] =
-      f => StateT.pure(Await.result(transform(f)(ec), 1 second))
+    override def fromFuture[T]: Future[T] => StateType[Either[T, Throwable]] =
+      f => StateT.pure(Await.result(transform(f), 1 second))
 
   }
 

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
@@ -9,27 +9,23 @@ import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 import pl.touk.nussknacker.engine.api.expression.Expression
 import pl.touk.nussknacker.engine.api.process.ComponentUseCase
-import pl.touk.nussknacker.engine.compile.ExpressionCompiler
-import pl.touk.nussknacker.engine.compiledgraph.evaluatedparam.Parameter
 import pl.touk.nussknacker.engine.compiledgraph.node._
 import pl.touk.nussknacker.engine.compiledgraph.service._
 import pl.touk.nussknacker.engine.compiledgraph.variable._
 import pl.touk.nussknacker.engine.component.NodeComponentInfoExtractor
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContext
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 private class InterpreterInternal[F[_]](listeners: Seq[ProcessListener],
                                         expressionEvaluator: ExpressionEvaluator,
                                         interpreterShape: InterpreterShape[F],
                                         componentUseCase: ComponentUseCase
                                        )(implicit metaData: MetaData, executor: ExecutionContext) {
-
 
   type Result[T] = Either[T, NuExceptionInfo[_ <: Throwable]]
 
@@ -202,11 +198,12 @@ private class InterpreterInternal[F[_]](listeners: Seq[ProcessListener],
       //TODO: what about implicit??
       listeners.foreach(_.serviceInvoked(node.id, ref.id, ctx, metaData, preparedParams, result))
     }
-    val syncEc = SynchronousExecutionContext.ctx
-    interpreterShape.fromFuture(syncEc)(resultFuture.map(ValueWithContext(_, ctx))(syncEc)).map {
-      case Right(ex) => Right(handleError(node, ctx)(ex))
-      case Left(value) => Left(value)
-    }
+    interpreterShape
+      .fromFuture(resultFuture)
+      .map {
+        case Right(ex) => Right(handleError(node, ctx)(ex))
+        case Left(value) => Left(ValueWithContext(value, ctx))
+      }
   }
 
   private def evaluateExpression[R](expr: Expression, ctx: Context, name: String)
@@ -214,7 +211,6 @@ private class InterpreterInternal[F[_]](listeners: Seq[ProcessListener],
     expressionEvaluator.evaluate(expr, name, node.id, ctx)
   }
 }
-
 
 class Interpreter(listeners: Seq[ProcessListener],
                   expressionEvaluator: ExpressionEvaluator,
@@ -250,7 +246,7 @@ object Interpreter {
 
     def monad: Monad[F]
 
-    def fromFuture[T](implicit ec: ExecutionContext): Future[T] => F[Either[T, Throwable]]
+    def fromFuture[T]: Future[T] => F[Either[T, Throwable]]
 
   }
 
@@ -262,15 +258,19 @@ object Interpreter {
 
     override def monad: Monad[IO] = Monad[IO]
 
-    override def fromFuture[T](implicit ec: ExecutionContext): Future[T] => IO[Either[T, Throwable]] =
-      f => IO.fromFuture(IO.pure(transform(f)))(IO.contextShift(ec))
+    override def fromFuture[T]: Future[T] => IO[Either[T, Throwable]] = {
+      implicit val ctx = SynchronousExecutionContext.ctx
+      f => IO.fromFuture(IO(transform(f)))(IO.contextShift(ctx))
+    }
   }
 
   class FutureShape(implicit ec: ExecutionContext) extends InterpreterShape[Future] {
 
     override def monad: Monad[Future] = cats.instances.future.catsStdInstancesForFuture(ec)
 
-    override def fromFuture[T](implicit ec: ExecutionContext): Future[T] => Future[Either[T, Throwable]] = transform(_)
+    override def fromFuture[T]: Future[T] => Future[Either[T, Throwable]] = {
+      transform(_)(SynchronousExecutionContext.ctx)
+    }
   }
 
 }

--- a/utils/lite-components-testkit/src/main/scala/pl/touk/nussknacker/engine/lite/util/test/SynchronousLiteInterpreter.scala
+++ b/utils/lite-components-testkit/src/main/scala/pl/touk/nussknacker/engine/lite/util/test/SynchronousLiteInterpreter.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.engine.lite.util.test
 
 import cats.data.{NonEmptyList, Validated}
-import cats.{Id, Monad, catsInstancesForId}
+import cats.{Id, Monad}
 import pl.touk.nussknacker.engine.Interpreter.InterpreterShape
 import pl.touk.nussknacker.engine.Interpreter.InterpreterShape.transform
 import pl.touk.nussknacker.engine.ModelData
@@ -37,7 +37,7 @@ object SynchronousLiteInterpreter {
 
     override def monad: Monad[Id] = Monad[Id]
 
-    override def fromFuture[T](implicit ec: ExecutionContext): Future[T] => Id[Either[T, Throwable]] = f => Await.result(transform(f), waitTime)
+    override def fromFuture[T]: Future[T] => Id[Either[T, Throwable]] = f => Await.result(transform(f), waitTime)
   }
   //todo add generate test data support
 


### PR DESCRIPTION
Fixed issues:

- `IOShape`: use `IO.apply` instead of `IO.pure` 
- `SyncInterpretationFunction`: in case of IO monad usage, the code should be symmetric to the Future-based implementation (added timeout to the sync run)
- `AsyncInterpretationFunction`: in case of the Future-based implementation - the callback was not invoked
- `interpreter.scala`: converting from Future to Effect (IO or Future) should be done using the sync execution context (now the intention is more clear than before)

IMO the issues above should be solved before bumping cats-effect lib. Ref: https://github.com/TouK/nussknacker/pull/4287

--- 

Benchmarks:

Before changes:
```
[info] Benchmark                                           Mode  Cnt        Score        Error  Units
[info] ManyParamsInterpreterBenchmark.benchmarkAsync      thrpt    8   256944.447 ±  14652.777  ops/s
[info] ManyParamsInterpreterBenchmark.benchmarkSync       thrpt    8   519288.756 ±   4219.996  ops/s
[info] OneParamInterpreterBenchmark.benchmarkAsyncIO      thrpt    8   174094.575 ±   6846.656  ops/s
[info] OneParamInterpreterBenchmark.benchmarkFutureAsync  thrpt    8    93019.418 ±   8049.856  ops/s
[info] OneParamInterpreterBenchmark.benchmarkFutureSync   thrpt    8  2543090.275 ± 135655.268  ops/s
[info] OneParamInterpreterBenchmark.benchmarkSyncIO       thrpt    8  1791769.229 ±  89304.281  ops/s
```

After changes:
```
[info] Benchmark                                           Mode  Cnt        Score       Error  Units
[info] ManyParamsInterpreterBenchmark.benchmarkAsync      thrpt    8   231363.777 ±  1324.431  ops/s
[info] ManyParamsInterpreterBenchmark.benchmarkSync       thrpt    8   422723.163 ± 17596.191  ops/s
[info] OneParamInterpreterBenchmark.benchmarkAsyncIO      thrpt    8   201109.627 ± 23130.016  ops/s
[info] OneParamInterpreterBenchmark.benchmarkFutureAsync  thrpt    8    76491.629 ± 12645.501  ops/s
[info] OneParamInterpreterBenchmark.benchmarkFutureSync   thrpt    8  2571591.618 ± 34357.808  ops/s
[info] OneParamInterpreterBenchmark.benchmarkSyncIO       thrpt    8  1517608.097 ± 33637.059  ops/s
```
