### PR TITLE
Align CustomAction api with predefined actions api (deploy, cancel)

### DIFF
--- a/designer/client/cypress/support/process.ts
+++ b/designer/client/cypress/support/process.ts
@@ -99,7 +99,7 @@ function deleteTestProcess(processName: string, force?: boolean) {
     }
 
     return archiveThenDeleteProcess()
-        .then((response) => (force && response.status === 409 ? cancelProcess().then(archiveThenDeleteProcess) : cy.wrap(response)))
+        .then((response) => (force && response.status === 403 ? cancelProcess().then(archiveThenDeleteProcess) : cy.wrap(response)))
         .its("status")
         .should("be.oneOf", [200, 404]);
 }

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/BaseDeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/BaseDeploymentManager.scala
@@ -34,7 +34,6 @@ trait BaseDeploymentManager extends DeploymentManager with AlwaysFreshProcessSta
   override def invokeCustomAction(
       actionRequest: CustomActionRequest,
       canonicalProcess: CanonicalProcess
-  ): Future[Either[CustomActionError, CustomActionResult]] =
-    Future.successful(Left(CustomActionNotImplemented(actionRequest)))
+  ): Future[CustomActionResult] = ???
 
 }

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
@@ -83,7 +83,7 @@ trait DeploymentManager extends AutoCloseable {
   def invokeCustomAction(
       actionRequest: CustomActionRequest,
       canonicalProcess: CanonicalProcess
-  ): Future[Either[CustomActionError, CustomActionResult]]
+  ): Future[CustomActionResult]
 
   // TODO: this is very flink specific, we should handle it via custom action
   def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult]

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/cache/CachingProcessStateDeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/cache/CachingProcessStateDeploymentManager.scala
@@ -85,7 +85,7 @@ class CachingProcessStateDeploymentManager(delegate: DeploymentManager, cacheTTL
   override def invokeCustomAction(
       actionRequest: CustomActionRequest,
       canonicalProcess: CanonicalProcess
-  ): Future[Either[CustomActionError, CustomActionResult]] =
+  ): Future[CustomActionResult] =
     delegate.invokeCustomAction(actionRequest, canonicalProcess)
 
   override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] =

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
@@ -96,8 +96,7 @@ class DeploymentManagerStub extends DeploymentManager with AlwaysFreshProcessSta
   override def invokeCustomAction(
       actionRequest: CustomActionRequest,
       canonicalProcess: CanonicalProcess
-  ): Future[Either[CustomActionError, CustomActionResult]] =
-    Future.successful(Left(CustomActionNotImplemented(actionRequest)))
+  ): Future[CustomActionResult] = ???
 
   override def close(): Unit = {}
 

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/CustomActionResponse.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/CustomActionResponse.scala
@@ -1,15 +1,10 @@
 package pl.touk.nussknacker.restmodel
 
 import io.circe.generic.JsonCodec
-import pl.touk.nussknacker.engine.api.deployment.{CustomActionError, CustomActionResult}
+import pl.touk.nussknacker.engine.api.deployment.CustomActionResult
 
 object CustomActionResponse {
-  def apply(actionResultE: Either[CustomActionError, CustomActionResult]): CustomActionResponse = {
-    actionResultE match {
-      case Right(result) => CustomActionResponse(isSuccess = true, msg = result.msg)
-      case Left(err)     => CustomActionResponse(isSuccess = false, msg = err.msg)
-    }
-  }
+  def apply(actionResult: CustomActionResult): CustomActionResponse = CustomActionResponse(isSuccess = true, msg = actionResult.msg)
 }
 
 @JsonCodec

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/EspError.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/EspError.scala
@@ -19,3 +19,5 @@ trait NotFoundError extends EspError
 trait BadRequestError extends EspError
 
 trait IllegalOperationError extends EspError
+
+trait ForbiddenError extends EspError

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
@@ -341,7 +341,7 @@ class DBProcessService(
         if (state.allowedActions.contains(actionToCheck)) {
           callback
         } else {
-          Future(Left(ProcessIllegalAction(actionToCheck, process.idWithName, state)))
+          Future(Left(ProcessIllegalAction(actionToCheck.toString, process.idWithName, state)))
         }
       })
   }
@@ -412,7 +412,7 @@ class DBProcessService(
   )(implicit user: LoggedUser): Future[XError[T]] =
     withProcess(processIdWithName) { process =>
       if (process.isArchived) {
-        Future(Left(ProcessIllegalAction.archived(action, process.idWithName)))
+        Future(Left(ProcessIllegalAction.archived(action.toString, process.idWithName)))
       } else {
         callback(process)
       }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentService.scala
@@ -11,7 +11,6 @@ import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessIdWithName, Pro
 import pl.touk.nussknacker.engine.deployment.ExternalDeploymentId
 import pl.touk.nussknacker.restmodel.process.ProcessingType
 import pl.touk.nussknacker.restmodel.processdetails.BaseProcessDetails
-import pl.touk.nussknacker.ui.process.repository.DeploymentComment
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -29,10 +28,10 @@ trait DeploymentService extends ProcessStateService {
   def deployProcessAsync(
       id: ProcessIdWithName,
       savepointPath: Option[String],
-      deploymentComment: Option[DeploymentComment]
+      comment: Option[String]
   )(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Future[Option[ExternalDeploymentId]]]
 
-  def cancelProcess(id: ProcessIdWithName, deploymentComment: Option[DeploymentComment])(
+  def cancelProcess(id: ProcessIdWithName,  comment: Option[String])(
       implicit loggedUser: LoggedUser,
       ec: ExecutionContext
   ): Future[Unit]

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/exception/ProcessIllegalAction.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/exception/ProcessIllegalAction.scala
@@ -1,28 +1,27 @@
 package pl.touk.nussknacker.ui.process.exception
 
-import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
 import pl.touk.nussknacker.engine.api.deployment.ProcessState
 import pl.touk.nussknacker.engine.api.process.ProcessIdWithName
-import pl.touk.nussknacker.ui.IllegalOperationError
+import pl.touk.nussknacker.ui.ForbiddenError
 
-final case class ProcessIllegalAction(message: String) extends Exception(message) with IllegalOperationError
+final case class ProcessIllegalAction(message: String) extends Exception(message) with ForbiddenError
 
 object ProcessIllegalAction {
 
   def apply(
-      action: ProcessActionType,
+      actionName: String,
       processIdWithName: ProcessIdWithName,
       state: ProcessState
   ): ProcessIllegalAction =
     ProcessIllegalAction(
-      s"Action: $action is not allowed in scenario (${processIdWithName.name.value}) state: ${state.status.name}, allowed actions: ${state.allowedActions
+      s"Action: $actionName is not allowed in scenario (${processIdWithName.name.value}) state: ${state.status.name}, allowed actions: ${state.allowedActions
           .mkString(",")}."
     )
 
-  def archived(action: ProcessActionType, processIdWithName: ProcessIdWithName): ProcessIllegalAction =
-    ProcessIllegalAction(s"Forbidden action: $action for archived scenario: ${processIdWithName.name.value}.")
+  def archived(actionName: String, processIdWithName: ProcessIdWithName): ProcessIllegalAction =
+    ProcessIllegalAction(s"Forbidden action: $actionName for archived scenario: ${processIdWithName.name.value}.")
 
-  def fragment(action: ProcessActionType, processIdWithName: ProcessIdWithName): ProcessIllegalAction =
-    ProcessIllegalAction(s"Forbidden action: $action for fragment: ${processIdWithName.name.value}.")
+  def fragment(actionName: String, processIdWithName: ProcessIdWithName): ProcessIllegalAction =
+    ProcessIllegalAction(s"Forbidden action: $actionName for fragment: ${processIdWithName.name.value}.")
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
@@ -145,7 +145,8 @@ class AkkaHttpBasedRouteProvider(
         processValidation,
         scenarioResolver,
         processChangeListener,
-        featureTogglesConfig.scenarioStateTimeout
+        featureTogglesConfig.scenarioStateTimeout,
+        featureTogglesConfig.deploymentCommentSettings
       )
       deploymentService.invalidateInProgressActions()
 
@@ -241,7 +242,6 @@ class AkkaHttpBasedRouteProvider(
           new ManagementResources(
             processAuthorizer,
             futureProcessRepository,
-            featureTogglesConfig.deploymentCommentSettings,
             deploymentService,
             dmDispatcher,
             customActionInvokerService,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesConcurrentSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesConcurrentSpec.scala
@@ -45,7 +45,7 @@ class ManagementResourcesConcurrentSpec
         secondStatus = status
       }
       val statuses = List(firstStatus, secondStatus)
-      statuses should contain only (StatusCodes.OK, StatusCodes.Conflict)
+      statuses should contain only (StatusCodes.OK, StatusCodes.Forbidden)
       eventually {
         deploymentManager.deploys.asScala.count(_ == ProcessName(processName)) shouldBe 1
       }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -18,7 +18,7 @@ import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName, V
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.spel.Implicits._
 import pl.touk.nussknacker.restmodel.processdetails._
-import pl.touk.nussknacker.restmodel.{CustomActionRequest, CustomActionResponse}
+import pl.touk.nussknacker.restmodel.CustomActionRequest
 import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.ui.api.helpers.TestFactory._
 import pl.touk.nussknacker.ui.api.helpers._
@@ -78,7 +78,7 @@ class ManagementResourcesSpec
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.DuringDeploy) {
       deployProcess(processName.value) ~> check {
-        status shouldBe StatusCodes.Conflict
+        status shouldBe StatusCodes.Forbidden
       }
     }
   }
@@ -88,7 +88,7 @@ class ManagementResourcesSpec
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Canceled) {
       cancelProcess(processName.value) ~> check {
-        status shouldBe StatusCodes.Conflict
+        status shouldBe StatusCodes.Forbidden
       }
     }
   }
@@ -99,8 +99,8 @@ class ManagementResourcesSpec
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Canceled) {
       deployProcess(processName.value) ~> check {
-        status shouldBe StatusCodes.Conflict
-        responseAs[String] shouldBe ProcessIllegalAction.archived(ProcessActionType.Deploy, processIdWithName).message
+        status shouldBe StatusCodes.Forbidden
+        responseAs[String] shouldBe ProcessIllegalAction.archived(ProcessActionType.Deploy.toString, processIdWithName).message
       }
     }
   }
@@ -110,8 +110,8 @@ class ManagementResourcesSpec
     val processIdWithName = ProcessIdWithName(id, processName)
 
     deployProcess(processName.value) ~> check {
-      status shouldBe StatusCodes.Conflict
-      responseAs[String] shouldBe ProcessIllegalAction.fragment(ProcessActionType.Deploy, processIdWithName).message
+      status shouldBe StatusCodes.Forbidden
+      responseAs[String] shouldBe ProcessIllegalAction.fragment(ProcessActionType.Deploy.toString, processIdWithName).message
     }
   }
 
@@ -120,8 +120,8 @@ class ManagementResourcesSpec
     val processIdWithName = ProcessIdWithName(id, processName)
 
     deployProcess(processName.value) ~> check {
-      status shouldBe StatusCodes.Conflict
-      responseAs[String] shouldBe ProcessIllegalAction.fragment(ProcessActionType.Deploy, processIdWithName).message
+      status shouldBe StatusCodes.Forbidden
+      responseAs[String] shouldBe ProcessIllegalAction.fragment(ProcessActionType.Deploy.toString, processIdWithName).message
     }
   }
 
@@ -416,7 +416,6 @@ class ManagementResourcesSpec
     createEmptyProcess(SampleProcess.processName)
     customAction(SampleProcess.processName, CustomActionRequest("hello")) ~> check {
       status shouldBe StatusCodes.OK
-      responseAs[CustomActionResponse] shouldBe CustomActionResponse(isSuccess = true, msg = "Hi")
     }
   }
 
@@ -424,10 +423,6 @@ class ManagementResourcesSpec
     createEmptyProcess(SampleProcess.processName)
     customAction(SampleProcess.processName, CustomActionRequest("non-existing")) ~> check {
       status shouldBe StatusCodes.NotFound
-      responseAs[CustomActionResponse] shouldBe CustomActionResponse(
-        isSuccess = false,
-        msg = "non-existing is not existing"
-      )
     }
   }
 
@@ -435,10 +430,6 @@ class ManagementResourcesSpec
     createEmptyProcess(SampleProcess.processName)
     customAction(SampleProcess.processName, CustomActionRequest("not-implemented")) ~> check {
       status shouldBe StatusCodes.NotImplemented
-      responseAs[CustomActionResponse] shouldBe CustomActionResponse(
-        isSuccess = false,
-        msg = "not-implemented is not implemented"
-      )
     }
   }
 
@@ -446,10 +437,6 @@ class ManagementResourcesSpec
     createEmptyProcess(SampleProcess.processName)
     customAction(SampleProcess.processName, CustomActionRequest("invalid-status")) ~> check {
       status shouldBe StatusCodes.Forbidden
-      responseAs[CustomActionResponse] shouldBe CustomActionResponse(
-        isSuccess = false,
-        msg = s"Scenario status: NOT_DEPLOYED is not allowed for action invalid-status"
-      )
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -158,7 +158,7 @@ class ProcessesResourcesSpec
 
     deploymentManager.withProcessRunning(processName) {
       archiveProcess(processName) { status =>
-        status shouldEqual StatusCodes.Conflict
+        status shouldEqual StatusCodes.Forbidden
       }
     }
   }
@@ -219,7 +219,7 @@ class ProcessesResourcesSpec
       val newName = ProcessName("ProcessChangedName")
 
       renameProcess(processName, newName) { status =>
-        status shouldEqual StatusCodes.Conflict
+        status shouldEqual StatusCodes.Forbidden
       }
     }
   }
@@ -229,7 +229,7 @@ class ProcessesResourcesSpec
     val newName = ProcessName("ProcessChangedName")
 
     renameProcess(processName, newName) { status =>
-      status shouldEqual StatusCodes.Conflict
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 
@@ -263,7 +263,7 @@ class ProcessesResourcesSpec
     val process = ProcessTestData.validProcess
 
     updateProcess(processName, process) {
-      status shouldEqual StatusCodes.Conflict
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 
@@ -326,7 +326,7 @@ class ProcessesResourcesSpec
     createArchivedProcess(processName)
 
     changeProcessCategory(processName, TestCat2, isAdmin = true) { status =>
-      status shouldEqual StatusCodes.Conflict
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 
@@ -769,7 +769,7 @@ class ProcessesResourcesSpec
     createArchivedProcess(processName)
 
     archiveProcess(processName) { status =>
-      status shouldEqual StatusCodes.Conflict
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 
@@ -777,7 +777,7 @@ class ProcessesResourcesSpec
     createEmptyProcess(processName)
 
     unArchiveProcess(processName) { status =>
-      status shouldEqual StatusCodes.Conflict
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 
@@ -804,7 +804,7 @@ class ProcessesResourcesSpec
     createEmptyProcess(processName)
 
     deleteProcess(processName) { status =>
-      status shouldEqual StatusCodes.Conflict
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockDeploymentManager.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockDeploymentManager.scala
@@ -211,12 +211,10 @@ class MockDeploymentManager(val defaultProcessStateStatus: StateStatus)(
   override def invokeCustomAction(
       actionRequest: CustomActionRequest,
       canonicalProcess: CanonicalProcess
-  ): Future[Either[CustomActionError, CustomActionResult]] =
-    Future.successful {
-      actionRequest.name match {
-        case "hello" | "invalid-status" => Right(CustomActionResult(actionRequest, "Hi"))
-        case _                          => Left(CustomActionNotImplemented(actionRequest))
-      }
+  ): Future[CustomActionResult] =
+    actionRequest.name match {
+      case "hello" | "invalid-status" => Future.successful(CustomActionResult(actionRequest, "Hi"))
+      case _                          => ???
     }
 
   override def close(): Unit = {}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/StubDeploymentService.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/StubDeploymentService.scala
@@ -12,7 +12,6 @@ import pl.touk.nussknacker.engine.deployment.ExternalDeploymentId
 import pl.touk.nussknacker.restmodel.process.ProcessingType
 import pl.touk.nussknacker.restmodel.processdetails
 import pl.touk.nussknacker.ui.process.deployment.DeploymentService
-import pl.touk.nussknacker.ui.process.repository.DeploymentComment
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,11 +30,11 @@ class StubDeploymentService(states: Map[ProcessName, ProcessState]) extends Depl
   override def deployProcessAsync(
       id: ProcessIdWithName,
       savepointPath: Option[String],
-      deploymentComment: Option[DeploymentComment]
+      comment: Option[String]
   )(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Future[Option[ExternalDeploymentId]]] =
     Future.successful(Future.successful(None))
 
-  override def cancelProcess(id: ProcessIdWithName, deploymentComment: Option[DeploymentComment])(
+  override def cancelProcess(id: ProcessIdWithName, comment: Option[String])(
       implicit loggedUser: LoggedUser,
       ec: ExecutionContext
   ): Future[Unit] = Future.successful(())

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/notifications/NotificationServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/notifications/NotificationServiceTest.scala
@@ -162,6 +162,7 @@ class NotificationServiceTest
       mock[ScenarioResolver],
       mock[ProcessChangeListener],
       None,
+      None,
       clock
     ) {
       override protected def validateBeforeDeploy(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentServiceSpec.scala
@@ -24,6 +24,7 @@ import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.deployment.{DeploymentId, ExternalDeploymentId}
 import pl.touk.nussknacker.restmodel.process.ProcessingType
 import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, NuScalaTestAssertions, PatientScalaFutures}
+import pl.touk.nussknacker.ui.api.DeploymentCommentSettings
 import pl.touk.nussknacker.ui.api.helpers.ProcessTestData.{existingSinkFactory, existingSourceFactory, processorId}
 import pl.touk.nussknacker.ui.api.helpers._
 import pl.touk.nussknacker.ui.listener.ProcessChangeEvent.OnDeployActionSuccess
@@ -101,7 +102,8 @@ class DeploymentServiceSpec
       processValidation,
       TestFactory.scenarioResolver,
       listener,
-      scenarioStateTimeout = scenarioStateTimeout
+      scenarioStateTimeout = scenarioStateTimeout,
+      deploymentCommentSettings = None
     )
   }
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -22,6 +22,7 @@
 * [#4707](https://github.com/TouK/nussknacker/pull/4707) Support for `overrideFrontendAuthenticationStrategy` configuration parameter in OIDC security model - works the same as in OAuth2 case.
 * [#4739](https://github.com/TouK/nussknacker/pull/4739) Add configuration parameter for sending additional headers to InfluxDB (`countsSettings.additionalHeaders`)
 * [#4762](https://github.com/TouK/nussknacker/pull/4762) Fix: RegExpParameterValidator, trimming SPeL comprehension
+* [#4687](https://github.com/TouK/nussknacker/pull/4687) Custom action invocation handles errors in the same manner as predefined actions, e.g. cancel.
 
 1.11.3 (11 Sep 2023)
 -------------------------

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
@@ -21,11 +21,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MockableDeploymentManagerProvider extends DeploymentManagerProvider {
 
-  override def createDeploymentManager(modelData: BaseModelData, config: Config)
-                                      (implicit ec: ExecutionContext,
-                                       actorSystem: ActorSystem,
-                                       sttpBackend: SttpBackend[Future, Any],
-                                       deploymentService: ProcessingTypeDeploymentService): DeploymentManager =
+  override def createDeploymentManager(modelData: BaseModelData, config: Config)(
+      implicit ec: ExecutionContext,
+      actorSystem: ActorSystem,
+      sttpBackend: SttpBackend[Future, Any],
+      deploymentService: ProcessingTypeDeploymentService
+  ): DeploymentManager =
     MockableDeploymentManager
 
   override def metaDataInitializer(config: Config): MetaDataInitializer =
@@ -49,26 +50,30 @@ object MockableDeploymentManagerProvider {
       this.processesStates.set(Map.empty)
     }
 
-    override def validate(processVersion: ProcessVersion,
-                          deploymentData: DeploymentData,
-                          canonicalProcess: CanonicalProcess): Future[Unit] =
+    override def validate(
+        processVersion: ProcessVersion,
+        deploymentData: DeploymentData,
+        canonicalProcess: CanonicalProcess
+    ): Future[Unit] =
       Future.successful(())
 
-    override def deploy(processVersion: ProcessVersion,
-                        deploymentData: DeploymentData,
-                        canonicalProcess: CanonicalProcess,
-                        savepointPath: Option[String]): Future[Option[ExternalDeploymentId]] =
+    override def deploy(
+        processVersion: ProcessVersion,
+        deploymentData: DeploymentData,
+        canonicalProcess: CanonicalProcess,
+        savepointPath: Option[String]
+    ): Future[Option[ExternalDeploymentId]] =
       Future.successful(None)
 
-    override def stop(name: ProcessName,
-                      savepointDir: Option[String],
-                      user: User): Future[SavepointResult] =
+    override def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] =
       Future.successful(SavepointResult(""))
 
-    override def stop(name: ProcessName,
-                      deploymentId: DeploymentId,
-                      savepointDir: Option[String],
-                      user: User): Future[SavepointResult] =
+    override def stop(
+        name: ProcessName,
+        deploymentId: DeploymentId,
+        savepointDir: Option[String],
+        user: User
+    ): Future[SavepointResult] =
       Future.successful(SavepointResult(""))
 
     override def cancel(name: ProcessName, user: User): Future[Unit] =
@@ -77,14 +82,16 @@ object MockableDeploymentManagerProvider {
     override def cancel(name: ProcessName, deploymentId: DeploymentId, user: User): Future[Unit] =
       Future.successful(())
 
-    override def test[T](name: ProcessName,
-                         canonicalProcess: CanonicalProcess,
-                         scenarioTestData: ScenarioTestData,
-                         variableEncoder: Any => T): Future[TestProcess.TestResults[T]] = ???
+    override def test[T](
+        name: ProcessName,
+        canonicalProcess: CanonicalProcess,
+        scenarioTestData: ScenarioTestData,
+        variableEncoder: Any => T
+    ): Future[TestProcess.TestResults[T]] = ???
 
-    override def getProcessState(idWithName: ProcessIdWithName,
-                                 lastStateAction: Option[ProcessAction])
-                                (implicit freshnessPolicy: DataFreshnessPolicy): Future[WithDataFreshnessStatus[ProcessState]] = {
+    override def getProcessState(idWithName: ProcessIdWithName, lastStateAction: Option[ProcessAction])(
+        implicit freshnessPolicy: DataFreshnessPolicy
+    ): Future[WithDataFreshnessStatus[ProcessState]] = {
       Future {
         val status = processesStates.get().getOrElse(idWithName.name, SimpleStateStatus.NotDeployed)
         WithDataFreshnessStatus(
@@ -94,8 +101,7 @@ object MockableDeploymentManagerProvider {
       }
     }
 
-    override def savepoint(name: ProcessName,
-                           savepointDir: Option[String]): Future[SavepointResult] =
+    override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] =
       Future.successful(SavepointResult(""))
 
     override def processStateDefinitionManager: ProcessStateDefinitionManager =
@@ -103,12 +109,14 @@ object MockableDeploymentManagerProvider {
 
     override def customActions: List[CustomAction] = Nil
 
-    override def invokeCustomAction(actionRequest: CustomActionRequest,
-                                    canonicalProcess: CanonicalProcess): Future[Either[CustomActionError, CustomActionResult]] =
-      Future.successful(Left(CustomActionNotImplemented(actionRequest)))
+    override def invokeCustomAction(
+        actionRequest: CustomActionRequest,
+        canonicalProcess: CanonicalProcess
+    ): Future[CustomActionResult] = ???
 
-    override def getProcessStates(name: ProcessName)
-                                 (implicit freshnessPolicy: DataFreshnessPolicy): Future[WithDataFreshnessStatus[List[StatusDetails]]] =
+    override def getProcessStates(name: ProcessName)(
+        implicit freshnessPolicy: DataFreshnessPolicy
+    ): Future[WithDataFreshnessStatus[List[StatusDetails]]] =
       Future.successful(WithDataFreshnessStatus(List.empty, cached = false))
 
     override def close(): Unit = {}

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicCustomActionsProviderFactory.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicCustomActionsProviderFactory.scala
@@ -23,7 +23,7 @@ trait PeriodicCustomActionsProvider {
   def invokeCustomAction(
       actionRequest: CustomActionRequest,
       canonicalProcess: CanonicalProcess
-  ): Future[Either[CustomActionError, CustomActionResult]]
+  ): Future[CustomActionResult]
 }
 
 object EmptyPeriodicCustomActionsProvider extends PeriodicCustomActionsProvider {
@@ -32,6 +32,5 @@ object EmptyPeriodicCustomActionsProvider extends PeriodicCustomActionsProvider 
   override def invokeCustomAction(
       actionRequest: CustomActionRequest,
       canonicalProcess: CanonicalProcess
-  ): Future[Either[CustomActionError, CustomActionResult]] =
-    Future.successful(Left(CustomActionNotImplemented(actionRequest)))
+  ): Future[CustomActionResult] = ???
 }

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -216,6 +216,6 @@ class PeriodicDeploymentManager private[periodic] (
   override def invokeCustomAction(
       actionRequest: CustomActionRequest,
       canonicalProcess: CanonicalProcess
-  ): Future[Either[CustomActionError, CustomActionResult]] =
+  ): Future[CustomActionResult] =
     customActionsProvider.invokeCustomAction(actionRequest, canonicalProcess)
 }

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
@@ -205,8 +205,7 @@ abstract class FlinkDeploymentManager(
   override def invokeCustomAction(
       actionRequest: CustomActionRequest,
       canonicalProcess: CanonicalProcess
-  ): Future[Either[CustomActionError, CustomActionResult]] =
-    Future.successful(Left(CustomActionNotImplemented(actionRequest)))
+  ): Future[CustomActionResult] = ???
 
   private def requireSingleRunningJob[T](processName: ProcessName, statusDetailsPredicate: StatusDetails => Boolean)(
       action: ExternalDeploymentId => Future[T]

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/CustomAction.scala
@@ -33,26 +33,4 @@ case class CustomActionRequest(name: String, processVersion: ProcessVersion, use
 
 case class CustomActionResult(req: CustomActionRequest, msg: String)
 
-sealed trait CustomActionError extends Exception {
-  def request: CustomActionRequest
 
-  def msg: String
-
-  override def getMessage: String = msg
-}
-
-case class CustomActionFailure(request: CustomActionRequest, msg: String) extends CustomActionError
-
-case class CustomActionInvalidStatus(request: CustomActionRequest, stateStatusName: String) extends CustomActionError {
-  override val msg: String = s"Scenario status: $stateStatusName is not allowed for action ${request.name}"
-}
-
-case class CustomActionNotImplemented(request: CustomActionRequest) extends CustomActionError {
-  override val msg: String = s"${request.name} is not implemented"
-}
-
-case class CustomActionNonExisting(request: CustomActionRequest) extends CustomActionError {
-  override val msg: String = s"${request.name} is not existing"
-}
-
-case class CustomActionForbidden(request: CustomActionRequest, msg: String) extends CustomActionError


### PR DESCRIPTION
## Describe your changes
The first step of CustomAction api refactor
1. Change type returned by invokeCustomAction to `Future[CustomActionResult]` to be coherrent with predefined deploy/cancel actions.
2. Move deployment comment validation from `ManagementResources` deploy/cancel routes into `DeploymentService`. On the service level the comment is a parameter of the invoked action. Here service is responsible for the whole transaction: all validations, interactions with repositories and invoking action itself.

Next steps:
3. Move `CustomActionInvokerService` to `DeploymentService` (according to the TODO comment)
4. Implement cancel/deploy as "custom action".
5. Add validators to `CustomActionParameter`. The validators are expected behave in the same way as in additional properties or node parameters. Adding validator to the parameter is available via custom action configuration.
6. Replace `deploymentComment` validation (configured by `DeploymentCommentSettings.validationPattern`) with a parameter validator.
7. Add dynamic validation like `api/nodes/.../validation` or `api/properties/.../validation` and handle validation results in FE

Also in next steps: introduce asynchronous actions.

Profits:
1. one coherrent behaviour of parameter validation for action, node and property
1. one coherrent api and the same approach for all actions, both predefined and custom
2. a control over action parameters validation, each NU instance is able to define its own validation rules (e.g. for cancel and deploy)
3. no hardcoded validations (e.g. deploymentComment)


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Code formatting checked
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [x] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
