### PR TITLE
NU-1058 fix popover for fragment status

### DIFF
--- a/designer/client/src/components/Process/ProcessErrors.tsx
+++ b/designer/client/src/components/Process/ProcessErrors.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ProcessStateType } from "./types";
+
+export function Errors({ state }: { state: ProcessStateType }) {
+    const { t } = useTranslation();
+
+    if (state.errors?.length < 1) {
+        return null;
+    }
+
+    return (
+        <div>
+            <span>{t("stateIcon.errors", "Errors:")}</span>
+            <ul>
+                {state.errors.map((error, key) => (
+                    <li key={key}>{error}</li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/designer/client/src/components/Process/ProcessStateIcon.tsx
+++ b/designer/client/src/components/Process/ProcessStateIcon.tsx
@@ -1,43 +1,23 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
 import { ProcessStateType, ProcessType } from "./types";
 import ProcessStateUtils from "./ProcessStateUtils";
 import UrlIcon from "../UrlIcon";
 import { Box, Divider, Popover, Typography } from "@mui/material";
+import { Errors } from "./ProcessErrors";
 
 interface Props {
     processState?: ProcessStateType;
     process: ProcessType;
 }
 
-function Errors({ state }: { state: ProcessStateType }) {
-    const { t } = useTranslation();
-
-    if (state.errors?.length < 1) {
-        return null;
-    }
-
-    return (
-        <div>
-            <span>{t("stateIcon.errors", "Errors:")}</span>
-            <ul>
-                {state.errors.map((error, key) => (
-                    <li key={key}>{error}</li>
-                ))}
-            </ul>
-        </div>
-    );
-}
-
 function ProcessStateIcon({ process, processState }: Props) {
     const icon = ProcessStateUtils.getStatusIcon(process, processState);
     const tooltip = ProcessStateUtils.getStatusTooltip(process, processState);
-
     const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
 
     return (
         <>
-            <UrlIcon src={icon} title={tooltip} onClick={(event) => setAnchorEl(event.currentTarget)} />
+            <UrlIcon src={icon} title={tooltip} onClick={(event) => processState && setAnchorEl(event.currentTarget)} />
             <Popover
                 anchorEl={anchorEl}
                 anchorOrigin={{

--- a/designer/client/src/components/toolbars/process/buttons/SaveButton.styl
+++ b/designer/client/src/components/toolbars/process/buttons/SaveButton.styl
@@ -1,3 +1,0 @@
-:local
-	.unsaved::after
-		content "*"

--- a/designer/client/src/components/toolbars/status/ProcessInfo.tsx
+++ b/designer/client/src/components/toolbars/status/ProcessInfo.tsx
@@ -1,16 +1,15 @@
-import i18next from "i18next";
 import React, { memo } from "react";
-import { connect } from "react-redux";
+import i18next from "i18next";
 import { SwitchTransition } from "react-transition-group";
+import { useSelector } from "react-redux";
 import { RootState } from "../../../reducers";
 import { getFetchedProcessDetails, getProcessUnsavedNewName, isProcessRenamed } from "../../../reducers/selectors/graph";
 import { getProcessState } from "../../../reducers/selectors/scenarioState";
 import { getCustomActions } from "../../../reducers/selectors/settings";
-import { UnknownRecord } from "../../../types/common";
 import { CssFade } from "../../CssFade";
 import ProcessStateIcon from "../../Process/ProcessStateIcon";
 import { ToolbarWrapper } from "../../toolbarComponents/toolbarWrapper/ToolbarWrapper";
-import { DefaultToolbarPanel, ToolbarPanelProps } from "../../toolbarComponents/DefaultToolbarPanel";
+import { ToolbarPanelProps } from "../../toolbarComponents/DefaultToolbarPanel";
 import { ToolbarButtons } from "../../toolbarComponents/toolbarButtons";
 import { ActionButton } from "../../toolbarSettings/buttons";
 import ProcessStateUtils from "../../Process/ProcessStateUtils";
@@ -23,59 +22,47 @@ import {
     ProcessRename,
 } from "./ProcessInfoComponents";
 
-type State = UnknownRecord;
+const ProcessInfo = memo(({ id, buttonsVariant, children }: ToolbarPanelProps) => {
+    const process = useSelector((state: RootState) => getFetchedProcessDetails(state));
+    const isRenamePending = useSelector((state: RootState) => isProcessRenamed(state));
+    const unsavedNewName = useSelector((state: RootState) => getProcessUnsavedNewName(state));
+    const processState = useSelector((state: RootState) => getProcessState(state));
+    const customActions = useSelector((state: RootState) => getCustomActions(state));
 
-class ProcessInfo extends React.Component<ToolbarPanelProps & StateProps, State> {
-    static defaultProps = {
-        isStateLoaded: false,
-    };
+    const description = ProcessStateUtils.getStateDescription(process, processState);
+    const transitionKey = ProcessStateUtils.getTransitionKey(process, processState);
+    // TODO: better styling of process info toolbar in case of many custom actions
 
-    render() {
-        const { process, processState, customActions, isRenamePending, unsavedNewName } = this.props;
-        const description = ProcessStateUtils.getStateDescription(process, processState);
-        const transitionKey = ProcessStateUtils.getTransitionKey(process, processState);
-        // TODO: better styling of process info toolbar in case of many custom actions
-        return (
-            <ToolbarWrapper title={i18next.t("panels.status.title", "Status")} id={this.props.id}>
-                <SwitchTransition>
-                    <CssFade key={transitionKey}>
-                        <PanelProcessInfo>
-                            <PanelProcessInfoIcon>
-                                <ProcessStateIcon process={process} processState={processState} />
-                            </PanelProcessInfoIcon>
-                            <ProcessInfoText>
-                                {isRenamePending ? (
-                                    <ProcessRename title={process.name}>{unsavedNewName}*</ProcessRename>
-                                ) : (
-                                    <ProcessName>{process.name}</ProcessName>
-                                )}
-                                <ProcessInfoDescription>{description}</ProcessInfoDescription>
-                            </ProcessInfoText>
-                        </PanelProcessInfo>
-                    </CssFade>
-                </SwitchTransition>
-                <ToolbarButtons variant={this.props.buttonsVariant}>
-                    {this.props.children}
-                    {
-                        //TODO: to be replaced by toolbar config
-                        customActions.map((action) => (
-                            <ActionButton name={action.name} key={action.name} />
-                        ))
-                    }
-                </ToolbarButtons>
-            </ToolbarWrapper>
-        );
-    }
-}
-
-const mapState = (state: RootState) => ({
-    process: getFetchedProcessDetails(state),
-    isRenamePending: isProcessRenamed(state),
-    unsavedNewName: getProcessUnsavedNewName(state),
-    processState: getProcessState(state),
-    customActions: getCustomActions(state),
+    return (
+        <ToolbarWrapper title={i18next.t("panels.status.title", "Status")} id={id}>
+            <SwitchTransition>
+                <CssFade key={transitionKey}>
+                    <PanelProcessInfo>
+                        <PanelProcessInfoIcon>
+                            <ProcessStateIcon process={process} processState={processState} />
+                        </PanelProcessInfoIcon>
+                        <ProcessInfoText>
+                            {isRenamePending ? (
+                                <ProcessRename title={process.name}>{unsavedNewName}*</ProcessRename>
+                            ) : (
+                                <ProcessName>{process.name}</ProcessName>
+                            )}
+                            <ProcessInfoDescription>{description}</ProcessInfoDescription>
+                        </ProcessInfoText>
+                    </PanelProcessInfo>
+                </CssFade>
+            </SwitchTransition>
+            <ToolbarButtons variant={buttonsVariant}>
+                {children}
+                {customActions.map((action) => (
+                    //TODO: to be replaced by toolbar config
+                    <ActionButton name={action.name} key={action.name} />
+                ))}
+            </ToolbarButtons>
+        </ToolbarWrapper>
+    );
 });
 
-type StateProps = ReturnType<typeof mapState>;
+ProcessInfo.displayName = "ProcessInfo";
 
-export default connect(mapState)(memo(ProcessInfo)) as typeof DefaultToolbarPanel;
+export default ProcessInfo;


### PR DESCRIPTION
## Describe your changes
fix popover fragment status, doesn't show red NU :)
rewrite ProccessInfo from class to function component.
before:
![image](https://github.com/TouK/nussknacker/assets/69891500/d1341b4a-4214-4216-aaac-8eecafbe8ca3)
after:
![image](https://github.com/TouK/nussknacker/assets/69891500/cf860b7c-7f2b-47c9-869d-70014cfe74c8)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Code formatting checked
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
