### PR TITLE
prepareComponentsGroupList not reliant on UIProcessDefinition

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/EvaluatedParameterPreparer.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/EvaluatedParameterPreparer.scala
@@ -1,22 +1,22 @@
 package pl.touk.nussknacker.ui.definition
 
-import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
+import pl.touk.nussknacker.engine.api.definition.Parameter
+import pl.touk.nussknacker.engine.graph.evaluatedparam.{Parameter => EvaluatedParameter}
 import pl.touk.nussknacker.engine.graph.expression.Expression
-import pl.touk.nussknacker.restmodel.definition.UIParameter
 
 object EvaluatedParameterPreparer {
-  def prepareEvaluatedParameter(parameters: List[UIParameter]): List[Parameter] = {
+  def prepareEvaluatedParameter(parameters: List[Parameter]): List[EvaluatedParameter] = {
     parameters
       .filterNot(_.branchParam)
       .map(createSpelExpressionParameter)
   }
 
-  def prepareEvaluatedBranchParameter(parameters: List[UIParameter]): List[Parameter] = {
+  def prepareEvaluatedBranchParameter(parameters: List[Parameter]): List[EvaluatedParameter] = {
     parameters
       .filter(_.branchParam)
       .map(createSpelExpressionParameter)
   }
 
-  private def createSpelExpressionParameter(parameter: UIParameter): Parameter =
-    Parameter(parameter.name, parameter.defaultValue)
+  private def createSpelExpressionParameter(parameter: Parameter): EvaluatedParameter =
+    EvaluatedParameter(parameter.name, parameter.defaultValue.getOrElse(Expression.spel("")))
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactory.scala
@@ -68,7 +68,8 @@ object UIProcessObjectsFactory {
     UIProcessObjects(
       componentGroups = ComponentDefinitionPreparer.prepareComponentsGroupList(
         user = user,
-        processDefinition = uiProcessDefinition,
+        processDefinition = staticObjectsDefinition,
+        fragmentInputs = fragmentInputs,
         isFragment = isFragment,
         componentsConfig = finalComponentsConfig,
         componentsGroupMapping = componentsGroupMapping,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/ComponentDefinitionPreparerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/ComponentDefinitionPreparerSpec.scala
@@ -192,7 +192,8 @@ class ComponentDefinitionPreparerSpec extends AnyFunSuite with Matchers with Tes
 
     val groups = ComponentDefinitionPreparer.prepareComponentsGroupList(
       user = TestFactory.adminUser("aa"),
-      processDefinition = uiProcessDefinition,
+      processDefinition = processDefinition,
+      fragmentInputs = fragmentInputs,
       isFragment = false,
       componentsConfig = componentsConfig,
       componentsGroupMapping = componentsGroupMapping,
@@ -207,7 +208,8 @@ class ComponentDefinitionPreparerSpec extends AnyFunSuite with Matchers with Tes
     val processDefinition = services.foldRight(ProcessDefinitionBuilder.empty)((s, p) => p.withService(s))
     val groups = ComponentDefinitionPreparer.prepareComponentsGroupList(
       user = TestFactory.adminUser("aa"),
-      processDefinition = UIProcessObjectsFactory.createUIProcessDefinition(processDefinition, Map(), Set.empty, processCategoryService),
+      processDefinition = processDefinition,
+      fragmentInputs = Map.empty,
       isFragment = false,
       componentsConfig = Map(),
       componentsGroupMapping = Map(),

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/DefinitionExtractor.scala
@@ -172,7 +172,10 @@ object DefinitionExtractor {
   case class ObjectDefinition(parameters: List[Parameter],
                               returnType: Option[TypingResult],
                               categories: Option[List[String]],
-                              componentConfig: SingleComponentConfig)
+                              componentConfig: SingleComponentConfig) {
+
+    val hasNoReturn: Boolean = returnType.isEmpty
+  }
 
   object ObjectWithMethodDef {
 


### PR DESCRIPTION
## Describe your changes
on second thoughts, `prepareComponentsGroupList` is an UI object, we probably don't want it to de-synchronize from UIProcessDefinition

publishing PR as inspiration for a potential future refactor

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Code formatting checked
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
