### PR TITLE
Fragment migration fixup

### DIFF
--- a/designer/client/src/reducers/selectors/graph.ts
+++ b/designer/client/src/reducers/selectors/graph.ts
@@ -44,8 +44,8 @@ export const isDeployPossible = createSelector(
     (saveDisabled, error, state, fragment) => !fragment && saveDisabled && !error && ProcessStateUtils.canDeploy(state),
 );
 export const isMigrationPossible = createSelector(
-    [isSaveDisabled, hasError, getProcessState],
-    (saveDisabled, error, state) => saveDisabled && !error && ProcessStateUtils.canDeploy(state),
+    [isSaveDisabled, hasError, getProcessState, isFragment],
+    (saveDisabled, error, state, fragment) => saveDisabled && !error && (fragment || ProcessStateUtils.canDeploy(state)),
 );
 export const isCancelPossible = createSelector(getProcessState, (state) => ProcessStateUtils.canCancel(state));
 export const isArchivePossible = createSelector(

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -28,6 +28,7 @@
 * [#4797](https://github.com/TouK/nussknacker/pull/4797) Ability to define the name of query parameter with access token that will be passed into tabs url
 * [#4804](https://github.com/TouK/nussknacker/pull/4804) Improvement: Allow passing globalVariables on TestRunner
 * [#4828](https://github.com/TouK/nussknacker/pull/4828) Improvement: Allow passing timestampAssigner at FlinkTestScenarioRunner
+* [#4839](https://github.com/TouK/nussknacker/pull/4839) Fixed: Fragment migration to secondary env is again available 
 
 1.11.3 (11 Sep 2023)
 -------------------------


### PR DESCRIPTION
## Description

For some time migration of fragments wasn't possible - checking for deploy on allowed actions list doesn't make sense because state for fragment is always null.