### PR TITLE
[NU-1104] Fix for: the release process published the release image under the release_VERSION-latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,9 @@ jobs:
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          JAVA_OPTS: "-Xss6M -Xms6G -Xmx6G -XX:ReservedCodeCacheSize=256M -XX:MaxMetaspaceSize=2500M -DdockerUpLatest=${{ env.NU_DOCKER_UPDATE_LATEST }}"
+          # dockerUpBranchLatest is set to false because branch latest tags are used by cypress tests and
+          # the image built during the release doesn't contain developer's extensions which are required by these tests
+          JAVA_OPTS: "-Xss6M -Xms6G -Xmx6G -XX:ReservedCodeCacheSize=256M -XX:MaxMetaspaceSize=2500M -DdockerUpLatest=${{ env.NU_DOCKER_UPDATE_LATEST }} -DdockerUpBranchLatest=false"
         run: sbt 'release ${{ env.SBT_RELEASE_NEXT_VERSION }} skip-tests'
 
       - name: "Push to master"


### PR DESCRIPTION
… which was bad because cypress tests relies on these images and release images doesn't contain developer's extensions which are required by these tests

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
