### PR TITLE
Improvement: Don't override exception handler at FlinkSpec. Small enhancement ConsumerRecordHelper.

### DIFF
--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/helpers/LifecycleRecordingExceptionConsumer.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/helpers/LifecycleRecordingExceptionConsumer.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import pl.touk.nussknacker.engine.api.MetaData
 import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
 import pl.touk.nussknacker.engine.flink.api.exception.{FlinkEspExceptionConsumer, FlinkEspExceptionConsumerProvider}
-import pl.touk.nussknacker.engine.flink.test.RecordingExceptionConsumerProvider.recordingConsumerIdPath
+import pl.touk.nussknacker.engine.flink.test.RecordingExceptionConsumerProvider.RecordingConsumerIdPath
 import pl.touk.nussknacker.engine.flink.test.{
   RecordingExceptionConsumer,
   RecordingExceptionConsumerProvider,
@@ -31,7 +31,7 @@ class LifecycleRecordingExceptionConsumerProvider extends FlinkEspExceptionConsu
   override val name: String = providerName
 
   override def create(metaData: MetaData, exceptionHandlerConfig: Config): FlinkEspExceptionConsumer = {
-    val id = exceptionHandlerConfig.as[String](recordingConsumerIdPath)
+    val id = exceptionHandlerConfig.as[String](RecordingConsumerIdPath)
     new LifecycleRecordingExceptionConsumer(id)
   }
 

--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/RecordingExceptionConsumer.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/RecordingExceptionConsumer.scala
@@ -29,13 +29,14 @@ class RecordingExceptionConsumer(id: String) extends FlinkEspExceptionConsumer {
 }
 
 object RecordingExceptionConsumerProvider {
-  final val providerName: String            = "RecordingException"
-  final val recordingConsumerIdPath: String = "recordingConsumerId"
+  final val ProviderName: String             = "RecordingException"
+  final val RecordingConsumerIdPath: String  = "recordingConsumerId"
+  final val ExceptionHandlerTypePath: String = "exceptionHandler.type"
 
   def configWithProvider(config: Config, consumerId: String): Config =
     config
-      .withValue("exceptionHandler.type", fromAnyRef(providerName))
-      .withValue(s"exceptionHandler.$recordingConsumerIdPath", fromAnyRef(consumerId))
+      .withValue(ExceptionHandlerTypePath, fromAnyRef(ProviderName))
+      .withValue(s"exceptionHandler.$RecordingConsumerIdPath", fromAnyRef(consumerId))
 
 }
 
@@ -43,10 +44,10 @@ class RecordingExceptionConsumerProvider extends FlinkEspExceptionConsumerProvid
   import RecordingExceptionConsumerProvider._
   import net.ceedubs.ficus.Ficus._
 
-  override val name: String = providerName
+  override val name: String = ProviderName
 
   override def create(metaData: MetaData, exceptionHandlerConfig: Config): FlinkEspExceptionConsumer = {
-    val id = exceptionHandlerConfig.getOrElse[String](recordingConsumerIdPath, UUID.randomUUID().toString)
+    val id = exceptionHandlerConfig.getOrElse[String](RecordingConsumerIdPath, UUID.randomUUID().toString)
     new RecordingExceptionConsumer(id)
   }
 

--- a/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/ConsumerRecordHelper.scala
+++ b/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/ConsumerRecordHelper.scala
@@ -1,15 +1,24 @@
 package pl.touk.nussknacker.engine.kafka
 
-import io.circe.Decoder
+import io.circe.{Decoder, Encoder}
 import pl.touk.nussknacker.engine.api.CirceUtil
 
 import java.nio.charset.StandardCharsets
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.ClassTag
 
 object ConsumerRecordHelper {
 
+  def asBytes[T: Encoder: ClassTag](data: T): Array[Byte] =
+    asStr(data).getBytes(StandardCharsets.UTF_8)
+
+  def asStr[T: Encoder: ClassTag](data: T): String =
+    data match {
+      case str: String => str
+      case value       => implicitly[Encoder[T]].apply(value).noSpaces
+    }
+
   def asJson[T: Decoder: ClassTag](data: Array[Byte]): T = {
-    val clazz = classTag[T].runtimeClass
+    val clazz = scala.reflect.classTag[T].runtimeClass
 
     if (classOf[String].isAssignableFrom(clazz)) {
       Option(data).map(value => new String(value, StandardCharsets.UTF_8)).orNull.asInstanceOf[T]

--- a/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaClient.scala
+++ b/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaClient.scala
@@ -11,6 +11,7 @@ import java.time.Duration
 import java.util
 import java.util.{Collections, UUID}
 import scala.concurrent.{Future, Promise}
+import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
 class KafkaClient(kafkaAddress: String, id: String) extends LazyLogging {
@@ -51,10 +52,10 @@ class KafkaClient(kafkaAddress: String, id: String) extends LazyLogging {
     promise.future
   }
 
-  def sendMessage[T: Encoder](topic: String, content: T): Future[RecordMetadata] =
+  def sendMessage[T: Encoder: ClassTag](topic: String, content: T): Future[RecordMetadata] =
     sendMessage(topic, null, content)
 
-  def sendMessage[T: Encoder](
+  def sendMessage[T: Encoder: ClassTag](
       topic: String,
       key: String,
       content: T,
@@ -62,13 +63,9 @@ class KafkaClient(kafkaAddress: String, id: String) extends LazyLogging {
       timestamp: java.lang.Long = null,
       headers: Headers = KafkaRecordUtils.emptyHeaders
   ): Future[RecordMetadata] = {
-    val strContent = content match {
-      case str: String => str
-      case _           => implicitly[Encoder[T]].apply(content).noSpaces
-    }
-
-    val promise = Promise[RecordMetadata]()
-    val record  = createRecord(topic, key, strContent, partition, timestamp, headers)
+    val strContent = ConsumerRecordHelper.asStr(content)
+    val promise    = Promise[RecordMetadata]()
+    val record     = createRecord(topic, key, strContent, partition, timestamp, headers)
     producer.send(record, producerCallback(promise))
     promise.future
   }


### PR DESCRIPTION
## Describe your changes
Before the change, FlinkSpec always overrode the exception handler from the config file by its own implementation. Now user can provide own implementation of configuration without overriding the whole config method. 

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [x] Verify that PR will be squashed during merge
