### PR TITLE
Add createdAt as a second sort param to place newest at the beginning of lists

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 1.13.0 (Not released yet)
 -------------------------
+* [#4985](https://github.com/TouK/nussknacker/pull/4985) Update sorting of PeriodicProcessDeployments from field `runAt` to tuple `(runAt, id)`
 * [#4711](https://github.com/TouK/nussknacker/pull/4711) [#4862](https://github.com/TouK/nussknacker/pull/4862) Added AdditionalUIConfigProviderFactory API that allows changing components' configs and scenario properties' UI configs without model reload
 * [#4860](https://github.com/TouK/nussknacker/pull/4860) Rename `additionalProperties` to `scenarioProperties`
 * [#4828](https://github.com/TouK/nussknacker/pull/4828) Improvement: Allow passing timestampAssigner at FlinkTestScenarioRunner

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,7 @@
 
 1.13.0 (Not released yet)
 -------------------------
-* [#4985](https://github.com/TouK/nussknacker/pull/4985) Update sorting of PeriodicProcessDeployments from field `runAt` to tuple `(runAt, id)`
+* [#4985](https://github.com/TouK/nussknacker/pull/4985) Update sorting of PeriodicProcessDeployments from field `runAt` to tuple `(runAt, createdAt)`
 * [#4711](https://github.com/TouK/nussknacker/pull/4711) [#4862](https://github.com/TouK/nussknacker/pull/4862) Added AdditionalUIConfigProviderFactory API that allows changing components' configs and scenario properties' UI configs without model reload
 * [#4860](https://github.com/TouK/nussknacker/pull/4860) Rename `additionalProperties` to `scenarioProperties`
 * [#4828](https://github.com/TouK/nussknacker/pull/4828) Improvement: Allow passing timestampAssigner at FlinkTestScenarioRunner

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManager.scala
@@ -29,7 +29,7 @@ object PeriodicProcessStateDefinitionManager {
 
   def statusTooltip(processStatus: PeriodicProcessStatus): String = {
     processStatus.limitedAndSortedDeployments
-      .map { case d @ DeploymentStatus(_, scheduleId, runAt, status, _, _) =>
+      .map { case d @ DeploymentStatus(_, _, scheduleId, runAt, status, _, _) =>
         val refinedStatus = {
           if (d.isCanceled) {
             "Canceled"

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -26,6 +26,7 @@ object PeriodicProcessesRepository {
     val process = createPeriodicProcess(processEntity)
     PeriodicProcessDeployment(
       processDeploymentEntity.id,
+      processDeploymentEntity.createdAt,
       process,
       processDeploymentEntity.runAt,
       ScheduleName(processDeploymentEntity.scheduleName),
@@ -309,7 +310,7 @@ class SlickPeriodicProcessesRepository(
         (
           rowNumber() :: Over
             .partitionBy((deployment.periodicProcessId, deployment.scheduleName))
-            .sortBy(deployment.runAt.desc, deployment.id.value.desc),
+            .sortBy(deployment.runAt.desc, deployment.createdAt.desc),
           process,
           deployment
         )
@@ -354,7 +355,7 @@ class SlickPeriodicProcessesRepository(
               .filter(deployment =>
                 deployment.periodicProcessId === process.id && (deployment.scheduleName === scheduleName || deployment.scheduleName.isEmpty && scheduleName.isEmpty)
               )
-              .sortBy(a => (a.runAt.desc, a.id.value.desc))
+              .sortBy(a => (a.runAt.desc, a.createdAt.desc))
               .take(deploymentsPerScheduleMaxCount)
               .result
               .map(_.map((process, _)))

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -309,7 +309,7 @@ class SlickPeriodicProcessesRepository(
         (
           rowNumber() :: Over
             .partitionBy((deployment.periodicProcessId, deployment.scheduleName))
-            .sortBy(deployment.runAt.desc),
+            .sortBy(deployment.runAt.desc, deployment.id.value.desc),
           process,
           deployment
         )
@@ -354,7 +354,7 @@ class SlickPeriodicProcessesRepository(
               .filter(deployment =>
                 deployment.periodicProcessId === process.id && (deployment.scheduleName === scheduleName || deployment.scheduleName.isEmpty && scheduleName.isEmpty)
               )
-              .sortBy(_.runAt.desc)
+              .sortBy(a => (a.runAt.desc, a.id.value.desc))
               .take(deploymentsPerScheduleMaxCount)
               .result
               .map(_.map((process, _)))

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcessDeployment.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcessDeployment.scala
@@ -9,6 +9,7 @@ import java.time.{Clock, LocalDateTime}
 // TODO: We should separate schedules concept from deployments - fully switch to ScheduleData and ScheduleDeploymentData
 case class PeriodicProcessDeployment(
     id: PeriodicProcessDeploymentId,
+    createdAt: LocalDateTime,
     periodicProcess: PeriodicProcess,
     runAt: LocalDateTime,
     scheduleName: ScheduleName,

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/SchedulesState.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/SchedulesState.scala
@@ -44,13 +44,14 @@ case class ScheduleId(processId: PeriodicProcessId, scheduleName: ScheduleName)
 
 case class ScheduleDeploymentData(
     id: PeriodicProcessDeploymentId,
+    createdAt: LocalDateTime,
     runAt: LocalDateTime,
     retriesLeft: Int,
     nextRetryAt: Option[LocalDateTime],
     state: PeriodicProcessDeploymentState
 ) {
   def toFullDeploymentData(process: PeriodicProcess, scheduleName: ScheduleName): PeriodicProcessDeployment =
-    PeriodicProcessDeployment(id, process, runAt, scheduleName, retriesLeft, nextRetryAt, state)
+    PeriodicProcessDeployment(id, createdAt, process, runAt, scheduleName, retriesLeft, nextRetryAt, state)
 
   def display = s"deploymentId=$id"
 
@@ -61,6 +62,7 @@ object ScheduleDeploymentData {
   def apply(deployment: PeriodicProcessDeploymentEntity): ScheduleDeploymentData = {
     ScheduleDeploymentData(
       deployment.id,
+      deployment.createdAt,
       deployment.runAt,
       deployment.retriesLeft,
       deployment.nextRetryAt,

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessDeploymentGen.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessDeploymentGen.scala
@@ -12,11 +12,14 @@ import java.time.LocalDateTime
 
 object PeriodicProcessDeploymentGen {
 
+  val now: LocalDateTime = LocalDateTime.now()
+
   def apply(): PeriodicProcessDeployment = {
     PeriodicProcessDeployment(
       id = PeriodicProcessDeploymentId(42),
+      createdAt = now.minusMinutes(10),
       periodicProcess = PeriodicProcessGen(),
-      runAt = LocalDateTime.now(),
+      runAt = now,
       scheduleName = ScheduleName(None),
       retriesLeft = 0,
       nextRetryAt = None,

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
@@ -22,6 +22,8 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
 
   private val fooRunAt = LocalDateTime.of(2023, 1, 1, 10, 0)
 
+  private val fooCreatedAt = fooRunAt.minusMinutes(5)
+
   private val notNamedScheduleId = ScheduleId(fooProcessId, ScheduleName(None))
 
   private val nextDeploymentId = new AtomicLong()
@@ -31,6 +33,7 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
   test("display periodic deployment status for not named schedule") {
     val deploymentStatus = DeploymentStatus(
       generateDeploymentId,
+      fooCreatedAt,
       notNamedScheduleId,
       fooRunAt,
       PeriodicProcessDeploymentStatus.Scheduled,
@@ -45,6 +48,7 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
     val firstScheduleId = generateScheduleId
     val firstDeploymentStatus = DeploymentStatus(
       generateDeploymentId,
+      fooCreatedAt,
       firstScheduleId,
       fooRunAt,
       PeriodicProcessDeploymentStatus.Deployed,
@@ -54,6 +58,7 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
     val secScheduleId = generateScheduleId
     val secDeploymentStatus = DeploymentStatus(
       generateDeploymentId,
+      fooCreatedAt,
       secScheduleId,
       fooRunAt,
       PeriodicProcessDeploymentStatus.Scheduled,

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
@@ -41,13 +41,13 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
     statusTooltip(status) shouldEqual "Scheduled at: 2023-01-01 10:00 status: Scheduled"
   }
 
-  test("display periodic deployment status for named schedules") {
+  test("display sorted periodic deployment status for named schedules") {
     val firstScheduleId = generateScheduleId
     val firstDeploymentStatus = DeploymentStatus(
       generateDeploymentId,
       firstScheduleId,
       fooRunAt,
-      PeriodicProcessDeploymentStatus.Scheduled,
+      PeriodicProcessDeploymentStatus.Deployed,
       processActive = true,
       None
     )
@@ -56,14 +56,14 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
       generateDeploymentId,
       secScheduleId,
       fooRunAt,
-      PeriodicProcessDeploymentStatus.Deployed,
+      PeriodicProcessDeploymentStatus.Scheduled,
       processActive = true,
       None
     )
     val status = PeriodicProcessStatus(List(firstDeploymentStatus, secDeploymentStatus), List.empty)
     statusTooltip(status) shouldEqual
-      s"""Schedule ${firstScheduleId.scheduleName.display} scheduled at: 2023-01-01 10:00 status: Scheduled,
-         |Schedule ${secScheduleId.scheduleName.display} scheduled at: 2023-01-01 10:00 status: Deployed""".stripMargin
+      s"""Schedule ${secScheduleId.scheduleName.display} scheduled at: 2023-01-01 10:00 status: Scheduled,
+         |Schedule ${firstScheduleId.scheduleName.display} scheduled at: 2023-01-01 10:00 status: Deployed""".stripMargin
   }
 
   private def generateDeploymentId = PeriodicProcessDeploymentId(nextDeploymentId.getAndIncrement())


### PR DESCRIPTION
Right now deployments are sorted by `runAt` and it might produce problems when in some specific cases you want to run instant batch without waiting for schedule (using custom actions). Then `runAt` is still set by CRON but deployment starts immediately. In such case we can produce > 1 records with `runAt` set to same value and NU cannot handle states properly.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
