### PR TITLE
Change authenticationMethod type from Auth to EndpointInput

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppApiEndpoints.scala
@@ -11,13 +11,12 @@ import pl.touk.nussknacker.ui.api.BaseEndpointDefinitions.SecuredEndpoint
 import pl.touk.nussknacker.ui.security.api.AuthCredentials
 import sttp.model.StatusCode.{InternalServerError, NoContent, Ok}
 import sttp.tapir.EndpointIO.Example
-import sttp.tapir.EndpointInput.Auth
 import sttp.tapir._
 import sttp.tapir.codec.enumeratum._
 import sttp.tapir.derevo.schema
 import sttp.tapir.json.circe.jsonBody
 
-class AppApiEndpoints(auth: Auth[AuthCredentials, _]) extends BaseEndpointDefinitions {
+class AppApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseEndpointDefinitions {
 
   import AppApiEndpoints.Dtos._
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/BaseEndpointDefinitions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/BaseEndpointDefinitions.scala
@@ -4,7 +4,6 @@ import pl.touk.nussknacker.ui.api.BaseEndpointDefinitions.ToSecure
 import pl.touk.nussknacker.ui.security.api.AuthCredentials
 import sttp.model.StatusCode.{Forbidden, Unauthorized}
 import sttp.tapir.EndpointIO.Example
-import sttp.tapir.EndpointInput.Auth
 import sttp.tapir._
 
 import scala.language.implicitConversions
@@ -32,7 +31,7 @@ object BaseEndpointDefinitions {
 
     import Codecs._
 
-    def withSecurity(auth: Auth[AuthCredentials, _]): SecuredEndpoint[INPUT, BUSINESS_ERROR, OUTPUT, R] = {
+    def withSecurity(auth: EndpointInput[AuthCredentials]): SecuredEndpoint[INPUT, BUSINESS_ERROR, OUTPUT, R] = {
       endpoint
         .securityIn(auth)
         .errorOutEither(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NuDesignerApiAvailableToExposeYamlSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NuDesignerApiAvailableToExposeYamlSpec.scala
@@ -8,9 +8,8 @@ import pl.touk.nussknacker.ui.security.api.AuthCredentials
 import pl.touk.nussknacker.ui.services.NuDesignerExposedApiHttpService
 import pl.touk.nussknacker.ui.util.Project
 import sttp.apispec.openapi.circe.yaml.RichOpenAPI
-import sttp.tapir.EndpointInput.Auth
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
-import sttp.tapir.{Endpoint, auth}
+import sttp.tapir.{Endpoint, EndpointInput, auth}
 
 import java.lang.reflect.{Method, Modifier}
 import scala.jdk.CollectionConverters._
@@ -63,7 +62,7 @@ object NuDesignerApiAvailableToExpose {
   }
 
   private def createInstanceOf(clazz: Class[_ <: BaseEndpointDefinitions]) = {
-    Try(clazz.getConstructor(classOf[Auth[AuthCredentials, _]]))
+    Try(clazz.getConstructor(classOf[EndpointInput[AuthCredentials]]))
       .map(_.newInstance(auth.basic[AuthCredentials]()))
       .orElse {
         Try(clazz.getDeclaredConstructor())

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 1.13.0 (Not released yet)
 -------------------------
+* [#4988](https://github.com/TouK/nussknacker/pull/4988) Refactor: Allow to use custom authentication methods
 * [#4711](https://github.com/TouK/nussknacker/pull/4711) [#4862](https://github.com/TouK/nussknacker/pull/4862) Added AdditionalUIConfigProviderFactory API that allows changing components' configs and scenario properties' UI configs without model reload
 * [#4860](https://github.com/TouK/nussknacker/pull/4860) Rename `additionalProperties` to `scenarioProperties`
 * [#4828](https://github.com/TouK/nussknacker/pull/4828) Improvement: Allow passing timestampAssigner at FlinkTestScenarioRunner

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,7 @@
 
 1.13.0 (Not released yet)
 -------------------------
-* [#4988](https://github.com/TouK/nussknacker/pull/4988) Refactor: Allow to use custom authentication methods
+* [#4988](https://github.com/TouK/nussknacker/pull/4988) Refactor: Allow to use custom authentication methods in user-defined Authentication Providers
 * [#4711](https://github.com/TouK/nussknacker/pull/4711) [#4862](https://github.com/TouK/nussknacker/pull/4862) Added AdditionalUIConfigProviderFactory API that allows changing components' configs and scenario properties' UI configs without model reload
 * [#4860](https://github.com/TouK/nussknacker/pull/4860) Rename `additionalProperties` to `scenarioProperties`
 * [#4828](https://github.com/TouK/nussknacker/pull/4828) Improvement: Allow passing timestampAssigner at FlinkTestScenarioRunner

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -6,6 +6,7 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 ## In version 1.13.x (Not released yet)
 
 ### Code API changes
+* [#4988](https://github.com/TouK/nussknacker/pull/4988) Method definition `def authenticationMethod(): Auth[AuthCredentials, _]` was changed to `def authenticationMethod(): EndpointInput[AuthCredentials]`
 * [#4860](https://github.com/TouK/nussknacker/pull/4860) DeploymentManagerProvider implementations have to implement the method `def scenarioPropertiesConfig(config: Config): Map[String, ScenarioPropertyConfig]` instead of `def additionalPropertiesConfig(config: Config): Map[String, AdditionalPropertyConfig]`
 * [#4919](https://github.com/TouK/nussknacker/pull/4919) Improvement: Support for handling runtime exceptions at FlinkTestScenarioRunner:
   * `TestProcess.exceptions` type changed from `List[ExceptionResult[T]]` to `List[NuExceptionInfo[_ <: Throwable]]`

--- a/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationResources.scala
+++ b/security/src/main/scala/pl/touk/nussknacker/ui/security/api/AuthenticationResources.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.server.directives.AuthenticationDirective
 import com.typesafe.config.Config
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import sttp.client3.SttpBackend
-import sttp.tapir.EndpointInput.Auth
+import sttp.tapir.EndpointInput
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -24,7 +24,7 @@ trait AuthenticationResources extends Directives with FailFastCirceSupport {
   // interpreter) or create our own.
   def authenticate(): Directive1[AuthenticatedUser]
 
-  def authenticationMethod(): Auth[AuthCredentials, _]
+  def authenticationMethod(): EndpointInput[AuthCredentials]
 
   def authenticate(authCredentials: AuthCredentials): Future[Option[AuthenticatedUser]]
 

--- a/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationResources.scala
+++ b/security/src/main/scala/pl/touk/nussknacker/ui/security/basicauth/BasicAuthenticationResources.scala
@@ -3,7 +3,6 @@ package pl.touk.nussknacker.ui.security.basicauth
 import akka.http.scaladsl.server.directives.{AuthenticationDirective, SecurityDirectives}
 import pl.touk.nussknacker.ui.security.api._
 import sttp.model.headers.WWWAuthenticateChallenge
-import sttp.tapir.EndpointInput.Auth
 import sttp.tapir._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -27,7 +26,7 @@ class BasicAuthenticationResources(realm: String, configuration: BasicAuthentica
       realm = realm
     )
 
-  override def authenticationMethod(): Auth[AuthCredentials, _] = {
+  override def authenticationMethod(): EndpointInput[AuthCredentials] = {
     auth.basic[AuthCredentials](WWWAuthenticateChallenge.basic.realm(realm))
   }
 

--- a/security/src/main/scala/pl/touk/nussknacker/ui/security/dummy/DummyAuthenticationResources.scala
+++ b/security/src/main/scala/pl/touk/nussknacker/ui/security/dummy/DummyAuthenticationResources.scala
@@ -12,7 +12,6 @@ import pl.touk.nussknacker.ui.security.api.{
   FrontendStrategySettings
 }
 import sttp.model.headers.WWWAuthenticateChallenge
-import sttp.tapir.EndpointInput.Auth
 import sttp.tapir._
 
 import scala.collection.immutable.ListMap
@@ -32,7 +31,7 @@ class DummyAuthenticationResources(override val name: String, configuration: Dum
     ]
   }
 
-  override def authenticationMethod(): Auth[AuthCredentials, _] =
+  override def authenticationMethod(): EndpointInput[AuthCredentials] =
     auth.basic(new WWWAuthenticateChallenge("Dummy", ListMap.empty).realm("Dummy"))
 
   override def authenticate(authCredentials: AuthCredentials): Future[Option[AuthenticatedUser]] =

--- a/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationResources.scala
+++ b/security/src/main/scala/pl/touk/nussknacker/ui/security/oauth2/OAuth2AuthenticationResources.scala
@@ -13,7 +13,6 @@ import pl.touk.nussknacker.ui.security.CertificatesAndKeys
 import pl.touk.nussknacker.ui.security.api._
 import sttp.client3.SttpBackend
 import sttp.model.headers.WWWAuthenticateChallenge
-import sttp.tapir.EndpointInput.Auth
 import sttp.tapir._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,7 +32,7 @@ class OAuth2AuthenticationResources(
 
   private val authenticator = OAuth2Authenticator(service)
 
-  override def authenticationMethod(): Auth[AuthCredentials, _] =
+  override def authenticationMethod(): EndpointInput[AuthCredentials] =
     auth.oauth2
       .authorizationCode(
         authorizationUrl = configuration.authorizeUrl.map(_.toString),


### PR DESCRIPTION
The change is needed to implement custom auth or to fallback while using multiple authentication methods. 

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
