### PR TITLE
Sort periodic process deployments not only by runAt but also by createdAt

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+1.12.4 (?? Oct 2023)
+* [#4992](https://github.com/TouK/nussknacker/pull/4992) Fix: Sort PeriodicProcessDeployments by `runAt` and `createdAt` and instead of `runAt` only.
+
 1.12.3 (26 Oct 2023)
 1.12.2 (25 Oct 2023)
 1.12.1 (25 Oct 2023)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 1.12.4 (?? Oct 2023)
-* [#4992](https://github.com/TouK/nussknacker/pull/4992) Fix: Sort PeriodicProcessDeployments by `runAt` and `createdAt` and instead of `runAt` only.
+* [#4992](https://github.com/TouK/nussknacker/pull/4992) Fix: List of periodic deployments is now sorted not only by schedule time but also by its creation time.
 
 1.12.3 (26 Oct 2023)
 1.12.2 (25 Oct 2023)

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
@@ -571,7 +571,7 @@ object PeriodicProcessService {
         lastActiveDeploymentStatusForEachSchedule.find(_.status == status)
 
       def last(status: PeriodicProcessDeploymentStatus) =
-        lastActiveDeploymentStatusForEachSchedule.findLast(_.status == status)
+        lastActiveDeploymentStatusForEachSchedule.reverse.find(_.status == status)
 
       first(PeriodicProcessDeploymentStatus.Deployed)
         .orElse(last(PeriodicProcessDeploymentStatus.Failed))

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
@@ -146,7 +146,7 @@ class PeriodicProcessService(
       // We retry scenarios that failed on deployment. Failure recovery of running scenarios should be handled by Flink's restart strategy
       toBeRetried <- scheduledProcessesRepository.findToBeRetried.run
       // We don't block scheduled deployments by retries
-    } yield toBeDeployed.sortBy(_.runAt) ++ toBeRetried.sortBy(_.nextRetryAt)
+    } yield toBeDeployed.sortBy(d => (d.runAt, d.createdAt)) ++ toBeRetried.sortBy(d => (d.nextRetryAt, d.createdAt))
   }
 
   // Currently we don't allow simultaneous runs of one scenario - only sequential, so if other schedule kicks in, it'll have to wait
@@ -419,6 +419,7 @@ class PeriodicProcessService(
         scheduleData.latestDeployments.map { deployment =>
           DeploymentStatus(
             deployment.id,
+            deployment.createdAt,
             scheduleId,
             deployment.runAt,
             deployment.state.status,
@@ -427,7 +428,8 @@ class PeriodicProcessService(
           )
         }
       }
-      .sortBy(_.runAt)(Ordering[LocalDateTime].reverse)
+      .sortBy(_.runAtWithCreatedAt)
+      .reverse
 
     for {
       activeSchedules <- getLatestDeploymentsForActiveSchedules(name, MaxDeploymentsStatus)
@@ -498,7 +500,8 @@ object PeriodicProcessService {
       (activeDeploymentsStatuses ++ inactiveDeploymentsStatuses.take(
         MaxDeploymentsStatus - activeDeploymentsStatuses.size
       ))
-        .sortBy(_.runAt)(Ordering[LocalDateTime].reverse)
+        .sortBy(_.runAtWithCreatedAt)
+        .reverse
 
     // We present merged name to be possible to filter scenario by status
     override def name: StatusName = mergedStatusDetails.status.name
@@ -566,7 +569,7 @@ object PeriodicProcessService {
     def pickMostImportantActiveDeployment: Option[DeploymentStatus] = {
       val lastActiveDeploymentStatusForEachSchedule =
         latestDeploymentForEachSchedule(activeDeploymentsStatuses)
-          .sortBy(_.runAt)(Ordering[LocalDateTime])
+          .sortBy(_.runAtWithCreatedAt)
       def first(status: PeriodicProcessDeploymentStatus) =
         lastActiveDeploymentStatusForEachSchedule.find(_.status == status)
 
@@ -586,7 +589,7 @@ object PeriodicProcessService {
         .groupBy(_.scheduleId)
         .values
         .toList
-        .map(_.sortBy(_.runAt)(Ordering[LocalDateTime].reverse).head)
+        .map(_.sortBy(_.runAtWithCreatedAt).reverse.head)
     }
 
   }
@@ -594,6 +597,7 @@ object PeriodicProcessService {
   case class DeploymentStatus( // Probably it is too much technical to present to users, but the only other alternative
       // to present to users is scheduleName+runAt
       deploymentId: PeriodicProcessDeploymentId,
+      createdAt: LocalDateTime,
       scheduleId: ScheduleId,
       runAt: LocalDateTime,
       // This status is almost fine but:
@@ -604,6 +608,8 @@ object PeriodicProcessService {
       // Some additional information that are available in StatusDetails returned by engine runtime
       runtimeStatusOpt: Option[StatusDetails]
   ) {
+
+    val runAtWithCreatedAt: (LocalDateTime, LocalDateTime) = (runAt, createdAt)
 
     def scheduleName: ScheduleName = scheduleId.scheduleName
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManager.scala
@@ -29,7 +29,7 @@ object PeriodicProcessStateDefinitionManager {
 
   def statusTooltip(processStatus: PeriodicProcessStatus): String = {
     processStatus.limitedAndSortedDeployments
-      .map { case d @ DeploymentStatus(_, scheduleId, runAt, status, _, _) =>
+      .map { case d @ DeploymentStatus(_, _, scheduleId, runAt, status, _, _) =>
         val refinedStatus = {
           if (d.isCanceled) {
             "Canceled"

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManager.scala
@@ -29,7 +29,7 @@ object PeriodicProcessStateDefinitionManager {
 
   def statusTooltip(processStatus: PeriodicProcessStatus): String = {
     processStatus.limitedAndSortedDeployments
-      .map { case d @ DeploymentStatus(_, _, scheduleId, runAt, status, _, _) =>
+      .map { case d @ DeploymentStatus(_, scheduleId, _, runAt, status, _, _) =>
         val refinedStatus = {
           if (d.isCanceled) {
             "Canceled"

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -310,7 +310,10 @@ class SlickPeriodicProcessesRepository(
         (
           rowNumber() :: Over
             .partitionBy((deployment.periodicProcessId, deployment.scheduleName))
-            .sortBy(deployment.runAt.desc, deployment.createdAt.desc),
+            .sortBy(
+              deployment.runAt.desc,
+              deployment.createdAt.desc
+            ), // Remember to change DeploymentStatus.ordering accordingly
           process,
           deployment
         )
@@ -355,7 +358,7 @@ class SlickPeriodicProcessesRepository(
               .filter(deployment =>
                 deployment.periodicProcessId === process.id && (deployment.scheduleName === scheduleName || deployment.scheduleName.isEmpty && scheduleName.isEmpty)
               )
-              .sortBy(a => (a.runAt.desc, a.createdAt.desc))
+              .sortBy(a => (a.runAt.desc, a.createdAt.desc)) // Remember to change DeploymentStatus.ordering accordingly
               .take(deploymentsPerScheduleMaxCount)
               .result
               .map(_.map((process, _)))

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -26,6 +26,7 @@ object PeriodicProcessesRepository {
     val process = createPeriodicProcess(processEntity)
     PeriodicProcessDeployment(
       processDeploymentEntity.id,
+      processDeploymentEntity.createdAt,
       process,
       processDeploymentEntity.runAt,
       ScheduleName(processDeploymentEntity.scheduleName),
@@ -309,7 +310,7 @@ class SlickPeriodicProcessesRepository(
         (
           rowNumber() :: Over
             .partitionBy((deployment.periodicProcessId, deployment.scheduleName))
-            .sortBy(deployment.runAt.desc),
+            .sortBy(deployment.runAt.desc, deployment.createdAt.desc),
           process,
           deployment
         )
@@ -354,7 +355,7 @@ class SlickPeriodicProcessesRepository(
               .filter(deployment =>
                 deployment.periodicProcessId === process.id && (deployment.scheduleName === scheduleName || deployment.scheduleName.isEmpty && scheduleName.isEmpty)
               )
-              .sortBy(_.runAt.desc)
+              .sortBy(a => (a.runAt.desc, a.createdAt.desc))
               .take(deploymentsPerScheduleMaxCount)
               .result
               .map(_.map((process, _)))

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -26,8 +26,8 @@ object PeriodicProcessesRepository {
     val process = createPeriodicProcess(processEntity)
     PeriodicProcessDeployment(
       processDeploymentEntity.id,
-      processDeploymentEntity.createdAt,
       process,
+      processDeploymentEntity.createdAt,
       processDeploymentEntity.runAt,
       ScheduleName(processDeploymentEntity.scheduleName),
       processDeploymentEntity.retriesLeft,

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcessDeployment.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcessDeployment.scala
@@ -9,6 +9,7 @@ import java.time.{Clock, LocalDateTime}
 // TODO: We should separate schedules concept from deployments - fully switch to ScheduleData and ScheduleDeploymentData
 case class PeriodicProcessDeployment(
     id: PeriodicProcessDeploymentId,
+    createdAt: LocalDateTime,
     periodicProcess: PeriodicProcess,
     runAt: LocalDateTime,
     scheduleName: ScheduleName,

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcessDeployment.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcessDeployment.scala
@@ -9,8 +9,8 @@ import java.time.{Clock, LocalDateTime}
 // TODO: We should separate schedules concept from deployments - fully switch to ScheduleData and ScheduleDeploymentData
 case class PeriodicProcessDeployment(
     id: PeriodicProcessDeploymentId,
-    createdAt: LocalDateTime,
     periodicProcess: PeriodicProcess,
+    createdAt: LocalDateTime,
     runAt: LocalDateTime,
     scheduleName: ScheduleName,
     retriesLeft: Int,

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/SchedulesState.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/SchedulesState.scala
@@ -51,7 +51,7 @@ case class ScheduleDeploymentData(
     state: PeriodicProcessDeploymentState
 ) {
   def toFullDeploymentData(process: PeriodicProcess, scheduleName: ScheduleName): PeriodicProcessDeployment =
-    PeriodicProcessDeployment(id, createdAt, process, runAt, scheduleName, retriesLeft, nextRetryAt, state)
+    PeriodicProcessDeployment(id, process, createdAt, runAt, scheduleName, retriesLeft, nextRetryAt, state)
 
   def display = s"deploymentId=$id"
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/SchedulesState.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/SchedulesState.scala
@@ -44,13 +44,14 @@ case class ScheduleId(processId: PeriodicProcessId, scheduleName: ScheduleName)
 
 case class ScheduleDeploymentData(
     id: PeriodicProcessDeploymentId,
+    createdAt: LocalDateTime,
     runAt: LocalDateTime,
     retriesLeft: Int,
     nextRetryAt: Option[LocalDateTime],
     state: PeriodicProcessDeploymentState
 ) {
   def toFullDeploymentData(process: PeriodicProcess, scheduleName: ScheduleName): PeriodicProcessDeployment =
-    PeriodicProcessDeployment(id, process, runAt, scheduleName, retriesLeft, nextRetryAt, state)
+    PeriodicProcessDeployment(id, createdAt, process, runAt, scheduleName, retriesLeft, nextRetryAt, state)
 
   def display = s"deploymentId=$id"
 
@@ -61,6 +62,7 @@ object ScheduleDeploymentData {
   def apply(deployment: PeriodicProcessDeploymentEntity): ScheduleDeploymentData = {
     ScheduleDeploymentData(
       deployment.id,
+      deployment.createdAt,
       deployment.runAt,
       deployment.retriesLeft,
       deployment.nextRetryAt,

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessDeploymentGen.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessDeploymentGen.scala
@@ -17,8 +17,8 @@ object PeriodicProcessDeploymentGen {
   def apply(): PeriodicProcessDeployment = {
     PeriodicProcessDeployment(
       id = PeriodicProcessDeploymentId(42),
-      createdAt = now.minusMinutes(10),
       periodicProcess = PeriodicProcessGen(),
+      createdAt = now.minusMinutes(10),
       runAt = now,
       scheduleName = ScheduleName(None),
       retriesLeft = 0,

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessDeploymentGen.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessDeploymentGen.scala
@@ -12,11 +12,14 @@ import java.time.LocalDateTime
 
 object PeriodicProcessDeploymentGen {
 
+  val now: LocalDateTime = LocalDateTime.now()
+
   def apply(): PeriodicProcessDeployment = {
     PeriodicProcessDeployment(
       id = PeriodicProcessDeploymentId(42),
+      createdAt = now.minusMinutes(10),
       periodicProcess = PeriodicProcessGen(),
-      runAt = LocalDateTime.now(),
+      runAt = now,
       scheduleName = ScheduleName(None),
       retriesLeft = 0,
       nextRetryAt = None,

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
@@ -49,7 +49,7 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
     val firstDeploymentStatus = DeploymentStatus(
       generateDeploymentId,
       firstScheduleId,
-      fooCreatedAt,
+      fooCreatedAt.minusMinutes(1),
       fooRunAt,
       PeriodicProcessDeploymentStatus.Deployed,
       processActive = true,

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
@@ -22,6 +22,8 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
 
   private val fooRunAt = LocalDateTime.of(2023, 1, 1, 10, 0)
 
+  private val fooCreatedAt = fooRunAt.minusMinutes(5)
+
   private val notNamedScheduleId = ScheduleId(fooProcessId, ScheduleName(None))
 
   private val nextDeploymentId = new AtomicLong()
@@ -31,6 +33,7 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
   test("display periodic deployment status for not named schedule") {
     val deploymentStatus = DeploymentStatus(
       generateDeploymentId,
+      fooCreatedAt,
       notNamedScheduleId,
       fooRunAt,
       PeriodicProcessDeploymentStatus.Scheduled,
@@ -41,29 +44,31 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
     statusTooltip(status) shouldEqual "Scheduled at: 2023-01-01 10:00 status: Scheduled"
   }
 
-  test("display periodic deployment status for named schedules") {
+  test("display sorted periodic deployment status for named schedules") {
     val firstScheduleId = generateScheduleId
     val firstDeploymentStatus = DeploymentStatus(
       generateDeploymentId,
+      fooCreatedAt,
       firstScheduleId,
       fooRunAt,
-      PeriodicProcessDeploymentStatus.Scheduled,
+      PeriodicProcessDeploymentStatus.Deployed,
       processActive = true,
       None
     )
     val secScheduleId = generateScheduleId
     val secDeploymentStatus = DeploymentStatus(
       generateDeploymentId,
+      fooCreatedAt,
       secScheduleId,
       fooRunAt,
-      PeriodicProcessDeploymentStatus.Deployed,
+      PeriodicProcessDeploymentStatus.Scheduled,
       processActive = true,
       None
     )
     val status = PeriodicProcessStatus(List(firstDeploymentStatus, secDeploymentStatus), List.empty)
     statusTooltip(status) shouldEqual
-      s"""Schedule ${firstScheduleId.scheduleName.display} scheduled at: 2023-01-01 10:00 status: Scheduled,
-         |Schedule ${secScheduleId.scheduleName.display} scheduled at: 2023-01-01 10:00 status: Deployed""".stripMargin
+      s"""Schedule ${secScheduleId.scheduleName.display} scheduled at: 2023-01-01 10:00 status: Scheduled,
+         |Schedule ${firstScheduleId.scheduleName.display} scheduled at: 2023-01-01 10:00 status: Deployed""".stripMargin
   }
 
   private def generateDeploymentId = PeriodicProcessDeploymentId(nextDeploymentId.getAndIncrement())

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
@@ -33,8 +33,8 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
   test("display periodic deployment status for not named schedule") {
     val deploymentStatus = DeploymentStatus(
       generateDeploymentId,
-      fooCreatedAt,
       notNamedScheduleId,
+      fooCreatedAt,
       fooRunAt,
       PeriodicProcessDeploymentStatus.Scheduled,
       processActive = true,
@@ -48,8 +48,8 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
     val firstScheduleId = generateScheduleId
     val firstDeploymentStatus = DeploymentStatus(
       generateDeploymentId,
-      fooCreatedAt,
       firstScheduleId,
+      fooCreatedAt,
       fooRunAt,
       PeriodicProcessDeploymentStatus.Deployed,
       processActive = true,
@@ -58,8 +58,8 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
     val secScheduleId = generateScheduleId
     val secDeploymentStatus = DeploymentStatus(
       generateDeploymentId,
-      fooCreatedAt,
       secScheduleId,
+      fooCreatedAt,
       fooRunAt,
       PeriodicProcessDeploymentStatus.Scheduled,
       processActive = true,


### PR DESCRIPTION
Right now deployments are sorted by `runAt` and it might produce problems when in some specific cases you want to run instant batch without waiting for schedule (using custom actions). Then `runAt` is still set by CRON but deployment starts immediately. In such case we can produce > 1 records with `runAt` set to same value and NU cannot handle states properly.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [x] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
