### PR TITLE
Fixup to async DefaultAsyncExecutionConfigPreparer

### DIFF
--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/AsyncExecutionContextPreparer.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/AsyncExecutionContextPreparer.scala
@@ -2,6 +2,10 @@ package pl.touk.nussknacker.engine.api.process
 
 import scala.concurrent.ExecutionContext
 
+/**
+  * * prepareExecutionContext will be called multiple times (for each asynch function subtask)
+  * * close will be called only once in UserCodeClassLoaderReleaseHook (look pl.touk.nussknacker.engine.process.registrar.AsyncInterpretationFunction)
+  */
 trait AsyncExecutionContextPreparer {
 
   def bufferSize: Int


### PR DESCRIPTION
Fixup to async DefaultAsyncExecutionConfigPreparer - using class loader release hook instead of counting prepareExecutionContext/close method calls:

* Closed ExecutorService could leak into execution after restart because lack of synchronization in close method (cached reference to Some in asyncExecutionContext var for thread)
* prepare/close counter could fall below zero and lead to odd behaviour in cases when close was called without a prior open method call (e.g. in case of operator initializeState error - look into org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.initializeStateAndOpenOperators and org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke)

## Checklist before merge
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
