### PR TITLE
[NU-1276] Fix unknown scenario status when changing version

### DIFF
--- a/designer/client/src/components/Process/messages.ts
+++ b/designer/client/src/components/Process/messages.ts
@@ -1,11 +1,11 @@
 import i18next from "i18next";
 
-export const unknownTooltip = () => i18next.t("process.unknownTooltip", "Unknown state of the scenario..");
+export const unknownTooltip = () => i18next.t("process.unknownTooltip", "Unknown state of the scenario.");
 
-export const unknownDescription = () => i18next.t("process.unknownDescription", "Unknown state of the scenario..");
+export const unknownDescription = () => i18next.t("process.unknownDescription", "Unknown state of the scenario.");
 
-export const descriptionFragment = () => i18next.t("process.descriptionFragment", "This is a scenario fragment");
+export const descriptionFragment = () => i18next.t("process.descriptionFragment", "This is a scenario fragment.");
 
-export const descriptionProcessArchived = () => i18next.t("process.descriptionProcessArchived", "This scenario was archived");
+export const descriptionProcessArchived = () => i18next.t("process.descriptionProcessArchived", "This scenario was archived.");
 
-export const descriptionFragmentArchived = () => i18next.t("process.descriptionFragmentArchived", "This scenario fragment was archived");
+export const descriptionFragmentArchived = () => i18next.t("process.descriptionFragmentArchived", "This scenario fragment was archived.");

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -175,7 +175,7 @@ class ProcessesResources(
             processService.getProcessWithDetails(
               processId,
               versionId,
-              GetScenarioWithDetailsOptions(FetchScenarioGraph(!skipValidateAndResolve), fetchState = false)
+              GetScenarioWithDetailsOptions(FetchScenarioGraph(!skipValidateAndResolve), fetchState = true)
             )
           }
         }


### PR DESCRIPTION
## Describe your changes
After refactoring the ProcessesResources with endpoint for getting a specified scenario version we stopped fetching scenario status and return null in that place. This caused an issue where after switching to another version the FE displayed an unknown scenario state status. Until FE stops using the status from the scenario endpoint, we have to fetch it every time. 

This also makes the FE hardcoded status messages consistent with convention of ending with one dot '.' 

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
