### PR TITLE
[NU-1104] Fix for: the release process published the release image un…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,9 @@ jobs:
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          JAVA_OPTS: "-Xss6M -Xms6G -Xmx6G -XX:ReservedCodeCacheSize=256M -XX:MaxMetaspaceSize=2500M -DdockerUpLatest=${{ env.NU_DOCKER_UPDATE_LATEST }}"
+          # dockerUpBranchLatest is set to false because branch latest tags are used by cypress tests and
+          # the image built during the release doesn't contain developer's extensions which are required by these tests
+          JAVA_OPTS: "-Xss6M -Xms6G -Xmx6G -XX:ReservedCodeCacheSize=256M -XX:MaxMetaspaceSize=2500M -DdockerUpLatest=${{ env.NU_DOCKER_UPDATE_LATEST }} -DdockerUpBranchLatest=false"
         run: sbt 'release ${{ env.SBT_RELEASE_NEXT_VERSION }} skip-tests'
 
       - name: "Push to master"

--- a/build.sbt
+++ b/build.sbt
@@ -47,13 +47,14 @@ val nexusUrlFromProps  = propOrEnv("nexusUrl")
 val nexusHostFromProps = nexusUrlFromProps.map(_.replaceAll("http[s]?://", "").replaceAll("[:/].*", ""))
 
 //Docker release configuration
-val dockerTagName          = propOrEnv("dockerTagName")
-val dockerPort             = propOrEnv("dockerPort", "8080").toInt
-val dockerUserName         = Option(propOrEnv("dockerUserName", "touk"))
-val dockerPackageName      = propOrEnv("dockerPackageName", "nussknacker")
-val dockerUpLatestFromProp = propOrEnv("dockerUpLatest").flatMap(p => Try(p.toBoolean).toOption)
-val addDevArtifacts        = propOrEnv("addDevArtifacts", "false").toBoolean
-val addManagerArtifacts    = propOrEnv("addManagerArtifacts", "false").toBoolean
+val dockerTagName                = propOrEnv("dockerTagName")
+val dockerPort                   = propOrEnv("dockerPort", "8080").toInt
+val dockerUserName               = Option(propOrEnv("dockerUserName", "touk"))
+val dockerPackageName            = propOrEnv("dockerPackageName", "nussknacker")
+val dockerUpLatestFromProp       = propOrEnv("dockerUpLatest").flatMap(p => Try(p.toBoolean).toOption)
+val dockerUpBranchLatestFromProp = propOrEnv("dockerUpBranchLatest", "true").toBoolean
+val addDevArtifacts              = propOrEnv("addDevArtifacts", "false").toBoolean
+val addManagerArtifacts          = propOrEnv("addManagerArtifacts", "false").toBoolean
 
 val requestResponseManagementPort = propOrEnv("requestResponseManagementPort", "8070").toInt
 val requestResponseProcessesPort  = propOrEnv("requestResponseProcessesPort", "8080").toInt
@@ -409,14 +410,18 @@ lazy val commonDockerSettings = {
 
       val alias = dockerAlias.value
 
-      val updateLatest  = if (dockerUpdateLatest.value) Some("latest") else None
-      val dockerVersion = Some(version.value)
-      // TODO: handle it more nicely, checkout actions in CI are not checking out actual branch
-      // other option would be to reset source branch to checkout out commit
-      val currentBranch = sys.env.getOrElse("GIT_SOURCE_BRANCH", git.gitCurrentBranch.value)
-      val latestBranch  = Some(currentBranch + "-latest")
+      val updateLatest       = if (dockerUpdateLatest.value) Some("latest") else None
+      val updateBranchLatest = if (dockerUpBranchLatestFromProp) {
+        // TODO: handle it more nicely, checkout actions in CI are not checking out actual branch
+        // other option would be to reset source branch to checkout out commit
+        val currentBranch = sys.env.getOrElse("GIT_SOURCE_BRANCH", git.gitCurrentBranch.value)
+        Some(currentBranch + "-latest")
+      } else {
+        None
+      }
+      val dockerVersion      = Some(version.value)
 
-      val tags                = List(dockerVersion, updateLatest, latestBranch, dockerTagName).flatten
+      val tags                = List(dockerVersion, updateLatest, updateBranchLatest, dockerTagName).flatten
       val scalaSuffix         = s"_scala-${CrossVersion.binaryScalaVersion(scalaVersion.value)}"
       val tagsWithScalaSuffix = tags.map(t => s"$t$scalaSuffix")
 


### PR DESCRIPTION
…der the release_VERSION-latest tag which was bad because cypress tests relies on these images and release images doesn't contain developer's extensions which are required by these tests

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
