### PR TITLE
[NU-1259] Replacing Akka HTTP in user endpoint with tapir

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/UserApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/UserApiEndpoints.scala
@@ -1,32 +1,36 @@
 package pl.touk.nussknacker.ui.api
 
-import akka.http.scaladsl.server.{Directives, Route}
-import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import derevo.circe.{decoder, encoder}
+import derevo.derive
 import io.circe.generic.JsonCodec
-import pl.touk.nussknacker.ui.process.{ProcessCategoryService, UserCategoryService}
+import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions
+import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions.SecuredEndpoint
+import pl.touk.nussknacker.security.AuthCredentials
 import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
 import pl.touk.nussknacker.ui.security.api.{AdminUser, CommonUser, LoggedUser}
+import sttp.model.StatusCode.Ok
+import sttp.tapir.derevo.schema
+import sttp.tapir.json.circe.jsonBody
+import sttp.tapir.{EndpointInput, statusCode}
 
-import scala.concurrent.ExecutionContext
+class UserApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseEndpointDefinitions {
 
-class UserResources(getProcessCategoryService: () => ProcessCategoryService)(implicit ec: ExecutionContext)
-    extends Directives
-    with FailFastCirceSupport
-    with RouteWithUser {
-
-  def securedRoute(implicit user: LoggedUser): Route =
-    path("user") {
-      get {
-        complete {
-          val allUserAccessibleCategories = new UserCategoryService(getProcessCategoryService()).getUserCategories(user)
-          DisplayableUser(user, allUserAccessibleCategories)
-        }
-      }
-    }
-
+  lazy val userInfoEndpoint: SecuredEndpoint[Unit, Unit, DisplayableUser, Any] =
+    baseNuApiEndpoint
+      .summary("Logged user info service")
+      .tag("User")
+      .get
+      .in("user")
+      .out(
+        statusCode(Ok).and(
+          jsonBody[DisplayableUser]
+        )
+      )
+      .withSecurity(auth)
 }
 
-@JsonCodec final case class DisplayableUser private (
+@derive(schema, encoder, decoder)
+final case class DisplayableUser private (
     id: String,
     username: String,
     isAdmin: Boolean,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/UserApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/UserApiEndpoints.scala
@@ -2,7 +2,6 @@ package pl.touk.nussknacker.ui.api
 
 import derevo.circe.{decoder, encoder}
 import derevo.derive
-import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions
 import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions.SecuredEndpoint
 import pl.touk.nussknacker.security.AuthCredentials
@@ -27,6 +26,7 @@ class UserApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseEndpoin
         )
       )
       .withSecurity(auth)
+
 }
 
 @derive(schema, encoder, decoder)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
@@ -48,7 +48,12 @@ import pl.touk.nussknacker.ui.process.processingtypedata.{
 import pl.touk.nussknacker.ui.process.repository._
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService
 import pl.touk.nussknacker.ui.processreport.ProcessCounter
-import pl.touk.nussknacker.ui.services.{AppApiHttpService, ComponentApiHttpService, NuDesignerExposedApiHttpService}
+import pl.touk.nussknacker.ui.services.{
+  AppApiHttpService,
+  ComponentApiHttpService,
+  NuDesignerExposedApiHttpService,
+  UserApiHttpService
+}
 import pl.touk.nussknacker.ui.security.api.{
   AuthenticationConfiguration,
   AuthenticationResources,
@@ -227,6 +232,11 @@ class AkkaHttpBasedRouteProvider(
         getProcessCategoryService = getProcessCategoryService,
         componentService = componentService
       )
+      val userApiHttpService = new UserApiHttpService(
+        config = resolvedConfig,
+        authenticator = authenticationResources,
+        getProcessCategoryService = getProcessCategoryService
+      )
 
       val notificationService = new NotificationServiceImpl(actionRepository, dbioRunner, notificationsConfig)
 
@@ -275,7 +285,6 @@ class AkkaHttpBasedRouteProvider(
             getProcessCategoryService,
             additionalUIConfigProvider
           ),
-          new UserResources(getProcessCategoryService),
           new NotificationResources(notificationService),
           new TestInfoResources(processAuthorizer, processService, scenarioTestService),
           new AttachmentResources(
@@ -330,7 +339,8 @@ class AkkaHttpBasedRouteProvider(
         authenticationResources.routeWithPathPrefix,
       )
 
-      val nuDesignerApi = new NuDesignerExposedApiHttpService(appApiHttpService, componentsApiHttpService)
+      val nuDesignerApi =
+        new NuDesignerExposedApiHttpService(appApiHttpService, componentsApiHttpService, userApiHttpService)
 
       createAppRoute(
         resolvedConfig = resolvedConfig,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/services/NuDesignerExposedApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/services/NuDesignerExposedApiHttpService.scala
@@ -9,10 +9,15 @@ import scala.concurrent.Future
 
 class NuDesignerExposedApiHttpService(
     appApiHttpService: AppApiHttpService,
-    componentsApiHttpService: ComponentApiHttpService
+    componentsApiHttpService: ComponentApiHttpService,
+    userApiHttpService: UserApiHttpService
 ) {
 
-  private val apiEndpoints        = appApiHttpService.serverEndpoints ++ componentsApiHttpService.serverEndpoints
+  private val apiEndpoints =
+    appApiHttpService.serverEndpoints ++
+      componentsApiHttpService.serverEndpoints ++
+      userApiHttpService.serverEndpoints
+
   private val endpointDefinitions = apiEndpoints.map(_.endpoint)
 
   private val swaggerEndpoints: List[ServerEndpoint[Any, Future]] =

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/services/UserApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/services/UserApiHttpService.scala
@@ -1,0 +1,33 @@
+package pl.touk.nussknacker.ui.services
+
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.ui.api.{DisplayableUser, UserApiEndpoints}
+import pl.touk.nussknacker.ui.process.{ProcessCategoryService, UserCategoryService}
+import pl.touk.nussknacker.ui.security.api.{AuthenticationResources, LoggedUser}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class UserApiHttpService(
+    config: Config,
+    authenticator: AuthenticationResources,
+    getProcessCategoryService: () => ProcessCategoryService,
+)(implicit executionContext: ExecutionContext)
+    extends BaseHttpService(config, getProcessCategoryService, authenticator)
+    with LazyLogging {
+
+  private val userApiEndpoints = new UserApiEndpoints(authenticator.authenticationMethod())
+
+  expose {
+    userApiEndpoints.userInfoEndpoint
+      .serverSecurityLogic(authorizeKnownUser[Unit])
+      .serverLogic { user: LoggedUser => _ =>
+        Future(
+          success(
+            DisplayableUser(user, new UserCategoryService(getProcessCategoryService()).getUserCategories(user))
+          )
+        )
+      }
+  }
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/UserApiSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/UserApiSpec.scala
@@ -75,7 +75,7 @@ class UserApiSpec
           .statusCode(405)
           .body(
             equalTo(
-              s"HTTP method not allowed, supported methods: GET"
+              s"Method Not Allowed"
             )
           )
       }

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -431,6 +431,42 @@ paths:
                     resource
       security:
       - httpAuth: []
+  /api/user:
+    get:
+      tags:
+      - User
+      summary: Logged user info service
+      operationId: getApiUser
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DisplayableUser'
+        '401':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                Example:
+                  summary: Authentication failed
+                  value: The supplied authentication is invalid
+        '403':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                Example:
+                  summary: Authorization failed
+                  value: The supplied authentication is not authorized to access this
+                    resource
+      security:
+      - httpAuth: []
 components:
   schemas:
     BuildInfoDto:
@@ -567,6 +603,30 @@ components:
           type: string
         lastAction:
           $ref: '#/components/schemas/ProcessAction'
+    DisplayableUser:
+      required:
+      - id
+      - username
+      - isAdmin
+      - categoryPermissions
+      type: object
+      properties:
+        id:
+          type: string
+        username:
+          type: string
+        isAdmin:
+          type: boolean
+        categories:
+          type: array
+          items:
+            type: string
+        categoryPermissions:
+          $ref: '#/components/schemas/Map_List_String'
+        globalPermissions:
+          type: array
+          items:
+            type: string
     FragmentUsageData:
       required:
       - fragmentNodeId
@@ -611,6 +671,12 @@ components:
           - 'null'
           items:
             type: string
+    Map_List_String:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: string
     Map_Map_String_String:
       type: object
       additionalProperties:


### PR DESCRIPTION
## Describe your changes
Replaced `UserResources` with `UserApiEndpoints` and `UserApiHttpService` using tapir.

This also updated nu-designer-penapi.yaml

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [x] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
