### PR TITLE
Fix not displaying runtime exceptions in test mode 

### DIFF
--- a/designer/client/src/common/TestResultUtils.ts
+++ b/designer/client/src/common/TestResultUtils.ts
@@ -22,8 +22,18 @@ export interface InvocationResult {
     value: unknown;
 }
 
-export interface Error {
+interface NodeComponentInfo {
     nodeId: NodeId;
+    componentInfo: ComponentInfo;
+}
+
+interface ComponentInfo {
+    type: string;
+    name: string;
+}
+
+export interface Error {
+    nodeComponentInfo: NodeComponentInfo;
     context: Context;
     throwable;
 }
@@ -117,7 +127,7 @@ class TestResultUtils {
     }
 
     private _errors(results: TestResults, nodeId: NodeId): Error[] {
-        return results?.exceptions?.filter((ex) => ex.nodeId === nodeId);
+        return results?.exceptions?.filter((ex) => ex.nodeComponentInfo.nodeId === nodeId);
     }
 
     private _contextDisplay = (context: Context): string => {


### PR DESCRIPTION
## Describe your changes
In test mode, runtime exceptions should be displayed inside the node. BE type with nodeId changed and the error cannot be displayed now. This fixes it by updating the FE type.  
![image](https://github.com/TouK/nussknacker/assets/92804917/47cbbaa5-1885-44ca-a87d-296f000fa535)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
