### PR TITLE
[NU-1356] Remove nondeterminism in NotificationApiSpec

### DIFF
--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NotificationApiSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NotificationApiSpec.scala
@@ -13,7 +13,7 @@ import pl.touk.nussknacker.test.{
 }
 import pl.touk.nussknacker.ui.api.helpers.{NuItTest, NuScenarioConfigurationHelper, WithMockableDeploymentManager}
 
-class NotificationApiTest
+class NotificationApiSpec
     extends AnyFreeSpecLike
     with NuItTest
     with WithMockableDeploymentManager
@@ -50,29 +50,8 @@ class NotificationApiTest
             equalTo("[]")
           )
 
-        val deployedProcessName = ProcessName("process-execution-canceled")
-        val processId           = createDeployedProcess(deployedProcessName)
-
-        given()
-          .auth()
-          .basic("admin", "admin")
-          .when()
-          .get(s"$nuDesignerHttpAddress/api/notifications")
-          .Then()
-          .statusCode(200)
-          .body(
-            matchJsonWithRegexValues(
-              s"""[{
-                   |  "id": "^\\\\w{8}-\\\\w{4}-\\\\w{4}-\\\\w{4}-\\\\w{12}$$",
-                   |  "scenarioName": "$deployedProcessName",
-                   |  "message": "Deployment finished",
-                   |  "type": null,
-                   |  "toRefresh": [ "versions", "activity", "state" ]
-                   |}]""".stripMargin
-            )
-          )
-
-        prepareCancel(processId)
+        val processName = ProcessName("process-execution-canceled")
+        createDeployedCanceledProcess(processName)
 
         given()
           .auth()
@@ -85,14 +64,14 @@ class NotificationApiTest
             matchJsonWithRegexValues(
               s"""[{
                  |  "id": "^\\\\w{8}-\\\\w{4}-\\\\w{4}-\\\\w{4}-\\\\w{12}$$",
-                 |  "scenarioName": "$deployedProcessName",
+                 |  "scenarioName": "$processName",
                  |  "message": "Deployment finished",
                  |  "type": null,
                  |  "toRefresh": [ "versions", "activity", "state" ]
                  |},
                  |{
                  |   "id": "^\\\\w{8}-\\\\w{4}-\\\\w{4}-\\\\w{4}-\\\\w{12}$$",
-                 |   "scenarioName": "$deployedProcessName",
+                 |   "scenarioName": "$processName",
                  |   "message": "Cancel finished",
                  |   "type": null,
                  |   "toRefresh": [ "versions", "activity", "state" ]


### PR DESCRIPTION
## Describe your changes
Removed a test after `prepareCancel` which is an asynchronous call from `NuScenarioConfigurationHelper`. Instead a method `createDeployedCanceledProcess` is used which creates 2 notifications in the same call.

Using just `createDeployedCanceledProcess` was one way to deal with the problem, could also just map a HTTP request on the `prepareCancel` call so it would be performed after the cancellation  happened.

Also, changed file name to `NotificationApiSpec` to comply with the naming convention.

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [x] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [x] Verify that PR will be squashed during merge
