### PR TITLE
[NU-1361] Move fragment input definition validation to BE

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -268,6 +268,10 @@ object ProcessCompilationError {
 
   final case class FragmentOutputNotDefined(id: String, nodeIds: Set[String]) extends ProcessCompilationError
 
+  final case class DuplicateFragmentInputParameter(paramName: String, nodeId: String)
+      extends PartSubGraphCompilationError
+      with InASingleNode
+
   final case class RequireValueFromEmptyFixedList(paramName: String, nodeIds: Set[String])
       extends PartSubGraphCompilationError
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -257,13 +257,13 @@ object ProcessCompilationError {
       OverwrittenVariable(variableName, nodeId.id, paramName)
   }
 
-  final case class InvalidVariableOutputName(name: String, nodeId: String, paramName: Option[String])
+  final case class InvalidVariableName(name: String, nodeId: String, paramName: Option[String])
       extends PartSubGraphCompilationError
       with InASingleNode
 
-  object InvalidVariableOutputName {
+  object InvalidVariableName {
     def apply(variableName: String, paramName: Option[String])(implicit nodeId: NodeId): PartSubGraphCompilationError =
-      InvalidVariableOutputName(variableName, nodeId.id, paramName)
+      InvalidVariableName(variableName, nodeId.id, paramName)
   }
 
   final case class FragmentOutputNotDefined(id: String, nodeIds: Set[String]) extends ProcessCompilationError

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ValidationContext.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ValidationContext.scala
@@ -3,26 +3,15 @@ package pl.touk.nussknacker.engine.api.context
 import cats.data.Validated.{Invalid, Valid}
 import cats.data._
 import cats.implicits._
-import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{InvalidVariableOutputName, OverwrittenVariable}
-import pl.touk.nussknacker.engine.api.context.ValidationContext.{empty, validateVariableName}
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.OverwrittenVariable
+import pl.touk.nussknacker.engine.api.context.ValidationContext.empty
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.api.NodeId
-
-import javax.lang.model.SourceVersion
+import pl.touk.nussknacker.engine.api.validation.Validations.validateVariableName
 
 object ValidationContext {
 
   def empty: ValidationContext = ValidationContext()
-
-  def isVariableNameValid(name: String): Boolean = SourceVersion.isIdentifier(name)
-
-  def validateVariableName(name: String, paramName: Option[String])(
-      implicit nodeId: NodeId
-  ): ValidatedNel[PartSubGraphCompilationError, String] = {
-    // TODO: add correct and more precise error messages
-    if (isVariableNameValid(name)) Valid(name)
-    else Invalid(InvalidVariableOutputName(name, paramName)).toValidatedNel
-  }
 
 }
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ValidationContext.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ValidationContext.scala
@@ -14,11 +14,13 @@ object ValidationContext {
 
   def empty: ValidationContext = ValidationContext()
 
+  def isVariableNameValid(name: String): Boolean = SourceVersion.isIdentifier(name)
+
   def validateVariableName(name: String, paramName: Option[String])(
       implicit nodeId: NodeId
   ): ValidatedNel[PartSubGraphCompilationError, String] = {
     // TODO: add correct and more precise error messages
-    if (SourceVersion.isIdentifier(name)) Valid(name)
+    if (isVariableNameValid(name)) Valid(name)
     else Invalid(InvalidVariableOutputName(name, paramName)).toValidatedNel
   }
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/validation/Validations.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/validation/Validations.scala
@@ -4,7 +4,7 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.data.ValidatedNel
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.PartSubGraphCompilationError
-import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.InvalidVariableOutputName
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.InvalidVariableName
 
 import javax.lang.model.SourceVersion
 
@@ -15,7 +15,7 @@ object Validations {
   ): ValidatedNel[PartSubGraphCompilationError, String] = {
     // TODO: add correct and more precise error messages
     if (isVariableNameValid(name)) Valid(name)
-    else Invalid(InvalidVariableOutputName(name, paramName)).toValidatedNel
+    else Invalid(InvalidVariableName(name, paramName)).toValidatedNel
   }
 
   def isVariableNameValid(name: String): Boolean = SourceVersion.isIdentifier(name)

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/validation/Validations.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/validation/Validations.scala
@@ -1,0 +1,23 @@
+package pl.touk.nussknacker.engine.api.validation
+
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.ValidatedNel
+import pl.touk.nussknacker.engine.api.NodeId
+import pl.touk.nussknacker.engine.api.context.PartSubGraphCompilationError
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.InvalidVariableOutputName
+
+import javax.lang.model.SourceVersion
+
+object Validations {
+
+  def validateVariableName(name: String, paramName: Option[String])(
+      implicit nodeId: NodeId
+  ): ValidatedNel[PartSubGraphCompilationError, String] = {
+    // TODO: add correct and more precise error messages
+    if (isVariableNameValid(name)) Valid(name)
+    else Invalid(InvalidVariableOutputName(name, paramName)).toValidatedNel
+  }
+
+  def isVariableNameValid(name: String): Boolean = SourceVersion.isIdentifier(name)
+
+}

--- a/designer/client/src/components/graph/node-modal/fragment-input-definition/FieldsSelect.tsx
+++ b/designer/client/src/components/graph/node-modal/fragment-input-definition/FieldsSelect.tsx
@@ -1,10 +1,8 @@
 import React, { useCallback, useMemo } from "react";
 import { FixedValuesPresets, NodeValidationError, Parameter, VariableTypes } from "../../../../types";
-import { mandatoryValueValidator, uniqueListValueValidator, extendErrors } from "../editors/Validators";
 import { DndItems } from "../../../common/dndItems/DndItems";
 import { NodeRowFieldsProvider } from "../node-row-fields-provider";
 import { Item, onChangeType, FragmentInputParameter } from "./item";
-import { isEmpty } from "lodash";
 
 export interface Option {
     value: string;
@@ -66,25 +64,10 @@ export function FieldsSelect(props: FieldsSelectProps): JSX.Element {
 
     const items = useMemo(
         () =>
-            fields.map((item: any, index, list) => {
-                const nameErrors = extendErrors([], item.name, "name", [
-                    mandatoryValueValidator,
-                    uniqueListValueValidator(
-                        list.map((v) => v.name),
-                        index,
-                    ),
-                ]);
-
-                /*
-                 * Display settings errors only when the name is correct, for now, the name is used in the fieldName to recognize the list item,
-                 * but it can be a situation where that name is not unique or is empty in a few parameters, in this case, there is a problem with a correct error display
-                 */
-                const displayableErrors = isEmpty(nameErrors) ? errors : nameErrors;
-                return {
-                    item,
-                    el: <ItemElement key={index} index={index} item={item} errors={displayableErrors} />,
-                };
-            }),
+            fields.map((item, index) => ({
+                item,
+                el: <ItemElement key={index} index={index} item={item as FragmentInputParameter} errors={errors} />,
+            })),
         [ItemElement, errors, fields],
     );
 

--- a/designer/client/src/components/graph/node-modal/fragment-input-definition/item/Item.tsx
+++ b/designer/client/src/components/graph/node-modal/fragment-input-definition/item/Item.tsx
@@ -59,7 +59,7 @@ export function Item(props: ItemProps): JSX.Element {
                         onChange={(e) => onChange(`${path}.name`, e.target.value)}
                         value={item.name}
                         placeholder="Field name"
-                        fieldErrors={getValidationErrorsForField(errors, "name")}
+                        fieldErrors={getValidationErrorsForField(errors, `$param.${item.name}.$name`)}
                     />
                 </NodeValue>
                 <TypeSelect

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -9,6 +9,7 @@ import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.graph.node.{
   InitialValueFieldName,
   InputModeFieldName,
+  ParameterNameFieldName,
   TypFieldName,
   ValidationExpressionFieldName,
   qualifiedParamFieldName
@@ -154,6 +155,12 @@ object PrettyValidationErrors {
         node(
           s"There is more than one output with '$name' name defined in the fragment, currently this is not allowed",
           "Please check fragment definition"
+        )
+      case DuplicateFragmentInputParameter(paramName, _) =>
+        node(
+          s"Parameter name '$paramName' has to be unique",
+          "Parameter name not unique",
+          fieldName = Some(qualifiedParamFieldName(paramName = paramName, subFieldName = Some(ParameterNameFieldName)))
         )
       case InitialValueNotPresentInPossibleValues(paramName, _) =>
         node(

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -117,13 +117,13 @@ object PrettyValidationErrors {
         )
       case OverwrittenVariable(varName, _, paramName) =>
         node(
-          s"Variable output name '$varName' is already defined.",
+          s"Variable name '$varName' is already defined.",
           "You cannot overwrite variables",
           fieldName = paramName
         )
-      case InvalidVariableOutputName(varName, _, paramName) =>
+      case InvalidVariableName(varName, _, paramName) =>
         node(
-          s"Variable output name '$varName' is not a valid identifier (only letters, numbers or '_', cannot be empty)",
+          s"Variable name '$varName' is not a valid identifier (only letters, numbers or '_', cannot be empty)",
           "Please use only letters, numbers or '_', also identifier cannot be empty.",
           fieldName = paramName
         )

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -16,14 +16,11 @@ import pl.touk.nussknacker.engine.compile.nodecompilation.NodeCompiler.NodeCompi
 import pl.touk.nussknacker.engine.compiledgraph
 import pl.touk.nussknacker.engine.compiledgraph.node
 import pl.touk.nussknacker.engine.compiledgraph.node.{FragmentUsageEnd, Node}
-import pl.touk.nussknacker.engine.definition.component.ComponentDefinitionWithImplementation
 import pl.touk.nussknacker.engine.graph.node._
 import pl.touk.nussknacker.engine.splittedgraph._
 import pl.touk.nussknacker.engine.splittedgraph.splittednode.{Next, SplittedNode}
 
 class PartSubGraphCompiler(expressionCompiler: ExpressionCompiler, nodeCompiler: NodeCompiler) {
-
-  type ParametersProviderT = ComponentDefinitionWithImplementation
 
   import CompilationResult._
 

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
@@ -186,7 +186,7 @@ class NodeCompiler(
       // duplicated name
       // TODO: display all errors when switching to field name errors not reliant on parameter name
       val displayUniqueNameReliantErrors = parameterNameValidation.fold(
-        errors => errors.collect { case _: DuplicateFragmentInputParameter => }.isEmpty,
+        errors => !errors.exists(_.isInstanceOf[DuplicateFragmentInputParameter]),
         _ => true
       )
 

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
@@ -52,7 +52,7 @@ import pl.touk.nussknacker.engine.{api, compiledgraph}
 import shapeless.Typeable
 import shapeless.syntax.typeable._
 import cats.implicits._
-import pl.touk.nussknacker.engine.api.context.ValidationContext.validateVariableName
+import pl.touk.nussknacker.engine.api.validation.Validations.validateVariableName
 
 object NodeCompiler {
 

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
@@ -7,9 +7,9 @@ import org.springframework.expression.spel.ast._
 import org.springframework.expression.spel.standard.{SpelExpression => SpringSpelExpression}
 import org.springframework.expression.spel.{SpelNode, SpelParserConfiguration}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
-import pl.touk.nussknacker.engine.api.context.ValidationContext.isVariableNameValid
 import pl.touk.nussknacker.engine.api.dict.UiDictServices
 import pl.touk.nussknacker.engine.api.typed.typing._
+import pl.touk.nussknacker.engine.api.validation.Validations.isVariableNameValid
 import pl.touk.nussknacker.engine.definition.clazz.{ClassDefinition, ClassDefinitionSet}
 import pl.touk.nussknacker.engine.definition.globalvariables.ExpressionConfigDefinition
 import pl.touk.nussknacker.engine.dict.LabelsDictTyper

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
@@ -7,6 +7,7 @@ import org.springframework.expression.spel.ast._
 import org.springframework.expression.spel.standard.{SpelExpression => SpringSpelExpression}
 import org.springframework.expression.spel.{SpelNode, SpelParserConfiguration}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
+import pl.touk.nussknacker.engine.api.context.ValidationContext.isVariableNameValid
 import pl.touk.nussknacker.engine.api.dict.UiDictServices
 import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.definition.clazz.{ClassDefinition, ClassDefinitionSet}
@@ -17,7 +18,6 @@ import pl.touk.nussknacker.engine.spel.Typer.TypingResultWithContext
 import pl.touk.nussknacker.engine.spel.ast.SpelAst.SpelNodeId
 import pl.touk.nussknacker.engine.spel.parser.NuTemplateAwareExpressionParser
 
-import javax.lang.model.SourceVersion
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Try}
 
@@ -89,7 +89,7 @@ class SpelExpressionSuggester(
             )
           case TypingResultWithContext(to: TypedObjectTypingResult, _) =>
             def filterIllegalIdentifierAfterDot(name: String) = {
-              SourceVersion.isIdentifier(name)
+              isVariableNameValid(name)
             }
             val collectSuggestionsFromClass = parentIsIndexer
             val suggestionsFromFields = filterMapByName(to.fields, p.getName).toList

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
@@ -317,7 +317,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
 
   test("should not allow to use special chars in variable name") {
     inside(validate(Variable("var1", "var@ 2", "42L", None), ValidationContext())) {
-      case ValidationPerformed(InvalidVariableOutputName("var@ 2", "var1", _) :: Nil, None, _) =>
+      case ValidationPerformed(InvalidVariableName("var@ 2", "var1", _) :: Nil, None, _) =>
     }
   }
 
@@ -612,7 +612,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
       )
     ) {
       case ValidationPerformed(
-            List(InvalidVariableOutputName(incorrectVarName, nodeId, Some(varFieldName))),
+            List(InvalidVariableName(incorrectVarName, nodeId, Some(varFieldName))),
             None,
             None
           ) =>
@@ -1181,7 +1181,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
     ) {
       case ValidationPerformed(
             List(
-              InvalidVariableOutputName(
+              InvalidVariableName(
                 "1",
                 "in",
                 Some("$param.1.$name")

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
@@ -1162,6 +1162,37 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
     }
   }
 
+  test("should return error on invalid parameter name") {
+    inside(
+      validate(
+        FragmentInputDefinition(
+          "in",
+          List(
+            FragmentParameter(
+              "1",
+              FragmentClazzRef[String]
+            )
+          ),
+        ),
+        ValidationContext.empty,
+        Map.empty,
+        outgoingEdges = List(OutgoingEdge("any", Some(FragmentOutput("out1"))))
+      )
+    ) {
+      case ValidationPerformed(
+            List(
+              InvalidVariableOutputName(
+                "1",
+                "in",
+                Some("$param-0-name")
+              )
+            ),
+            None,
+            None
+          ) =>
+    }
+  }
+
   private def genericParameters = List(
     Parameter[String]("par1")
       .copy(

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
@@ -1193,6 +1193,75 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
     }
   }
 
+  test("should return error on duplicated parameter name") {
+    val duplicatedParam = FragmentParameter(
+      "paramName",
+      FragmentClazzRef[String]
+    )
+    inside(
+      validate(
+        FragmentInputDefinition(
+          "in",
+          List(
+            duplicatedParam,
+            duplicatedParam
+          ),
+        ),
+        ValidationContext.empty,
+        Map.empty,
+        outgoingEdges = List(OutgoingEdge("any", Some(FragmentOutput("out1"))))
+      )
+    ) {
+      case ValidationPerformed(
+            List(
+              DuplicateFragmentInputParameter("paramName", "in")
+            ),
+            None,
+            None
+          ) =>
+    }
+  }
+
+  test("should not return specific errors based on parameter name when parameter names are duplicated") {
+    inside(
+      validate(
+        FragmentInputDefinition(
+          "in",
+          List(
+            FragmentParameter(
+              name = "paramName",
+              typ = FragmentClazzRef[String],
+              initialValue = None,
+              hintText = None,
+              valueEditor = None,
+              valueCompileTimeValidation = Some(
+                ParameterValueCompileTimeValidation(
+                  "invalidExpr",
+                  None
+                )
+              )
+            ),
+            FragmentParameter(
+              "paramName",
+              FragmentClazzRef[String],
+            )
+          ),
+        ),
+        ValidationContext.empty,
+        Map.empty,
+        outgoingEdges = List(OutgoingEdge("any", Some(FragmentOutput("out1"))))
+      )
+    ) {
+      case ValidationPerformed(
+            List(
+              DuplicateFragmentInputParameter("paramName", "in")
+            ),
+            None,
+            None
+          ) =>
+    }
+  }
+
   private def genericParameters = List(
     Parameter[String]("par1")
       .copy(

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
@@ -1184,7 +1184,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
               InvalidVariableOutputName(
                 "1",
                 "in",
-                Some("$param-0-name")
+                Some("$param.1.$name")
               )
             ),
             None,

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/graph/node.scala
@@ -353,8 +353,10 @@ object node {
 
   }
 
-  val IdFieldName                   = "$id"
+  val IdFieldName = "$id"
+  // TODO: move these FragmentInputDefinition related vals/def under FragmentInputDefinition for better organization
   val ParameterFieldNamePrefix      = "$param"
+  val ParameterNameFieldName        = "$name"
   val InitialValueFieldName         = "$initialValue"
   val InputModeFieldName            = "$inputMode"
   val TypFieldName                  = "$typ"


### PR DESCRIPTION
## Describe your changes
### Scope
Moves remaining fragment parameters validation to BE - that is checking if:
1. Parameter name is unique
2. Parameter name is a valid identifier.

To ensure consistency, I've centralized the logic of checking variable identifier validity in api.

### Problems
When names are duplicated, the validation doesn't return more specific errors than about names. The errors are displayed based on name so if it wasn't fail-fast, we'd get duplicated errors for parameters with duplicated names. And  we shouldn't rely on index since that causes problems with drag'n'drop.

A good way to solve this would be to rely on an identifier from FE. To not pass this data to db, a custom encoder could skip the id field. I can leave it as is - this behaviour should be exactly the same from user perspective or I can make this change if we think this is a clean enough solution.

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [x] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
