### PR TITLE
Recreate assembled model JAR for Flink if it got removed (e.g. by systemd-tmpfiles)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,6 +5,7 @@
 * [#5257](https://github.com/TouK/nussknacker/pull/5257) Updated Flink 1.16.2 -> 1.16.3
 * [#5253](https://github.com/TouK/nussknacker/pull/5253) Removed the option to configure fragments via config. Due to the recent expansion of FragmentParameter, the option has become largely redundant. Removed to decrease unnecessary complexity.
 * [#5271](https://github.com/TouK/nussknacker/pull/5271) Changed `AdditionalUIConfigProvider.getAllForProcessingType` API to be more in line with FragmentParameter
+* [#5278](https://github.com/TouK/nussknacker/pull/5278) Recreate assembled model JAR for Flink if it got removed (e.g. by systemd-tmpfiles)
 
 1.13.0 (Not released yet)
 -------------------------

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/JarManagerTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/JarManagerTest.scala
@@ -7,11 +7,14 @@ import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.process.{ProcessName, VersionId}
 import pl.touk.nussknacker.engine.api.{MetaData, ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.management.FlinkModelJarProvider
 import pl.touk.nussknacker.engine.management.periodic.flink.FlinkJarManager
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData
 import pl.touk.nussknacker.engine.modelconfig.InputConfigDuringExecution
 import pl.touk.nussknacker.test.PatientScalaFutures
 
 import java.nio.file.{Files, Path, Paths}
+import scala.concurrent.Future
 
 class JarManagerTest extends AnyFunSuite with Matchers with ScalaFutures with PatientScalaFutures {
 
@@ -19,6 +22,7 @@ class JarManagerTest extends AnyFunSuite with Matchers with ScalaFutures with Pa
   private val processVersionId = 5
   private val processVersion =
     ProcessVersion.empty.copy(processName = ProcessName(processName), versionId = VersionId(processVersionId))
+  private val process             = CanonicalProcess(MetaData("foo", StreamMetaData()), Nil)
   private val jarsDir             = Files.createTempDirectory("jars-dir")
   private val modelJarFileContent = "abc".getBytes
 
@@ -28,26 +32,49 @@ class JarManagerTest extends AnyFunSuite with Matchers with ScalaFutures with Pa
     tempFile.toFile
   }
 
+  private val currentModelUrls = List(currentModelJarFile.toURI.toURL)
+
   private val jarManager = createJarManager(jarsDir = jarsDir)
 
-  private def createJarManager(jarsDir: Path): JarManager = {
+  private def createJarManager(
+      jarsDir: Path,
+      modelJarProvider: FlinkModelJarProvider = new FlinkModelJarProvider(currentModelUrls)
+  ): JarManager = {
+
     new FlinkJarManager(
       flinkClient = new FlinkClientStub,
       jarsDir = jarsDir,
       inputConfigDuringExecution = InputConfigDuringExecution(ConfigFactory.empty()),
-      createCurrentModelJarFile = currentModelJarFile
+      modelJarProvider = modelJarProvider
     )
   }
 
   test("prepareDeploymentWithJar - should copy to local dir") {
-    val result =
-      jarManager.prepareDeploymentWithJar(processVersion, CanonicalProcess(MetaData("foo", StreamMetaData()), Nil))
+    val result = jarManager.prepareDeploymentWithJar(processVersion, process)
 
     val copiedJarFileName = result.futureValue.jarFileName
     copiedJarFileName should fullyMatch regex s"^$processName-$processVersionId-\\d+\\.jar$$"
     val copiedJarFile = jarsDir.resolve(copiedJarFileName)
     Files.exists(copiedJarFile) shouldBe true
     Files.readAllBytes(copiedJarFile) shouldBe modelJarFileContent
+  }
+
+  test("prepareDeploymentWithJar - should handle disappearing model JAR") {
+    val modelJarProvider = new FlinkModelJarProvider(currentModelUrls)
+    val jarManager       = createJarManager(jarsDir, modelJarProvider)
+
+    def verifyAndDeleteJar(result: Future[DeploymentWithJarData]): Unit = {
+      val copiedJarFile = jarsDir.resolve(result.futureValue.jarFileName)
+      Files.exists(copiedJarFile) shouldBe true
+      Files.readAllBytes(copiedJarFile) shouldBe modelJarFileContent
+      Files.delete(copiedJarFile)
+    }
+
+    verifyAndDeleteJar(jarManager.prepareDeploymentWithJar(processVersion, process))
+
+    modelJarProvider.getJobJar().delete() shouldBe true
+
+    verifyAndDeleteJar(jarManager.prepareDeploymentWithJar(processVersion, process))
   }
 
   test("prepareDeploymentWithJar - should create jars dir if not exists") {
@@ -57,8 +84,7 @@ class JarManagerTest extends AnyFunSuite with Matchers with ScalaFutures with Pa
 
     Files.exists(jarsDir) shouldBe false
 
-    val result =
-      jarManager.prepareDeploymentWithJar(processVersion, CanonicalProcess(MetaData("foo", StreamMetaData()), Nil))
+    val result = jarManager.prepareDeploymentWithJar(processVersion, process)
 
     val copiedJarFileName = result.futureValue.jarFileName
     Files.exists(jarsDir) shouldBe true


### PR DESCRIPTION
## Describe your changes

Recreate model JAR for Flink if model written to temp directory got removed. E.g. systemd-tmpfiles on CentOS removes files from default `java.io.tmpdir` after 10 days.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
