### PR TITLE
Consistent ProcessName naming in the whole project

### DIFF
--- a/common-api/src/main/scala/pl/touk/nussknacker/engine/api/MetaData.scala
+++ b/common-api/src/main/scala/pl/touk/nussknacker/engine/api/MetaData.scala
@@ -5,10 +5,15 @@ import io.circe.generic.extras.ConfiguredJsonCodec
 import io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
 import io.circe.{Decoder, Encoder, HCursor}
 import pl.touk.nussknacker.engine.api.CirceUtil._
+import pl.touk.nussknacker.engine.api.process.ProcessName
 
 @JsonCodec case class LayoutData(x: Long, y: Long)
 
-// TODO: MetaData should hold ProcessName as id
+// TODO: We should remove id/name from here and:
+//       - In components, we should allow to specify that the Component need to get ProcessName NodeDependency
+//         and separately ProcessProperties dependency (description should be probably just another property)
+//       - Scenario graph should contains only nodes and edges - ProcessName is already passed to the engine as a separate
+//         information next to version, modelVersion, user that deploy scenario and other
 @ConfiguredJsonCodec(encodeOnly = true) case class MetaData(id: String, additionalFields: ProcessAdditionalFields) {
   def isFragment: Boolean = typeSpecificData.isFragment
 
@@ -17,6 +22,8 @@ import pl.touk.nussknacker.engine.api.CirceUtil._
   def withTypeSpecificData(typeSpecificData: TypeSpecificData): MetaData = {
     MetaData(id, typeSpecificData)
   }
+
+  def name: ProcessName = ProcessName(id)
 
 }
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -4,6 +4,7 @@ import cats.Applicative
 import cats.data.ValidatedNel
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.InASingleNode
+import pl.touk.nussknacker.engine.api.process.ProcessName
 
 sealed trait ProcessCompilationError {
   def nodeIds: Set[String]
@@ -322,9 +323,11 @@ object ProcessCompilationError {
     val id: String
   }
 
-  final case class ScenarioIdError(errorType: IdErrorType, id: String, isFragment: Boolean)
+  final case class ScenarioNameError(errorType: IdErrorType, name: ProcessName, isFragment: Boolean)
       extends IdError
-      with ScenarioPropertiesError
+      with ScenarioPropertiesError {
+    override val id: String = name.value
+  }
 
   final case class NodeIdValidationError(errorType: IdErrorType, id: String) extends IdError with InASingleNode {
     override protected def nodeId: String = id

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/runtimecontext/ContextIdGenerator.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/runtimecontext/ContextIdGenerator.scala
@@ -29,6 +29,6 @@ object IncContextIdGenerator {
     withProcessIdNodeIdPrefix(jobData.metaData, nodeId)
 
   def withProcessIdNodeIdPrefix(metaData: MetaData, nodeId: String): IncContextIdGenerator =
-    new IncContextIdGenerator(metaData.id + "-" + nodeId)
+    new IncContextIdGenerator(metaData.name.value + "-" + nodeId)
 
 }

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/http/backend/SharedHttpClient.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/http/backend/SharedHttpClient.scala
@@ -28,7 +28,7 @@ class SharedHttpClientBackendProvider(httpClientConfig: HttpClientConfig) extend
 object SharedHttpClientBackendProvider extends SharedServiceHolder[HttpClientConfig, SharedHttpClient] {
 
   override protected def createService(config: HttpClientConfig, metaData: MetaData): SharedHttpClient = {
-    val httpClientConfig = config.toAsyncHttpClientConfig(Option(metaData.id))
+    val httpClientConfig = config.toAsyncHttpClientConfig(Option(metaData.name))
     new SharedHttpClient(new DefaultAsyncHttpClient(httpClientConfig.build()), config)
   }
 

--- a/designer/client/cypress/e2e/processes.cy.ts
+++ b/designer/client/cypress/e2e/processes.cy.ts
@@ -26,7 +26,7 @@ describe("Processes list", () => {
         cy.contains(/^new scenario$/i)
             .should("be.visible")
             .click();
-        cy.get("#newProcessId", { timeout: 30000 }).type(this.processName);
+        cy.get("#newProcessName", { timeout: 30000 }).type(this.processName);
         cy.contains(/^create$/i)
             .should("be.enabled")
             .click();
@@ -71,7 +71,7 @@ describe.skip("Processes list (new table)", () => {
         cy.contains(/^new scenario$/i)
             .should("be.visible")
             .click();
-        cy.get("#newProcessId", { timeout: 30000 }).type(this.processName);
+        cy.get("#newProcessName", { timeout: 30000 }).type(this.processName);
         cy.contains(/^create$/i)
             .should("be.enabled")
             .click();

--- a/designer/client/cypress/support/process.ts
+++ b/designer/client/cypress/support/process.ts
@@ -156,12 +156,12 @@ function getTestProcesses(filter?: string) {
     const url = `/api/processes`;
     return cy
         .request({ url })
-        .then(({ body }) => body.filter(({ id }) => id.includes(filter || Cypress.env("processName"))).map(({ id }) => id));
+        .then(({ body }) => body.filter(({ name }) => name.includes(filter || Cypress.env("processName"))).map(({ name }) => name));
 }
 
 function deleteAllTestProcesses({ filter, force }: { filter?: string; force?: boolean }) {
-    return cy.getTestProcesses(filter).each((id: string) => {
-        cy.deleteTestProcess(id, force);
+    return cy.getTestProcesses(filter).each((name: string) => {
+        cy.deleteTestProcess(name, force);
     });
 }
 

--- a/designer/client/src/actions/nk/comment.ts
+++ b/designer/client/src/actions/nk/comment.ts
@@ -1,20 +1,20 @@
 import HttpService from "../../http/HttpService";
 import { displayProcessActivity } from "./displayProcessActivity";
-import { ProcessId } from "../../types";
+import { ProcessName } from "../../types";
 import { ThunkAction } from "../reduxTypes";
 
-export function addComment(processId: ProcessId, processVersionId, comment): ThunkAction {
+export function addComment(processName: ProcessName, processVersionId, comment): ThunkAction {
     return (dispatch) => {
-        return HttpService.addComment(processId, processVersionId, comment).then(() => {
-            return dispatch(displayProcessActivity(processId));
+        return HttpService.addComment(processName, processVersionId, comment).then(() => {
+            return dispatch(displayProcessActivity(processName));
         });
     };
 }
 
-export function deleteComment(processId: ProcessId, commentId): ThunkAction {
+export function deleteComment(processName: ProcessName, commentId): ThunkAction {
     return (dispatch) => {
-        return HttpService.deleteComment(processId, commentId).then(() => {
-            return dispatch(displayProcessActivity(processId));
+        return HttpService.deleteComment(processName, commentId).then(() => {
+            return dispatch(displayProcessActivity(processName));
         });
     };
 }

--- a/designer/client/src/actions/nk/displayProcessActivity.ts
+++ b/designer/client/src/actions/nk/displayProcessActivity.ts
@@ -8,9 +8,9 @@ export type DisplayProcessActivityAction = {
     attachments: Attachment[];
 };
 
-export function displayProcessActivity(processId: string): ThunkAction {
+export function displayProcessActivity(processName: string): ThunkAction {
     return (dispatch) => {
-        return HttpService.fetchProcessActivity(processId).then((response) => {
+        return HttpService.fetchProcessActivity(processName).then((response) => {
             return dispatch({
                 type: "DISPLAY_PROCESS_ACTIVITY",
                 comments: response.data.comments,

--- a/designer/client/src/actions/nk/displayTestResults.ts
+++ b/designer/client/src/actions/nk/displayTestResults.ts
@@ -1,44 +1,44 @@
 import HttpService, { SourceWithParametersTest, TestProcessResponse } from "../../http/HttpService";
 import { displayProcessCounts } from "./displayProcessCounts";
 import { TestResults } from "../../common/TestResultUtils";
-import { Expression, Process, ProcessId } from "../../types";
+import { Expression, Process, ProcessName } from "../../types";
 import { ThunkAction } from "../reduxTypes";
 import { withoutHackOfEmptyEdges } from "../../components/graph/GraphPartialsInTS/EdgeUtils";
 
-export function testProcessFromFile(id: ProcessId, testDataFile: File, process: Process): ThunkAction {
+export function testProcessFromFile(processName: ProcessName, testDataFile: File, process: Process): ThunkAction {
     return (dispatch) => {
         dispatch({
             type: "PROCESS_LOADING",
         });
 
         const processWithCleanEdges = withoutHackOfEmptyEdges(process);
-        HttpService.testProcess(id, testDataFile, processWithCleanEdges)
+        HttpService.testProcess(processName, testDataFile, processWithCleanEdges)
             .then((response) => dispatch(displayTestResults(response.data)))
             .catch(() => dispatch({ type: "LOADING_FAILED" }));
     };
 }
 
-export function testProcessWithParameters(id: ProcessId, testData: SourceWithParametersTest, process: Process): ThunkAction {
+export function testProcessWithParameters(processName: ProcessName, testData: SourceWithParametersTest, process: Process): ThunkAction {
     return (dispatch) => {
         dispatch({
             type: "PROCESS_LOADING",
         });
 
         const processWithCleanEdges = withoutHackOfEmptyEdges(process);
-        HttpService.testProcessWithParameters(id, testData, processWithCleanEdges)
+        HttpService.testProcessWithParameters(processName, testData, processWithCleanEdges)
             .then((response) => dispatch(displayTestResults(response.data)))
             .catch(() => dispatch({ type: "LOADING_FAILED" }));
     };
 }
 
-export function testScenarioWithGeneratedData(id: ProcessId, testSampleSize: string, process: Process): ThunkAction {
+export function testScenarioWithGeneratedData(processName: ProcessName, testSampleSize: string, process: Process): ThunkAction {
     return (dispatch) => {
         dispatch({
             type: "PROCESS_LOADING",
         });
 
         const processWithCleanEdges = withoutHackOfEmptyEdges(process);
-        HttpService.testScenarioWithGeneratedData(id, testSampleSize, processWithCleanEdges)
+        HttpService.testScenarioWithGeneratedData(processName, testSampleSize, processWithCleanEdges)
             .then((response) => dispatch(displayTestResults(response.data)))
             .catch(() => dispatch({ type: "LOADING_FAILED" }));
     };

--- a/designer/client/src/actions/nk/fetchVisualizationData.ts
+++ b/designer/client/src/actions/nk/fetchVisualizationData.ts
@@ -4,9 +4,9 @@ import { displayProcessActivity } from "./displayProcessActivity";
 import { fetchProcessDefinition } from "./processDefinitionData";
 import { handleHTTPError } from "./errors";
 import { loadProcessToolbarsConfiguration } from "./loadProcessToolbarsConfiguration";
-import { ProcessId } from "../../types";
+import { ProcessName } from "../../types";
 
-export function fetchVisualizationData(processName: ProcessId): ThunkAction {
+export function fetchVisualizationData(processName: ProcessName): ThunkAction {
     return async (dispatch) => {
         try {
             const fetchedProcessDetails = await dispatch(displayCurrentProcessVersion(processName));

--- a/designer/client/src/actions/nk/importExport.ts
+++ b/designer/client/src/actions/nk/importExport.ts
@@ -1,13 +1,13 @@
 import HttpService from "../../http/HttpService";
-import { ProcessId } from "../../types";
+import { ProcessName } from "../../types";
 import { ThunkAction } from "../reduxTypes";
 
-export function importFiles(processId: ProcessId, files: File[]): ThunkAction {
+export function importFiles(processName: ProcessName, files: File[]): ThunkAction {
     return (dispatch) => {
         files.forEach(async (file: File) => {
             try {
                 dispatch({ type: "PROCESS_LOADING" });
-                const process = await HttpService.importProcess(processId, file);
+                const process = await HttpService.importProcess(processName, file);
                 dispatch({ type: "UPDATE_IMPORTED_PROCESS", processJson: process.data });
             } catch (error) {
                 dispatch({ type: "LOADING_FAILED" });

--- a/designer/client/src/actions/nk/loadProcessToolbarsConfiguration.ts
+++ b/designer/client/src/actions/nk/loadProcessToolbarsConfiguration.ts
@@ -1,9 +1,9 @@
 import { ThunkAction } from "../reduxTypes";
 import HttpService from "../../http/HttpService";
 
-export function loadProcessToolbarsConfiguration(processId: string): ThunkAction {
+export function loadProcessToolbarsConfiguration(processName: string): ThunkAction {
     return (dispatch) =>
-        HttpService.fetchProcessToolbarsConfiguration(processId).then((response) =>
+        HttpService.fetchProcessToolbarsConfiguration(processName).then((response) =>
             dispatch({
                 type: "PROCESS_TOOLBARS_CONFIGURATION_LOADED",
                 data: response.data,

--- a/designer/client/src/actions/nk/loadProcessVersions.ts
+++ b/designer/client/src/actions/nk/loadProcessVersions.ts
@@ -1,5 +1,5 @@
 import HttpService from "../../http/HttpService";
-import { ProcessId } from "../../types";
+import { ProcessName } from "../../types";
 import { ProcessActionType, ProcessVersionType } from "../../components/Process/types";
 import { ThunkAction } from "../reduxTypes";
 
@@ -10,9 +10,9 @@ export type LoadProcessVersionsAction = {
     lastDeployedAction: ProcessActionType;
 };
 
-export function loadProcessVersions(processId: ProcessId): ThunkAction<Promise<LoadProcessVersionsAction>> {
+export function loadProcessVersions(processName: ProcessName): ThunkAction<Promise<LoadProcessVersionsAction>> {
     return (dispatch) =>
-        HttpService.fetchProcessDetails(processId).then((response) => {
+        HttpService.fetchProcessDetails(processName).then((response) => {
             return dispatch({
                 type: "PROCESS_VERSIONS_LOADED",
                 history: response.data.history,

--- a/designer/client/src/actions/nk/nodeDetails.ts
+++ b/designer/client/src/actions/nk/nodeDetails.ts
@@ -52,18 +52,18 @@ export function nodeDetailsClosed(nodeId: string): NodeDetailsClosed {
 //we don't return ThunkAction here as it would not work correctly with debounce
 //TODO: use sth better, how long should be timeout?
 const validate = debounce(
-    async (processId: string, validationRequestData: ValidationRequest, callback: (data: ValidationData, nodeId: NodeId) => void) => {
+    async (processName: string, validationRequestData: ValidationRequest, callback: (data: ValidationData, nodeId: NodeId) => void) => {
         const nodeId = validationRequestData.nodeData.id;
         const nodeWithChangedName = applyIdFromFakeName(validationRequestData.nodeData);
         if (NodeUtils.nodeIsProperties(nodeWithChangedName)) {
             //NOTE: we don't validationRequestData contains processProperties, but they are refreshed only on modal open
-            const { data } = await HttpService.validateProperties(processId, {
+            const { data } = await HttpService.validateProperties(processName, {
                 additionalFields: nodeWithChangedName.additionalFields,
-                id: nodeWithChangedName.id,
+                name: nodeWithChangedName.id,
             });
             callback(data, nodeId);
         } else {
-            const { data } = await HttpService.validateNode(processId, {
+            const { data } = await HttpService.validateNode(processName, {
                 ...validationRequestData,
                 nodeData: nodeWithChangedName,
             });
@@ -73,9 +73,9 @@ const validate = debounce(
     500,
 );
 
-export function validateNodeData(processId: string, validationRequestData: ValidationRequest): ThunkAction {
+export function validateNodeData(processName: string, validationRequestData: ValidationRequest): ThunkAction {
     return (dispatch, getState) => {
-        validate(processId, validationRequestData, (data, nodeId) => {
+        validate(processName, validationRequestData, (data, nodeId) => {
             // node details view creates this on open and removes after close
             if (getState().nodeDetails[nodeId]) {
                 dispatch(nodeValidationDataUpdated(nodeId, data));

--- a/designer/client/src/actions/nk/process.ts
+++ b/designer/client/src/actions/nk/process.ts
@@ -1,5 +1,5 @@
 import { ThunkAction } from "../reduxTypes";
-import { Process, ProcessDefinitionData, ProcessId } from "../../types";
+import { Process, ProcessDefinitionData, ProcessName } from "../../types";
 import HttpService from "./../../http/HttpService";
 import { ProcessType, ProcessVersionId } from "../../components/Process/types";
 import { displayProcessActivity } from "./displayProcessActivity";
@@ -10,11 +10,11 @@ export type ScenarioActions =
     | { type: "CORRECT_INVALID_SCENARIO"; processDefinitionData: ProcessDefinitionData }
     | { type: "DISPLAY_PROCESS"; fetchedProcessDetails: ProcessType };
 
-export function fetchProcessToDisplay(processId: ProcessId, versionId?: ProcessVersionId): ThunkAction<Promise<ProcessType>> {
+export function fetchProcessToDisplay(processName: ProcessName, versionId?: ProcessVersionId): ThunkAction<Promise<ProcessType>> {
     return (dispatch) => {
         dispatch({ type: "PROCESS_FETCH" });
 
-        return HttpService.fetchProcessDetails(processId, versionId).then((response) => {
+        return HttpService.fetchProcessDetails(processName, versionId).then((response) => {
             dispatch(displayTestCapabilities(response.data.json));
             dispatch({
                 type: "DISPLAY_PROCESS",
@@ -25,9 +25,9 @@ export function fetchProcessToDisplay(processId: ProcessId, versionId?: ProcessV
     };
 }
 
-export function loadProcessState(processId: ProcessId): ThunkAction {
+export function loadProcessState(processName: ProcessName): ThunkAction {
     return (dispatch) =>
-        HttpService.fetchProcessState(processId).then(({ data }) =>
+        HttpService.fetchProcessState(processName).then(({ data }) =>
             dispatch({
                 type: "PROCESS_STATE_LOADED",
                 processState: data,
@@ -55,13 +55,13 @@ export function displayTestCapabilities(processDetails: Process) {
         );
 }
 
-export function displayCurrentProcessVersion(processId: ProcessId) {
-    return fetchProcessToDisplay(processId);
+export function displayCurrentProcessVersion(processName: ProcessName) {
+    return fetchProcessToDisplay(processName);
 }
 
-export function displayScenarioVersion(processId: ProcessId, versionId: ProcessVersionId): ThunkAction {
+export function displayScenarioVersion(processName: ProcessName, versionId: ProcessVersionId): ThunkAction {
     return async (dispatch, getState) => {
-        await dispatch(fetchProcessToDisplay(processId, versionId));
+        await dispatch(fetchProcessToDisplay(processName, versionId));
         const processDefinitionData = getProcessDefinitionData(getState());
         dispatch({ type: "CORRECT_INVALID_SCENARIO", processDefinitionData });
     };
@@ -78,7 +78,7 @@ export function hideRunProcessDetails() {
     return { type: "HIDE_RUN_PROCESS_DETAILS" };
 }
 
-export function addAttachment(processId: ProcessId, processVersionId: ProcessVersionId, file: File) {
+export function addAttachment(processName: ProcessName, processVersionId: ProcessVersionId, file: File) {
     return (dispatch) =>
-        HttpService.addAttachment(processId, processVersionId, file).then(() => dispatch(displayProcessActivity(processId)));
+        HttpService.addAttachment(processName, processVersionId, file).then(() => dispatch(displayProcessActivity(processName)));
 }

--- a/designer/client/src/common/DialogMessages.ts
+++ b/designer/client/src/common/DialogMessages.ts
@@ -1,31 +1,33 @@
 import i18next from "i18next";
-import { ProcessId } from "../types";
+import { ProcessName } from "../types";
 
 export const unsavedProcessChanges = () => {
     return i18next.t("dialogMessages.unsavedProcessChanges", "There are some unsaved scenario changes. Discard unsaved changes?");
 };
 
-export const deploy = (processId: ProcessId) => {
-    return i18next.t("dialogMessages.deploy", "Are you sure you want to deploy {{processId}}?", { processId });
+export const deploy = (processName: ProcessName) => {
+    return i18next.t("dialogMessages.deploy", "Are you sure you want to deploy {{processName}}?", { processName });
 };
 
-export const migrate = (processId, environmentId) => {
-    return i18next.t("dialogMessages.migrate", "Are you sure you want to migrate {{processId}} to {{environmentId}}?", {
-        processId,
+export const migrate = (processName, environmentId) => {
+    return i18next.t("dialogMessages.migrate", "Are you sure you want to migrate {{processName}} to {{environmentId}}?", {
+        processName,
         environmentId,
     });
 };
 
-export const stop = (processId: ProcessId) => {
-    return i18next.t("dialogMessages.stop", "Are you sure you want to stop {{processId}}?", { processId });
+export const stop = (processName: ProcessName) => {
+    return i18next.t("dialogMessages.stop", "Are you sure you want to stop {{processName}}?", { processName });
 };
 
-export const archiveProcess = (processId: ProcessId) => {
-    return i18next.t("dialogMessages.archiveProcess", "Are you sure you want to archive {{processId}}?", { processId });
+export const archiveProcess = (processName: ProcessName) => {
+    return i18next.t("dialogMessages.archiveProcess", "Are you sure you want to archive {{processName}}?", { processName });
 };
 
-export const unArchiveProcess = (processId: ProcessId) => {
-    return i18next.t("dialogMessages.unArchiveProcess", "Are you sure you want to unarchive {{processId}}?", { processId });
+export const unArchiveProcess = (processName: ProcessName) => {
+    return i18next.t("dialogMessages.unArchiveProcess", "Are you sure you want to unarchive {{processName}}?", {
+        processName,
+    });
 };
 
 export const deleteComment = () => {

--- a/designer/client/src/components/AddProcessDialog.tsx
+++ b/designer/client/src/components/AddProcessDialog.tsx
@@ -20,22 +20,22 @@ export function AddProcessDialog(props: AddProcessDialogProps): JSX.Element {
     const { t } = useTranslation();
     const { isFragment, errors = [], ...passProps } = props;
     const nameValidators = useProcessNameValidators();
-    const [value, setState] = useState({ processId: "", processCategory: "" });
+    const [value, setState] = useState({ processName: "", processCategory: "" });
     const [processNameFromBackend, setProcessNameFromBackendError] = useState<NodeValidationError[]>([]);
 
     const fieldErrors = getValidationErrorsForField(
-        extendErrors([...errors, ...processNameFromBackend], value.processId, "processName", nameValidators),
+        extendErrors([...errors, ...processNameFromBackend], value.processName, "processName", nameValidators),
         "processName",
     );
 
     const navigate = useNavigate();
     const createProcess = useCallback(async () => {
         if (isEmpty(fieldErrors)) {
-            const { processId, processCategory } = value;
+            const { processName, processCategory } = value;
             try {
-                await HttpService.createProcess(processId, processCategory, isFragment);
+                await HttpService.createProcess(processName, processCategory, isFragment);
                 passProps.close();
-                navigate(visualizationUrl(processId));
+                navigate(visualizationUrl(processName));
             } catch (error) {
                 if (error?.response?.status == 400) {
                     setProcessNameFromBackendError(() => [

--- a/designer/client/src/components/AddProcessForm.tsx
+++ b/designer/client/src/components/AddProcessForm.tsx
@@ -10,7 +10,7 @@ import { NodeRow } from "./graph/node-modal/NodeDetailsContent/NodeStyled";
 import { NodeLabelStyled } from "./graph/node-modal/node";
 import { FieldError } from "./graph/node-modal/editors/Validators";
 
-export type FormValue = { processId: string; processCategory: string };
+export type FormValue = { processName: string; processCategory: string };
 
 interface AddProcessFormProps extends ChangeableValue<FormValue> {
     fieldErrors: FieldError[];
@@ -44,9 +44,9 @@ export function AddProcessForm({ value, onChange, fieldErrors }: AddProcessFormP
                         <div className="node-value">
                             <NodeInput
                                 type="text"
-                                id="newProcessId"
-                                value={value.processId}
-                                onChange={(e) => onFieldChange("processId", e.target.value)}
+                                id="newProcessName"
+                                value={value.processName}
+                                onChange={(e) => onFieldChange("processName", e.target.value)}
                             />
                             <ValidationLabels fieldErrors={fieldErrors} />
                         </div>

--- a/designer/client/src/components/Process/ProcessBackButton.tsx
+++ b/designer/client/src/components/Process/ProcessBackButton.tsx
@@ -34,19 +34,22 @@ const ProcessLinkButton = styled(ProcessLink)(({ theme }) => ({
 export default function ProcessBackButton() {
     const { t } = useTranslation();
     const { pathname } = useLocation();
-    const processId = useMemo(() => {
-        const match = matchPath(`${MetricsBasePath}/:processId`, pathname);
-        return match?.params?.processId;
+    const processName = useMemo(() => {
+        const match = matchPath(`${MetricsBasePath}/:processName`, pathname);
+        return match?.params?.processName;
     }, [pathname]);
 
-    if (!processId) {
+    if (!processName) {
         return null;
     }
 
     return (
-        <ProcessLinkButton processId={processId} title={t("processBackButton.title", "Go back to {{processId}} graph page", { processId })}>
+        <ProcessLinkButton
+            processName={processName}
+            title={t("processBackButton.title", "Go back to {{processName}} graph page", { processName })}
+        >
             <BackIcon />
-            <ButtonText>{t("processBackButton.text", "back to {{processId}}", { processId })}</ButtonText>
+            <ButtonText>{t("processBackButton.text", "back to {{processName}}", { processName })}</ButtonText>
         </ProcessLinkButton>
     );
 }

--- a/designer/client/src/components/Process/ProcessStateUtils.ts
+++ b/designer/client/src/components/Process/ProcessStateUtils.ts
@@ -54,11 +54,11 @@ class ProcessStateUtils {
         return processState?.tooltip || state?.tooltip || unknownTooltip();
     }
 
-    getTransitionKey({ id, isArchived, isFragment, state }: ProcessType, processState: ProcessStateType): string {
+    getTransitionKey({ name, isArchived, isFragment, state }: ProcessType, processState: ProcessStateType): string {
         if (isArchived || isFragment) {
-            return `${id}`;
+            return `${name}`;
         }
-        return `${id}-${processState?.icon || state?.icon || unknownIcon}`;
+        return `${name}-${processState?.icon || state?.icon || unknownIcon}`;
     }
 }
 

--- a/designer/client/src/components/Process/types.ts
+++ b/designer/client/src/components/Process/types.ts
@@ -38,9 +38,7 @@ export type ProcessVersionType = {
 };
 
 export interface ProcessType {
-    id: string;
     name: string;
-    processId: number;
     processVersionId: number;
     isArchived: boolean;
     isFragment: boolean;

--- a/designer/client/src/components/comment/ProcessComments.tsx
+++ b/designer/client/src/components/comment/ProcessComments.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { addComment, deleteComment } from "../../actions/nk";
-import { getProcessId, getProcessVersionId } from "../../reducers/selectors/graph";
+import { getProcessName, getProcessVersionId } from "../../reducers/selectors/graph";
 import CommentInput from "./CommentInput";
 import { useWindows } from "../../windowManager";
 import * as DialogMessages from "../../common/DialogMessages";
@@ -15,7 +15,7 @@ function ProcessComments(): JSX.Element {
     const dispatch = useDispatch();
     const { confirm } = useWindows();
 
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const processVersionId = useSelector(getProcessVersionId);
     const capabilities = useSelector(getCapabilities);
 
@@ -28,21 +28,21 @@ function ProcessComments(): JSX.Element {
                 denyText: "NO",
                 onConfirmCallback: async (confirmed) => {
                     if (confirmed) {
-                        await dispatch(deleteComment(processId, comment.id));
+                        await dispatch(deleteComment(processName, comment.id));
                     }
                     setPending(false);
                 },
             });
         },
-        [confirm, dispatch, processId],
+        [confirm, dispatch, processName],
     );
 
     const _addComment = useCallback(async () => {
         setPending(true);
-        await dispatch(addComment(processId, processVersionId, comment));
+        await dispatch(addComment(processName, processVersionId, comment));
         setPending(false);
         setComment("");
-    }, [dispatch, processId, processVersionId, comment]);
+    }, [dispatch, processName, processVersionId, comment]);
 
     const onInputChange = useCallback((e) => setComment(e.target.value), []);
 

--- a/designer/client/src/components/graph/NodeUtils.ts
+++ b/designer/client/src/components/graph/NodeUtils.ts
@@ -47,7 +47,8 @@ class NodeUtils {
 
     edgesFromProcess = (process: Process) => process.edges || [];
 
-    getProcessProperties = ({ id, properties }: Process, name?: string) => ({ id: name || id, ...properties });
+    // For sake of consistency with other nodes, name must be renamed to id
+    getProcessPropertiesNode = ({ name, properties }: Process, unsavedName?: string) => ({ id: name || unsavedName, ...properties });
 
     getNodeById = (nodeId: NodeId, process: Process) => this.nodesFromProcess(process).find((n) => n.id === nodeId);
 

--- a/designer/client/src/components/graph/node-modal/NodeAdditionalInfoBox.tsx
+++ b/designer/client/src/components/graph/node-modal/NodeAdditionalInfoBox.tsx
@@ -4,7 +4,7 @@ import ReactMarkdown from "react-markdown/with-html";
 import { useDebounce } from "use-debounce";
 import { NodeType } from "../../../types";
 import { useSelector } from "react-redux";
-import { getProcessId } from "./NodeDetailsContent/selectors";
+import { getProcessName } from "./NodeDetailsContent/selectors";
 import NodeUtils from "../NodeUtils";
 import { styled } from "@mui/material";
 
@@ -44,7 +44,7 @@ const ReactMarkdownStyled = styled(ReactMarkdown)`
 
 export default function NodeAdditionalInfoBox(props: Props): JSX.Element {
     const { node } = props;
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
 
     const [additionalInfo, setAdditionalInfo] = useState<AdditionalInfo>(null);
 
@@ -53,17 +53,17 @@ export default function NodeAdditionalInfoBox(props: Props): JSX.Element {
     const [debouncedNode] = useDebounce(node, 1000);
     useEffect(() => {
         let ignore = false;
-        if (processId) {
+        if (processName) {
             const nodeType = NodeUtils.nodeType(debouncedNode) === "Properties";
             const promise = nodeType
-                ? HttpService.getPropertiesAdditionalInfo(processId, debouncedNode)
-                : HttpService.getNodeAdditionalInfo(processId, debouncedNode);
+                ? HttpService.getPropertiesAdditionalInfo(processName, debouncedNode)
+                : HttpService.getNodeAdditionalInfo(processName, debouncedNode);
             promise.then(({ data }) => ignore || setAdditionalInfo(data));
         }
         return () => {
             ignore = true;
         };
-    }, [processId, debouncedNode]);
+    }, [processName, debouncedNode]);
 
     if (!additionalInfo?.type) {
         return null;

--- a/designer/client/src/components/graph/node-modal/NodeDetailsContent/selectors.tsx
+++ b/designer/client/src/components/graph/node-modal/NodeDetailsContent/selectors.tsx
@@ -48,7 +48,7 @@ export const getNodeExpressionType = createSelector(getExpressionType, getNodeTy
     };
 });
 export const getProcessProperties = createSelector(getProcessToDisplay, (s) => s.properties);
-export const getProcessId = createSelector(getProcessToDisplay, (s) => s.id);
+export const getProcessName = createSelector(getProcessToDisplay, (s) => s.name);
 export const getCurrentErrors = createSelector(
     getValidationPerformed,
     getValidationErrors,

--- a/designer/client/src/components/graph/node-modal/NodeTypeDetailsContent.tsx
+++ b/designer/client/src/components/graph/node-modal/NodeTypeDetailsContent.tsx
@@ -6,7 +6,7 @@ import {
     getDynamicParameterDefinitions,
     getFindAvailableBranchVariables,
     getFindAvailableVariables,
-    getProcessId,
+    getProcessName,
     getProcessProperties,
 } from "./NodeDetailsContent/selectors";
 import { adjustParameters } from "./ParametersUtils";
@@ -57,7 +57,7 @@ export function NodeTypeDetailsContent({
     const findAvailableVariables = useSelector(getFindAvailableVariables);
     const getParameterDefinitions = useSelector(getDynamicParameterDefinitions);
     const getBranchVariableTypes = useSelector(getFindAvailableBranchVariables);
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const processProperties = useSelector(getProcessProperties);
 
     const variableTypes = useMemo(() => findAvailableVariables?.(node.id), [findAvailableVariables, node.id]);
@@ -133,7 +133,7 @@ export function NodeTypeDetailsContent({
     useEffect(() => {
         if (showValidation) {
             dispatch(
-                validateNodeData(processId, {
+                validateNodeData(processName, {
                     //see NODES_CONNECTED/NODES_DISCONNECTED
                     outgoingEdges: edges.filter((e) => e.to != ""),
                     nodeData: node,
@@ -143,7 +143,7 @@ export function NodeTypeDetailsContent({
                 }),
             );
         }
-    }, [dispatch, edges, getBranchVariableTypes, node, processId, processProperties, showValidation, variableTypes]);
+    }, [dispatch, edges, getBranchVariableTypes, node, processName, processProperties, showValidation, variableTypes]);
 
     useEffect(() => {
         setEditedNode((node) => {

--- a/designer/client/src/components/graph/node-modal/nodeUtils.tsx
+++ b/designer/client/src/components/graph/node-modal/nodeUtils.tsx
@@ -13,5 +13,5 @@ export function generateUUIDs(editedNode: NodeType, properties: string[]): NodeT
 }
 
 export function getNodeId(processToDisplay: Process, node: NodeType): string {
-    return processToDisplay.properties.isFragment ? node.id.replace(`${processToDisplay.id}-`, "") : node.id;
+    return processToDisplay.properties.isFragment ? node.id.replace(`${processToDisplay.name}-`, "") : node.id;
 }

--- a/designer/client/src/components/modals/CalculateCounts/CalculateCountsDialog.tsx
+++ b/designer/client/src/components/modals/CalculateCounts/CalculateCountsDialog.tsx
@@ -5,7 +5,7 @@ import React, { PropsWithChildren, useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchAndDisplayProcessCounts } from "../../../actions/nk";
-import { getProcessId, getProcessToDisplay } from "../../../reducers/selectors/graph";
+import { getProcessName, getProcessToDisplay } from "../../../reducers/selectors/graph";
 import { WindowContent } from "../../../windowManager";
 import { PickerInput } from "./Picker";
 import { CalculateCountsForm } from "./CalculateCountsForm";
@@ -26,13 +26,13 @@ const initState = (): State => {
 export function CountsDialog({ children, ...props }: PropsWithChildren<WindowContentProps>): JSX.Element {
     const { t } = useTranslation();
     const [state, setState] = useState(initState);
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const dispatch = useDispatch();
     const processToDisplay = useSelector(getProcessToDisplay);
 
     const confirm = useCallback(async () => {
-        await dispatch(fetchAndDisplayProcessCounts(processId, moment(state.from), moment(state.to), processToDisplay));
-    }, [dispatch, processId, state.from, state.to, processToDisplay]);
+        await dispatch(fetchAndDisplayProcessCounts(processName, moment(state.from), moment(state.to), processToDisplay));
+    }, [dispatch, processName, state.from, state.to, processToDisplay]);
 
     const isStateValid = moment(state.from).isValid() && moment(state.to).isValid();
     const buttons: WindowButtonProps[] = useMemo(

--- a/designer/client/src/components/modals/CalculateCounts/CountsRanges.tsx
+++ b/designer/client/src/components/modals/CalculateCounts/CountsRanges.tsx
@@ -2,7 +2,7 @@ import { Moment } from "moment";
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { getProcessId } from "../../../reducers/selectors/graph";
+import { getProcessName } from "../../../reducers/selectors/graph";
 import { CountsRangesButtons } from "./CountsRangesButtons";
 import { useDeployHistory } from "./useDeployHistory";
 import { predefinedRanges } from "./utils";
@@ -15,8 +15,8 @@ interface RangesProps {
 
 export function CountsRanges({ label, onChange }: RangesProps): JSX.Element {
     const { t } = useTranslation<string>();
-    const processId = useSelector(getProcessId);
-    const deploys = useDeployHistory(processId);
+    const processName = useSelector(getProcessName);
+    const deploys = useDeployHistory(processName);
     const dates = useMemo(() => predefinedRanges(t), [t]);
 
     return (

--- a/designer/client/src/components/modals/CalculateCounts/useDeployHistory.ts
+++ b/designer/client/src/components/modals/CalculateCounts/useDeployHistory.ts
@@ -5,12 +5,12 @@ import { DATE_FORMAT } from "../../../config";
 import { Range } from "./CountsRangesButtons";
 import moment from "moment";
 
-export function useDeployHistory(processId: string): Range[] {
+export function useDeployHistory(processName: string): Range[] {
     const { t } = useTranslation();
     const [deploys, setDeploys] = useState<Range[]>([]);
 
     useEffect(() => {
-        HttpService.fetchProcessesDeployments(processId)
+        HttpService.fetchProcessesDeployments(processName)
             .then((dates) =>
                 dates.map((current, i, all) => {
                     const from = moment(current);
@@ -28,7 +28,7 @@ export function useDeployHistory(processId: string): Range[] {
                 }),
             )
             .then(setDeploys);
-    }, [t, processId]);
+    }, [t, processName]);
 
     return deploys;
 }

--- a/designer/client/src/components/modals/CompareVersionsDialog.tsx
+++ b/designer/client/src/components/modals/CompareVersionsDialog.tsx
@@ -8,7 +8,7 @@ import { WindowContent } from "../../windowManager";
 import { formatAbsolutely } from "../../common/DateUtils";
 import { flattenObj, objectDiff } from "../../common/JsonUtils";
 import HttpService from "../../http/HttpService";
-import { getProcessId, getProcessVersionId, getVersions } from "../../reducers/selectors/graph";
+import { getProcessName, getProcessVersionId, getVersions } from "../../reducers/selectors/graph";
 import { getTargetEnvironmentId } from "../../reducers/selectors/settings";
 import EdgeDetailsContent from "../graph/node-modal/edge/EdgeDetailsContent";
 import { ProcessVersionType } from "../Process/types";
@@ -35,18 +35,18 @@ const VersionsForm = () => {
     };
 
     const [state, setState] = useState<State>(initState);
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const version = useSelector(getProcessVersionId);
     const otherEnvironment = useSelector(getTargetEnvironmentId);
     const versions = useSelector(getVersions);
 
     useEffect(() => {
-        if (processId && otherEnvironment) {
-            HttpService.fetchRemoteVersions(processId).then((response) =>
+        if (processName && otherEnvironment) {
+            HttpService.fetchRemoteVersions(processName).then((response) =>
                 setState((prevState) => ({ ...prevState, remoteVersions: response.data || [] })),
             );
         }
-    }, [processId, otherEnvironment]);
+    }, [processName, otherEnvironment]);
 
     function isLayoutChangeOnly(diffId: string): boolean {
         const { type, currentNode, otherNode } = state.difference[diffId];
@@ -57,7 +57,7 @@ const VersionsForm = () => {
 
     const loadVersion = (versionId: string) => {
         if (versionId) {
-            HttpService.compareProcesses(processId, version, versionToPass(versionId), isRemote(versionId)).then((response) =>
+            HttpService.compareProcesses(processName, version, versionToPass(versionId), isRemote(versionId)).then((response) =>
                 setState((prevState) => ({ ...prevState, difference: response.data, otherVersion: versionId, currentDiffId: null })),
             );
         } else {

--- a/designer/client/src/components/modals/CustomActionDialog.tsx
+++ b/designer/client/src/components/modals/CustomActionDialog.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { loadProcessState } from "../../actions/nk";
 import HttpService from "../../http/HttpService";
-import { getProcessId } from "../../reducers/selectors/graph";
+import { getProcessName } from "../../reducers/selectors/graph";
 import { CustomAction } from "../../types";
 import { UnknownRecord } from "../../types/common";
 import { WindowContent } from "../../windowManager";
@@ -72,7 +72,7 @@ function CustomActionForm(props: CustomActionFormProps): JSX.Element {
 }
 
 export function CustomActionDialog(props: WindowContentProps<WindowKind, CustomAction>): JSX.Element {
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const dispatch = useDispatch();
     const action = props.data.meta;
     const [validationError, setValidationError] = useState("");
@@ -80,15 +80,15 @@ export function CustomActionDialog(props: WindowContentProps<WindowKind, CustomA
     const [value, setValue] = useState<UnknownRecord>();
 
     const confirm = useCallback(async () => {
-        await HttpService.customAction(processId, action.name, value).then((response) => {
+        await HttpService.customAction(processName, action.name, value).then((response) => {
             if (response.isSuccess) {
-                dispatch(loadProcessState(processId));
+                dispatch(loadProcessState(processName));
                 props.close();
             } else {
                 setValidationError(response.msg);
             }
         });
-    }, [processId, action.name, value, props, dispatch]);
+    }, [processName, action.name, value, props, dispatch]);
 
     const { t } = useTranslation();
     const buttons: WindowButtonProps[] = useMemo(

--- a/designer/client/src/components/modals/DeployProcessDialog.tsx
+++ b/designer/client/src/components/modals/DeployProcessDialog.tsx
@@ -3,16 +3,16 @@ import { WindowButtonProps, WindowContentProps } from "@touk/window-manager";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { getProcessId } from "../../reducers/selectors/graph";
+import { getProcessName } from "../../reducers/selectors/graph";
 import { getFeatureSettings } from "../../reducers/selectors/settings";
-import { ProcessId } from "../../types";
+import { ProcessName } from "../../types";
 import { PromptContent, WindowKind } from "../../windowManager";
 import CommentInput from "../comment/CommentInput";
 import { ValidationLabel } from "../common/ValidationLabel";
 import ProcessDialogWarnings from "./ProcessDialogWarnings";
 
 export type ToggleProcessActionModalData = {
-    action: (processId: ProcessId, comment: string) => Promise<unknown>;
+    action: (processName: ProcessName, comment: string) => Promise<unknown>;
     displayWarnings?: boolean;
 };
 
@@ -21,7 +21,7 @@ export function DeployProcessDialog(props: WindowContentProps<WindowKind, Toggle
     const {
         meta: { action, displayWarnings },
     } = props.data;
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const [comment, setComment] = useState("");
     const [validationError, setValidationError] = useState("");
     const featureSettings = useSelector(getFeatureSettings);
@@ -31,12 +31,12 @@ export function DeployProcessDialog(props: WindowContentProps<WindowKind, Toggle
 
     const confirmAction = useCallback(async () => {
         try {
-            await action(processId, comment);
+            await action(processName, comment);
             props.close();
         } catch (error) {
             setValidationError(error?.response?.data);
         }
-    }, [action, comment, dispatch, processId, props]);
+    }, [action, comment, dispatch, processName, props]);
 
     const { t } = useTranslation();
     const buttons: WindowButtonProps[] = useMemo(

--- a/designer/client/src/components/modals/GenerateDataAndTestDialog.tsx
+++ b/designer/client/src/components/modals/GenerateDataAndTestDialog.tsx
@@ -3,7 +3,7 @@ import { WindowButtonProps, WindowContentProps } from "@touk/window-manager";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector, useDispatch } from "react-redux";
-import { getProcessId, getProcessToDisplay } from "../../reducers/selectors/graph";
+import { getProcessName, getProcessToDisplay } from "../../reducers/selectors/graph";
 import { getFeatureSettings } from "../../reducers/selectors/settings";
 import { PromptContent } from "../../windowManager";
 import {
@@ -22,7 +22,7 @@ import { isEmpty } from "lodash";
 function GenerateDataAndTestDialog(props: WindowContentProps): JSX.Element {
     const { t } = useTranslation();
     const dispatch = useDispatch();
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const processToDisplay = useSelector(getProcessToDisplay);
     const maxSize = useSelector(getFeatureSettings).testDataSettings.maxSamplesCount;
 
@@ -31,9 +31,9 @@ function GenerateDataAndTestDialog(props: WindowContentProps): JSX.Element {
     });
 
     const confirmAction = useCallback(async () => {
-        await dispatch(testScenarioWithGeneratedData(processId, testSampleSize, processToDisplay));
+        await dispatch(testScenarioWithGeneratedData(processName, testSampleSize, processToDisplay));
         props.close();
-    }, [dispatch, processId, processToDisplay, props, testSampleSize]);
+    }, [dispatch, processName, processToDisplay, props, testSampleSize]);
 
     const validators = [literalIntegerValueValidator, minimalNumberValidator(0), maximalNumberValidator(maxSize), mandatoryValueValidator];
     const errors = extendErrors([], testSampleSize, "testData", validators);

--- a/designer/client/src/components/modals/GenerateTestDataDialog.tsx
+++ b/designer/client/src/components/modals/GenerateTestDataDialog.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import HttpService from "../../http/HttpService";
-import { getProcessId, getProcessToDisplay } from "../../reducers/selectors/graph";
+import { getProcessName, getProcessToDisplay } from "../../reducers/selectors/graph";
 import { getFeatureSettings } from "../../reducers/selectors/settings";
 import { PromptContent } from "../../windowManager";
 import {
@@ -21,7 +21,7 @@ import { isEmpty } from "lodash";
 
 function GenerateTestDataDialog(props: WindowContentProps): JSX.Element {
     const { t } = useTranslation();
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const processToDisplay = useSelector(getProcessToDisplay);
     const maxSize = useSelector(getFeatureSettings).testDataSettings.maxSamplesCount;
 
@@ -31,9 +31,9 @@ function GenerateTestDataDialog(props: WindowContentProps): JSX.Element {
     });
 
     const confirmAction = useCallback(async () => {
-        await HttpService.generateTestData(processId, testSampleSize, processToDisplay);
+        await HttpService.generateTestData(processName, testSampleSize, processToDisplay);
         props.close();
-    }, [processId, processToDisplay, props, testSampleSize]);
+    }, [processName, processToDisplay, props, testSampleSize]);
 
     const validators = [literalIntegerValueValidator, minimalNumberValidator(0), maximalNumberValidator(maxSize), mandatoryValueValidator];
     const errors = extendErrors([], testSampleSize, "testData", validators);

--- a/designer/client/src/components/modals/GenericActionDialog.tsx
+++ b/designer/client/src/components/modals/GenericActionDialog.tsx
@@ -3,7 +3,7 @@ import { WindowButtonProps, WindowContentProps } from "@touk/window-manager";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { getProcessId } from "../../reducers/selectors/graph";
+import { getProcessName } from "../../reducers/selectors/graph";
 import { Expression, NodeValidationError, UIParameter, VariableTypes } from "../../types";
 import { WindowContent } from "../../windowManager";
 import { WindowKind } from "../../windowManager";
@@ -111,7 +111,7 @@ function GenericActionForm(props: GenericActionDialogProps): JSX.Element {
 }
 
 export function GenericActionDialog(props: WindowContentProps<WindowKind, GenericAction>): JSX.Element {
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const { t } = useTranslation();
     const action = props.data.meta;
     const [value, setValue] = useState(() =>
@@ -129,7 +129,7 @@ export function GenericActionDialog(props: WindowContentProps<WindowKind, Generi
     const confirm = useCallback(async () => {
         action.onConfirmAction(value);
         props.close();
-    }, [processId, action.layout.name, value, props]);
+    }, [processName, action.layout.name, value, props]);
 
     const cancelText = action.layout.cancelText ? action.layout.cancelText : "cancel";
     const confirmText = action.layout.confirmText ? action.layout.confirmText : "confirm";

--- a/designer/client/src/components/modals/SaveProcessDialog.tsx
+++ b/designer/client/src/components/modals/SaveProcessDialog.tsx
@@ -21,18 +21,18 @@ export function SaveProcessDialog(props: WindowContentProps): JSX.Element {
             return async (dispatch, getState) => {
                 const state = getState();
                 const processJson = getProcessToDisplay(state);
-                const currentProcessName = processJson.id;
+                const currentProcessName = processJson.name;
 
-                // save changes before rename and force same processId everywhere
+                // save changes before rename and force same processName everywhere
                 await HttpService.saveProcess(currentProcessName, processJson, comment);
 
                 const unsavedNewName = getProcessUnsavedNewName(state);
                 const isRenamed = isProcessRenamed(state) && (await HttpService.changeProcessName(currentProcessName, unsavedNewName));
-                const processId = isRenamed ? unsavedNewName : currentProcessName;
+                const processName = isRenamed ? unsavedNewName : currentProcessName;
 
                 await dispatch(UndoActionCreators.clearHistory());
-                await dispatch(displayCurrentProcessVersion(processId));
-                await dispatch(displayProcessActivity(processId));
+                await dispatch(displayCurrentProcessVersion(processName));
+                await dispatch(displayProcessActivity(processName));
 
                 if (isRenamed) {
                     await dispatch(loadProcessToolbarsConfiguration(unsavedNewName));

--- a/designer/client/src/components/processAttach/AddAttachment.tsx
+++ b/designer/client/src/components/processAttach/AddAttachment.tsx
@@ -3,7 +3,7 @@ import Dropzone from "react-dropzone";
 import { useTranslation } from "react-i18next";
 import { addAttachment } from "../../actions/nk";
 import { useDispatch, useSelector } from "react-redux";
-import { getProcessId, getProcessVersionId } from "../../reducers/selectors/graph";
+import { getProcessName, getProcessVersionId } from "../../reducers/selectors/graph";
 import ButtonUpload from "../../assets/img/icons/buttonUpload.svg";
 import { NodeInput } from "../withFocus";
 import { AddAttachmentsWrapper, AttachmentButton, AttachmentButtonText, AttachmentDropZone, AttachmentsContainer } from "./StyledAttach";
@@ -11,12 +11,12 @@ import { AddAttachmentsWrapper, AttachmentButton, AttachmentButtonText, Attachme
 export function AddAttachment() {
     const { t } = useTranslation();
     const dispatch = useDispatch();
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const processVersionId = useSelector(getProcessVersionId);
 
     const addFiles = useCallback(
-        (files) => files.forEach((file) => dispatch(addAttachment(processId, processVersionId, file))),
-        [dispatch, processId, processVersionId],
+        (files) => files.forEach((file) => dispatch(addAttachment(processName, processVersionId, file))),
+        [dispatch, processName, processVersionId],
     );
 
     return (

--- a/designer/client/src/components/processAttach/AttachmentEl.tsx
+++ b/designer/client/src/components/processAttach/AttachmentEl.tsx
@@ -4,14 +4,13 @@ import { Attachment } from "../../reducers/processActivity";
 import HttpService from "../../http/HttpService";
 import Date from "../common/Date";
 import { AttachmentDetails, DownloadAttachment, DownloadButton, AttachHeader } from "./StyledAttach";
+import { ProcessName } from "../../types";
 
-export function AttachmentEl({ data }: { data: Attachment }) {
+export function AttachmentEl({ data, processName }: { data: Attachment; processName: ProcessName }) {
     return (
         <li style={{ display: "flex" }}>
             <DownloadAttachment className="download-attachment">
-                <DownloadButton
-                    onClick={() => HttpService.downloadAttachment(data.processId, data.processVersionId, data.id, data.fileName)}
-                >
+                <DownloadButton onClick={() => HttpService.downloadAttachment(processName, data.id, data.fileName)}>
                     <DownloadIcon sx={{ width: 13, height: 13 }} />
                 </DownloadButton>
             </DownloadAttachment>

--- a/designer/client/src/components/processAttach/ProcessAttachments.tsx
+++ b/designer/client/src/components/processAttach/ProcessAttachments.tsx
@@ -5,16 +5,18 @@ import { getCapabilities } from "../../reducers/selectors/other";
 import { AttachmentEl } from "./AttachmentEl";
 import { AddAttachment } from "./AddAttachment";
 import { ProcessAttachmentsList, ProcessAttachmentsStyled } from "./StyledAttach";
+import { getProcessName } from "../../reducers/selectors/graph";
 
 export function ProcessAttachments() {
     const { write } = useSelector(getCapabilities);
+    const processName = useSelector(getProcessName);
     const attachments = useSelector((s: RootState) => s.processActivity.attachments);
 
     return (
         <ProcessAttachmentsStyled>
             <ProcessAttachmentsList>
                 {attachments.map((a) => (
-                    <AttachmentEl key={a.id} data={a} />
+                    <AttachmentEl key={a.id} data={a} processName={processName} />
                 ))}
             </ProcessAttachmentsList>
             {write && <AddAttachment />}

--- a/designer/client/src/components/tips/error/NodeErrorsLinkSection.tsx
+++ b/designer/client/src/components/tips/error/NodeErrorsLinkSection.tsx
@@ -17,7 +17,7 @@ interface NodeErrorsLinkSectionProps {
 
 export default function NodeErrorsLinkSection(props: NodeErrorsLinkSectionProps): JSX.Element {
     const { nodeIds, message, showDetails, currentProcess, errorsOnTop } = props;
-    const name = useSelector(getProcessUnsavedNewName);
+    const unsavedName = useSelector(getProcessUnsavedNewName);
     const separator = ", ";
 
     return (
@@ -27,7 +27,7 @@ export default function NodeErrorsLinkSection(props: NodeErrorsLinkSectionProps)
                 {nodeIds.map((nodeId, index) => {
                     const details =
                         nodeId === "properties"
-                            ? NodeUtils.getProcessProperties(currentProcess, name)
+                            ? NodeUtils.getProcessPropertiesNode(currentProcess, unsavedName)
                             : NodeUtils.getNodeById(nodeId, currentProcess);
                     return (
                         <React.Fragment key={nodeId}>

--- a/designer/client/src/components/toolbarSettings/buttons/ActionButton.tsx
+++ b/designer/client/src/components/toolbarSettings/buttons/ActionButton.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { useSelector } from "react-redux";
-import { getProcessId } from "../../../reducers/selectors/graph";
+import { getProcessName } from "../../../reducers/selectors/graph";
 import { getProcessState } from "../../../reducers/selectors/scenarioState";
 import { getCustomActions } from "../../../reducers/selectors/settings";
 import CustomActionButton from "../../toolbars/status/buttons/CustomActionButton";
@@ -10,11 +10,11 @@ export interface ActionButtonProps {
 }
 
 export function ActionButton({ name }: ActionButtonProps): JSX.Element {
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const status = useSelector(getProcessState)?.status;
     const customActions = useSelector(getCustomActions);
 
     const action = useMemo(() => customActions.find((a) => a.name === name), [customActions, name]);
 
-    return action ? <CustomActionButton action={action} processId={processId} processStatus={status} /> : null;
+    return action ? <CustomActionButton action={action} processName={processName} processStatus={status} /> : null;
 }

--- a/designer/client/src/components/toolbars/process/buttons/ArchiveButton.tsx
+++ b/designer/client/src/components/toolbars/process/buttons/ArchiveButton.tsx
@@ -3,15 +3,15 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import Icon from "../../../../assets/img/toolbarButtons/archive.svg";
 import * as DialogMessages from "../../../../common/DialogMessages";
-import { getProcessId, isArchivePossible } from "../../../../reducers/selectors/graph";
+import { getProcessName, isArchivePossible } from "../../../../reducers/selectors/graph";
 import { useWindows } from "../../../../windowManager";
 import { CapabilitiesToolbarButton } from "../../../toolbarComponents/CapabilitiesToolbarButton";
 import { ToolbarButtonProps } from "../../types";
 import { useArchiveHelper } from "./useArchiveHelper";
 
 function ArchiveButton({ disabled }: ToolbarButtonProps): JSX.Element {
-    const processId = useSelector(getProcessId);
-    const { confirmArchiveCallback } = useArchiveHelper(processId);
+    const processName = useSelector(getProcessName);
+    const { confirmArchiveCallback } = useArchiveHelper(processName);
     const archivePossible = useSelector(isArchivePossible);
     const available = !disabled && archivePossible;
     const { t } = useTranslation();
@@ -21,12 +21,12 @@ function ArchiveButton({ disabled }: ToolbarButtonProps): JSX.Element {
         () =>
             available &&
             confirm({
-                text: DialogMessages.archiveProcess(processId),
+                text: DialogMessages.archiveProcess(processName),
                 onConfirmCallback: confirmArchiveCallback,
                 confirmText: t("panels.actions.process-archive.yes", "Yes"),
                 denyText: t("panels.actions.process-archive.no", "No"),
             }),
-        [available, confirm, processId, t, confirmArchiveCallback],
+        [available, confirm, processName, t, confirmArchiveCallback],
     );
 
     return (

--- a/designer/client/src/components/toolbars/process/buttons/ImportButton.tsx
+++ b/designer/client/src/components/toolbars/process/buttons/ImportButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { importFiles } from "../../../../actions/nk/importExport";
 import { CapabilitiesToolbarButton } from "../../../toolbarComponents/CapabilitiesToolbarButton";
-import { getProcessId } from "../../../../reducers/selectors/graph";
+import { getProcessName } from "../../../../reducers/selectors/graph";
 import { useTranslation } from "react-i18next";
 import Icon from "../../../../assets/img/toolbarButtons/import.svg";
 import { ToolbarButtonProps } from "../../types";
@@ -13,7 +13,7 @@ function ImportButton(props: Props) {
     const { disabled } = props;
     const { t } = useTranslation();
     const dispatch = useDispatch();
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
 
     return (
         <CapabilitiesToolbarButton
@@ -21,7 +21,7 @@ function ImportButton(props: Props) {
             name={t("panels.actions.process-import.button", "import")}
             icon={<Icon />}
             disabled={disabled}
-            onDrop={(files) => dispatch(importFiles(processId, files))}
+            onDrop={(files) => dispatch(importFiles(processName, files))}
         />
     );
 }

--- a/designer/client/src/components/toolbars/process/buttons/MigrateButton.tsx
+++ b/designer/client/src/components/toolbars/process/buttons/MigrateButton.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import Icon from "../../../../assets/img/toolbarButtons/migrate.svg";
 import * as DialogMessages from "../../../../common/DialogMessages";
 import HttpService from "../../../../http/HttpService";
-import { getProcessId, getProcessVersionId, isMigrationPossible } from "../../../../reducers/selectors/graph";
+import { getProcessName, getProcessVersionId, isMigrationPossible } from "../../../../reducers/selectors/graph";
 import { getFeatureSettings, getTargetEnvironmentId } from "../../../../reducers/selectors/settings";
 import { useWindows } from "../../../../windowManager";
 import { CapabilitiesToolbarButton } from "../../../toolbarComponents/CapabilitiesToolbarButton";
@@ -15,7 +15,7 @@ type Props = ToolbarButtonProps;
 
 function MigrateButton(props: Props) {
     const { disabled } = props;
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const versionId = useSelector(getProcessVersionId);
     const featuresSettings = useSelector(getFeatureSettings);
     const migrationPossible = useSelector(isMigrationPossible);
@@ -28,12 +28,12 @@ function MigrateButton(props: Props) {
     const onClick = useCallback(
         () =>
             confirm({
-                text: DialogMessages.migrate(processId, targetEnvironmentId),
-                onConfirmCallback: (confirmed) => confirmed && HttpService.migrateProcess(processId, versionId),
+                text: DialogMessages.migrate(processName, targetEnvironmentId),
+                onConfirmCallback: (confirmed) => confirmed && HttpService.migrateProcess(processName, versionId),
                 confirmText: t("panels.actions.process-migrate.yes", "Yes"),
                 denyText: t("panels.actions.process-migrate.no", "No"),
             }),
-        [confirm, processId, t, targetEnvironmentId, versionId],
+        [confirm, processName, t, targetEnvironmentId, versionId],
     );
 
     if (isEmpty(featuresSettings?.remoteEnvironment)) {

--- a/designer/client/src/components/toolbars/process/buttons/PDFButton.tsx
+++ b/designer/client/src/components/toolbars/process/buttons/PDFButton.tsx
@@ -3,7 +3,7 @@ import { RootState } from "../../../../reducers/index";
 import ProcessUtils from "../../../../common/ProcessUtils";
 import { connect } from "react-redux";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
-import { getProcessId, getProcessVersionId } from "../../../../reducers/selectors/graph";
+import { getProcessName, getProcessVersionId } from "../../../../reducers/selectors/graph";
 import { useTranslation } from "react-i18next";
 import { useGraph } from "../../../graph/GraphContext";
 import Icon from "../../../../assets/img/toolbarButtons/PDF.svg";
@@ -13,7 +13,7 @@ import HttpService from "../../../../http/HttpService";
 type Props = StateProps & ToolbarButtonProps;
 
 function PDFButton(props: Props) {
-    const { processId, versionId, canExport, disabled } = props;
+    const { processName, versionId, canExport, disabled } = props;
     const available = !disabled && canExport;
     const { t } = useTranslation();
     const graphGetter = useGraph();
@@ -28,7 +28,7 @@ function PDFButton(props: Props) {
                 // TODO: try to do this in worker
                 // TODO: try to do this more in redux/react style
                 const exportedGraph = await graphGetter?.()?.exportGraph();
-                HttpService.exportProcessToPdf(processId, versionId, exportedGraph);
+                HttpService.exportProcessToPdf(processName, versionId, exportedGraph);
             }}
         />
     );
@@ -36,7 +36,7 @@ function PDFButton(props: Props) {
 
 const mapState = (state: RootState) => {
     return {
-        processId: getProcessId(state),
+        processName: getProcessName(state),
         versionId: getProcessVersionId(state),
         canExport: ProcessUtils.canExport(state),
     };

--- a/designer/client/src/components/toolbars/process/buttons/UnArchiveButton.tsx
+++ b/designer/client/src/components/toolbars/process/buttons/UnArchiveButton.tsx
@@ -4,14 +4,14 @@ import { useDispatch, useSelector } from "react-redux";
 import Icon from "../../../../assets/img/toolbarButtons/unarchive.svg";
 import * as DialogMessages from "../../../../common/DialogMessages";
 import HttpService from "../../../../http/HttpService";
-import { getProcessId, isArchived } from "../../../../reducers/selectors/graph";
+import { getProcessName, isArchived } from "../../../../reducers/selectors/graph";
 import { useWindows } from "../../../../windowManager";
 import { CapabilitiesToolbarButton } from "../../../toolbarComponents/CapabilitiesToolbarButton";
 import { ToolbarButtonProps } from "../../types";
 import { displayCurrentProcessVersion, loadProcessToolbarsConfiguration } from "../../../../actions/nk";
 
 function UnArchiveButton({ disabled }: ToolbarButtonProps) {
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const archived = useSelector(isArchived);
     const available = !disabled || !archived;
     const { t } = useTranslation();
@@ -22,17 +22,17 @@ function UnArchiveButton({ disabled }: ToolbarButtonProps) {
         () =>
             available &&
             confirm({
-                text: DialogMessages.unArchiveProcess(processId),
+                text: DialogMessages.unArchiveProcess(processName),
                 onConfirmCallback: (confirmed) =>
                     confirmed &&
-                    HttpService.unArchiveProcess(processId).then(() => {
-                        dispatch(loadProcessToolbarsConfiguration(processId));
-                        dispatch(displayCurrentProcessVersion(processId));
+                    HttpService.unArchiveProcess(processName).then(() => {
+                        dispatch(loadProcessToolbarsConfiguration(processName));
+                        dispatch(displayCurrentProcessVersion(processName));
                     }),
                 confirmText: t("panels.actions.process-unarchive.yes", "Yes"),
                 denyText: t("panels.actions.process-unarchive.no", "No"),
             }),
-        [available, confirm, dispatch, processId, t],
+        [available, confirm, dispatch, processName, t],
     );
 
     return (

--- a/designer/client/src/components/toolbars/process/buttons/useArchiveHelper.ts
+++ b/designer/client/src/components/toolbars/process/buttons/useArchiveHelper.ts
@@ -9,7 +9,7 @@ import { getFeatureSettings } from "../../../../reducers/selectors/settings";
 import { displayCurrentProcessVersion, loadProcessToolbarsConfiguration } from "../../../../actions/nk";
 import { useCallback } from "react";
 
-export const useArchiveHelper = (processId: string) => {
+export const useArchiveHelper = (processName: string) => {
     const dispatch = useDispatch();
     const navigate = useNavigate();
     const { confirm } = useWindows();
@@ -17,16 +17,16 @@ export const useArchiveHelper = (processId: string) => {
     const { redirectAfterArchive } = useSelector(getFeatureSettings);
 
     const archive = useCallback(async () => {
-        return HttpService.archiveProcess(processId).then(() => {
+        return HttpService.archiveProcess(processName).then(() => {
             dispatch({ type: "ARCHIVED" });
             if (redirectAfterArchive) {
                 navigate(ArchivedPath);
             } else {
-                dispatch(loadProcessToolbarsConfiguration(processId));
-                dispatch(displayCurrentProcessVersion(processId));
+                dispatch(loadProcessToolbarsConfiguration(processName));
+                dispatch(displayCurrentProcessVersion(processName));
             }
         });
-    }, [dispatch, navigate, processId, redirectAfterArchive]);
+    }, [dispatch, navigate, processName, redirectAfterArchive]);
 
     const confirmArchiveCallback = useCallback(
         async (archiveConfirmed: boolean) => {

--- a/designer/client/src/components/toolbars/status/buttons/CancelDeployButton.tsx
+++ b/designer/client/src/components/toolbars/status/buttons/CancelDeployButton.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { loadProcessState } from "../../../../actions/nk";
 import Icon from "../../../../assets/img/toolbarButtons/stop.svg";
 import HttpService from "../../../../http/HttpService";
-import { getProcessId, isCancelPossible } from "../../../../reducers/selectors/graph";
+import { getProcessName, isCancelPossible } from "../../../../reducers/selectors/graph";
 import { getCapabilities } from "../../../../reducers/selectors/other";
 import { useWindows } from "../../../../windowManager";
 import { WindowKind } from "../../../../windowManager/WindowKind";
@@ -17,13 +17,13 @@ export default function CancelDeployButton(props: ToolbarButtonProps) {
     const dispatch = useDispatch();
     const { disabled } = props;
     const cancelPossible = useSelector(isCancelPossible);
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const capabilities = useSelector(getCapabilities);
     const available = !disabled && cancelPossible && capabilities.deploy;
 
     const { open } = useWindows();
-    const action = (p, c) => HttpService.cancel(p, c).finally(() => dispatch(loadProcessState(processId)));
-    const message = t("panels.actions.deploy-canel.dialog", "Cancel scenario {{name}}", { name: processId });
+    const action = (p, c) => HttpService.cancel(p, c).finally(() => dispatch(loadProcessState(processName)));
+    const message = t("panels.actions.deploy-canel.dialog", "Cancel scenario {{name}}", { name: processName });
 
     return (
         <ToolbarButton

--- a/designer/client/src/components/toolbars/status/buttons/CustomActionButton.tsx
+++ b/designer/client/src/components/toolbars/status/buttons/CustomActionButton.tsx
@@ -12,7 +12,7 @@ import { FallbackProps } from "react-error-boundary";
 
 type CustomActionProps = {
     action: CustomAction;
-    processId: string;
+    processName: string;
     processStatus: StatusType | null;
 } & ToolbarButtonProps;
 

--- a/designer/client/src/components/toolbars/status/buttons/DeployButton.tsx
+++ b/designer/client/src/components/toolbars/status/buttons/DeployButton.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { disableToolTipsHighlight, enableToolTipsHighlight, loadProcessState } from "../../../../actions/nk";
 import Icon from "../../../../assets/img/toolbarButtons/deploy.svg";
 import HttpService from "../../../../http/HttpService";
-import { getProcessId, hasError, isDeployPossible, isSaveDisabled } from "../../../../reducers/selectors/graph";
+import { getProcessName, hasError, isDeployPossible, isSaveDisabled } from "../../../../reducers/selectors/graph";
 import { getCapabilities } from "../../../../reducers/selectors/other";
 import { useWindows } from "../../../../windowManager";
 import { WindowKind } from "../../../../windowManager/WindowKind";
@@ -17,7 +17,7 @@ export default function DeployButton(props: ToolbarButtonProps) {
     const deployPossible = useSelector(isDeployPossible);
     const saveDisabled = useSelector(isSaveDisabled);
     const hasErrors = useSelector(hasError);
-    const processId = useSelector(getProcessId);
+    const processName = useSelector(getProcessName);
     const capabilities = useSelector(getCapabilities);
     const { disabled } = props;
 
@@ -36,8 +36,8 @@ export default function DeployButton(props: ToolbarButtonProps) {
 
     const { open } = useWindows();
 
-    const message = t("panels.actions.deploy.dialog", "Deploy scenario {{name}}", { name: processId });
-    const action = (p, c) => HttpService.deploy(p, c).finally(() => dispatch(loadProcessState(processId)));
+    const message = t("panels.actions.deploy.dialog", "Deploy scenario {{name}}", { name: processName });
+    const action = (p, c) => HttpService.deploy(p, c).finally(() => dispatch(loadProcessState(processName)));
 
     return (
         <ToolbarButton

--- a/designer/client/src/components/toolbars/status/buttons/PropertiesButton.tsx
+++ b/designer/client/src/components/toolbars/status/buttons/PropertiesButton.tsx
@@ -17,7 +17,7 @@ function PropertiesButton(props: ToolbarButtonProps): JSX.Element {
     const propertiesErrors = useSelector(hasPropertiesErrors);
     const errors = useSelector(hasError);
 
-    const processProperties = useMemo(() => NodeUtils.getProcessProperties(processToDisplay, name), [name, processToDisplay]);
+    const processProperties = useMemo(() => NodeUtils.getProcessPropertiesNode(processToDisplay, name), [name, processToDisplay]);
 
     const onClick = useCallback(
         () => openNodeWindow(processProperties, processToDisplay),

--- a/designer/client/src/components/toolbars/test/buttons/FromFileButton.tsx
+++ b/designer/client/src/components/toolbars/test/buttons/FromFileButton.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { RootState } from "../../../../reducers/index";
 import { connect } from "react-redux";
 import { CapabilitiesToolbarButton } from "../../../toolbarComponents/CapabilitiesToolbarButton";
-import { getProcessId, getProcessToDisplay, getTestCapabilities } from "../../../../reducers/selectors/graph";
+import { getProcessName, getProcessToDisplay, getTestCapabilities } from "../../../../reducers/selectors/graph";
 import Icon from "../../../../assets/img/toolbarButtons/from-file.svg";
 import { ToolbarButtonProps } from "../../types";
 import { testProcessFromFile } from "../../../../actions/nk/displayTestResults";
@@ -11,7 +11,7 @@ import { testProcessFromFile } from "../../../../actions/nk/displayTestResults";
 type Props = StateProps & ToolbarButtonProps;
 
 function FromFileButton(props: Props) {
-    const { processId, processToDisplay, testCapabilities, disabled } = props;
+    const { processName, processToDisplay, testCapabilities, disabled } = props;
     const { testProcessFromFile } = props;
     const { t } = useTranslation();
     const available = !disabled && testCapabilities && testCapabilities.canBeTested;
@@ -23,14 +23,14 @@ function FromFileButton(props: Props) {
             title={t("panels.actions.test-from-file.button.title", "run test on data from file")}
             icon={<Icon />}
             disabled={!available}
-            onDrop={(files) => files.forEach((file) => testProcessFromFile(processId, file, processToDisplay))}
+            onDrop={(files) => files.forEach((file) => testProcessFromFile(processName, file, processToDisplay))}
         />
     );
 }
 
 const mapState = (state: RootState) => ({
     testCapabilities: getTestCapabilities(state),
-    processId: getProcessId(state),
+    processName: getProcessName(state),
     processToDisplay: getProcessToDisplay(state),
 });
 

--- a/designer/client/src/components/toolbars/test/buttons/TestWithFormButton.tsx
+++ b/designer/client/src/components/toolbars/test/buttons/TestWithFormButton.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import Icon from "../../../../assets/img/toolbarButtons/test-with-form.svg";
 import {
-    getProcessId,
+    getProcessName,
     getProcessToDisplay,
     getTestCapabilities,
     getTestParameters,
@@ -32,7 +32,7 @@ function TestWithFormButton(props: Props) {
     const testCapabilities = useSelector(getTestCapabilities);
     const isRenamed = useSelector(isProcessRenamed);
     const testFormParameters: TestFormParameters[] = useSelector(getTestParameters);
-    const scenarioName = useSelector(getProcessId);
+    const scenarioName = useSelector(getProcessName);
     const processToDisplay = useSelector(getProcessToDisplay);
     const findAvailableVariables = useSelector(getFindAvailableVariables);
     const dispatch = useDispatch();

--- a/designer/client/src/containers/Metrics.tsx
+++ b/designer/client/src/containers/Metrics.tsx
@@ -4,31 +4,31 @@ import { useParams } from "react-router-dom";
 import HttpService from "../http/HttpService";
 import { getMetricsSettings } from "../reducers/selectors/settings";
 import { CustomTabWrapper } from "./CustomTabPage";
-import { ProcessId } from "../types";
+import { ProcessName } from "../types";
 
-function useMetricsUrl(processId?: ProcessId): string {
+function useMetricsUrl(processName?: ProcessName): string {
     const [processingType, setProcessingType] = useState("");
     useEffect(() => {
-        if (processId) {
-            HttpService.fetchProcessDetails(processId).then(({ data }) => {
+        if (processName) {
+            HttpService.fetchProcessDetails(processName).then(({ data }) => {
                 setProcessingType(data.processingType);
             });
         } else {
             setProcessingType("");
         }
-    }, [processId]);
+    }, [processName]);
 
     const settings = useSelector(getMetricsSettings);
     return useMemo(() => {
         const dashboard = settings.scenarioTypeToDashboard?.[processingType] || settings.defaultDashboard;
-        const scenarioName = processId || "All";
+        const scenarioName = processName || "All";
         return settings.url?.replace("$dashboard", dashboard).replace("$scenarioName", scenarioName);
-    }, [processId, processingType, settings]);
+    }, [processName, processingType, settings]);
 }
 
 function Metrics(): JSX.Element {
-    const { processId } = useParams<{ processId: string }>();
-    const url = useMetricsUrl(processId);
+    const { processName } = useParams<{ processName: string }>();
+    const url = useMetricsUrl(processName);
     return <CustomTabWrapper tab={{ url, type: "IFrame", accessTokenInQuery: { enabled: true, parameterName: "auth_token" } }} />;
 }
 

--- a/designer/client/src/containers/Notifications.tsx
+++ b/designer/client/src/containers/Notifications.tsx
@@ -11,7 +11,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import DangerousIcon from "@mui/icons-material/Dangerous";
 import { markBackendNotificationRead, updateBackendNotifications } from "../actions/nk/notifications";
 import { displayProcessActivity, loadProcessState } from "../actions/nk";
-import { getProcessId } from "../reducers/selectors/graph";
+import { getProcessName } from "../reducers/selectors/graph";
 import { loadProcessVersions } from "../actions/nk/loadProcessVersions";
 import { useChangeConnectionError } from "./connectionErrorProvider";
 import i18next from "i18next";
@@ -93,7 +93,7 @@ export function Notifications(): JSX.Element {
 
     useEffect(() => HttpService.setNotificationActions(bindActionCreators(NotificationActions, dispatch)));
 
-    const currentScenarioName = useSelector(getProcessId);
+    const currentScenarioName = useSelector(getProcessName);
 
     const refresh = useCallback(() => {
         HttpService.loadBackendNotifications()

--- a/designer/client/src/containers/RootRoutes.tsx
+++ b/designer/client/src/containers/RootRoutes.tsx
@@ -25,7 +25,7 @@ export default createRoutesFromElements(
         <Route index element={<DefaultRedirect />} />
         <Route path="/404" element={<NotFound />} />
         <Route errorElement={<ErrorBoundaryFallbackComponent />}>
-            <Route path={`${VisualizationBasePath}/:id`} element={<Visualization />} />
+            <Route path={`${VisualizationBasePath}/:processName`} element={<Visualization />} />
 
             {/* overrides scenarios custom tab */}
             <Route path={ScenariosBasePath} element={<ScenariosTab />} />
@@ -37,7 +37,7 @@ export default createRoutesFromElements(
             {/* overrides metrics custom tab */}
             <Route path={MetricsBasePath}>
                 <Route index element={<Metrics />} />
-                <Route path=":processId" element={<Metrics />} />
+                <Route path=":processName" element={<Metrics />} />
             </Route>
 
             <Route path="/:id/*" element={<CustomTab />} />

--- a/designer/client/src/containers/Visualization.tsx
+++ b/designer/client/src/containers/Visualization.tsx
@@ -48,24 +48,24 @@ function useUnmountCleanup() {
 function useProcessState(time = 10000) {
     const dispatch = useDispatch();
     const fetchedProcessDetails = useSelector(getFetchedProcessDetails);
-    const { isFragment, isArchived, id } = fetchedProcessDetails || {};
+    const { isFragment, isArchived, name } = fetchedProcessDetails || {};
 
-    const fetch = useCallback(() => dispatch(loadProcessState(id)), [dispatch, id]);
+    const fetch = useCallback(() => dispatch(loadProcessState(name)), [dispatch, name]);
 
     useEffect(() => {
         let processStateIntervalId;
-        if (id && !isFragment && !isArchived) {
+        if (name && !isFragment && !isArchived) {
             processStateIntervalId = setInterval(fetch, time);
         }
         return () => {
             clearInterval(processStateIntervalId);
         };
-    }, [fetch, id, isArchived, isFragment, time]);
+    }, [fetch, name, isArchived, isFragment, time]);
 }
 
 function useCountsIfNeeded() {
     const dispatch = useDispatch();
-    const id = useSelector(getFetchedProcessDetails)?.id;
+    const name = useSelector(getFetchedProcessDetails)?.name;
     const processToDisplay = useSelector(getProcessToDisplay);
 
     const [searchParams] = useSearchParams();
@@ -73,14 +73,14 @@ function useCountsIfNeeded() {
     const to = searchParams.get("to");
     useEffect(() => {
         const countParams = VisualizationUrl.extractCountParams({ from, to });
-        if (id && countParams) {
-            dispatch(fetchAndDisplayProcessCounts(id, countParams.from, countParams.to, processToDisplay));
+        if (name && countParams) {
+            dispatch(fetchAndDisplayProcessCounts(name, countParams.from, countParams.to, processToDisplay));
         }
-    }, [dispatch, from, id, to, processToDisplay]);
+    }, [dispatch, from, name, to, processToDisplay]);
 }
 
 function Visualization() {
-    const { id: processId } = useDecodedParams<{ id: string }>();
+    const { processName } = useDecodedParams<{ processName: string }>();
     const dispatch = useDispatch();
 
     const graphRef = useRef<Graph>();
@@ -114,8 +114,8 @@ function Visualization() {
     }, [getGraphInstance]);
 
     useEffect(() => {
-        fetchData(processId);
-    }, [fetchData, processId]);
+        fetchData(processName);
+    }, [fetchData, processName]);
 
     useProcessState();
     useCountsIfNeeded();

--- a/designer/client/src/containers/hooks/useModalDetailsIfNeeded.tsx
+++ b/designer/client/src/containers/hooks/useModalDetailsIfNeeded.tsx
@@ -5,7 +5,7 @@ import { parseWindowsQueryParams } from "./useSearchQuery";
 import NodeUtils from "../../components/graph/NodeUtils";
 
 export function getFragmentNodesPrefix(fragmentContent: Process) {
-    return fragmentContent ? `${fragmentContent.id}-` : "";
+    return fragmentContent ? `${fragmentContent.name}-` : "";
 }
 
 function removePrefix(input: string, prefix: string): string {
@@ -27,7 +27,7 @@ export function useModalDetailsIfNeeded() {
     const openNodes = useCallback(
         (scenario: Process) => {
             return getNodeIds()
-                .map((id) => NodeUtils.getNodeById(id, scenario) ?? (scenario.id === id && NodeUtils.getProcessProperties(scenario)))
+                .map((id) => NodeUtils.getNodeById(id, scenario) ?? (scenario.name === id && NodeUtils.getProcessPropertiesNode(scenario)))
                 .filter(Boolean)
                 .map((node) => openNodeWindow(node, scenario));
         },

--- a/designer/client/src/containers/processLink.tsx
+++ b/designer/client/src/containers/processLink.tsx
@@ -1,11 +1,11 @@
 import React, { PropsWithChildren } from "react";
 import { visualizationUrl } from "../common/VisualizationUrl";
-import { ProcessId } from "../types";
+import { ProcessName } from "../types";
 import { PlainStyleLink } from "./plainStyleLink";
 
 export function ProcessLink({
-    processId,
+    processName,
     ...props
-}: PropsWithChildren<{ processId: ProcessId; className?: string; title?: string }>): JSX.Element {
-    return <PlainStyleLink to={visualizationUrl(processId)} {...props} />;
+}: PropsWithChildren<{ processName: ProcessName; className?: string; title?: string }>): JSX.Element {
+    return <PlainStyleLink to={visualizationUrl(processName)} {...props} />;
 }

--- a/designer/client/src/reducers/processActivity.ts
+++ b/designer/client/src/reducers/processActivity.ts
@@ -1,12 +1,11 @@
 import { Action } from "../actions/reduxTypes";
 import { Instant } from "../types/common";
-import { ProcessId } from "../types";
+import { ProcessName } from "../types";
 import { ProcessVersionId } from "../components/Process/types";
 
 export type User = string;
 
 export type Attachment = {
-    processId: ProcessId;
     processVersionId: ProcessVersionId;
     id: string;
     createDate: Instant;
@@ -16,7 +15,6 @@ export type Attachment = {
 
 export type Comment = {
     id: number;
-    processId: string;
     processVersionId: string;
     user: User;
     content: string;

--- a/designer/client/src/reducers/selectors/graph.ts
+++ b/designer/client/src/reducers/selectors/graph.ts
@@ -13,8 +13,7 @@ export const getGraph = (state: RootState) => state.graphReducer.history.present
 export const getFetchedProcessDetails = createSelector(getGraph, (g) => g.fetchedProcessDetails);
 export const getProcessToDisplay = createSelector(getGraph, (g) => g.processToDisplay || ({} as Process));
 export const getProcessNodesIds = createSelector(getProcessToDisplay, (p) => NodeUtils.nodesFromProcess(p).map((n) => n.id));
-export const getProcessId = createSelector(getFetchedProcessDetails, (d) => d?.name);
-export const getProcessName = getProcessId;
+export const getProcessName = createSelector(getFetchedProcessDetails, (d) => d?.name);
 export const getProcessUnsavedNewName = createSelector(getGraph, (g) => g?.unsavedNewName);
 export const getProcessVersionId = createSelector(getFetchedProcessDetails, (d) => d?.processVersionId);
 export const getProcessCategory = createSelector(getFetchedProcessDetails, (d) => d?.processCategory || "");
@@ -38,7 +37,7 @@ export const isProcessRenamed = createSelector(
 );
 export const getProcessToDisplayWithUnsavedName = createSelector(
     [getProcessToDisplay, getProcessUnsavedNewName, isProcessRenamed],
-    (process, unsavedName, isProcessRenamed) => ({ ...process, id: isProcessRenamed ? unsavedName : process.id }),
+    (process, unsavedName, isProcessRenamed) => ({ ...process, name: isProcessRenamed ? unsavedName : process.name }),
 );
 
 export const isSaveDisabled = createSelector([isPristine, isLatestProcessVersion], (pristine, latest) => pristine && latest);

--- a/designer/client/src/types/process.ts
+++ b/designer/client/src/types/process.ts
@@ -9,7 +9,7 @@ import { ScenarioPropertyConfig } from "../components/graph/node-modal/ScenarioP
 import { FixedValuesOption } from "../components/graph/node-modal/fragment-input-definition/item";
 
 export type Process = {
-    id: string;
+    name: string;
     nodes: NodeType[];
     edges: Edge[];
     properties: PropertiesType;
@@ -18,7 +18,7 @@ export type Process = {
     category?: string; // optional - see the comment for a field with the same name in DisplayableProcess.scala
 };
 
-export type ProcessId = Process["id"];
+export type ProcessName = Process["name"];
 
 export type Category = string;
 

--- a/designer/client/test/ProcessAttachments-test.js
+++ b/designer/client/test/ProcessAttachments-test.js
@@ -22,7 +22,6 @@ jest.mock("react-i18next", () => ({
 
 const processAttachment = (id) => ({
     id: `${id}`,
-    processId: "proc1",
     processVersionId: 1,
     createDate: "2016-10-10T12:39:44.092",
     user: "TouK",

--- a/designer/client/test/reducer-test.js
+++ b/designer/client/test/reducer-test.js
@@ -2,9 +2,7 @@ import reducer from "../src/reducers/index";
 import NodeUtils from "../src/components/graph/NodeUtils";
 
 const baseProcessState = {
-    id: "DEFGH",
     name: "DEFGH",
-    processVersionId: 23,
     isLatestVersion: true,
     processType: "graph",
     processCategory: "Category1",
@@ -14,7 +12,7 @@ const baseProcessState = {
     tags: [],
     currentlyDeployedAt: ["test"],
     json: {
-        id: "DEFGH",
+        name: "DEFGH",
         properties: {
             parallelism: 3,
             additionalFields: {
@@ -116,7 +114,7 @@ const reduceAll = (actions) => actions.reduce((state, action) => reducer(state, 
 
 describe("Reducer suite", () => {
     it("Display process", () => {
-        expect(baseStateWithProcess.graphReducer.processToDisplay.id).toEqual(baseProcessState.id);
+        expect(baseStateWithProcess.graphReducer.processToDisplay.name).toEqual(baseProcessState.name);
     });
 });
 

--- a/designer/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/ListenerScenarioWithDetails.scala
+++ b/designer/listener-api/src/main/scala/pl/touk/nussknacker/ui/listener/ListenerScenarioWithDetails.scala
@@ -7,8 +7,6 @@ import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, Processin
 import java.time.Instant
 
 trait ListenerScenarioWithDetails {
-  def id: String
-
   def name: ProcessName
 
   def processId: ProcessId

--- a/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/CountsReporter.scala
+++ b/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/CountsReporter.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.processCounts
 
 import com.typesafe.config.Config
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import sttp.client3.SttpBackend
 
 import java.time.format.DateTimeFormatter
@@ -24,7 +25,7 @@ trait CountsReporterCreator {
 
 trait CountsReporter[F[_]] extends AutoCloseable {
 
-  def prepareRawCounts(processId: String, countsRequest: CountsRequest): F[String => Option[Long]]
+  def prepareRawCounts(processName: ProcessName, countsRequest: CountsRequest): F[String => Option[Long]]
 
 }
 

--- a/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxCountsReporter.scala
+++ b/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxCountsReporter.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.processCounts.influxdb
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.processCounts._
 import sttp.client3.SttpBackend
 import sttp.monad.MonadError
@@ -24,28 +25,28 @@ class InfluxCountsReporter[F[_]](env: String, config: InfluxConfig)(implicit bac
 
   private val metricsConfig = config.metricsConfig.getOrElse(MetricsConfig())
 
-  override def prepareRawCounts(processId: String, countsRequest: CountsRequest): F[String => Option[Long]] =
+  override def prepareRawCounts(processName: ProcessName, countsRequest: CountsRequest): F[String => Option[Long]] =
     (countsRequest match {
-      case RangeCount(fromDate, toDate) => prepareRangeCounts(processId, fromDate, toDate)
+      case RangeCount(fromDate, toDate) => prepareRangeCounts(processName, fromDate, toDate)
       case ExecutionCount(pointInTime) =>
-        influxGenerator.queryBySingleDifference(processId, None, pointInTime, metricsConfig)
+        influxGenerator.queryBySingleDifference(processName, None, pointInTime, metricsConfig)
     }).map(_.get)
 
   override def close(): Unit = {}
 
-  private def prepareRangeCounts(processId: String, fromDate: Instant, toDate: Instant): F[Map[String, Long]] = {
+  private def prepareRangeCounts(processName: ProcessName, fromDate: Instant, toDate: Instant): F[Map[String, Long]] = {
 
-    influxGenerator.detectRestarts(processId, fromDate, toDate, metricsConfig).flatMap { restarts =>
+    influxGenerator.detectRestarts(processName, fromDate, toDate, metricsConfig).flatMap { restarts =>
       (restarts, config.queryMode) match {
         case (_, QueryMode.OnlySumOfDifferences) =>
-          influxGenerator.queryBySumOfDifferences(processId, fromDate, toDate, metricsConfig)
+          influxGenerator.queryBySumOfDifferences(processName, fromDate, toDate, metricsConfig)
         case (Nil, QueryMode.SumOfDifferencesForRestarts) =>
-          influxGenerator.queryBySingleDifference(processId, Some(fromDate), toDate, metricsConfig)
+          influxGenerator.queryBySingleDifference(processName, Some(fromDate), toDate, metricsConfig)
         case (nonEmpty, QueryMode.SumOfDifferencesForRestarts) =>
           logger.debug(s"Restarts detected: ${nonEmpty.mkString(",")}, querying with differential")
-          influxGenerator.queryBySumOfDifferences(processId, fromDate, toDate, metricsConfig)
+          influxGenerator.queryBySumOfDifferences(processName, fromDate, toDate, metricsConfig)
         case (Nil, QueryMode.OnlySingleDifference) =>
-          influxGenerator.queryBySingleDifference(processId, Some(fromDate), toDate, metricsConfig)
+          influxGenerator.queryBySingleDifference(processName, Some(fromDate), toDate, metricsConfig)
         case (dates, QueryMode.OnlySingleDifference) =>
           monadError.error(CannotFetchCountsError.restartsDetected(dates))
         // should not happen, unfortunately scalac cannot detect that all enum values were handled...

--- a/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxGenerator.scala
+++ b/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxGenerator.scala
@@ -6,6 +6,8 @@ import sttp.client3.SttpBackend
 import sttp.monad.MonadError
 import sttp.monad.syntax._
 import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.api.process.ProcessName
+
 import scala.language.higherKinds
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 
@@ -19,7 +21,7 @@ private[influxdb] class InfluxGenerator[F[_]](config: InfluxConfig, env: String)
   private val influxClient = new SimpleInfluxClient(config)
 
   def queryBySingleDifference(
-      processName: String,
+      processName: ProcessName,
       dateFrom: Option[Instant],
       dateTo: Instant,
       config: MetricsConfig
@@ -37,7 +39,7 @@ private[influxdb] class InfluxGenerator[F[_]](config: InfluxConfig, env: String)
   }
 
   def queryBySumOfDifferences(
-      processName: String,
+      processName: ProcessName,
       dateFrom: Instant,
       dateTo: Instant,
       config: MetricsConfig
@@ -51,7 +53,7 @@ private[influxdb] class InfluxGenerator[F[_]](config: InfluxConfig, env: String)
   }
 
   def detectRestarts(
-      processName: String,
+      processName: ProcessName,
       dateFrom: Instant,
       dateTo: Instant,
       config: MetricsConfig
@@ -115,7 +117,7 @@ object InfluxGenerator extends LazyLogging {
   // TODO: probably we should just take one of them, but the one which is closer to t1?
   class PointInTimeQuery[F[_]: MonadError](
       invokeQuery: String => F[List[InfluxSeries]],
-      processName: String,
+      processName: ProcessName,
       env: String,
       config: MetricsConfig
   ) extends LazyLogging {

--- a/designer/processReports/src/test/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxGeneratorSpec.scala
+++ b/designer/processReports/src/test/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxGeneratorSpec.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.processCounts.influxdb
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.CirceUtil
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.test.PatientScalaFutures
 import sttp.client3.Identity
 import sttp.client3.monad.IdMonad
@@ -17,7 +18,7 @@ class InfluxGeneratorSpec extends AnyFunSuite with Matchers with PatientScalaFut
   test("Point in time query returns correct results") {
 
     val pointInTimeQuery =
-      new PointInTimeQuery[Identity](_ => sampleInfluxOutput, "process1", "test", MetricsConfig())(IdMonad)
+      new PointInTimeQuery[Identity](_ => sampleInfluxOutput, ProcessName("process1"), "test", MetricsConfig())(IdMonad)
 
     pointInTimeQuery.query(Instant.now()) shouldBe Map(
       "start" -> (552855221L + 557871409L),

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/component/ComponentApiEndpoints.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/component/ComponentApiEndpoints.scala
@@ -75,9 +75,7 @@ class ComponentApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseEn
                 summary = Some("List component usages"),
                 value = List(
                   ComponentUsagesInScenario(
-                    id = "scenario1",
                     name = ProcessName("scenario1"),
-                    processId = ProcessId(1),
                     nodesUsagesData = List(
                       ScenarioUsageData("csv-source")
                     ),
@@ -113,9 +111,7 @@ class ComponentApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseEn
                 summary = Some("List component usages with no last Action"),
                 value = List(
                   ComponentUsagesInScenario(
-                    id = "scenario1",
                     name = ProcessName("scenario1"),
-                    processId = ProcessId(1),
                     nodesUsagesData = List(
                       ScenarioUsageData("csv-source")
                     ),

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/component/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/component/package.scala
@@ -61,9 +61,7 @@ package object component {
 
   @JsonCodec
   final case class ComponentUsagesInScenario(
-      id: String,
       name: ProcessName,
-      processId: ProcessId,
       nodesUsagesData: List[NodeUsageData],
       isFragment: Boolean,
       processCategory: String,

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/process/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/process/package.scala
@@ -9,8 +9,8 @@ package object process {
   @JsonCodec final case class UpdateProcessCategoryResponse(oldCategory: String, newCategory: String)
 
   object UpdateProcessNameResponse {
-    def create(oldNameString: String, newNameString: String): UpdateProcessNameResponse =
-      UpdateProcessNameResponse(ProcessName(oldNameString), ProcessName(newNameString))
+    def create(oldNameString: ProcessName, newNameString: ProcessName): UpdateProcessNameResponse =
+      UpdateProcessNameResponse(oldNameString, newNameString)
   }
 
   @JsonCodec final case class UpdateProcessNameResponse(oldName: ProcessName, newName: ProcessName)

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/scenariodetails/ScenarioWithDetails.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/scenariodetails/ScenarioWithDetails.scala
@@ -1,25 +1,18 @@
 package pl.touk.nussknacker.restmodel.scenariodetails
 
-import io.circe.generic.JsonCodec
+import io.circe.{Decoder, Encoder}
 import pl.touk.nussknacker.engine.api.deployment.{ProcessAction, ProcessState}
 import pl.touk.nussknacker.engine.api.displayedgraph.DisplayableProcess
-import pl.touk.nussknacker.engine.api.process.{
-  ProcessId => ApiProcessId,
-  ProcessIdWithName,
-  ProcessName,
-  ProcessingType,
-  ScenarioVersion,
-  VersionId
-}
+import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.restmodel.validation.{ValidatedDisplayableProcess, ValidationResults}
 
 import java.time.Instant
 
-@JsonCodec
 final case class ScenarioWithDetails(
-    id: String,
     name: ProcessName,
-    processId: ApiProcessId,
+    // TODO: This field is not passed to FE as we always use ProcessName in our API (see the encoder below)
+    //       We should use entity in places where it is used on BE side or extract another class for DTO without this field
+    processId: Option[ProcessId],
     processVersionId: VersionId,
     isLatestVersion: Boolean,
     description: Option[String],
@@ -43,8 +36,6 @@ final case class ScenarioWithDetails(
     state: Option[ProcessState]
 ) {
 
-  lazy val idWithName: ProcessIdWithName = ProcessIdWithName(processId, name)
-
   def withScenarioGraphAndValidationResult(
       scenarioWithValidationResult: ValidatedDisplayableProcess
   ): ScenarioWithDetails = {
@@ -64,5 +55,20 @@ final case class ScenarioWithDetails(
 
   def scenarioGraphAndValidationResultUnsafe: ValidatedDisplayableProcess =
     json.getOrElse(throw new IllegalStateException("Missing scenario graph and validation result"))
+
+  def processIdUnsafe: ProcessId = processId.getOrElse(throw new IllegalStateException("Missing processId"))
+
+}
+
+object ScenarioWithDetails {
+
+  import io.circe.generic.semiauto._
+
+  implicit val encoder: Encoder[ScenarioWithDetails] =
+    deriveEncoder[ScenarioWithDetails]
+      .contramap[ScenarioWithDetails](_.copy(processId = None))
+
+  implicit val decoder: Decoder[ScenarioWithDetails] =
+    deriveDecoder[ScenarioWithDetails]
 
 }

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -62,7 +62,7 @@ object PrettyValidationErrors {
         node(
           message,
           description,
-          fieldName = Some(CanonicalProcess.IdFieldName),
+          fieldName = Some(CanonicalProcess.NameFieldName),
         )
       case SpecificDataValidationError(field, message) => node(message, message, fieldName = Some(field))
       case NonUniqueEdgeType(etype, nodeId) =>
@@ -245,11 +245,11 @@ object PrettyValidationErrors {
 
   private def mapIdErrorToNodeError(error: IdError) = {
     val validatedObjectType = error match {
-      case ScenarioIdError(_, _, isFragment) => if (isFragment) "Fragment" else "Scenario"
-      case NodeIdValidationError(_, _)       => "Node"
+      case ScenarioNameError(_, _, isFragment) => if (isFragment) "Fragment" else "Scenario"
+      case NodeIdValidationError(_, _)         => "Node"
     }
     val errorSeverity = error match {
-      case ScenarioIdError(_, _, _) => NodeValidationErrorType.SaveAllowed
+      case ScenarioNameError(_, _, _) => NodeValidationErrorType.SaveAllowed
       case NodeIdValidationError(errorType, _) =>
         errorType match {
           case ProcessCompilationError.EmptyValue | IllegalCharactersId(_) => NodeValidationErrorType.RenderNotAllowed
@@ -257,7 +257,7 @@ object PrettyValidationErrors {
         }
     }
     val fieldName = error match {
-      case ScenarioIdError(_, _, _)    => CanonicalProcess.IdFieldName
+      case ScenarioNameError(_, _, _)  => CanonicalProcess.NameFieldName
       case NodeIdValidationError(_, _) => pl.touk.nussknacker.engine.graph.node.IdFieldName
     }
     val message = error.errorType match {

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/ValidatedDisplayableProcess.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/ValidatedDisplayableProcess.scala
@@ -4,23 +4,24 @@ import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.engine.api.CirceUtil._
 import pl.touk.nussknacker.engine.api.displayedgraph.displayablenode.Edge
 import pl.touk.nussknacker.engine.api.displayedgraph.{DisplayableProcess, ProcessProperties}
-import pl.touk.nussknacker.engine.api.process.ProcessingType
+import pl.touk.nussknacker.engine.api.process.{ProcessName, ProcessingType}
 import pl.touk.nussknacker.engine.graph.node.NodeData
 import pl.touk.nussknacker.engine.graph.node.NodeData._
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationResult
 
 @JsonCodec final case class ValidatedDisplayableProcess(
-    id: String,
+    // TODO: remove - it is already available in ScenarioWithDetails
+    name: ProcessName,
     properties: ProcessProperties,
     nodes: List[NodeData],
     edges: List[Edge],
-    // TODO: remove both processingType and category
+    // TODO: remove both processingType and category - they are already available in ScenarioWithDetails
     processingType: ProcessingType,
     category: String,
     validationResult: Option[ValidationResult]
 ) {
 
-  def toDisplayable: DisplayableProcess = DisplayableProcess(id, properties, nodes, edges, processingType, category)
+  def toDisplayable: DisplayableProcess = DisplayableProcess(name, properties, nodes, edges, processingType, category)
 
 }
 
@@ -31,7 +32,7 @@ object ValidatedDisplayableProcess {
       validationResult: ValidationResult
   ): ValidatedDisplayableProcess =
     new ValidatedDisplayableProcess(
-      displayableProcess.id,
+      displayableProcess.name,
       displayableProcess.properties,
       displayableProcess.nodes,
       displayableProcess.edges,
@@ -42,7 +43,7 @@ object ValidatedDisplayableProcess {
 
   def withEmptyValidationResult(displayableProcess: DisplayableProcess): ValidatedDisplayableProcess =
     new ValidatedDisplayableProcess(
-      displayableProcess.id,
+      displayableProcess.name,
       displayableProcess.properties,
       displayableProcess.nodes,
       displayableProcess.edges,

--- a/designer/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/NodeDataCodecSpec.scala
+++ b/designer/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/NodeDataCodecSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.displayedgraph.displayablenode.Edge
 import pl.touk.nussknacker.engine.api.displayedgraph.{DisplayableProcess, ProcessProperties}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.{ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.graph.evaluatedparam.{Parameter => NodeParameter}
 import pl.touk.nussknacker.engine.graph.expression.Expression
@@ -16,7 +17,7 @@ class NodeDataCodecSpec extends AnyFunSuite with Matchers with EitherValuesDetai
 
   test("displayable process encode and decode") {
     val process = DisplayableProcess(
-      "",
+      ProcessName(""),
       ProcessProperties.combineTypeSpecificProperties(
         StreamMetaData(),
         ProcessAdditionalFields(Some("a"), Map("field1" -> "value1"), StreamMetaData.typeName)
@@ -54,13 +55,13 @@ class NodeDataCodecSpec extends AnyFunSuite with Matchers with EitherValuesDetai
   }
 
   test("decode displayable process in legacy format with typeSpecificProperties") {
-    val givenProcessName    = "foo1"
+    val givenProcessName    = ProcessName("foo1")
     val givenProcessingType = "fooProcessingType"
     val givenCategory       = "FooCategory"
     val givenParallelism    = 10
     val legacyJsonWithNoFields =
       s"""{
-         |  "id" : "$givenProcessName",
+         |  "name" : "$givenProcessName",
          |  "properties" : {
          |    "typeSpecificProperties" : {
          |      "parallelism" : $givenParallelism,

--- a/designer/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrorsTest.scala
+++ b/designer/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrorsTest.scala
@@ -13,9 +13,10 @@ import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{
   IllegalCharactersId,
   LeadingSpacesId,
   NodeIdValidationError,
-  ScenarioIdError,
+  ScenarioNameError,
   TrailingSpacesId
 }
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeValidationErrorType
 
 class PrettyValidationErrorsTest extends AnyFunSuite with Matchers with Inside {
@@ -39,7 +40,7 @@ class PrettyValidationErrorsTest extends AnyFunSuite with Matchers with Inside {
               formattedErrorType shouldBe NodeValidationErrorType.RenderNotAllowed
             case _ => formattedErrorType shouldBe NodeValidationErrorType.SaveAllowed
           }
-        case ScenarioIdError(_, _, _) => formattedErrorType shouldBe NodeValidationErrorType.SaveAllowed
+        case ScenarioNameError(_, _, _) => formattedErrorType shouldBe NodeValidationErrorType.SaveAllowed
       }
     }
   }
@@ -48,29 +49,29 @@ class PrettyValidationErrorsTest extends AnyFunSuite with Matchers with Inside {
 
 object IdErrorTestData {
 
-  val emptyIdScenarioError: ScenarioIdError   = ScenarioIdError(EmptyValue, "", isFragment = false)
-  val emptyIdFragmentError: ScenarioIdError   = ScenarioIdError(EmptyValue, "", isFragment = true)
+  val emptyIdScenarioError: ScenarioNameError = ScenarioNameError(EmptyValue, ProcessName(""), isFragment = false)
+  val emptyIdFragmentError: ScenarioNameError = ScenarioNameError(EmptyValue, ProcessName(""), isFragment = true)
   val emptyIdNodeError: NodeIdValidationError = NodeIdValidationError(EmptyValue, "")
 
-  val blankIdScenarioError: ScenarioIdError   = ScenarioIdError(BlankId, " ", isFragment = false)
-  val blankIdFragmentError: ScenarioIdError   = ScenarioIdError(BlankId, " ", isFragment = true)
+  val blankIdScenarioError: ScenarioNameError = ScenarioNameError(BlankId, ProcessName(" "), isFragment = false)
+  val blankIdFragmentError: ScenarioNameError = ScenarioNameError(BlankId, ProcessName(" "), isFragment = true)
   val blankIdNodeError: NodeIdValidationError = NodeIdValidationError(BlankId, " ")
 
-  val leadingSpacesIdScenarioError: ScenarioIdError =
-    ScenarioIdError(LeadingSpacesId, " leadingSpace", isFragment = false)
-  val leadingSpacesIdFragmentError: ScenarioIdError =
-    ScenarioIdError(LeadingSpacesId, " leadingSpace", isFragment = true)
+  val leadingSpacesIdScenarioError: ScenarioNameError =
+    ScenarioNameError(LeadingSpacesId, ProcessName(" leadingSpace"), isFragment = false)
+  val leadingSpacesIdFragmentError: ScenarioNameError =
+    ScenarioNameError(LeadingSpacesId, ProcessName(" leadingSpace"), isFragment = true)
   val leadingSpacesIdNodeError: NodeIdValidationError = NodeIdValidationError(LeadingSpacesId, " leadingSpace")
 
-  val trailingSpacesIdScenarioError: ScenarioIdError =
-    ScenarioIdError(TrailingSpacesId, "trailingSpace ", isFragment = false)
-  val trailingSpacesIdFragmentError: ScenarioIdError =
-    ScenarioIdError(TrailingSpacesId, "trailingSpace ", isFragment = true)
+  val trailingSpacesIdScenarioError: ScenarioNameError =
+    ScenarioNameError(TrailingSpacesId, ProcessName("trailingSpace "), isFragment = false)
+  val trailingSpacesIdFragmentError: ScenarioNameError =
+    ScenarioNameError(TrailingSpacesId, ProcessName("trailingSpace "), isFragment = true)
   val trailingSpacesIdNodeError: NodeIdValidationError = NodeIdValidationError(TrailingSpacesId, "trailingSpace ")
 
   val illegalCharsReadable = "Some illegal character (x), another illegal character (!)"
-  val illegalCharactersIdScenarioError: ScenarioIdError =
-    ScenarioIdError(IllegalCharactersId(illegalCharsReadable), "idWithIllegalChars!", isFragment = false)
+  val illegalCharactersIdScenarioError: ScenarioNameError =
+    ScenarioNameError(IllegalCharactersId(illegalCharsReadable), ProcessName("idWithIllegalChars!"), isFragment = false)
   val illegalCharactersIdNodeError: NodeIdValidationError =
     NodeIdValidationError(IllegalCharactersId(illegalCharsReadable), "idWithIllegalChars!")
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -19,6 +19,7 @@ import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 import pl.touk.nussknacker.engine.testmode.TestProcess.{ExpressionInvocationResult, _}
 import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
 import pl.touk.nussknacker.engine.api.displayedgraph.DisplayableProcess
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.restmodel.{CustomActionRequest, CustomActionResponse}
 import pl.touk.nussknacker.ui.BadRequestError
 import pl.touk.nussknacker.ui.api.NodesResources.prepareTestFromParametersDecoder
@@ -153,7 +154,7 @@ class ManagementResources(
 
   def securedRoute(implicit user: LoggedUser): Route = {
     pathPrefix("adminProcessManagement") {
-      path("snapshot" / Segment) { processName =>
+      path("snapshot" / ProcessNameSegment) { processName =>
         (post & processId(processName) & parameters(Symbol("savepointDir").?)) { (processId, savepointDir) =>
           canDeploy(processId) {
             complete {
@@ -166,7 +167,7 @@ class ManagementResources(
           }
         }
       } ~
-        path("stop" / Segment) { processName =>
+        path("stop" / ProcessNameSegment) { processName =>
           (post & processId(processName) & parameters(Symbol("savepointDir").?)) { (processId, savepointDir) =>
             canDeploy(processId) {
               complete {
@@ -179,7 +180,7 @@ class ManagementResources(
             }
           }
         } ~
-        path("deploy" / Segment) { processName =>
+        path("deploy" / ProcessNameSegment) { processName =>
           (post & processId(processName) & parameters(Symbol("savepointPath"))) { (processId, savepointPath) =>
             canDeploy(processId) {
               withDeploymentComment { deploymentComment =>
@@ -194,7 +195,7 @@ class ManagementResources(
         }
     } ~
       pathPrefix("processManagement") {
-        path("deploy" / Segment) { processName =>
+        path("deploy" / ProcessNameSegment) { processName =>
           (post & processId(processName)) { processId =>
             canDeploy(processId) {
               withDeploymentComment { deploymentComment =>
@@ -209,7 +210,7 @@ class ManagementResources(
             }
           }
         } ~
-          path("cancel" / Segment) { processName =>
+          path("cancel" / ProcessNameSegment) { processName =>
             (post & processId(processName)) { processId =>
               canDeploy(processId) {
                 withDeploymentComment { deploymentComment =>
@@ -223,7 +224,7 @@ class ManagementResources(
             }
           } ~
           // TODO: maybe Write permission is enough here?
-          path("test" / Segment) { processName =>
+          path("test" / ProcessNameSegment) { processName =>
             (post & processId(processName)) { idWithName =>
               canDeploy(idWithName.id) {
                 formFields(Symbol("testData"), Symbol("processJson")) { (testDataContent, displayableProcessJson) =>
@@ -253,7 +254,7 @@ class ManagementResources(
             {
               (post & entity(as[DisplayableProcess])) { displayableProcess =>
                 {
-                  processId(displayableProcess.id) { idWithName =>
+                  processId(displayableProcess.name) { idWithName =>
                     canDeploy(idWithName) {
                       complete {
                         measureTime("generateAndTest", metricRegistry) {
@@ -278,7 +279,7 @@ class ManagementResources(
               }
             }
           } ~
-          path("testWithParameters" / Segment) { processName =>
+          path("testWithParameters" / ProcessNameSegment) { processName =>
             {
               (post & processDetailsForName(processName)) { process =>
                 val modelData = typeToConfig.forTypeUnsafe(process.processingType)
@@ -286,7 +287,7 @@ class ManagementResources(
                   prepareTestFromParametersDecoder(modelData)
                 (post & entity(as[TestFromParametersRequest])) { testParametersRequest =>
                   {
-                    processId(testParametersRequest.displayableProcess.id) { idWithName =>
+                    processId(testParametersRequest.displayableProcess.name) { idWithName =>
                       canDeploy(idWithName) {
                         complete {
                           scenarioTestService
@@ -306,7 +307,7 @@ class ManagementResources(
               }
             }
           } ~
-          path("customAction" / Segment) { processName =>
+          path("customAction" / ProcessNameSegment) { processName =>
             (post & processId(processName) & entity(as[CustomActionRequest])) { (process, req) =>
               val params = req.params.getOrElse(Map.empty)
               complete {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessAttachmentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessAttachmentService.scala
@@ -38,7 +38,7 @@ class ProcessAttachmentService(config: AttachmentsConfig, processActivityReposit
 
   def readAttachment(
       attachmentId: Long
-  )(implicit ec: ExecutionContext, loggedUser: LoggedUser): Future[Option[AttachmentDataWithName]] = {
+  )(implicit ec: ExecutionContext): Future[Option[AttachmentDataWithName]] = {
     val attachmentFutureOpt = processActivityRepository.findAttachment(attachmentId)
     CatsSyntax.futureOpt.map(attachmentFutureOpt) { attachment =>
       (attachment.fileName, attachment.data)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessDirectives.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessDirectives.scala
@@ -6,17 +6,18 @@ import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
 import pl.touk.nussknacker.ui.process.ProcessService
 import pl.touk.nussknacker.ui.process.ProcessService.GetScenarioWithDetailsOptions
 import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.util.NuPathMatchers
 
 import scala.concurrent.ExecutionContext
 
-trait ProcessDirectives {
+trait ProcessDirectives extends NuPathMatchers {
   import akka.http.scaladsl.server.Directives._
 
   protected val processService: ProcessService
   implicit val ec: ExecutionContext
 
   def processDetailsForName(
-      processName: String
+      processName: ProcessName
   )(implicit loggedUser: LoggedUser): Directive1[ScenarioWithDetails] = {
     processId(processName).flatMap { processIdWithName =>
       onSuccess(
@@ -25,9 +26,9 @@ trait ProcessDirectives {
     }
   }
 
-  def processId(processName: String): Directive1[ProcessIdWithName] = {
-    onSuccess(processService.getProcessId(ProcessName(processName)))
-      .map(ProcessIdWithName(_, ProcessName(processName)))
+  def processId(processName: ProcessName): Directive1[ProcessIdWithName] = {
+    onSuccess(processService.getProcessId(processName))
+      .map(ProcessIdWithName(_, processName))
       .flatMap(provide)
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessReportResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessReportResources.scala
@@ -9,6 +9,7 @@ import akka.stream.Materializer
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.syntax._
 import pl.touk.nussknacker.engine.api.displayedgraph.DisplayableProcess
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.processCounts._
 import pl.touk.nussknacker.ui.process.ProcessService
 import pl.touk.nussknacker.ui.process.marshall.ProcessConverter
@@ -40,7 +41,7 @@ class ProcessReportResources(
   }
 
   def securedRoute(implicit loggedUser: LoggedUser): Route = {
-    path("processCounts" / Segment) { processName =>
+    path("processCounts" / ProcessNameSegment) { processName =>
       (get & processId(processName) & parameters(
         Symbol("dateFrom").as[Instant].optional,
         Symbol("dateTo").as[Instant].optional
@@ -75,7 +76,7 @@ class ProcessReportResources(
       countsRequest: CountsRequest
   )(implicit loggedUser: LoggedUser): Future[ToResponseMarshallable] = {
     countsReporter
-      .prepareRawCounts(process.id, countsRequest)
+      .prepareRawCounts(process.name, countsRequest)
       .map(computeFinalCounts(process, _))
       .recover { case CannotFetchCountsError(msg) =>
         HttpResponse(status = StatusCodes.BadRequest, entity = msg)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResources.scala
@@ -9,7 +9,7 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.Encoder
 import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.engine.api.displayedgraph.DisplayableProcess
-import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, VersionId}
+import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName, VersionId}
 import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
 import pl.touk.nussknacker.ui.NuDesignerError
 import pl.touk.nussknacker.ui.NuDesignerError.XError
@@ -35,6 +35,7 @@ class RemoteEnvironmentResources(
 
   def securedRoute(implicit user: LoggedUser): Route = {
     pathPrefix("remoteEnvironment") {
+      // TODO: remove this endpoint, it isn't used anywhere
       path("compare") {
         get {
           complete {
@@ -48,25 +49,26 @@ class RemoteEnvironmentResources(
           }
         }
       } ~
-        path(Segment / VersionIdSegment / "compare" / VersionIdSegment) { (processName, version, otherVersion) =>
-          (get & processId(processName)) { processIdWithName =>
-            complete {
-              withProcess(
-                processIdWithName,
-                version,
-                (process, _) => remoteEnvironment.compare(process, Some(otherVersion))
-              )
+        path(ProcessNameSegment / VersionIdSegment / "compare" / VersionIdSegment) {
+          (processName, version, otherVersion) =>
+            (get & processId(processName)) { processIdWithName =>
+              complete {
+                withProcess(
+                  processIdWithName,
+                  version,
+                  (process, _) => remoteEnvironment.compare(process, Some(otherVersion))
+                )
+              }
             }
-          }
         } ~
-        path(Segment / VersionIdSegment / "migrate") { (processName, version) =>
+        path(ProcessNameSegment / VersionIdSegment / "migrate") { (processName, version) =>
           (post & processId(processName)) { processIdWithName =>
             complete {
               withProcess(processIdWithName, version, remoteEnvironment.migrate)
             }
           }
         } ~
-        path(Segment / "versions") { processName =>
+        path(ProcessNameSegment / "versions") { processName =>
           (get & processId(processName)) { processId =>
             complete {
               remoteEnvironment.processVersions(processId.name)
@@ -107,9 +109,9 @@ class RemoteEnvironmentResources(
       process: DisplayableProcess
   )(implicit ec: ExecutionContext): Future[XError[ProcessDifference]] = {
     remoteEnvironment.compare(process, None).map {
-      case Right(differences) => Right(ProcessDifference(process.id, presentOnOther = true, differences))
+      case Right(differences) => Right(ProcessDifference(process.name, presentOnOther = true, differences))
       case Left(RemoteEnvironmentCommunicationError(StatusCodes.NotFound, _)) =>
-        Right(ProcessDifference(process.id, presentOnOther = false, Map()))
+        Right(ProcessDifference(process.name, presentOnOther = false, Map()))
       case Left(error) => Left(error)
     }
   }
@@ -120,9 +122,10 @@ class RemoteEnvironmentResources(
 @JsonCodec final case class EnvironmentComparisonResult(processDifferences: List[ProcessDifference])
 
 @JsonCodec final case class ProcessDifference(
-    id: String,
+    id: ProcessName,
     presentOnOther: Boolean,
     differences: Map[String, ProcessComparator.Difference]
 ) {
+
   def areSame: Boolean = presentOnOther && differences.isEmpty
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestInfoResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestInfoResources.scala
@@ -32,7 +32,7 @@ class TestInfoResources(
     pathPrefix("testInfo") {
       post {
         entity(as[DisplayableProcess]) { displayableProcess =>
-          processId(displayableProcess.id) { idWithName =>
+          processId(displayableProcess.name) { idWithName =>
             canDeploy(idWithName.id) {
               path("capabilities") {
                 complete {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentDefinitionPreparer.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentDefinitionPreparer.scala
@@ -302,7 +302,7 @@ object ComponentDefinitionPreparer {
           }
           // TODO: enable choice of output type
           NodeEdges(
-            ComponentInfo(ComponentType.Fragment, process.metaData.id),
+            ComponentInfo(ComponentType.Fragment, process.name.value),
             outputs.map(EdgeType.FragmentOutput),
             canChooseNodes = false,
             isForInputDefinition = false

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/component/ComponentService.scala
@@ -57,9 +57,7 @@ object DefaultComponentService {
       nodesUsagesData: List[NodeUsageData]
   ): ComponentUsagesInScenario =
     ComponentUsagesInScenario(
-      id = process.id, // Right now we assume that scenario id is name..
-      name = process.idWithName.name,
-      processId = process.processId,
+      name = process.name,
       nodesUsagesData = nodesUsagesData,
       isFragment = process.isFragment,
       processCategory = process.processCategory,
@@ -119,7 +117,7 @@ class DefaultComponentService(
             Right(
               data
                 .map { case (process, nodesUsagesData) => toComponentUsagesInScenario(process, nodesUsagesData) }
-                .sortBy(_.id)
+                .sortBy(_.name.value)
             )
           )
           .getOrElse(Left(ComponentNotFoundError(componentId)))

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactory.scala
@@ -155,7 +155,7 @@ object UIProcessObjectsFactory {
       details    <- fragmentsDetails
       definition <- definitionExtractor.extractFragmentComponentDefinition(details.canonical).toOption
     } yield {
-      details.canonical.id -> definition.toStaticDefinition(details.category)
+      details.canonical.name.value -> definition.toStaticDefinition(details.category)
     }).toMap
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/notifications/Notification.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/notifications/Notification.scala
@@ -34,7 +34,7 @@ object Notification {
     Notification(
       id,
       Some(name),
-      s"${displayableActionName(actionType)} of ${name.value} failed" + failureMessageOpt
+      s"${displayableActionName(actionType)} of $name failed" + failureMessageOpt
         .map(" with reason: " + _)
         .getOrElse(""),
       Some(NotificationType.error),

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/NewProcessPreparer.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/NewProcessPreparer.scala
@@ -31,16 +31,16 @@ class NewProcessPreparer(
     additionalFields: ProcessingTypeDataProvider[Map[String, ScenarioPropertyConfig], _]
 ) {
 
-  def prepareEmptyProcess(processId: String, processingType: ProcessingType, isFragment: Boolean)(
+  def prepareEmptyProcess(processName: ProcessName, processingType: ProcessingType, isFragment: Boolean)(
       implicit user: LoggedUser
   ): CanonicalProcess = {
     val creator = emptyProcessCreate.forTypeUnsafe(processingType)
     val initialProperties = additionalFields.forTypeUnsafe(processingType).map { case (key, config) =>
       (key, config.defaultValue.getOrElse(""))
     }
-    val name = ProcessName(processId)
     val initialMetadata =
-      if (isFragment) MetaData(name.value, initialFragmentFields) else creator.create(name, initialProperties)
+      if (isFragment) MetaData(processName.value, initialFragmentFields)
+      else creator.create(processName, initialProperties)
 
     val emptyCanonical = CanonicalProcess(
       metaData = initialMetadata,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ScenarioWithDetailsConversions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ScenarioWithDetailsConversions.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.ui.process
 
 import pl.touk.nussknacker.engine.api.displayedgraph.DisplayableProcess
+import pl.touk.nussknacker.engine.api.process.ProcessId
 import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
 import pl.touk.nussknacker.restmodel.validation.ValidatedDisplayableProcess
 import pl.touk.nussknacker.ui.process.repository.ScenarioWithDetailsEntity
@@ -23,9 +24,8 @@ object ScenarioWithDetailsConversions {
       details: ScenarioWithDetailsEntity[_]
   ): ScenarioWithDetails = {
     ScenarioWithDetails(
-      id = details.id,
       name = details.name,
-      processId = details.processId,
+      processId = Some(details.processId),
       processVersionId = details.processVersionId,
       isLatestVersion = details.isLatestVersion,
       description = details.description,
@@ -62,9 +62,10 @@ object ScenarioWithDetailsConversions {
 
     private def toEntity[T](prepareJson: => T): ScenarioWithDetailsEntity[T] = {
       ScenarioWithDetailsEntity(
-        id = scenarioWithDetails.id,
         name = scenarioWithDetails.name,
-        processId = scenarioWithDetails.processId,
+        // We can't just use processIdUnsafe because it is used also for testMigrations which gets ScenarioWithDetails
+        // via REST API so this information will be missing
+        processId = scenarioWithDetails.processId.getOrElse(ProcessId(-1)),
         processVersionId = scenarioWithDetails.processVersionId,
         isLatestVersion = scenarioWithDetails.isLatestVersion,
         description = scenarioWithDetails.description,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentServiceImpl.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentServiceImpl.scala
@@ -92,7 +92,7 @@ class DeploymentServiceImpl(
           }
         deployedScenarioDataTry match {
           case Failure(exception) =>
-            logger.error(s"Exception during resolving deployed scenario ${details.id}", exception)
+            logger.error(s"Exception during resolving deployed scenario ${details.name}", exception)
             None
           case Success(value) => Some(Future.successful(value))
         }
@@ -250,9 +250,9 @@ class DeploymentServiceImpl(
       processDetails: ScenarioWithDetailsEntity[PS]
   ): Unit = {
     if (processDetails.isArchived) {
-      throw ProcessIllegalAction.archived(actionType, processDetails.idWithName)
+      throw ProcessIllegalAction.archived(actionType, processDetails.name)
     } else if (processDetails.isFragment) {
-      throw ProcessIllegalAction.fragment(actionType, processDetails.idWithName)
+      throw ProcessIllegalAction.fragment(actionType, processDetails.name)
     }
   }
 
@@ -263,7 +263,7 @@ class DeploymentServiceImpl(
   ): Unit = {
     if (!ps.allowedActions.contains(actionType)) {
       logger.debug(s"Action: $actionType on process: ${processDetails.name} not allowed in ${ps.status} state")
-      throw ProcessIllegalAction(actionType, processDetails.idWithName, ps)
+      throw ProcessIllegalAction(actionType, processDetails.name, ps)
     }
   }
 
@@ -369,7 +369,7 @@ class DeploymentServiceImpl(
             case process =>
               getProcessState(
                 process.toEntity,
-                actionsInProgress.getOrElse(process.processId, Set.empty)
+                actionsInProgress.getOrElse(process.processIdUnsafe, Set.empty)
               ).map(state => process.copy(state = Some(state)))
           }
           .sequence[DB, ScenarioWithDetails]
@@ -385,7 +385,9 @@ class DeploymentServiceImpl(
     processTraverse.toList match {
       case Nil => DBIO.successful(Map.empty)
       case head :: Nil =>
-        actionRepository.getInProgressActionTypes(head.processId).map(actionTypes => Map(head.processId -> actionTypes))
+        actionRepository
+          .getInProgressActionTypes(head.processIdUnsafe)
+          .map(actionTypes => Map(head.processIdUnsafe -> actionTypes))
       case _ =>
         // We are getting only Deploy and Cancel InProgress actions as only these two impact ProcessState
         actionRepository.getInProgressActionTypes(Set(Deploy, Cancel))
@@ -506,7 +508,7 @@ class DeploymentServiceImpl(
   ): Future[Option[ProcessAction]] = {
     implicit val user: AdminUser            = NussknackerInternalUser.instance
     implicit val listenerUser: ListenerUser = ListenerApiUser(user)
-    logger.debug(s"About to mark process ${processName.value} as finished if last action was DEPLOY")
+    logger.debug(s"About to mark process $processName as finished if last action was DEPLOY")
     dbioRunner.run(for {
       processIdOpt      <- processRepository.fetchProcessId(processName)
       processId         <- existsOrFail(processIdOpt, ProcessNotFoundError(processName.value))
@@ -514,10 +516,10 @@ class DeploymentServiceImpl(
       processDetails    <- existsOrFail(processDetailsOpt, ProcessNotFoundError(processId.value.toString))
       _ = validateExpectedProcessingType(expectedProcessingType, processDetails.processingType)
       cancelActionOpt <- {
-        logger.debug(s"lastDeployedAction for ${processName.value}: ${processDetails.lastDeployedAction}")
+        logger.debug(s"lastDeployedAction for $processName: ${processDetails.lastDeployedAction}")
         processDetails.lastDeployedAction
           .map { lastDeployedAction =>
-            logger.info(s"Marking process ${processName.value} as finished")
+            logger.info(s"Marking process $processName as finished")
             val finishedComment = DeploymentComment.unsafe("Scenario finished").toComment(ProcessActionType.Cancel)
             processChangeListener.handle(OnFinished(processDetails.processId, lastDeployedAction.processVersionId))
             actionRepository

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/exception/ProcessIllegalAction.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/exception/ProcessIllegalAction.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.ui.process.exception
 
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
 import pl.touk.nussknacker.engine.api.deployment.ProcessState
-import pl.touk.nussknacker.engine.api.process.ProcessIdWithName
+import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName}
 import pl.touk.nussknacker.ui.IllegalOperationError
 
 final case class ProcessIllegalAction(message: String) extends IllegalOperationError(message, details = "")
@@ -11,18 +11,18 @@ object ProcessIllegalAction {
 
   def apply(
       action: ProcessActionType,
-      processIdWithName: ProcessIdWithName,
+      processName: ProcessName,
       state: ProcessState
   ): ProcessIllegalAction =
     ProcessIllegalAction(
-      s"Action: $action is not allowed in scenario (${processIdWithName.name.value}) state: ${state.status.name}, allowed actions: ${state.allowedActions
+      s"Action: $action is not allowed in scenario ($processName) state: ${state.status.name}, allowed actions: ${state.allowedActions
           .mkString(",")}."
     )
 
-  def archived(action: ProcessActionType, processIdWithName: ProcessIdWithName): ProcessIllegalAction =
-    ProcessIllegalAction(s"Forbidden action: $action for archived scenario: ${processIdWithName.name.value}.")
+  def archived(action: ProcessActionType, processName: ProcessName): ProcessIllegalAction =
+    ProcessIllegalAction(s"Forbidden action: $action for archived scenario: $processName.")
 
-  def fragment(action: ProcessActionType, processIdWithName: ProcessIdWithName): ProcessIllegalAction =
-    ProcessIllegalAction(s"Forbidden action: $action for fragment: ${processIdWithName.name.value}.")
+  def fragment(action: ProcessActionType, processName: ProcessName): ProcessIllegalAction =
+    ProcessIllegalAction(s"Forbidden action: $action for fragment: $processName.")
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/fragment/FragmentResolver.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/fragment/FragmentResolver.scala
@@ -15,7 +15,7 @@ class FragmentResolver(fragmentRepository: FragmentRepository) {
     val fragments =
       fragmentRepository
         .fetchLatestFragmentsSync(processingType)
-        .map(s => ProcessName(s.canonical.id) -> s.canonical)
+        .map(s => s.canonical.name -> s.canonical)
         .toMap
     pl.touk.nussknacker.engine.compile.FragmentResolver(fragments.get _).resolve(process)
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverter.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverter.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.graph.EdgeType
 import pl.touk.nussknacker.engine.graph.EdgeType.FragmentOutput
 import pl.touk.nussknacker.engine.graph.node._
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
-import pl.touk.nussknacker.engine.api.process.ProcessingType
+import pl.touk.nussknacker.engine.api.process.{ProcessName, ProcessingType}
 
 object ProcessConverter {
 
@@ -29,7 +29,7 @@ object ProcessConverter {
         }
     }
     val props = ProcessProperties(process.metaData.additionalFields)
-    DisplayableProcess(process.metaData.id, props, nodes, edges, processingType, category)
+    DisplayableProcess(process.name, props, nodes, edges, processingType, category)
   }
 
   def findNodes(process: CanonicalProcess): List[NodeData] = {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigrator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/ProcessModelMigrator.scala
@@ -12,8 +12,6 @@ import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 final case class MigrationResult(process: CanonicalProcess, migrationsApplied: List[ProcessMigration]) {
 
-  def id: String = process.metaData.id
-
   def toUpdateAction(processId: ProcessId): UpdateProcessAction = UpdateProcessAction(
     id = processId,
     canonicalProcess = process,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
@@ -200,8 +200,7 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](val dbRef: DbRef, action
       history: Option[Seq[ScenarioVersion]]
   ): ScenarioWithDetailsEntity[PS] = {
     repository.ScenarioWithDetailsEntity[PS](
-      id = process.name.value, // TODO: replace by Long / ProcessId
-      processId = process.id,  // TODO: Remove it weh we will support Long / ProcessId
+      processId = process.id,
       name = process.name,
       processVersionId = processVersion.id,
       isLatestVersion = isLatestVersion,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessRepository.scala
@@ -118,7 +118,7 @@ class DBProcessRepository(val dbRef: DbRef, val modelVersion: ProcessingTypeData
     val insertNew =
       processesTable.returning(processesTable.map(_.id)).into { case (entity, newId) => entity.copy(id = newId) }
 
-    logger.debug(s"Saving scenario ${action.processName.value} by user $userName")
+    logger.debug(s"Saving scenario ${action.processName} by user $userName")
 
     latestProcessVersionsNoJsonQuery(action.processName).result.headOption.flatMap {
       case Some(_) => DBIOAction.failed(ProcessAlreadyExists(action.processName.value))
@@ -269,7 +269,7 @@ class DBProcessRepository(val dbRef: DbRef, val modelVersion: ProcessingTypeData
           newCommentAction(
             process.id,
             version.id,
-            Some(UpdateProcessComment(s"Rename: [${process.name.value}] -> [$newName]"))
+            Some(UpdateProcessComment(s"Rename: [${process.name}] -> [$newName]"))
           )
         case None => DBIO.successful(())
       }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ScenarioWithDetailsEntity.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ScenarioWithDetailsEntity.scala
@@ -18,9 +18,8 @@ import java.time.Instant
 
 // TODO we should split ScenarioDetails and ScenarioShape (json)
 final case class ScenarioWithDetailsEntity[ScenarioShape](
-    id: String, // It temporary holds the name of process, because it's used everywhere in GUI - TODO: change type to ProcessId and explicitly use processName
     name: ProcessName,
-    processId: ProcessId, // TODO: Remove it when we will support Long / ProcessId
+    processId: ProcessId,
     processVersionId: VersionId,
     isLatestVersion: Boolean,
     description: Option[String],
@@ -53,7 +52,7 @@ final case class ScenarioWithDetailsEntity[ScenarioShape](
 
   def toEngineProcessVersion: EngineProcessVersion = EngineProcessVersion(
     versionId = processVersionId,
-    processName = idWithName.name,
+    processName = name,
     processId = processId,
     user = modifiedBy,
     modelVersion = modelVersion

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/processreport/ProcessCounter.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/processreport/ProcessCounter.scala
@@ -64,8 +64,8 @@ class ProcessCounter(fragmentRepository: FragmentRepository) {
     computeCounts(List())(canonicalProcess.allStartNodes)
   }
 
-  private def getFragment(fragmentId: ProcessName)(implicit user: LoggedUser): Option[CanonicalProcess] = {
-    fragmentRepository.fetchLatestFragmentSync(fragmentId).map(_.canonical)
+  private def getFragment(fragmentName: ProcessName)(implicit user: LoggedUser): Option[CanonicalProcess] = {
+    fragmentRepository.fetchLatestFragmentSync(fragmentName).map(_.canonical)
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/services/AppApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/services/AppApiHttpService.scala
@@ -174,7 +174,7 @@ class AppApiHttpService(
       .map { processes =>
         processes
           .filterNot(_.validationResultUnsafe.errors.isEmpty)
-          .map(_.id)
+          .map(_.name.value)
       }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/util/NuPathMatchers.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/util/NuPathMatchers.scala
@@ -1,14 +1,14 @@
 package pl.touk.nussknacker.ui.util
 
 import akka.http.scaladsl.server.{PathMatcher1, PathMatchers}
-import pl.touk.nussknacker.engine.api.process.VersionId
+import pl.touk.nussknacker.engine.api.process.{ProcessName, VersionId}
 
 import scala.util.Try
 
 trait NuPathMatchers extends PathMatchers {
 
-  def EnumSegment[T <: Enumeration](enumCompanion: T): PathMatcher1[enumCompanion.Value] =
-    Segment.flatMap(value => Try(enumCompanion.withName(value)).toOption)
+  def ProcessNameSegment: PathMatcher1[ProcessName] =
+    Segment.map(ProcessName(_))
 
   def VersionIdSegment: PathMatcher1[VersionId] =
     Segment.flatMap(value => Try(value.toLong).map(VersionId(_)).toOption)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/validation/UIProcessValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/validation/UIProcessValidator.scala
@@ -61,7 +61,7 @@ class UIProcessValidator(
   // that have loose nodes. If you want to achieve this result, you need to add these validations here and deduplicate
   // resulting errors later.
   def uiValidation(displayable: DisplayableProcess): ValidationResult = {
-    validateScenarioId(displayable)
+    validateScenarioName(displayable)
       .add(validateNodesId(displayable))
       .add(validateDuplicates(displayable))
       .add(validateLooseNodes(displayable))
@@ -113,8 +113,8 @@ class UIProcessValidator(
     ValidationResult.warnings(disabledNodesWarnings)
   }
 
-  private def validateScenarioId(displayable: DisplayableProcess): ValidationResult = {
-    IdValidator.validateScenarioId(displayable.id, displayable.metaData.isFragment) match {
+  private def validateScenarioName(displayable: DisplayableProcess): ValidationResult = {
+    IdValidator.validateScenarioName(displayable.name, displayable.metaData.isFragment) match {
       case Valid(_)   => ValidationResult.success
       case Invalid(e) => formatErrors(e)
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ComponentApiSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ComponentApiSpec.scala
@@ -308,9 +308,7 @@ class ComponentApiSpec
           .body(
             matchJsonWithRegexValues(
               s"""[{
-                 |  "id": "${processName.value}",
-                 |  "name": "${processName.value}",
-                 |  "processId": ${processId.value},
+                 |  "name": "$processName",
                  |  "nodesUsagesData": [ { "nodeId": "source", "type": "ScenarioUsageData" } ],
                  |  "isFragment": false,
                  |  "processCategory": "$Category1",

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DefinitionResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DefinitionResourcesSpec.scala
@@ -103,7 +103,7 @@ class DefinitionResourcesSpec
       )
     }
 
-    val processName         = ProcessName(SampleProcess.process.id)
+    val processName         = SampleProcess.process.name
     val processWithFragment = ProcessTestData.validProcessWithFragment(processName, fragmentWithFixedValuesEditor)
     val displayableFragment = ProcessConverter.toDisplayable(
       processWithFragment.fragment,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesConcurrentSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesConcurrentSpec.scala
@@ -26,10 +26,10 @@ class ManagementResourcesConcurrentSpec
     with NuResourcesTest {
 
   test("not allow concurrent deployment of same process") {
-    val processName = s"sameConcurrentDeployments"
+    val processName = ProcessName(s"sameConcurrentDeployments")
     saveProcessAndAssertSuccess(processName, SampleProcess.process)
 
-    deploymentManager.withWaitForDeployFinish(ProcessName(processName)) {
+    deploymentManager.withWaitForDeployFinish(processName) {
       val firstDeployResult  = deployProcess(processName)
       val secondDeployResult = deployProcess(processName)
       eventually {
@@ -47,20 +47,20 @@ class ManagementResourcesConcurrentSpec
       val statuses = List(firstStatus, secondStatus)
       statuses should contain only (StatusCodes.OK, StatusCodes.Conflict)
       eventually {
-        deploymentManager.deploys.asScala.count(_ == ProcessName(processName)) shouldBe 1
+        deploymentManager.deploys.asScala.count(_ == processName) shouldBe 1
       }
     }
   }
 
   test("allow concurrent deployment and cancel of same process") {
-    val processName = "concurrentDeployAndCancel"
+    val processName = ProcessName("concurrentDeployAndCancel")
 
     saveProcessAndAssertSuccess(processName, SampleProcess.process)
-    deploymentManager.withWaitForDeployFinish(ProcessName(processName)) {
+    deploymentManager.withWaitForDeployFinish(processName) {
       val firstDeployResult = deployProcess(processName)
       // we have to check if deploy was invoke, otherwise cancel can be faster than deploy
       eventually {
-        deploymentManager.deploys.asScala.count(_ == ProcessName(processName)) shouldBe 1
+        deploymentManager.deploys.asScala.count(_ == processName) shouldBe 1
       }
       cancelProcess(processName) ~> check {
         status shouldBe StatusCodes.OK

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -7,26 +7,26 @@ import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
 import cats.instances.all._
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.Json
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, OptionValues}
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.BeMatcher
-import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
-import pl.touk.nussknacker.engine.api.deployment.{ProcessAction, ProcessActionType}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, OptionValues}
+import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
-import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName, VersionId}
+import pl.touk.nussknacker.engine.api.deployment.{ProcessAction, ProcessActionType}
+import pl.touk.nussknacker.engine.api.process.{ProcessName, VersionId}
+import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
+import pl.touk.nussknacker.engine.kafka.KafkaFactory
 import pl.touk.nussknacker.engine.spel.Implicits._
 import pl.touk.nussknacker.restmodel.scenariodetails._
 import pl.touk.nussknacker.restmodel.{CustomActionRequest, CustomActionResponse}
 import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.ui.api.helpers.TestFactory._
 import pl.touk.nussknacker.ui.api.helpers._
+import pl.touk.nussknacker.ui.process.ScenarioQuery
 import pl.touk.nussknacker.ui.process.exception.ProcessIllegalAction
 import pl.touk.nussknacker.ui.process.repository.DbProcessActivityRepository.ProcessActivity
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.deployment.ProcessActionType.ProcessActionType
-import pl.touk.nussknacker.engine.kafka.KafkaFactory
-import pl.touk.nussknacker.ui.process.ScenarioQuery
 
 import java.time.Instant
 
@@ -41,13 +41,13 @@ class ManagementResourcesSpec
     with BeforeAndAfterAll
     with NuResourcesTest {
 
-  import TestCategories._
   import KafkaFactory._
+  import TestCategories._
 
   private implicit final val string: FromEntityUnmarshaller[String] =
     Unmarshaller.stringUnmarshaller.forContentTypes(ContentTypeRange.*)
 
-  private val processName: ProcessName = ProcessName(SampleProcess.process.id)
+  private val processName: ProcessName = SampleProcess.process.name
 
   private def deployedWithVersions(versionId: Long): BeMatcher[Option[ProcessAction]] = {
     BeMatcher[(ProcessActionType, VersionId)](equal((ProcessActionType.Deploy, VersionId(versionId))))
@@ -56,13 +56,13 @@ class ManagementResourcesSpec
   }
 
   test("process deployment should be visible in process history") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
-    deployProcess(SampleProcess.process.id) ~> checkThatEventually {
+    saveProcessAndAssertSuccess(processName, SampleProcess.process)
+    deployProcess(processName) ~> checkThatEventually {
       status shouldBe StatusCodes.OK
       getProcess(processName) ~> check {
         decodeDetails.lastStateAction shouldBe deployedWithVersions(2)
-        updateProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
-        deployProcess(SampleProcess.process.id) ~> checkThatEventually {
+        updateProcessAndAssertSuccess(processName, SampleProcess.process)
+        deployProcess(processName) ~> checkThatEventually {
           getProcess(processName) ~> check {
             decodeDetails.lastStateAction shouldBe deployedWithVersions(2)
           }
@@ -75,7 +75,7 @@ class ManagementResourcesSpec
     createDeployedProcess(processName, Category1)
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.DuringDeploy) {
-      deployProcess(processName.value) ~> check {
+      deployProcess(processName) ~> check {
         status shouldBe StatusCodes.Conflict
       }
     }
@@ -85,48 +85,45 @@ class ManagementResourcesSpec
     createDeployedCanceledProcess(processName, Category1)
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Canceled) {
-      cancelProcess(processName.value) ~> check {
+      cancelProcess(processName) ~> check {
         status shouldBe StatusCodes.Conflict
       }
     }
   }
 
   test("can't deploy archived process") {
-    val id                = createArchivedProcess(processName)
-    val processIdWithName = ProcessIdWithName(id, processName)
+    createArchivedProcess(processName)
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Canceled) {
-      deployProcess(processName.value) ~> check {
+      deployProcess(processName) ~> check {
         status shouldBe StatusCodes.Conflict
-        responseAs[String] shouldBe ProcessIllegalAction.archived(ProcessActionType.Deploy, processIdWithName).message
+        responseAs[String] shouldBe ProcessIllegalAction.archived(ProcessActionType.Deploy, processName).message
       }
     }
   }
 
   test("can't deploy fragment") {
-    val id                = createValidProcess(processName, Category1, isFragment = true)
-    val processIdWithName = ProcessIdWithName(id, processName)
+    createValidProcess(processName, Category1, isFragment = true)
 
-    deployProcess(processName.value) ~> check {
+    deployProcess(processName) ~> check {
       status shouldBe StatusCodes.Conflict
-      responseAs[String] shouldBe ProcessIllegalAction.fragment(ProcessActionType.Deploy, processIdWithName).message
+      responseAs[String] shouldBe ProcessIllegalAction.fragment(ProcessActionType.Deploy, processName).message
     }
   }
 
   test("can't cancel fragment") {
-    val id                = createValidProcess(processName, Category1, isFragment = true)
-    val processIdWithName = ProcessIdWithName(id, processName)
+    createValidProcess(processName, Category1, isFragment = true)
 
-    deployProcess(processName.value) ~> check {
+    deployProcess(processName) ~> check {
       status shouldBe StatusCodes.Conflict
-      responseAs[String] shouldBe ProcessIllegalAction.fragment(ProcessActionType.Deploy, processIdWithName).message
+      responseAs[String] shouldBe ProcessIllegalAction.fragment(ProcessActionType.Deploy, processName).message
     }
   }
 
   test("deploys and cancels with comment") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
     deployProcess(
-      SampleProcess.process.id,
+      SampleProcess.process.name,
       Some(DeploymentCommentSettings.unsafe("deploy.*", Some("deployComment"))),
       comment = Some("deployComment")
     ) ~> checkThatEventually {
@@ -135,7 +132,7 @@ class ManagementResourcesSpec
         processDetails.lastStateAction.exists(_.actionType.equals(ProcessActionType.Deploy)) shouldBe true
       }
       cancelProcess(
-        SampleProcess.process.id,
+        SampleProcess.process.name,
         Some(DeploymentCommentSettings.unsafe("cancel.*", Some("cancelComment"))),
         comment = Some("cancelComment")
       ) ~> check {
@@ -143,13 +140,13 @@ class ManagementResourcesSpec
         // TODO: remove Deployment:, Stop: after adding custom icons
         val expectedDeployComment = "Deployment: deployComment"
         val expectedStopComment   = "Stop: cancelComment"
-        getActivity(ProcessName(SampleProcess.process.id)) ~> check {
+        getActivity(SampleProcess.process.name) ~> check {
           val comments = responseAs[ProcessActivity].comments.sortBy(_.id)
           comments.map(_.content) shouldBe List(expectedDeployComment, expectedStopComment)
 
           val firstCommentId :: secondCommentId :: Nil = comments.map(_.id)
 
-          Get(s"/processes/${SampleProcess.process.id}/deployments") ~> withAllPermissions(processesRoute) ~> check {
+          Get(s"/processes/${SampleProcess.process.name}/deployments") ~> withAllPermissions(processesRoute) ~> check {
             val deploymentHistory = responseAs[List[ProcessAction]]
             val curTime           = Instant.now()
             deploymentHistory.map(a =>
@@ -179,9 +176,9 @@ class ManagementResourcesSpec
   }
 
   test("rejects deploy without comment if comment required") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
     deployProcess(
-      SampleProcess.process.id,
+      SampleProcess.process.name,
       deploymentCommentSettings =
         Some(DeploymentCommentSettings.unsafe("requiredCommentPattern", Some("exampleRequiredComment")))
     ) ~> check {
@@ -192,7 +189,7 @@ class ManagementResourcesSpec
   test("deploy technical process and mark it as deployed") {
     createValidProcess(processName, Category1, false)
 
-    deployProcess(processName.value) ~> checkThatEventually {
+    deployProcess(processName) ~> checkThatEventually {
       status shouldBe StatusCodes.OK
       getProcess(processName) ~> check {
         val processDetails = responseAs[ScenarioWithDetails]
@@ -203,12 +200,12 @@ class ManagementResourcesSpec
   }
 
   test("recognize process cancel in deployment list") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
-    deployProcess(SampleProcess.process.id) ~> checkThatEventually {
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
+    deployProcess(SampleProcess.process.name) ~> checkThatEventually {
       status shouldBe StatusCodes.OK
       getProcess(processName) ~> check {
         decodeDetails.lastStateAction shouldBe deployedWithVersions(2)
-        cancelProcess(SampleProcess.process.id) ~> check {
+        cancelProcess(SampleProcess.process.name) ~> check {
           getProcess(processName) ~> check {
             decodeDetails.lastStateAction.exists(_.actionType.equals(ProcessActionType.Cancel)) shouldBe true
           }
@@ -218,18 +215,18 @@ class ManagementResourcesSpec
   }
 
   test("recognize process deploy and cancel in global process list") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
-    deployProcess(SampleProcess.process.id) ~> checkThatEventually {
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
+    deployProcess(SampleProcess.process.name) ~> checkThatEventually {
       status shouldBe StatusCodes.OK
 
       forScenariosReturned(ScenarioQuery.empty) { processes =>
-        val process = processes.find(_.name == SampleProcess.process.id).head
+        val process = processes.find(_.name == SampleProcess.process.name.value).head
         process.lastActionVersionId shouldBe Some(2L)
         process.isDeployed shouldBe true
 
-        cancelProcess(SampleProcess.process.id) ~> check {
+        cancelProcess(SampleProcess.process.name) ~> check {
           forScenariosReturned(ScenarioQuery.empty) { processes =>
-            val process = processes.find(_.name == SampleProcess.process.id).head
+            val process = processes.find(_.name == SampleProcess.process.name.value).head
             process.lastActionVersionId shouldBe Some(2L)
             process.isCanceled shouldBe true
           }
@@ -239,8 +236,8 @@ class ManagementResourcesSpec
   }
 
   test("not authorize user with write permission to deploy") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
-    Post(s"/processManagement/deploy/${SampleProcess.process.id}") ~> withPermissions(
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
+    Post(s"/processManagement/deploy/${SampleProcess.process.name}") ~> withPermissions(
       deployRoute(),
       testPermissionWrite
     ) ~> check {
@@ -256,8 +253,8 @@ class ManagementResourcesSpec
       .filter("input", "#input != null", Some(true))
       .emptySink("end", "kafka-string", TopicParamName -> "'end.topic'", SinkValueParamName -> "#input")
 
-    saveProcessAndAssertSuccess(SampleProcess.process.id, processWithDisabledFilter)
-    deployProcess(processName.value) ~> check {
+    saveProcessAndAssertSuccess(SampleProcess.process.name, processWithDisabledFilter)
+    deployProcess(processName) ~> check {
       status shouldBe StatusCodes.OK
     }
   }
@@ -268,14 +265,14 @@ class ManagementResourcesSpec
       .parallelism(1)
       .source("start", "not existing")
       .emptySink("end", "kafka-string", TopicParamName -> "'end.topic'", SinkValueParamName -> "#output")
-    saveProcessAndAssertSuccess(invalidScenario.id, invalidScenario)
+    saveProcessAndAssertSuccess(invalidScenario.name, invalidScenario)
 
-    deploymentManager.withEmptyProcessState(ProcessName(invalidScenario.id)) {
-      deployProcess(invalidScenario.id) ~> check {
+    deploymentManager.withEmptyProcessState(invalidScenario.name) {
+      deployProcess(invalidScenario.name) ~> check {
         responseAs[String] shouldBe "Cannot deploy invalid scenario"
         status shouldBe StatusCodes.Conflict
       }
-      getProcess(ProcessName(invalidScenario.id)) ~> check {
+      getProcess(invalidScenario.name) ~> check {
         decodeDetails.state.value.status shouldEqual SimpleStateStatus.NotDeployed
       }
     }
@@ -283,12 +280,15 @@ class ManagementResourcesSpec
 
   test("should return failure for not validating deployment") {
     val largeParallelismScenario = SampleProcess.process.copy(metaData =
-      MetaData(SampleProcess.process.id, StreamMetaData(parallelism = Some(MockDeploymentManager.maxParallelism + 1)))
+      MetaData(
+        SampleProcess.process.name.value,
+        StreamMetaData(parallelism = Some(MockDeploymentManager.maxParallelism + 1))
+      )
     )
-    saveProcessAndAssertSuccess(largeParallelismScenario.id, largeParallelismScenario)
+    saveProcessAndAssertSuccess(largeParallelismScenario.name, largeParallelismScenario)
 
-    deploymentManager.withFailingDeployment(ProcessName(largeParallelismScenario.id)) {
-      deployProcess(largeParallelismScenario.id) ~> check {
+    deploymentManager.withFailingDeployment(largeParallelismScenario.name) {
+      deployProcess(largeParallelismScenario.name) ~> check {
         status shouldBe StatusCodes.BadRequest
         responseAs[String] shouldBe "Parallelism too large"
       }
@@ -296,19 +296,19 @@ class ManagementResourcesSpec
   }
 
   test("return from deploy before deployment manager proceeds") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
 
-    deploymentManager.withWaitForDeployFinish(ProcessName(SampleProcess.process.id)) {
-      deployProcess(SampleProcess.process.id) ~> check {
+    deploymentManager.withWaitForDeployFinish(SampleProcess.process.name) {
+      deployProcess(SampleProcess.process.name) ~> check {
         status shouldBe StatusCodes.OK
       }
     }
   }
 
   test("snapshots process") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
-    deploymentManager.withProcessRunning(ProcessName(SampleProcess.process.id)) {
-      snapshot(SampleProcess.process.id) ~> check {
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
+    deploymentManager.withProcessRunning(SampleProcess.process.name) {
+      snapshot(SampleProcess.process.name) ~> check {
         status shouldBe StatusCodes.OK
         responseAs[String] shouldBe MockDeploymentManager.savepointPath
       }
@@ -316,9 +316,9 @@ class ManagementResourcesSpec
   }
 
   test("stops process") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
-    deploymentManager.withProcessRunning(ProcessName(SampleProcess.process.id)) {
-      stop(SampleProcess.process.id) ~> check {
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
+    deploymentManager.withProcessRunning(SampleProcess.process.name) {
+      stop(SampleProcess.process.name) ~> check {
         status shouldBe StatusCodes.OK
         responseAs[String] shouldBe MockDeploymentManager.stopSavepointPath
       }
@@ -329,7 +329,7 @@ class ManagementResourcesSpec
     val testDataContent =
       """{"sourceId":"startProcess","record":"ala"}
         |{"sourceId":"startProcess","record":"bela"}""".stripMargin
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
 
     testScenario(SampleProcess.process, testDataContent) ~> check {
 
@@ -369,7 +369,7 @@ class ManagementResourcesSpec
     val testDataContent =
       """{"sourceId":"startProcess","record":"ala"}
         |"bela"""".stripMargin
-    saveProcessAndAssertSuccess(process.id, process)
+    saveProcessAndAssertSuccess(process.name, process)
 
     testScenario(process, testDataContent) ~> check {
       status shouldEqual StatusCodes.OK
@@ -387,7 +387,7 @@ class ManagementResourcesSpec
         .source("startProcess", "csv-source")
         .emptySink("end", "kafka-string", TopicParamName -> "'end.topic'")
     }
-    saveProcessAndAssertSuccess(process.id, process)
+    saveProcessAndAssertSuccess(process.name, process)
     val tooLargeTestDataContentList = List((1 to 50).mkString("\n"), (1 to 50000).mkString("-"))
 
     tooLargeTestDataContentList.foreach { tooLargeData =>
@@ -398,7 +398,7 @@ class ManagementResourcesSpec
   }
 
   test("rejects test record with non-existing source") {
-    saveProcessAndAssertSuccess(SampleProcess.process.id, SampleProcess.process)
+    saveProcessAndAssertSuccess(SampleProcess.process.name, SampleProcess.process)
     val testDataContent =
       """{"sourceId":"startProcess","record":"ala"}
         |{"sourceId":"unknown","record":"bela"}""".stripMargin

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesResourcesSpec.scala
@@ -10,6 +10,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, OptionValues}
 import pl.touk.nussknacker.engine.additionalInfo.{AdditionalInfo, MarkdownAdditionalInfo}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.displayedgraph.ProcessProperties
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.typed.typing
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 import pl.touk.nussknacker.engine.api.{ProcessAdditionalFields, StreamMetaData}
@@ -89,7 +90,7 @@ class NodesResourcesSpec
     saveProcess(testProcess) {
       val data: NodeData =
         Enricher("1", ServiceRef("paramService", List(NodeParameter("id", Expression.spel("'a'")))), "out", None)
-      Post(s"/nodes/${testProcess.id}/additionalInfo", toEntity(data)) ~> withPermissions(
+      Post(s"/nodes/${testProcess.name}/additionalInfo", toEntity(data)) ~> withPermissions(
         nodeRoute,
         testPermissionRead
       ) ~> check {
@@ -99,7 +100,7 @@ class NodesResourcesSpec
       }
 
       val dataEmpty: NodeData = Enricher("1", ServiceRef("otherService", List()), "out", None)
-      Post(s"/nodes/${testProcess.id}/additionalInfo", toEntity(dataEmpty)) ~> withPermissions(
+      Post(s"/nodes/${testProcess.name}/additionalInfo", toEntity(dataEmpty)) ~> withPermissions(
         nodeRoute,
         testPermissionRead
       ) ~> check {
@@ -119,7 +120,7 @@ class NodesResourcesSpec
         None
       )
 
-      Post(s"/nodes/${testProcess.id}/validation", toEntity(request)) ~> withPermissions(
+      Post(s"/nodes/${testProcess.name}/validation", toEntity(request)) ~> withPermissions(
         nodeRoute,
         testPermissionRead
       ) ~> check {
@@ -164,7 +165,7 @@ class NodesResourcesSpec
         None
       )
 
-      Post(s"/nodes/${testProcess.id}/validation", toEntity(request)) ~> withPermissions(
+      Post(s"/nodes/${testProcess.name}/validation", toEntity(request)) ~> withPermissions(
         nodeRoute,
         testPermissionRead
       ) ~> check {
@@ -190,7 +191,7 @@ class NodesResourcesSpec
       val data: node.Filter = node.Filter("id", Expression.spel("#DICT.Bar != #DICT.Foo"))
       val request           = NodeValidationRequest(data, ProcessProperties(StreamMetaData()), Map(), None, None)
 
-      Post(s"/nodes/${testProcess.id}/validation", toEntity(request)) ~> withPermissions(
+      Post(s"/nodes/${testProcess.name}/validation", toEntity(request)) ~> withPermissions(
         nodeRoute,
         testPermissionRead
       ) ~> check {
@@ -207,7 +208,7 @@ class NodesResourcesSpec
   test("it should return additional info for process properties") {
     saveProcess(testProcess) {
 
-      Post(s"/properties/${testProcess.id}/additionalInfo", toEntity(processProperties)) ~> withPermissions(
+      Post(s"/properties/${testProcess.name}/additionalInfo", toEntity(processProperties)) ~> withPermissions(
         nodeRoute,
         testPermissionRead
       ) ~> check {
@@ -224,7 +225,7 @@ class NodesResourcesSpec
       val data: node.Filter = node.Filter(blankValue, Expression.spel("true"))
       val request           = NodeValidationRequest(data, ProcessProperties(StreamMetaData()), Map(), None, None)
 
-      Post(s"/nodes/${testProcess.id}/validation", toEntity(request)) ~> withPermissions(
+      Post(s"/nodes/${testProcess.name}/validation", toEntity(request)) ~> withPermissions(
         nodeRoute,
         testPermissionRead
       ) ~> check {
@@ -243,10 +244,10 @@ class NodesResourcesSpec
           metaDataType = StreamMetaData.typeName,
           description = None
         ),
-        id = testProcess.id
+        name = testProcess.name
       )
 
-      Post(s"/properties/${testProcess.id}/validation", toEntity(request)) ~> withPermissions(
+      Post(s"/properties/${testProcess.name}/validation", toEntity(request)) ~> withPermissions(
         nodeRoute,
         testPermissionRead
       ) ~> check {
@@ -266,14 +267,14 @@ class NodesResourcesSpec
 
   test("validate scenario id") {
     saveProcess(testProcess) {
-      val blankValue = " "
+      val blankValue = ProcessName(" ")
       val request = PropertiesValidationRequest(
         additionalFields = ProcessAdditionalFields(
           properties = StreamMetaData().toMap ++ Map("numberOfThreads" -> "a", "environment" -> "test"),
           metaDataType = StreamMetaData.typeName,
           description = None
         ),
-        id = blankValue
+        name = blankValue
       )
 
       val expectedErrors = List(
@@ -287,10 +288,10 @@ class NodesResourcesSpec
           )
         ),
         PrettyValidationErrors.formatErrorMessage(
-          ScenarioIdError(BlankId, blankValue, isFragment = false)
+          ScenarioNameError(BlankId, blankValue, isFragment = false)
         )
       )
-      Post(s"/properties/${testProcess.id}/validation", toEntity(request)) ~> withPermissions(
+      Post(s"/properties/${testProcess.name}/validation", toEntity(request)) ~> withPermissions(
         nodeRoute,
         testPermissionRead
       ) ~> check {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessActivityResourceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessActivityResourceSpec.scala
@@ -43,20 +43,20 @@ class ProcessActivityResourceSpec
     val commentContent = "test message"
     saveProcess(processToSave) { status shouldEqual StatusCodes.OK }
     Post(
-      s"/processes/${processToSave.id}/1/activity/comments",
+      s"/processes/${processToSave.name}/1/activity/comments",
       HttpEntity(ContentTypes.`text/plain(UTF-8)`, commentContent)
     ) ~> processActivityRouteWithAllPermissions ~> check {
       status shouldEqual StatusCodes.OK
-      getActivity(ProcessName(processToSave.id)) ~> check {
+      getActivity(processToSave.name) ~> check {
         val processActivity = responseAs[ProcessActivity]
         val firstComment    = processActivity.comments.head
         processActivity.comments should have size 1
         processActivity.comments.head.content shouldBe commentContent
         Delete(
-          s"/processes/${processToSave.id}/activity/comments/${firstComment.id}"
+          s"/processes/${processToSave.name}/activity/comments/${firstComment.id}"
         ) ~> processActivityRouteWithAllPermissions ~> check {
           status shouldEqual StatusCodes.OK
-          getActivity(ProcessName(processToSave.id)) ~> check {
+          getActivity(processToSave.name) ~> check {
             val newProcessActivity = responseAs[ProcessActivity]
             newProcessActivity.comments shouldBe empty
           }
@@ -74,17 +74,16 @@ class ProcessActivityResourceSpec
     val mutipartFile = MultipartUtils.prepareMultiPart(fileContent, "attachment", fileName)
 
     Post(
-      s"/processes/${processToSave.id}/1/activity/attachments",
+      s"/processes/${processToSave.name}/1/activity/attachments",
       mutipartFile
     ) ~> attachmentsRouteWithAllPermissions ~> check {
       status shouldEqual StatusCodes.OK
 
-      getActivity(ProcessName(processToSave.id)) ~> check {
+      getActivity(processToSave.name) ~> check {
         val processActivity = responseAs[ProcessActivity]
         val attachment      = processActivity.attachments.head
         attachment.fileName shouldBe fileName
-        attachment.processId shouldBe processToSave.id
-        getAttachment(processToSave.id, attachment.id) { responseAs[String] shouldBe fileContent }
+        getAttachment(processToSave.name, attachment.id) { responseAs[String] shouldBe fileContent }
       }
     }
   }
@@ -100,29 +99,31 @@ class ProcessActivityResourceSpec
     val mutipartFile2 = MultipartUtils.prepareMultiPart(fileContent2, "attachment", fileName)
 
     Post(
-      s"/processes/${processToSave.id}/1/activity/attachments",
+      s"/processes/${processToSave.name}/1/activity/attachments",
       mutipartFile1
     ) ~> attachmentsRouteWithAllPermissions ~> check {
       status shouldEqual StatusCodes.OK
       Post(
-        s"/processes/${processToSave.id}/1/activity/attachments",
+        s"/processes/${processToSave.name}/1/activity/attachments",
         mutipartFile2
       ) ~> attachmentsRouteWithAllPermissions ~> check {
         status shouldEqual StatusCodes.OK
-        getActivity(ProcessName(processToSave.id)) ~> check {
+        getActivity(processToSave.name) ~> check {
           val processActivity = responseAs[ProcessActivity]
           processActivity.attachments.size shouldBe 2
           val attachmentsOrdered         = processActivity.attachments.sortBy(_.createDate)
           val (attachment1, attachment2) = (attachmentsOrdered.head, attachmentsOrdered(1))
-          getAttachment(processToSave.id, attachment1.id) { responseAs[String] shouldBe fileContent1 }
-          getAttachment(processToSave.id, attachment2.id) { responseAs[String] shouldBe fileContent2 }
+          getAttachment(processToSave.name, attachment1.id) { responseAs[String] shouldBe fileContent1 }
+          getAttachment(processToSave.name, attachment2.id) { responseAs[String] shouldBe fileContent2 }
         }
       }
     }
   }
 
-  private def getAttachment(processId: String, attachmentId: Long)(testCode: => Assertion) = {
-    Get(s"/processes/$processId/1/activity/attachments/$attachmentId") ~> attachmentsRouteWithAllPermissions ~> check {
+  private def getAttachment(processName: ProcessName, attachmentId: Long)(testCode: => Assertion) = {
+    Get(
+      s"/processes/$processName/activity/attachments/$attachmentId"
+    ) ~> attachmentsRouteWithAllPermissions ~> check {
       testCode
     }
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessAttachmentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessAttachmentServiceSpec.scala
@@ -7,12 +7,12 @@ import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessIdWithName, VersionId}
+import pl.touk.nussknacker.engine.api.process.{ProcessId, VersionId}
 import pl.touk.nussknacker.ui.config.AttachmentsConfig
 import pl.touk.nussknacker.ui.db.entity.AttachmentEntityData
+import pl.touk.nussknacker.ui.listener.Comment
 import pl.touk.nussknacker.ui.process.repository.{DbProcessActivityRepository, ProcessActivityRepository}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
-import pl.touk.nussknacker.ui.listener.Comment
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.util.Random
@@ -57,7 +57,7 @@ private object TestProcessActivityRepository extends ProcessActivityRepository {
 
   override def deleteComment(commentId: Long)(implicit ec: ExecutionContext): Future[Unit] = ???
 
-  override def findActivity(processId: ProcessIdWithName)(
+  override def findActivity(processId: ProcessId)(
       implicit ec: ExecutionContext
   ): Future[DbProcessActivityRepository.ProcessActivity] = ???
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesExportImportResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesExportImportResourcesSpec.scala
@@ -55,7 +55,7 @@ class ProcessesExportImportResourcesSpec
 
   test("export process from displayable") {
     val processToExport = ProcessTestData.sampleDisplayableProcess
-    createEmptyProcess(ProcessTestData.sampleDisplayableProcess.processName)
+    createEmptyProcess(ProcessTestData.sampleDisplayableProcess.name)
 
     Post(s"/processesExport", processToExport) ~> routeWithAllPermissions ~> check {
       status shouldEqual StatusCodes.OK
@@ -80,7 +80,7 @@ class ProcessesExportImportResourcesSpec
       status shouldEqual StatusCodes.OK
     }
 
-    Get(s"/processesExport/${processToSave.id}/2") ~> route ~> check {
+    Get(s"/processesExport/${processToSave.name}/2") ~> route ~> check {
       val response       = responseAs[String]
       val processDetails = ProcessMarshaller.fromJson(response).toOption.get
       assertProcessPrettyPrinted(response, processDetails)
@@ -89,11 +89,11 @@ class ProcessesExportImportResourcesSpec
         processDetails.metaData.withTypeSpecificData(typeSpecificData = StreamMetaData(Some(987)))
       )
       val multipartForm = MultipartUtils.prepareMultiPart(modified.asJson.spaces2, "process")
-      Post(s"/processes/import/${processToSave.id}", multipartForm) ~> route ~> check {
+      Post(s"/processes/import/${processToSave.name}", multipartForm) ~> route ~> check {
         status shouldEqual StatusCodes.OK
         val imported = responseAs[DisplayableProcess]
         imported.properties.typeSpecificProperties.asInstanceOf[StreamMetaData].parallelism shouldBe Some(987)
-        imported.id shouldBe processToSave.id
+        imported.name shouldBe processToSave.name
         imported.nodes shouldBe processToSave.nodes
       }
     }
@@ -115,17 +115,17 @@ class ProcessesExportImportResourcesSpec
       status shouldEqual StatusCodes.OK
     }
 
-    Get(s"/processesExport/${processToSave.id}/2") ~> routeWithAllPermissions ~> check {
+    Get(s"/processesExport/${processToSave.name}/2") ~> routeWithAllPermissions ~> check {
       val response = responseAs[String]
       response shouldNot include(description)
       assertProcessPrettyPrinted(response, processToSave)
     }
 
-    Get(s"/processesExport/${processToSave.id}/3") ~> routeWithAllPermissions ~> check {
+    Get(s"/processesExport/${processToSave.name}/3") ~> routeWithAllPermissions ~> check {
       val latestProcessVersion = io.circe.parser.parse(responseAs[String])
       latestProcessVersion.toOption.get.spaces2 should include(description)
 
-      Get(s"/processesExport/${processToSave.id}") ~> routeWithAllPermissions ~> check {
+      Get(s"/processesExport/${processToSave.name}") ~> routeWithAllPermissions ~> check {
         io.circe.parser.parse(responseAs[String]) shouldBe latestProcessVersion
       }
 
@@ -142,7 +142,7 @@ class ProcessesExportImportResourcesSpec
         "<path d=\"M20,20h20m5,0h20m5,0h20\" stroke=\"#c00000\" stroke-width=\"10\"/>\n  " +
         "<path d=\"M20,40h20m5,0h20m5,0h20M30,30v20m25,0v-20m25,0v20\" stroke=\"#008000\" stroke-width=\"6\"/>\n</svg>"
 
-      Post(s"/processesExport/pdf/${processToSave.id}/2", HttpEntity(testSvg)) ~> routeWithAllPermissions ~> check {
+      Post(s"/processesExport/pdf/${processToSave.name}/2", HttpEntity(testSvg)) ~> routeWithAllPermissions ~> check {
 
         status shouldEqual StatusCodes.OK
         contentType shouldEqual ContentTypes.`application/octet-stream`

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResourcesSpec.scala
@@ -47,8 +47,7 @@ class RemoteEnvironmentResourcesSpec
   private implicit final val string: FromEntityUnmarshaller[String] =
     Unmarshaller.stringUnmarshaller.forContentTypes(ContentTypeRange.*)
 
-  private val processId: String        = ProcessTestData.validProcess.id
-  private val processName: ProcessName = ProcessName(processId)
+  private val processName: ProcessName = ProcessTestData.validProcess.name
 
   val readWritePermissions: CategorizedPermission = testPermissionRead |+| testPermissionWrite
 
@@ -63,12 +62,12 @@ class RemoteEnvironmentResourcesSpec
       readWritePermissions
     )
 
-    Get(s"/remoteEnvironment/$processId/2/compare/1") ~> route ~> check {
+    Get(s"/remoteEnvironment/$processName/2/compare/1") ~> route ~> check {
       status shouldEqual StatusCodes.NotFound
       responseAs[String] should include("No scenario fooProcess found")
     }
 
-    Post(s"/remoteEnvironment/$processId/2/migrate") ~> route ~> check {
+    Post(s"/remoteEnvironment/$processName/2/migrate") ~> route ~> check {
       status shouldEqual StatusCodes.NotFound
       responseAs[String] should include("No scenario fooProcess found")
     }
@@ -81,7 +80,7 @@ class RemoteEnvironmentResourcesSpec
   it should "invoke migration for found scenario" in {
     val category   = Category1
     val difference = Map("node1" -> NodeNotPresentInCurrent("node1", Filter("node1", Expression.spel("#input == 4"))))
-    val remoteEnvironment = new MockRemoteEnvironment(mockDifferences = Map(processId -> difference))
+    val remoteEnvironment = new MockRemoteEnvironment(mockDifferences = Map(processName -> difference))
 
     val route = withPermissions(
       new RemoteEnvironmentResources(
@@ -94,14 +93,14 @@ class RemoteEnvironmentResourcesSpec
     val expectedDisplayable = ProcessTestData.validDisplayableProcess.toDisplayable.copy(category = category)
 
     saveProcess(processName, ProcessTestData.validProcess, category) {
-      Get(s"/remoteEnvironment/$processId/2/compare/1") ~> route ~> check {
+      Get(s"/remoteEnvironment/$processName/2/compare/1") ~> route ~> check {
         status shouldEqual StatusCodes.OK
 
         responseAs[Map[String, Difference]] shouldBe difference
       }
       remoteEnvironment.compareInvocations shouldBe List(expectedDisplayable)
 
-      Post(s"/remoteEnvironment/$processId/2/migrate") ~> route ~> check {
+      Post(s"/remoteEnvironment/$processName/2/migrate") ~> route ~> check {
         status shouldEqual StatusCodes.OK
       }
       remoteEnvironment.migrateInvocations shouldBe List(expectedDisplayable)
@@ -120,8 +119,8 @@ class RemoteEnvironmentResourcesSpec
       new RemoteEnvironmentResources(
         new MockRemoteEnvironment(mockDifferences =
           Map(
-            processId1.value -> Map("n1" -> difference),
-            processId2.value -> Map()
+            processId1 -> Map("n1" -> difference),
+            processId2 -> Map()
           )
         ),
         processService,
@@ -130,12 +129,12 @@ class RemoteEnvironmentResourcesSpec
       testPermissionRead
     )
 
-    saveProcess(processId1, ProcessTestData.validProcessWithId(processId1.value), Category1) {
-      saveProcess(processId2, ProcessTestData.validProcessWithId(processId2.value), Category1) {
+    saveProcess(processId1, ProcessTestData.validProcessWithName(processId1), Category1) {
+      saveProcess(processId2, ProcessTestData.validProcessWithName(processId2), Category1) {
         Get(s"/remoteEnvironment/compare") ~> route ~> check {
           status shouldEqual StatusCodes.OK
           responseAs[EnvironmentComparisonResult] shouldBe EnvironmentComparisonResult(
-            List(ProcessDifference(processId1.value, presentOnOther = true, Map("n1" -> difference)))
+            List(ProcessDifference(processId1, presentOnOther = true, Map("n1" -> difference)))
           )
         }
       }
@@ -154,7 +153,7 @@ class RemoteEnvironmentResourcesSpec
       new RemoteEnvironmentResources(
         new MockRemoteEnvironment(mockDifferences =
           Map(
-            processId1.value -> Map("n1" -> difference)
+            processId1 -> Map("n1" -> difference)
           )
         ),
         processService,
@@ -163,14 +162,14 @@ class RemoteEnvironmentResourcesSpec
       readWritePermissions
     )
 
-    saveProcess(processId1, ProcessTestData.validProcessWithId(processId1.value), Category1) {
-      saveProcess(processId2, ProcessTestData.validProcessWithId(processId2.value), Category1) {
+    saveProcess(processId1, ProcessTestData.validProcessWithName(processId1), Category1) {
+      saveProcess(processId2, ProcessTestData.validProcessWithName(processId2), Category1) {
         Get(s"/remoteEnvironment/compare") ~> route ~> check {
           status shouldEqual StatusCodes.OK
           responseAs[EnvironmentComparisonResult] shouldBe EnvironmentComparisonResult(
             List(
-              ProcessDifference(processId1.value, presentOnOther = true, Map("n1" -> difference)),
-              ProcessDifference(processId2.value, presentOnOther = false, Map())
+              ProcessDifference(processId1, presentOnOther = true, Map("n1" -> difference)),
+              ProcessDifference(processId2, presentOnOther = false, Map())
             )
           )
         }
@@ -180,7 +179,7 @@ class RemoteEnvironmentResourcesSpec
 
   class MockRemoteEnvironment(
       testMigrationResults: List[TestMigrationResult] = List(),
-      val mockDifferences: Map[String, Map[String, ProcessComparator.Difference]] = Map()
+      val mockDifferences: Map[ProcessName, Map[String, ProcessComparator.Difference]] = Map()
   ) extends RemoteEnvironment {
 
     var migrateInvocations = List[DisplayableProcess]()
@@ -200,7 +199,7 @@ class RemoteEnvironmentResourcesSpec
       compareInvocations = localProcess :: compareInvocations
       Future.successful(
         mockDifferences
-          .get(localProcess.id)
+          .get(localProcess.name)
           .fold[Either[NuDesignerError, Map[String, ProcessComparator.Difference]]](
             Left(RemoteEnvironmentCommunicationError(StatusCodes.NotFound, ""))
           )(diffs => Right(diffs))

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
@@ -14,6 +14,7 @@ import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.api.displayedgraph.displayablenode.Edge
 import pl.touk.nussknacker.engine.api.displayedgraph.{DisplayableProcess, ProcessProperties}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.dict.{ProcessDictSubstitutor, SimpleDictRegistry}
 import pl.touk.nussknacker.engine.graph.expression.Expression
@@ -122,7 +123,7 @@ class ValidationResourcesSpec
   }
 
   it should "find errors in scenario id" in {
-    createAndValidateScenario(ProcessTestData.validProcessWithId(" ")) {
+    createAndValidateScenario(ProcessTestData.validProcessWithName(ProcessName(" "))) {
       status shouldEqual StatusCodes.OK
       val entity = entityAs[String]
       entity should include("Scenario name cannot be blank")
@@ -247,9 +248,9 @@ class ValidationResourcesSpec
     }
   }
 
-  private def newDisplayableProcess(id: String, nodes: List[NodeData], edges: List[Edge]): DisplayableProcess = {
+  private def newDisplayableProcess(name: String, nodes: List[NodeData], edges: List[Edge]): DisplayableProcess = {
     DisplayableProcess(
-      id = id,
+      name = ProcessName(name),
       properties = ProcessProperties(StreamMetaData(Some(2), Some(false))),
       nodes = nodes,
       edges = edges,
@@ -262,7 +263,7 @@ class ValidationResourcesSpec
     createAndValidateScenario(TestProcessUtil.toDisplayable(scenario))(testCode)
 
   private def createAndValidateScenario(displayable: DisplayableProcess)(testCode: => Assertion): Assertion = {
-    createEmptyProcess(displayable.processName)
+    createEmptyProcess(displayable.name)
     validateScenario(displayable)(testCode)
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepository.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepository.scala
@@ -65,19 +65,19 @@ class MockFetchingProcessRepository private (
   override def fetchLatestProcessDetailsForProcessId[PS: ScenarioShapeFetchStrategy](
       id: ProcessId
   )(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[Option[ScenarioWithDetailsEntity[PS]]] =
-    getUserProcesses[PS].map(_.filter(p => p.idWithName.id == id).lastOption)
+    getUserProcesses[PS].map(_.filter(p => p.processId == id).lastOption)
 
   override def fetchProcessDetailsForId[PS: ScenarioShapeFetchStrategy](processId: ProcessId, versionId: VersionId)(
       implicit loggedUser: LoggedUser,
       ec: ExecutionContext
   ): Future[Option[ScenarioWithDetailsEntity[PS]]] =
-    getUserProcesses[PS].map(_.find(p => p.idWithName.id == processId && p.processVersionId == versionId))
+    getUserProcesses[PS].map(_.find(p => p.processId == processId && p.processVersionId == versionId))
 
   override def fetchProcessId(processName: ProcessName)(implicit ec: ExecutionContext): Future[Option[ProcessId]] =
-    Future(processes.find(p => p.idWithName.name == processName).map(_.processId))
+    Future(processes.find(p => p.name == processName).map(_.processId))
 
   override def fetchProcessName(processId: ProcessId)(implicit ec: ExecutionContext): Future[Option[ProcessName]] =
-    Future(processes.find(p => p.processId == processId).map(_.idWithName.name))
+    Future(processes.find(p => p.processId == processId).map(_.name))
 
   override def fetchProcessingType(
       processId: ProcessId

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepositorySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/MockFetchingProcessRepositorySpec.scala
@@ -167,7 +167,7 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
     )
 
     forAll(testingData) { (user: LoggedUser, expected: List[ScenarioWithDetailsEntity[DisplayableProcess]]) =>
-      val names = processes.map(_.idWithName.name)
+      val names = processes.map(_.name)
       val result = mockRepository
         .fetchLatestProcessesDetails(
           ScenarioQuery(names = Some(names), isArchived = Some(false), isFragment = Some(false))
@@ -301,7 +301,7 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
   }
 
   it should "return ProcessId for ProcessName" in {
-    val data = processes.map(p => (p.idWithName.name, Some(p.processId))) ++ List((ProcessName("not-exist-name"), None))
+    val data = processes.map(p => (p.name, Some(p.processId))) ++ List((ProcessName("not-exist-name"), None))
 
     data.foreach { case (processName, processId) =>
       val result = mockRepository.fetchProcessId(processName).futureValue
@@ -310,7 +310,7 @@ class MockFetchingProcessRepositorySpec extends AnyFlatSpec with Matchers with S
   }
 
   it should "return ProcessName for ProcessId" in {
-    val data = processes.map(p => (p.processId, Some(p.idWithName.name))) ++ List((ProcessId(666), None))
+    val data = processes.map(p => (p.processId, Some(p.name))) ++ List((ProcessId(666), None))
 
     data.foreach { case (processId, processName) =>
       val result = mockRepository.fetchProcessName(processId).futureValue

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/NuResourcesTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/NuResourcesTest.scala
@@ -227,11 +227,11 @@ trait NuResourcesTest
   }
 
   protected def saveProcessAndAssertSuccess(
-      processId: String,
+      processName: ProcessName,
       process: CanonicalProcess,
       category: String = Category1
   ): Assertion =
-    saveProcess(ProcessName(processId), process, category) {
+    saveProcess(processName, process, category) {
       status shouldEqual StatusCodes.OK
     }
 
@@ -248,7 +248,7 @@ trait NuResourcesTest
     }
 
   protected def saveProcess(process: DisplayableProcess)(testCode: => Assertion): Assertion = {
-    createProcessRequest(ProcessName(process.id), process.category) { code =>
+    createProcessRequest(process.name, process.category) { code =>
       code shouldBe StatusCodes.Created
       updateProcess(process)(testCode)
     }
@@ -257,7 +257,7 @@ trait NuResourcesTest
   protected def createProcessRequest(processName: ProcessName, category: String = Category1)(
       callback: StatusCode => Assertion
   ): Assertion =
-    Post(s"/processes/${processName.value}/$category?isFragment=false") ~> processesRouteWithAllPermissions ~> check {
+    Post(s"/processes/$processName/$category?isFragment=false") ~> processesRouteWithAllPermissions ~> check {
       callback(status)
     }
 
@@ -267,7 +267,9 @@ trait NuResourcesTest
   }
 
   protected def savefragment(process: DisplayableProcess)(testCode: => Assertion): Assertion = {
-    Post(s"/processes/${process.id}/${process.category}?isFragment=true") ~> processesRouteWithAllPermissions ~> check {
+    Post(
+      s"/processes/${process.name}/${process.category}?isFragment=true"
+    ) ~> processesRouteWithAllPermissions ~> check {
       status shouldBe StatusCodes.Created
       updateProcess(process)(testCode)
     }
@@ -275,7 +277,7 @@ trait NuResourcesTest
 
   protected def updateProcess(process: DisplayableProcess)(testCode: => Assertion): Assertion =
     Put(
-      s"/processes/${process.id}",
+      s"/processes/${process.name}",
       TestFactory.posting.toEntityAsProcessToSave(process)
     ) ~> processesRouteWithAllPermissions ~> check {
       testCode
@@ -283,14 +285,14 @@ trait NuResourcesTest
 
   protected def updateProcess(process: UpdateProcessCommand)(testCode: => Assertion): Assertion =
     Put(
-      s"/processes/${process.process.id}",
+      s"/processes/${process.process.name}",
       TestFactory.posting.toEntity(process)
     ) ~> processesRouteWithAllPermissions ~> check {
       testCode
     }
 
-  protected def updateProcessAndAssertSuccess(processId: String, process: CanonicalProcess): Assertion =
-    updateProcess(ProcessName(processId), process) {
+  protected def updateProcessAndAssertSuccess(processName: ProcessName, process: CanonicalProcess): Assertion =
+    updateProcess(processName, process) {
       status shouldEqual StatusCodes.OK
     }
 
@@ -298,14 +300,14 @@ trait NuResourcesTest
       testCode: => Assertion
   ): Assertion =
     Put(
-      s"/processes/${processName.value}",
+      s"/processes/$processName",
       TestFactory.posting.toEntityAsProcessToSave(process, comment)
     ) ~> processesRouteWithAllPermissions ~> check {
       testCode
     }
 
   protected def deployProcess(
-      processName: String,
+      processName: ProcessName,
       deploymentCommentSettings: Option[DeploymentCommentSettings] = None,
       comment: Option[String] = None
   ): RouteTestResult =
@@ -316,20 +318,23 @@ trait NuResourcesTest
       withPermissions(deployRoute(deploymentCommentSettings), testPermissionDeploy |+| testPermissionRead)
 
   protected def cancelProcess(
-      id: String,
+      processName: ProcessName,
       deploymentCommentSettings: Option[DeploymentCommentSettings] = None,
       comment: Option[String] = None
   ): RouteTestResult =
-    Post(s"/processManagement/cancel/$id", HttpEntity(ContentTypes.`application/json`, comment.getOrElse(""))) ~>
+    Post(
+      s"/processManagement/cancel/$processName",
+      HttpEntity(ContentTypes.`application/json`, comment.getOrElse(""))
+    ) ~>
       withPermissions(deployRoute(deploymentCommentSettings), testPermissionDeploy |+| testPermissionRead)
 
-  protected def snapshot(processName: String): RouteTestResult =
+  protected def snapshot(processName: ProcessName): RouteTestResult =
     Post(s"/adminProcessManagement/snapshot/$processName") ~> withPermissions(
       deployRoute(),
       testPermissionDeploy |+| testPermissionRead
     )
 
-  protected def stop(processName: String): RouteTestResult =
+  protected def stop(processName: ProcessName): RouteTestResult =
     Post(s"/adminProcessManagement/stop/$processName") ~> withPermissions(
       deployRoute(),
       testPermissionDeploy |+| testPermissionRead
@@ -345,17 +350,17 @@ trait NuResourcesTest
       "testData"    -> testDataContent,
       "processJson" -> displayableProcess.asJson.noSpaces
     )()
-    Post(s"/processManagement/test/${scenario.id}", multiPart) ~> withPermissions(
+    Post(s"/processManagement/test/${scenario.name}", multiPart) ~> withPermissions(
       deployRoute(),
       testPermissionDeploy |+| testPermissionRead
     )
   }
 
   protected def getProcess(processName: ProcessName): RouteTestResult =
-    Get(s"/processes/${processName.value}") ~> withPermissions(processesRoute, testPermissionRead)
+    Get(s"/processes/$processName") ~> withPermissions(processesRoute, testPermissionRead)
 
   protected def getActivity(processName: ProcessName): RouteTestResult =
-    Get(s"/processes/${processName.value}/activity") ~> processActivityRouteWithAllPermissions
+    Get(s"/processes/$processName/activity") ~> processActivityRouteWithAllPermissions
 
   protected def forScenarioReturned(processName: ProcessName, isAdmin: Boolean = false)(
       callback: ProcessJson => Unit
@@ -369,7 +374,7 @@ trait NuResourcesTest
   protected def tryForScenarioReturned(processName: ProcessName, isAdmin: Boolean = false)(
       callback: (StatusCode, String) => Unit
   ): Unit =
-    Get(s"/processes/${processName.value}") ~> routeWithPermissions(processesRoute, isAdmin) ~> check {
+    Get(s"/processes/$processName") ~> routeWithPermissions(processesRoute, isAdmin) ~> check {
       callback(status, responseAs[String])
     }
 
@@ -427,7 +432,7 @@ trait NuResourcesTest
       category: String,
       isFragment: Boolean
   ): Future[ProcessId] = {
-    val emptyProcess = newProcessPreparer.prepareEmptyProcess(processName.value, Streaming, isFragment)
+    val emptyProcess = newProcessPreparer.prepareEmptyProcess(processName, Streaming, isFragment)
     saveAndGetId(emptyProcess, category, isFragment)
   }
 
@@ -437,7 +442,7 @@ trait NuResourcesTest
       isFragment: Boolean,
       processingType: ProcessingType = Streaming
   ): Future[ProcessId] = {
-    val processName = ProcessName(process.id)
+    val processName = process.name
     val action =
       CreateProcessAction(processName, category, process, processingType, isFragment, forwardedUserName = None)
     for {
@@ -508,9 +513,7 @@ object ProcessJson extends OptionValues {
     val state      = process.hcursor.downField("state").as[Option[Json]].toOption.value
 
     new ProcessJson(
-      process.hcursor.downField("id").as[String].toOption.value,
       process.hcursor.downField("name").as[String].toOption.value,
-      process.hcursor.downField("processId").as[Long].toOption.value,
       lastAction.map(_.hcursor.downField("processVersionId").as[Long].toOption.value),
       lastAction.map(_.hcursor.downField("actionType").as[String].toOption.value),
       state.map(StateJson(_)),
@@ -523,9 +526,7 @@ object ProcessJson extends OptionValues {
 }
 
 final case class ProcessJson(
-    id: String,
     name: String,
-    processId: Long,
     lastActionVersionId: Option[Long],
     lastActionType: Option[String],
     state: Option[StateJson],

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/NuScenarioConfigurationHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/NuScenarioConfigurationHelper.scala
@@ -90,7 +90,7 @@ trait NuScenarioConfigurationHelper extends ScalaFutures {
       isFragment: Boolean,
       processingType: ProcessingType = Streaming
   ): Future[ProcessId] = {
-    val processName = ProcessName(process.id)
+    val processName = process.name
     val action =
       CreateProcessAction(processName, category, process, processingType, isFragment, forwardedUserName = None)
     for {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/ProcessTestData.scala
@@ -129,7 +129,7 @@ object ProcessTestData {
     new FragmentResolver(new StubFragmentRepository(Map.empty))
   )
 
-  val validProcess: CanonicalProcess = validProcessWithId("fooProcess")
+  val validProcess: CanonicalProcess = validProcessWithName(ProcessName("fooProcess"))
 
   val validProcessWithEmptySpelExpr: CanonicalProcess =
     validProcessWithParam("fooProcess", "expression" -> Expression.spel(""))
@@ -141,8 +141,8 @@ object ProcessTestData {
   val archivedValidProcessDetails: ScenarioWithDetails =
     TestProcessUtil.validatedToProcess(validDisplayableProcess).copy(isArchived = true)
 
-  def validProcessWithId(id: String): CanonicalProcess = ScenarioBuilder
-    .streaming(id)
+  def validProcessWithName(name: ProcessName): CanonicalProcess = ScenarioBuilder
+    .streaming(name.value)
     .source("source", existingSourceFactory)
     .processor("processor", existingServiceId)
     .customNode("custom", "out1", existingStreamTransformer)
@@ -255,7 +255,7 @@ object ProcessTestData {
   }
 
   val processWithInvalidScenarioProperties: DisplayableProcess = DisplayableProcess(
-    id = "fooProcess",
+    name = ProcessName("fooProcess"),
     properties = ProcessProperties.combineTypeSpecificProperties(
       StreamMetaData(Some(2)),
       ProcessAdditionalFields(
@@ -276,7 +276,7 @@ object ProcessTestData {
 
   val sampleDisplayableProcess: DisplayableProcess = {
     DisplayableProcess(
-      id = "fooProcess",
+      name = ProcessName("fooProcess"),
       properties = ProcessProperties.combineTypeSpecificProperties(
         StreamMetaData(Some(2)),
         ProcessAdditionalFields(Some("process description"), Map.empty, StreamMetaData.typeName)
@@ -354,7 +354,7 @@ object ProcessTestData {
       comment: Option[UpdateProcessComment]
   ): UpdateProcessCommand = {
     val displayableProcess = DisplayableProcess(
-      id = processName.value,
+      name = processName,
       properties = ProcessProperties(StreamMetaData(Some(1), Some(true))),
       nodes = List.empty,
       edges = List.empty,
@@ -374,8 +374,8 @@ object ProcessTestData {
         .streaming(processName.value)
         .source("source", existingSourceFactory)
         .fragment(
-          fragment.metaData.id,
-          fragment.metaData.id,
+          fragment.name.value,
+          fragment.name.value,
           Nil,
           Map.empty,
           Map(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/StubFragmentRepository.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/helpers/StubFragmentRepository.scala
@@ -17,6 +17,6 @@ class StubFragmentRepository(val fragmentsByProcessingType: Map[ProcessingType, 
   override def fetchLatestFragment(fragmentName: ProcessName)(
       implicit user: LoggedUser
   ): Future[Option[FragmentDetails]] =
-    Future.successful(fragmentsByProcessingType.values.flatten.find(_.canonical.id == fragmentName.value))
+    Future.successful(fragmentsByProcessingType.values.flatten.find(_.canonical.name == fragmentName))
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/ComponentTestProcessData.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/ComponentTestProcessData.scala
@@ -131,8 +131,8 @@ object ComponentTestProcessData {
         .source(SecondSourceName, SharedSourceName)
         .filter(SecondFilterName, "#input.id != null")
         .fragment(
-          FraudFragment.id,
-          FraudFragment.id,
+          FraudFragment.name.value,
+          FraudFragment.name.value,
           Nil,
           Map.empty,
           Map(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/ComponentsUsageHelperTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/ComponentsUsageHelperTest.scala
@@ -126,8 +126,8 @@ class ComponentsUsageHelperTest extends AnyFunSuite with Matchers with TableDriv
     .source("source", existingSourceFactory)
     .customNode("custom", "outCustom", otherExistingStreamTransformer2)
     .fragment(
-      fragment.metaData.id,
-      fragment.metaData.id,
+      fragment.name.value,
+      fragment.name.value,
       Nil,
       Map.empty,
       Map(
@@ -213,7 +213,7 @@ class ComponentsUsageHelperTest extends AnyFunSuite with Matchers with TableDriv
         Map(
           sid(Source, existingSourceFactory)                    -> 1,
           sid(Sink, existingSinkFactory)                        -> 1,
-          sid(Fragment, fragment.metaData.id)                   -> 1,
+          sid(Fragment, fragment.name.value)                    -> 1,
           sid(CustomComponent, otherExistingStreamTransformer2) -> 2,
           bid(BuiltInComponentInfo.FragmentInputDefinition)     -> 1,
           bid(BuiltInComponentInfo.FragmentOutputDefinition)    -> 1
@@ -316,8 +316,8 @@ class ComponentsUsageHelperTest extends AnyFunSuite with Matchers with TableDriv
             (fragmentDetails, List(ScenarioUsageData("f1")))
           ),
           sid(Sink, existingSinkFactory) -> List((processDetailsWithFragment, List(ScenarioUsageData("sink")))),
-          sid(Fragment, fragment.metaData.id) -> List(
-            (processDetailsWithFragment, List(ScenarioUsageData(fragment.metaData.id)))
+          sid(Fragment, fragment.name.value) -> List(
+            (processDetailsWithFragment, List(ScenarioUsageData(fragment.name.value)))
           ),
           bid(BuiltInComponentInfo.FragmentInputDefinition) -> List(
             (fragmentDetails, List(ScenarioUsageData("start")))

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactorySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/UIProcessObjectsFactorySpec.scala
@@ -159,7 +159,7 @@ class UIProcessObjectsFactorySpec extends AnyFunSuite with Matchers {
 
     val processObjects = prepareUIProcessObjects(model, List(FragmentDetails(fragmentWithDocsUrl, "Category1")))
 
-    processObjects.componentsConfig(fragmentWithDocsUrl.id).docsUrl shouldBe Some(docsUrl)
+    processObjects.componentsConfig(fragmentWithDocsUrl.name.value).docsUrl shouldBe Some(docsUrl)
   }
 
   test("should skip empty fragments in definitions") {
@@ -169,7 +169,7 @@ class UIProcessObjectsFactorySpec extends AnyFunSuite with Matchers {
     val fragment       = CanonicalProcess(MetaData("emptyFragment", FragmentSpecificData()), List.empty, List.empty)
     val processObjects = prepareUIProcessObjects(model, List(FragmentDetails(fragment, "Category1")))
 
-    processObjects.components.get(ComponentInfo(ComponentType.Fragment, fragment.id)) shouldBe empty
+    processObjects.components.get(ComponentInfo(ComponentType.Fragment, fragment.name.value)) shouldBe empty
   }
 
   test("should override component's parameter config with additionally provided config") {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/initialization/InitializationOnDbItSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/initialization/InitializationOnDbItSpec.scala
@@ -28,7 +28,7 @@ abstract class InitializationOnDbItSpec
   import Initialization.nussknackerUser
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  private val processId = "proc1"
+  private val processName = ProcessName("proc1")
 
   private val migrations = mapProcessingTypeDataProvider(TestProcessingTypes.Streaming -> new TestMigrations(1, 2))
 
@@ -38,7 +38,7 @@ abstract class InitializationOnDbItSpec
 
   private lazy val writeRepository = TestFactory.newWriteProcessRepository(testDbRef)
 
-  private def sampleCanonicalProcess(processId: String) = ProcessTestData.validProcessWithId(processId)
+  private def sampleCanonicalProcess(processName: ProcessName) = ProcessTestData.validProcessWithName(processName)
 
   it should "migrate processes" in {
     saveSampleProcess()
@@ -55,11 +55,11 @@ abstract class InitializationOnDbItSpec
 
   it should "migrate processes when fragments present" in {
     (1 to 20).foreach { id =>
-      saveSampleProcess(s"sub$id", fragment = true)
+      saveSampleProcess(ProcessName(s"sub$id"), fragment = true)
     }
 
     (1 to 20).foreach { id =>
-      saveSampleProcess(s"id$id")
+      saveSampleProcess(ProcessName(s"id$id"))
     }
 
     Initialization.init(migrations, testDbRef, repository, "env1")
@@ -95,11 +95,11 @@ abstract class InitializationOnDbItSpec
       .map(d => (d.name.value, d.modelVersion)) shouldBe List(("proc1", Some(1)))
   }
 
-  private def saveSampleProcess(processName: String = processId, fragment: Boolean = false): Unit = {
+  private def saveSampleProcess(processName: ProcessName = processName, fragment: Boolean = false): Unit = {
     val action = CreateProcessAction(
-      ProcessName(processName),
+      processName,
       "RTM",
-      sampleCanonicalProcess(processId),
+      sampleCanonicalProcess(processName),
       TestProcessingTypes.Streaming,
       fragment,
       forwardedUserName = None

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
@@ -12,6 +12,7 @@ import pl.touk.nussknacker.engine.api.component.{ComponentGroupName, ParameterCo
 import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.api.displayedgraph.displayablenode.Edge
 import pl.touk.nussknacker.engine.api.displayedgraph.{DisplayableProcess, ProcessProperties}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.{FragmentSpecificData, StreamMetaData}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -259,7 +260,7 @@ class BaseFlowTest
     val response1 = httpClient.send(
       quickRequest
         .post(
-          uri"$nuDesignerHttpAddress/api/processes/${scenario.id}/Category1?isFragment=${scenario.metaData.isFragment}"
+          uri"$nuDesignerHttpAddress/api/processes/${scenario.name}/Category1?isFragment=${scenario.metaData.isFragment}"
         )
         .auth
         .basic("admin", "admin")
@@ -286,7 +287,7 @@ class BaseFlowTest
     val processId = UUID.randomUUID().toString
 
     val process = DisplayableProcess(
-      id = processId,
+      name = ProcessName(processId),
       properties = ProcessProperties(FragmentSpecificData()),
       nodes = List(
         FragmentInputDefinition("input1", List(FragmentParameter("badParam", FragmentClazzRef("i.do.not.exist")))),
@@ -351,7 +352,7 @@ class BaseFlowTest
 
     val response = httpClient.send(
       quickRequest
-        .post(uri"$nuDesignerHttpAddress/api/processManagement/test/${process.id}")
+        .post(uri"$nuDesignerHttpAddress/api/processManagement/test/${process.name}")
         .contentType(MediaType.MultipartFormData)
         .multipartBody(
           sttpPrepareMultiParts(
@@ -491,14 +492,14 @@ class BaseFlowTest
     val response = httpClient.send(
       quickRequest.auth
         .basic("admin", "admin")
-        .post(uri"$nuDesignerHttpAddress/api/processes/${process.id}/Category1?isFragment=false")
+        .post(uri"$nuDesignerHttpAddress/api/processes/${process.name}/Category1?isFragment=false")
     )
     response.code shouldEqual StatusCode.Created
     updateProcess(process)
   }
 
   private def updateProcess(process: CanonicalProcess) = {
-    val processId = process.id
+    val processId = process.name
     val response = httpClient.send(
       quickRequest.auth
         .basic("admin", "admin")
@@ -517,7 +518,7 @@ class BaseFlowTest
 
     val response = httpClient.send(
       quickRequest
-        .post(uri"$nuDesignerHttpAddress/api/processManagement/test/${process.id}")
+        .post(uri"$nuDesignerHttpAddress/api/processManagement/test/${process.name}")
         .contentType(MediaType.MultipartFormData)
         .multipartBody(
           sttpPrepareMultiParts(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/DictsFlowTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/DictsFlowTest.scala
@@ -5,6 +5,7 @@ import io.circe.Json
 import org.scalatest.OptionValues
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.spel.Implicits._
@@ -44,7 +45,7 @@ class DictsFlowTest
     val expressionUsingDictWithInvalidLabel = s"#DICT['invalid']"
     val process = sampleProcessWithExpression(UUID.randomUUID().toString, expressionUsingDictWithInvalidLabel)
 
-    createEmptyScenario(process.id)
+    createEmptyScenario(process.name)
 
     val response1 = httpClient.send(
       quickRequest
@@ -74,7 +75,7 @@ class DictsFlowTest
 
     val response2 = httpClient.send(
       quickRequest
-        .get(uri"$nuDesignerHttpAddress/api/processes/${process.id}")
+        .get(uri"$nuDesignerHttpAddress/api/processes/${process.name}")
         .auth
         .basic("admin", "admin")
     )
@@ -108,7 +109,7 @@ class DictsFlowTest
 
     val response1 = httpClient.send(
       quickRequest
-        .post(uri"$nuDesignerHttpAddress/api/processes/${process.id}/Category1?isFragment=false")
+        .post(uri"$nuDesignerHttpAddress/api/processes/${process.name}/Category1?isFragment=false")
         .auth
         .basic("admin", "admin")
     )
@@ -136,7 +137,7 @@ class DictsFlowTest
 
     val response = httpClient.send(
       quickRequest
-        .post(uri"$nuDesignerHttpAddress/api/processManagement/test/${process.id}")
+        .post(uri"$nuDesignerHttpAddress/api/processManagement/test/${process.name}")
         .contentType(MediaType.MultipartFormData)
         .multipartBody(
           sttpPrepareMultiParts(
@@ -165,7 +166,7 @@ class DictsFlowTest
       process: CanonicalProcess,
       endResultExpressionToPost: String
   ): Json = {
-    createEmptyScenario(process.id)
+    createEmptyScenario(process.name)
 
     val response1 = httpClient.send(
       quickRequest
@@ -182,7 +183,7 @@ class DictsFlowTest
 
     val response2 = httpClient.send(
       quickRequest
-        .get(uri"$nuDesignerHttpAddress/api/processes/${process.id}")
+        .get(uri"$nuDesignerHttpAddress/api/processes/${process.name}")
         .auth
         .basic("admin", "admin")
     )
@@ -193,10 +194,10 @@ class DictsFlowTest
     response2.extractFieldJsonValue("json", "validationResult", "errors", "invalidNodes")
   }
 
-  private def createEmptyScenario(processId: String) = {
+  private def createEmptyScenario(processName: ProcessName) = {
     val response = httpClient.send(
       quickRequest
-        .post(uri"$nuDesignerHttpAddress/api/processes/$processId/Category1?isFragment=false")
+        .post(uri"$nuDesignerHttpAddress/api/processes/$processName/Category1?isFragment=false")
         .auth
         .basic("admin", "admin")
     )
@@ -206,7 +207,7 @@ class DictsFlowTest
   private def extractValidationResult(process: CanonicalProcess): Json = {
     val response = httpClient.send(
       quickRequest
-        .put(uri"$nuDesignerHttpAddress/api/processes/${process.id}")
+        .put(uri"$nuDesignerHttpAddress/api/processes/${process.name}")
         .contentType(MediaType.ApplicationJson)
         .body(TestFactory.posting.toJsonAsProcessToSave(process).spaces2)
         .auth

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/ConfigProcessToolbarServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/ConfigProcessToolbarServiceSpec.scala
@@ -4,7 +4,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.util.UriUtils
-import pl.touk.nussknacker.engine.api.process.ProcessingType
+import pl.touk.nussknacker.engine.api.process.{ProcessName, ProcessingType}
 import pl.touk.nussknacker.ui.api.helpers.TestProcessUtil
 import pl.touk.nussknacker.ui.config.processtoolbar._
 import pl.touk.nussknacker.ui.process.repository.ScenarioWithDetailsEntity
@@ -547,5 +547,5 @@ class ConfigProcessToolbarServiceSpec extends AnyFlatSpec with Matchers {
   }
 
   private def createProcess(name: String, category: ProcessingType, isFragment: Boolean, isArchived: Boolean) =
-    TestProcessUtil.toDetails(name, category, isFragment = isFragment, isArchived = isArchived)
+    TestProcessUtil.toDetails(ProcessName(name), category, isFragment = isFragment, isArchived = isArchived)
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/DBProcessServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/DBProcessServiceSpec.scala
@@ -126,7 +126,7 @@ class DBProcessServiceSpec extends AnyFlatSpec with Matchers with PatientScalaFu
     val dBProcessService = createDbProcessService(processes)
 
     val categoryDisplayable =
-      ProcessTestData.sampleDisplayableProcess.copy(id = category1Process.name.value, category = Category1)
+      ProcessTestData.sampleDisplayableProcess.copy(name = category1Process.name, category = Category1)
     val categoryStringData = ProcessConverter.fromDisplayable(categoryDisplayable).asJson.spaces2
     val baseProcessData    = ProcessConverter.fromDisplayable(ProcessTestData.sampleDisplayableProcess).asJson.spaces2
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/NewProcessPreparerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/NewProcessPreparerSpec.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.ui.process
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.ui.api.helpers.TestFactory.mapProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.api.helpers.ProcessTestData
 import pl.touk.nussknacker.ui.security.api.{AdminUser, LoggedUser}
@@ -19,9 +20,9 @@ class NewProcessPreparerSpec extends AnyFlatSpec with Matchers {
       mapProcessingTypeDataProvider(processingType -> Map.empty)
     )
 
-    val emptyProcess = preparer.prepareEmptyProcess("processId1", processingType, isFragment = false)
+    val emptyProcess = preparer.prepareEmptyProcess(ProcessName("processId1"), processingType, isFragment = false)
 
-    emptyProcess.metaData.id shouldBe "processId1"
+    emptyProcess.name shouldBe ProcessName("processId1")
     emptyProcess.nodes shouldBe List.empty
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentServiceSpec.scala
@@ -207,7 +207,7 @@ class DeploymentServiceSpec
     lastStateAction.state shouldBe ProcessActionState.ExecutionFinished
     // we want to hide finished deploys
     processDetails.lastDeployedAction shouldBe empty
-    activityRepository.findActivity(ProcessIdWithName(processId, processName)).futureValue.comments should have length 1
+    activityRepository.findActivity(processId).futureValue.comments should have length 1
 
     deploymentManager.withEmptyProcessState(processName) {
       val stateAfterJobRetention =

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/fragment/FragmentRepositorySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/fragment/FragmentRepositorySpec.scala
@@ -33,7 +33,7 @@ class FragmentRepositorySpec
       status shouldEqual StatusCodes.OK
     }
 
-    ProcessTestData.sampleFragment.metaData.id shouldBe ProcessTestData.sampleFragment2.metaData.id
+    ProcessTestData.sampleFragment.name shouldBe ProcessTestData.sampleFragment2.name
     ProcessTestData.sampleFragment should not be ProcessTestData.sampleFragment2
 
     fragmentRepository.fetchLatestFragments(TestProcessingTypes.Streaming)(adminUser).futureValue shouldBe List(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/marshall/ProcessConverterSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import pl.touk.nussknacker.engine.api.displayedgraph.displayablenode.Edge
 import pl.touk.nussknacker.engine.api.displayedgraph.{DisplayableProcess, ProcessProperties}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, Unknown}
 import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
@@ -77,7 +78,7 @@ class ProcessConverterSpec extends AnyFunSuite with Matchers with TableDrivenPro
 
   test("be able to handle different node order") {
     val process = DisplayableProcess(
-      "t1",
+      ProcessName("t1"),
       ProcessProperties(metaData),
       List(
         Processor("e", ServiceRef("ref", List())),
@@ -104,7 +105,7 @@ class ProcessConverterSpec extends AnyFunSuite with Matchers with TableDrivenPro
       )
     ) { unexpectedEnd =>
       val process = ValidatedDisplayableProcess(
-        "t1",
+        ProcessName("t1"),
         ProcessProperties(metaData),
         List(Source("s", SourceRef("sourceRef", List())), unexpectedEnd),
         List(Edge("s", "e", None)),
@@ -143,7 +144,7 @@ class ProcessConverterSpec extends AnyFunSuite with Matchers with TableDrivenPro
       additionalFields = ProcessAdditionalFields(None, Map.empty, StreamMetaData.typeName)
     )
     val process = ValidatedDisplayableProcess(
-      meta.id,
+      meta.name,
       ProcessProperties(meta.typeSpecificData),
       List(
         Source("s", SourceRef("sourceRef", List())),
@@ -202,7 +203,7 @@ class ProcessConverterSpec extends AnyFunSuite with Matchers with TableDrivenPro
 
   test("convert process with branches") {
     val process = DisplayableProcess(
-      "t1",
+      ProcessName("t1"),
       ProcessProperties(metaData),
       List(
         Processor("e", ServiceRef("ref", List.empty)),

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/GroupByMigrationSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/GroupByMigrationSpec.scala
@@ -34,7 +34,7 @@ class GroupByMigrationSpec extends AnyFunSuite {
     val results = testMigration.testMigrations(List(TestProcessUtil.validatedToProcess(process)), List())
 
     results should have size 1
-    val processMigrationResult = results.find(_.converted.id == process.id).get
+    val processMigrationResult = results.find(_.converted.name == process.name).get
     processMigrationResult.shouldFail shouldBe false
     getFirst[CustomNode](processMigrationResult).parameters shouldBe List(NodeParameter("groupBy", "#input"))
   }
@@ -53,7 +53,7 @@ class GroupByMigrationSpec extends AnyFunSuite {
     val results = testMigration.testMigrations(List(TestProcessUtil.validatedToProcess(process)), List())
 
     results should have size 1
-    val processMigrationResult = results.find(_.converted.id == process.id).get
+    val processMigrationResult = results.find(_.converted.name == process.name).get
     processMigrationResult.shouldFail shouldBe false
     getFirst[CustomNode](processMigrationResult).parameters shouldBe List(NodeParameter("keyBy", "#input"))
   }
@@ -71,7 +71,7 @@ class GroupByMigrationSpec extends AnyFunSuite {
     val results = testMigration.testMigrations(List(TestProcessUtil.validatedToProcess(process)), List())
 
     results should have size 1
-    val processMigrationResult = results.find(_.converted.id == process.id).get
+    val processMigrationResult = results.find(_.converted.name == process.name).get
     processMigrationResult.shouldFail shouldBe false
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrationsSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrationsSpec.scala
@@ -126,7 +126,7 @@ class TestModelMigrationsSpec extends AnyFunSuite with Matchers {
         ScenarioBuilder
           .streaming("fooProcess")
           .source("source", existingSourceFactory)
-          .fragmentOneOut("fragment", fragment.id, "output", "fragmentResult", "param1" -> "'foo'")
+          .fragmentOneOut("fragment", fragment.name.value, "output", "fragmentResult", "param1" -> "'foo'")
           .emptySink("sink", existingSinkFactory)
       )
 
@@ -134,7 +134,7 @@ class TestModelMigrationsSpec extends AnyFunSuite with Matchers {
 
     results should have size 2
     val (fragmentMigrationResult, processMigrationResult) =
-      (results.find(_.converted.id == fragment.id).get, results.find(_.converted.id == process.id).get)
+      (results.find(_.converted.name == fragment.name).get, results.find(_.converted.name == process.name).get)
     fragmentMigrationResult.shouldFail shouldBe false
     processMigrationResult.shouldFail shouldBe false
     getFirst[FragmentInputDefinition](fragmentMigrationResult).parameters shouldBe List(
@@ -158,7 +158,7 @@ class TestModelMigrationsSpec extends AnyFunSuite with Matchers {
         ScenarioBuilder
           .streaming("fooProcess")
           .source("source", existingSourceFactory)
-          .fragmentOneOut("fragment", fragment.id, "output", "fragmentResult", "param1" -> "'foo'")
+          .fragmentOneOut("fragment", fragment.name.value, "output", "fragmentResult", "param1" -> "'foo'")
           .emptySink("sink", existingSinkFactory)
       )
 
@@ -167,7 +167,7 @@ class TestModelMigrationsSpec extends AnyFunSuite with Matchers {
       List(validatedToProcess(fragment).copy(modelVersion = Some(10)))
     )
 
-    val processMigrationResult = results.find(_.converted.id == process.id).get
+    val processMigrationResult = results.find(_.converted.name == process.name).get
     processMigrationResult.newErrors.hasErrors shouldBe false
     processMigrationResult.newErrors.hasWarnings shouldBe false
     processMigrationResult.converted.validationResult.value.hasErrors shouldBe false

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/UnionParametersMigrationSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/UnionParametersMigrationSpec.scala
@@ -34,7 +34,7 @@ class UnionParametersMigrationSpec extends AnyFunSuite {
     val results = testMigration.testMigrations(List(TestProcessUtil.validatedToProcess(process)), List())
 
     results should have size 1
-    val processMigrationResult = results.find(_.converted.id == process.id).get
+    val processMigrationResult = results.find(_.converted.name == process.name).get
     processMigrationResult.shouldFail shouldBe false
     getFirst[CustomNode](processMigrationResult).parameters shouldBe List(
       NodeParameter("Output expression", "#input")
@@ -55,7 +55,7 @@ class UnionParametersMigrationSpec extends AnyFunSuite {
     val results = testMigration.testMigrations(List(TestProcessUtil.validatedToProcess(process)), List())
 
     results should have size 1
-    val processMigrationResult = results.find(_.converted.id == process.id).get
+    val processMigrationResult = results.find(_.converted.name == process.name).get
     processMigrationResult.shouldFail shouldBe false
     getFirst[CustomNode](processMigrationResult).parameters shouldBe List(NodeParameter("value", "#input"))
   }
@@ -73,7 +73,7 @@ class UnionParametersMigrationSpec extends AnyFunSuite {
     val results = testMigration.testMigrations(List(TestProcessUtil.validatedToProcess(process)), List())
 
     results should have size 1
-    val processMigrationResult = results.find(_.converted.id == process.id).get
+    val processMigrationResult = results.find(_.converted.name == process.name).get
     processMigrationResult.shouldFail shouldBe false
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/util/PdfExporterSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/util/PdfExporterSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.StreamMetaData
 import pl.touk.nussknacker.engine.api.displayedgraph.{DisplayableProcess, ProcessProperties}
-import pl.touk.nussknacker.engine.api.process.{ScenarioVersion, VersionId}
+import pl.touk.nussknacker.engine.api.process.{ProcessName, ScenarioVersion, VersionId}
 import pl.touk.nussknacker.engine.graph.node.{Filter, UserDefinedAdditionalNodeFields}
 import pl.touk.nussknacker.engine.util.ResourceLoader
 import pl.touk.nussknacker.ui.api.helpers.{SampleProcess, TestCategories, TestProcessUtil, TestProcessingTypes}
@@ -36,7 +36,6 @@ class PdfExporterSpec extends AnyFlatSpec with Matchers {
       .map(commentId =>
         Comment(
           commentId,
-          process.id,
           details.processVersionId,
           "Jakiś taki dziwny ten proces??",
           "Wacław Wójcik",
@@ -55,7 +54,7 @@ class PdfExporterSpec extends AnyFlatSpec with Matchers {
 
   it should "export empty process to " in {
     val displayable: DisplayableProcess = DisplayableProcess(
-      "Proc11",
+      ProcessName("Proc11"),
       ProcessProperties(StreamMetaData()),
       List(),
       List(),
@@ -74,7 +73,7 @@ class PdfExporterSpec extends AnyFlatSpec with Matchers {
 
   it should "not allow entities in provided SVG" in {
     val displayable: DisplayableProcess = DisplayableProcess(
-      "Proc11",
+      ProcessName("Proc11"),
       ProcessProperties(StreamMetaData()),
       List(),
       List(),
@@ -93,7 +92,7 @@ class PdfExporterSpec extends AnyFlatSpec with Matchers {
   }
 
   private def createDetails(displayable: DisplayableProcess) = TestProcessUtil.toDetails(
-    "My process",
+    ProcessName("My process"),
     json = Some(displayable),
     description = Some(
       "My fancy description, which is quite, quite, quite looooooooong. \n And it contains maaaany, maaany strange features..."

--- a/designer/submodules/packages/components/src/common/scenarioHref.tsx
+++ b/designer/submodules/packages/components/src/common/scenarioHref.tsx
@@ -10,30 +10,30 @@ export function makeRelative(href: string): string {
     return href.replace(BASE_HREF, (match, offset) => (offset > 0 ? match : "/"));
 }
 
-function nuHref(path: string, scenarioId: string): string {
-    // , and / allowed in scenarioId
-    const sid = encodeURIComponent(scenarioId);
+function nuHref(path: string, scenarioName: string): string {
+    // , and / allowed in scenarioName
+    const sid = encodeURIComponent(scenarioName);
     return urljoin(BASE_HREF, path, sid);
 }
 
-export function scenarioHref(scenarioId: string): string {
-    return nuHref("visualization", scenarioId);
+export function scenarioHref(scenarioName: string): string {
+    return nuHref("visualization", scenarioName);
 }
 
-function scenarioWithNodesHref(scenarioId: string, nodeIds: string[]): string {
+function scenarioWithNodesHref(scenarioName: string, nodeIds: string[]): string {
     // , and / allowed in nodeId
     const ids = nodeIds.map((nodeId: string): string => encodeURIComponent(encodeURIComponent(nodeId)));
-    return urljoin(scenarioHref(scenarioId), `?nodeId=${ids.join(",")}`);
+    return urljoin(scenarioHref(scenarioName), `?nodeId=${ids.join(",")}`);
 }
 
-export function nodeHref(scenarioId: string, nodeId: string): string {
-    return scenarioWithNodesHref(scenarioId, [nodeId]);
+export function nodeHref(scenarioName: string, nodeId: string): string {
+    return scenarioWithNodesHref(scenarioName, [nodeId]);
 }
 
-export function fragmentNodeHref(scenarioId: string, fragmentNodeId: string, nodeId: string): string {
-    return scenarioWithNodesHref(scenarioId, [fragmentNodeId, `${fragmentNodeId}-${nodeId}`]);
+export function fragmentNodeHref(scenarioName: string, fragmentNodeId: string, nodeId: string): string {
+    return scenarioWithNodesHref(scenarioName, [fragmentNodeId, `${fragmentNodeId}-${nodeId}`]);
 }
 
-export function metricsHref(scenarioId: string): string {
-    return nuHref("metrics", scenarioId);
+export function metricsHref(scenarioName: string): string {
+    return nuHref("metrics", scenarioName);
 }

--- a/designer/submodules/packages/components/src/components/usages/nodesCell.tsx
+++ b/designer/submodules/packages/components/src/components/usages/nodesCell.tsx
@@ -27,7 +27,7 @@ export const NodesCell = ({
 }): JSX.Element => {
     const {
         value,
-        row: { id },
+        row: { name },
     } = props;
     const filterSegments = useMemo(() => filterText?.toLowerCase().toString().trim().split(/\s/) || [], [filterText]);
 
@@ -62,7 +62,7 @@ export const NodesCell = ({
     );
 
     const elements = sorted.map(([match, node]) => (
-        <NodeChip key={getNodeName(node)} icon={icon} node={node} filterText={filterText} rowId={id} matched={filterText ? match : -1} />
+        <NodeChip key={getNodeName(node)} icon={icon} node={node} filterText={filterText} rowId={name} matched={filterText ? match : -1} />
     ));
     return <TruncateWrapper {...props}>{elements}</TruncateWrapper>;
 };

--- a/designer/submodules/packages/components/src/components/usages/scenarioCell.tsx
+++ b/designer/submodules/packages/components/src/components/usages/scenarioCell.tsx
@@ -9,7 +9,7 @@ import Stack from "@mui/material/Stack";
 export function ScenarioCell({ filterText, ...props }: GridRenderCellParams & { filterText: string }): JSX.Element {
     const { row, value } = props;
     return (
-        <CellLink component={ExternalLink} underline="hover" disabled={!value} cellProps={props} href={scenarioHref(row.id)}>
+        <CellLink component={ExternalLink} underline="hover" disabled={!value} cellProps={props} href={scenarioHref(row.name)}>
             <Stack direction="row" alignItems="center">
                 <ScenarioAvatar process={row} />
                 <Highlight value={value} filterText={filterText} />

--- a/designer/submodules/packages/components/src/components/usages/usagesTable.tsx
+++ b/designer/submodules/packages/components/src/components/usages/usagesTable.tsx
@@ -163,6 +163,7 @@ export function UsagesTable(props: TableViewData<UsageWithStatus>): JSX.Element 
         <TableWrapper<ComponentUsageType, UsagesFiltersModel>
             sx={sx}
             getRowClassName={rowClassName}
+            getRowId={(row) => row.name}
             columns={columns}
             data={data}
             isLoading={isLoading}

--- a/designer/submodules/packages/components/src/components/useComponentsQuery.tsx
+++ b/designer/submodules/packages/components/src/components/useComponentsQuery.tsx
@@ -58,7 +58,7 @@ export function useComponentUsagesWithStatus(componentId: string): UseQueryResul
             ...usagesQuery,
             data: usages.map((el) => ({
                 ...el,
-                state: statuses?.[el.id],
+                state: statuses?.[el.name],
             })),
         } as UseQueryResult<UsageWithStatus[]>;
     }, [usagesQuery, usages, statuses]);

--- a/designer/submodules/packages/components/src/scenarios/filters/filterRules.tsx
+++ b/designer/submodules/packages/components/src/scenarios/filters/filterRules.tsx
@@ -8,7 +8,7 @@ export const filterRules = createFilterRules<RowType, ScenariosFiltersModel>({
         if (!text?.length) return true;
         const segments = text.trim().split(/\s/);
         return segments.every((segment) =>
-            ["id"]
+            ["name"]
                 .map((field) => row[field]?.toString().toLowerCase())
                 .filter(Boolean)
                 .some((value) => value.includes(segment.toLowerCase())),

--- a/designer/submodules/packages/components/src/scenarios/list/item.tsx
+++ b/designer/submodules/packages/components/src/scenarios/list/item.tsx
@@ -40,8 +40,8 @@ export function FirstLine({ row }: { row: RowType }): JSX.Element {
 
     return (
         <Stack direction="row" spacing={1} alignItems="center" divider={<Divider orientation="vertical" flexItem />}>
-            <CopyTooltip text={row.id} title={t("scenario.copyName", "Copy name to clipboard")}>
-                <Highlight value={row.id} filterText={filtersContext.getFilter("NAME")} />
+            <CopyTooltip text={row.name} title={t("scenario.copyName", "Copy name to clipboard")}>
+                <Highlight value={row.name} filterText={filtersContext.getFilter("NAME")} />
             </CopyTooltip>
             <Category value={row.processCategory} filtersContext={filtersContext} />
         </Stack>

--- a/designer/submodules/packages/components/src/scenarios/list/itemsList.tsx
+++ b/designer/submodules/packages/components/src/scenarios/list/itemsList.tsx
@@ -20,7 +20,7 @@ import { ScenarioAvatar } from "./scenarioAvatar";
 
 const ListRowContent = React.memo(function ListRowContent({ row }: { row: RowType }): JSX.Element {
     return (
-        <ListItemButton component={ExternalLink} href={scenarioHref(row.id)}>
+        <ListItemButton component={ExternalLink} href={scenarioHref(row.name)}>
             <ListItemAvatar>
                 <ScenarioAvatar process={row} />
             </ListItemAvatar>
@@ -39,7 +39,7 @@ const ListRow = React.memo(function ListRow({ row, style }: { row: RowType; styl
                 sx={{ opacity }}
                 secondaryAction={
                     !row.isFragment && (
-                        <IconButton component={ExternalLink} href={metricsHref(row.id)}>
+                        <IconButton component={ExternalLink} href={metricsHref(row.name)}>
                             <AssessmentIcon />
                         </IconButton>
                     )

--- a/designer/submodules/packages/components/src/scenarios/useScenariosQuery.tsx
+++ b/designer/submodules/packages/components/src/scenarios/useScenariosQuery.tsx
@@ -87,7 +87,7 @@ export function useScenariosWithStatus(): UseQueryResult<ProcessType[]> {
             ...scenarios,
             data: data.map((scenario) => ({
                 ...scenario,
-                state: statuses?.data?.[scenario.id] || scenario.state,
+                state: statuses?.data?.[scenario.name] || scenario.state,
             })),
         } as UseQueryResult<ProcessType[]>;
     }, [scenarios, statuses]);

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -28,9 +28,7 @@ paths:
                 Example0:
                   summary: List component usages
                   value:
-                  - id: scenario1
-                    name: scenario1
-                    processId: 1
+                  - name: scenario1
                     nodesUsagesData:
                     - nodeId: csv-source
                       type: ScenarioUsageData
@@ -54,9 +52,7 @@ paths:
                 Example1:
                   summary: List component usages with no last Action
                   value:
-                  - id: scenario1
-                    name: scenario1
-                    processId: 1
+                  - name: scenario1
                     nodesUsagesData:
                     - nodeId: csv-source
                       type: ScenarioUsageData
@@ -628,9 +624,7 @@ components:
       - builtin
     ComponentUsagesInScenario:
       required:
-      - id
       - name
-      - processId
       - isFragment
       - processCategory
       - modificationDate
@@ -640,12 +634,8 @@ components:
       - createdBy
       type: object
       properties:
-        id:
-          type: string
         name:
           $ref: '#/components/schemas/ProcessName'
-        processId:
-          $ref: '#/components/schemas/ProcessId'
         nodesUsagesData:
           type: array
           items:

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -6,7 +6,6 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 ## In version 1.14.x (Not released yet)
 
 ### Code API changes
-
 * [#5271](https://github.com/TouK/nussknacker/pull/5271) Changed `AdditionalUIConfigProvider.getAllForProcessingType` API to be more in line with FragmentParameter
   * `SingleComponentConfigWithoutId` renamed to `ComponentAdditionalConfig`
   * field `params: Map[String, ParameterConfig]` changed to `parameterConfigs: Map[String, ParameterAdditionalUIConfig]`
@@ -14,6 +13,18 @@ To see the biggest differences please consult the [changelog](Changelog.md).
     *  `ParameterConfig.defaultValue` -> `ParameterAdditionalUIConfig.initialValue`
     *  `ParameterConfig.hintText` -> `ParameterAdditionalUIConfig.hintText`
     *  most of the capabilities of `ParameterConfig.editor` and `ParameterConfig.validators` are covered by `ParameterAdditionalUIConfig.valueEditor` and `ParameterAdditionalUIConfig.valueCompileTimeValidation`
+* [#5285](https://github.com/TouK/nussknacker/pull/5285) Changes around scenario id/name fields:
+  * `CanonicalProcess.id` of type `String` was replaced by `name` field of type `ProcessName` 
+  * `CanonicalProcess.withProcessId` was renamed to `withProcessName` 
+  * `ScenarioWithDetails.id` was removed (it had the same value as `name`)
+  * `ScenarioWithDetails.processId` changed the type to `Option[ProcessId]` and will have always `None` value
+  * `ComponentUsagesInScenario.id` was removed (it had the same value as `name`)
+  * `ComponentUsagesInScenario.processId` was removed
+  * `ListenerScenarioWithDetails.id` was removed (it had the same value as `name`)
+  * `ValidatedDisplayableProcess.id` of type `String` was replaced by `name` field of type `ProcessName`
+  * `DisplayableProcess.id` of type `String` was replaced by `name` field of type `ProcessName`, `processName` field is removed
+  * deprecated `AsyncExecutionContextPreparer.prepareExecutionContext` was removed
+  * `AsyncExecutionContextPreparer.prepare` now takes `ProcessName` instead of `String`
 
 ### REST API changes
 * [#5280](https://github.com/TouK/nussknacker/pull/5280) Changes in the definition API:
@@ -25,6 +36,17 @@ To see the biggest differences please consult the [changelog](Changelog.md).
       and nested `clazzName` inside each element was extracted
     * `nodeId` field inside `edgesForNodes` was renamed into `componentId` in the flat `$componentType-$componentName` format
     * `defaultAsyncInterpretation` field was removed
+* [#5285](https://github.com/TouK/nussknacker/pull/5285) Changes around scenario id/name fields:
+  * `/process(Details)/**` endpoints:
+    * `id` fields was removed (it had the same value as `name`)
+    * `processId` fields return always `null`
+    * `.json.id` fields was renamed to `.json.name`
+  * `components/*/usages` endpoint:
+    * `id` fields was removed (it had the same value as `name`)
+    * `processId` fields was removed
+  * `processes/**/activity/attachments` - `processId` fields was removed
+  * `processes/**/activity/comments` - `processId` fields was removed
+  * GET `processes/$name/$version/activity/attachments` - `$version` segment is removed now
 
 ### Other changes
 * [#4287](https://github.com/TouK/nussknacker/pull/4287) Cats Effect 3 bump

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/exception/DefaultExceptionConsumers.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/exception/DefaultExceptionConsumers.scala
@@ -14,7 +14,7 @@ case class VerboselyLoggingExceptionConsumer(processMetaData: MetaData, params: 
 
   override def consume(e: NuExceptionInfo[NonTransientException]): Unit = {
     logger.error(
-      s"${processMetaData.id}: Exception during processing job, params: $params, context: ${e.context}",
+      s"${processMetaData.name}: Exception during processing job, params: $params, context: ${e.context}",
       e.throwable
     )
   }
@@ -27,7 +27,7 @@ case class BrieflyLoggingExceptionConsumer(processMetaData: MetaData, params: Ma
 
   override def consume(e: NuExceptionInfo[NonTransientException]): Unit = {
     warnWithDebugStack(
-      s"${processMetaData.id}: Exception: ${e.throwable.getMessage} (${e.throwable.getClass.getName}), params: $params",
+      s"${processMetaData.name}: Exception: ${e.throwable.getMessage} (${e.throwable.getClass.getName}), params: $params",
       e.throwable
     )
   }

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/BlockingQueueSource.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/BlockingQueueSource.scala
@@ -75,7 +75,7 @@ class BlockingQueueSource[T: TypeInformation](timestampAssigner: AssignerWithPun
   ): DataStream[Context] = {
     env
       .addSource(flinkSourceFunction, implicitly[TypeInformation[T]])
-      .name(s"${flinkNodeContext.metaData.id}-${flinkNodeContext.nodeId}-source")
+      .name(s"${flinkNodeContext.metaData.name}-${flinkNodeContext.nodeId}-source")
       .map(
         new FlinkContextInitializingFunction(
           contextInitializer,

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/EmitWatermarkAfterEachElementCollectionSource.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/EmitWatermarkAfterEachElementCollectionSource.scala
@@ -62,7 +62,7 @@ class EmitWatermarkAfterEachElementCollectionSource[T: TypeInformation](
   ): DataStream[Context] = {
     env
       .addSource(flinkSourceFunction, implicitly[TypeInformation[T]])
-      .name(s"${flinkNodeContext.metaData.id}-${flinkNodeContext.nodeId}-source")
+      .name(s"${flinkNodeContext.metaData.name}-${flinkNodeContext.nodeId}-source")
       .map(
         new FlinkContextInitializingFunction(
           contextInitializer,

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PeriodicSourceFactory.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PeriodicSourceFactory.scala
@@ -55,11 +55,11 @@ class PeriodicSourceFactory(timestampAssigner: TimestampWatermarkHandler[AnyRef]
           flinkNodeContext: FlinkCustomNodeContext
       ): DataStream[Context] = {
 
-        val count     = Option(nullableCount).map(_.toInt).getOrElse(1)
-        val processId = flinkNodeContext.metaData.id
+        val count       = Option(nullableCount).map(_.toInt).getOrElse(1)
+        val processName = flinkNodeContext.metaData.name
         val stream = env
           .addSource(new PeriodicFunction(period))
-          .map(_ => Context(processId))
+          .map(_ => Context(processName.value))
           .flatMap(flinkNodeContext.lazyParameterHelper.lazyMapFunction(value))
           .flatMap { (v: ValueWithContext[AnyRef], c: Collector[AnyRef]) =>
             1.to(count).map(_ => v.value).foreach(c.collect)

--- a/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformerSpec.scala
+++ b/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformerSpec.scala
@@ -126,7 +126,7 @@ class ForEachTransformerSpec extends AnyFunSuite with FlinkSpec with Matchers wi
   private def runProcess(model: LocalModelData, testProcess: CanonicalProcess): Unit = {
     val stoppableEnv = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(stoppableEnv, model)(testProcess)
-    stoppableEnv.executeAndWaitForFinished(testProcess.id)()
+    stoppableEnv.executeAndWaitForFinished(testProcess.name.value)()
   }
 
 }

--- a/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/PeriodicSourceFactorySpec.scala
+++ b/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/PeriodicSourceFactorySpec.scala
@@ -39,7 +39,7 @@ class PeriodicSourceFactorySpec extends AnyFunSuite with FlinkSpec with PatientS
     val stoppableEnv = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(stoppableEnv, model)(scenario)
 
-    val id = stoppableEnv.executeAndWaitForStart(scenario.id)
+    val id = stoppableEnv.executeAndWaitForStart(scenario.name.value)
     try {
       eventually {
         val results = collectingListener.results.nodeResults.get(sinkId)

--- a/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformersTestModeSpec.scala
+++ b/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformersTestModeSpec.scala
@@ -140,7 +140,7 @@ class UnionTransformersTestModeSpec
   private def runProcess(modelData: LocalModelData, scenario: CanonicalProcess): Unit = {
     val stoppableEnv = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(stoppableEnv, modelData)(scenario)
-    stoppableEnv.executeAndWaitForFinished(scenario.id)()
+    stoppableEnv.executeAndWaitForFinished(scenario.name.value)()
   }
 
 }

--- a/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionWithMemoTransformerSpec.scala
+++ b/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionWithMemoTransformerSpec.scala
@@ -216,7 +216,7 @@ class UnionWithMemoTransformerSpec extends AnyFunSuite with FlinkSpec with Match
     )
     val stoppableEnv = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(stoppableEnv, model)(testProcess)
-    stoppableEnv.withJobRunning(testProcess.id)(action)
+    stoppableEnv.withJobRunning(testProcess.name.value)(action)
   }
 
   def prepareComponents(

--- a/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/FullOuterJoinTransformerSpec.scala
+++ b/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/FullOuterJoinTransformerSpec.scala
@@ -116,7 +116,7 @@ class FullOuterJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Match
     input1.finish()
     input2.finish()
 
-    stoppableEnv.waitForJobState(id.getJobID, process.id, ExecutionState.FINISHED)()
+    stoppableEnv.waitForJobState(id.getJobID, process.name.value, ExecutionState.FINISHED)()
 
     val outValues = collectingListener.results
       .nodeResults(EndNodeId)
@@ -519,7 +519,7 @@ class FullOuterJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Match
     val model        = modelData(input1, input2, collectingListener)
     val stoppableEnv = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(stoppableEnv, model)(testProcess)
-    val id = stoppableEnv.executeAndWaitForStart(testProcess.id)
+    val id = stoppableEnv.executeAndWaitForStart(testProcess.name.value)
     (id, stoppableEnv)
   }
 

--- a/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/JavaCollectionsSerializationTest.scala
+++ b/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/JavaCollectionsSerializationTest.scala
@@ -79,7 +79,7 @@ class JavaCollectionsSerializationTest extends AnyFunSuite with FlinkSpec with M
   ): Unit = {
     val stoppableEnv = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(stoppableEnv, model)(testProcess)
-    stoppableEnv.executeAndWaitForFinished(testProcess.id)()
+    stoppableEnv.executeAndWaitForFinished(testProcess.name.value)()
   }
 
 }

--- a/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/SingleSideJoinTransformerSpec.scala
+++ b/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/SingleSideJoinTransformerSpec.scala
@@ -99,7 +99,7 @@ class SingleSideJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Matc
     input1.add(OneRecord(key, 2, -1))
     input1.finish()
 
-    stoppableEnv.waitForJobState(id.getJobID, process.id, ExecutionState.FINISHED)()
+    stoppableEnv.waitForJobState(id.getJobID, process.name.value, ExecutionState.FINISHED)()
 
     val outValues = collectingListener.results
       .nodeResults(EndNodeId)
@@ -121,7 +121,7 @@ class SingleSideJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Matc
     val model        = modelData(input1, input2, collectingListener)
     val stoppableEnv = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(stoppableEnv, model)(testProcess)
-    val id = stoppableEnv.executeAndWaitForStart(testProcess.id)
+    val id = stoppableEnv.executeAndWaitForStart(testProcess.name.value)
     (id, stoppableEnv)
   }
 

--- a/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/TransformersTest.scala
+++ b/engine/flink/components/base/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/TransformersTest.scala
@@ -533,7 +533,7 @@ class TransformersTest extends AnyFunSuite with FlinkSpec with Matchers with Ins
   ): Unit = {
     val stoppableEnv = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(stoppableEnv, model)(testProcess)
-    stoppableEnv.executeAndWaitForFinished(testProcess.id)()
+    stoppableEnv.executeAndWaitForFinished(testProcess.name.value)()
   }
 
   private def variablesForKey(

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/ExecutionConfigPreparer.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/ExecutionConfigPreparer.scala
@@ -53,7 +53,7 @@ object ExecutionConfigPreparer extends LazyLogging {
         config: ExecutionConfig
     )(jobData: JobData, deploymentData: DeploymentData): Unit = {
       val namingParameters = objectNaming
-        .objectNamingParameters(jobData.metaData.id, modelConfig, new NamingContext(FlinkUsageKey))
+        .objectNamingParameters(jobData.metaData.name.value, modelConfig, new NamingContext(FlinkUsageKey))
         .map(p => NamingParameters(p.toTags))
 
       NkGlobalParameters.setInContext(

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/FlinkScenarioNameValidator.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/FlinkScenarioNameValidator.scala
@@ -16,8 +16,8 @@ class FlinkScenarioNameValidator(config: Config) extends CustomProcessValidator 
   private val flinkProcessNameValidationPattern = "[a-zA-Z0-9_-]++[a-zA-Z0-9_ -]*+(?<! )".r
 
   def validate(process: CanonicalProcess): ValidatedNel[ScenarioNameValidationError, Unit] = {
-    val scenarioName = process.metaData.id
-    if (flinkProcessNameValidationPattern.pattern.matcher(scenarioName).matches()) {
+    val scenarioName = process.name
+    if (flinkProcessNameValidationPattern.pattern.matcher(scenarioName.value).matches()) {
       Valid(())
     } else {
       Invalid(

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkEngineRuntimeContextImpl.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkEngineRuntimeContextImpl.scala
@@ -11,6 +11,6 @@ case class FlinkEngineRuntimeContextImpl(jobData: JobData, runtimeContext: Runti
   override val metricsProvider: MetricsProviderForScenario = new FlinkMetricsProviderForScenario(runtimeContext)
 
   override def contextIdGenerator(nodeId: String): ContextIdGenerator =
-    new IncContextIdGenerator(jobData.metaData.id + "-" + nodeId + "-" + runtimeContext.getIndexOfThisSubtask)
+    new IncContextIdGenerator(jobData.metaData.name.value + "-" + nodeId + "-" + runtimeContext.getIndexOfThisSubtask)
 
 }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
@@ -37,7 +37,7 @@ private[registrar] class AsyncInterpretationFunction(
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
-    serviceExecutionContext = serviceExecutionContextPreparer.prepare(compilerData.metaData.id)
+    serviceExecutionContext = serviceExecutionContextPreparer.prepare(compilerData.metaData.name)
   }
 
   override def asyncInvoke(input: Context, collector: ResultFuture[InterpretationResult]): Unit = {

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
@@ -12,6 +12,7 @@ import pl.touk.nussknacker.engine.InterpretationResult
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.component.NodeComponentInfo
 import pl.touk.nussknacker.engine.api.context.{JoinContextTransformation, ValidationContext}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.compiledgraph.part._
 import pl.touk.nussknacker.engine.deployment.DeploymentData
@@ -429,7 +430,7 @@ object FlinkProcessRegistrar {
       splittedNode: splittednode.SplittedNode[NodeData],
       operation: String
   ) = {
-    s"${metaData.id}-${splittedNode.id}-$operation"
+    s"${metaData.name}-${splittedNode.id}-$operation"
   }
 
   private[registrar] def interpretationOperatorName(
@@ -438,16 +439,16 @@ object FlinkProcessRegistrar {
       interpretationName: String,
       shouldUseAsyncInterpretation: Boolean
   ): String = {
-    interpretationOperatorName(metaData.id, splittedNode.id, interpretationName, shouldUseAsyncInterpretation)
+    interpretationOperatorName(metaData.name, splittedNode.id, interpretationName, shouldUseAsyncInterpretation)
   }
 
   private[registrar] def interpretationOperatorName(
-      scenarioId: String,
+      scenarioName: ProcessName,
       nodeId: String,
       interpretationName: String,
       shouldUseAsyncInterpretation: Boolean
   ) = {
-    s"$scenarioId-$nodeId-$interpretationName${if (shouldUseAsyncInterpretation) "Async" else "Sync"}"
+    s"$scenarioName-$nodeId-$interpretationName${if (shouldUseAsyncInterpretation) "Async" else "Sync"}"
   }
 
 }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/runner/FlinkStreamingProcessMain.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/runner/FlinkStreamingProcessMain.scala
@@ -31,7 +31,7 @@ object FlinkStreamingProcessMain extends FlinkProcessMain[StreamExecutionEnviron
       FlinkProcessRegistrar(compilerFactory, FlinkJobConfig.parse(modelData.modelConfig), prepareExecutionConfig)
     registrar.register(env, process, processVersion, deploymentData)
     val preparedName =
-      modelData.objectNaming.prepareName(process.id, modelData.modelConfig, new NamingContext(FlinkUsageKey))
+      modelData.objectNaming.prepareName(process.name.value, modelData.modelConfig, new NamingContext(FlinkUsageKey))
     env.execute(preparedName)
   }
 

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/runner/FlinkStubbedRunner.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/runner/FlinkStubbedRunner.scala
@@ -39,7 +39,7 @@ trait FlinkStubbedRunner {
     env.getCheckpointConfig.disableCheckpointing()
 
     val streamGraph = env.getStreamGraph
-    streamGraph.setJobName(process.id)
+    streamGraph.setJobName(process.name.value)
 
     val jobGraph = streamGraph.getJobGraph()
     jobGraph.setClasspaths(modelData.modelClassLoader.urls.asJava)

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/helpers/ProcessTestHelpers.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/helpers/ProcessTestHelpers.scala
@@ -36,7 +36,7 @@ trait ProcessTestHelpers extends FlinkSpec { self: Suite =>
       MockService.clear()
       SinkForStrings.clear()
       SinkForInts.clear()
-      env.executeAndWaitForFinished(process.id)()
+      env.executeAndWaitForFinished(process.name.value)()
     }
 
   }

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/registrar/InterpretationFunctionFlinkGraphSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/registrar/InterpretationFunctionFlinkGraphSpec.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.process.registrar
 import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.flink.streaming.api.graph.{StreamGraph, StreamNode}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.process.registrar.FlinkProcessRegistrar._
 import pl.touk.nussknacker.engine.spel.Implicits.asSpelExpression
@@ -11,7 +12,7 @@ import scala.jdk.CollectionConverters._
 
 class InterpretationFunctionFlinkGraphSpec extends FlinkStreamGraphSpec {
 
-  private val scenarioId = "test"
+  private val scenarioName = ProcessName("test")
   private val interpretationNodeNames =
     Set(InterpretationName, CustomNodeInterpretationName, BranchInterpretationName, SinkInterpretationName)
 
@@ -43,42 +44,47 @@ class InterpretationFunctionFlinkGraphSpec extends FlinkStreamGraphSpec {
     exactly(3, operatorNames) should endWith("Async")
     exactly(8, operatorNames) should endWith("Sync")
     operatorNames should contain only (
-      interpretationOperatorName(scenarioId, "sourceId1", InterpretationName, shouldUseAsyncInterpretation = true),
-      interpretationOperatorName(scenarioId, "sourceId2", InterpretationName, shouldUseAsyncInterpretation = false),
-      interpretationOperatorName(scenarioId, "joinId", BranchInterpretationName, shouldUseAsyncInterpretation = false),
+      interpretationOperatorName(scenarioName, "sourceId1", InterpretationName, shouldUseAsyncInterpretation = true),
+      interpretationOperatorName(scenarioName, "sourceId2", InterpretationName, shouldUseAsyncInterpretation = false),
       interpretationOperatorName(
-        scenarioId,
+        scenarioName,
+        "joinId",
+        BranchInterpretationName,
+        shouldUseAsyncInterpretation = false
+      ),
+      interpretationOperatorName(
+        scenarioName,
         "customId4",
         CustomNodeInterpretationName,
         shouldUseAsyncInterpretation = false
       ),
-      interpretationOperatorName(scenarioId, "sinkId4", SinkInterpretationName, shouldUseAsyncInterpretation = false),
+      interpretationOperatorName(scenarioName, "sinkId4", SinkInterpretationName, shouldUseAsyncInterpretation = false),
       interpretationOperatorName(
-        scenarioId,
+        scenarioName,
         "customId5",
         CustomNodeInterpretationName,
         shouldUseAsyncInterpretation = false
       ),
-      interpretationOperatorName(scenarioId, "sinkId5", SinkInterpretationName, shouldUseAsyncInterpretation = false),
+      interpretationOperatorName(scenarioName, "sinkId5", SinkInterpretationName, shouldUseAsyncInterpretation = false),
       interpretationOperatorName(
-        scenarioId,
+        scenarioName,
         "customId6",
         CustomNodeInterpretationName,
         shouldUseAsyncInterpretation = true
       ),
       interpretationOperatorName(
-        scenarioId,
+        scenarioName,
         "customId7",
         CustomNodeInterpretationName,
         shouldUseAsyncInterpretation = true
       ),
       interpretationOperatorName(
-        scenarioId,
+        scenarioName,
         "customEnding8",
         CustomNodeInterpretationName,
         shouldUseAsyncInterpretation = false
       ),
-      interpretationOperatorName(scenarioId, "sinkId9", SinkInterpretationName, shouldUseAsyncInterpretation = false),
+      interpretationOperatorName(scenarioName, "sinkId9", SinkInterpretationName, shouldUseAsyncInterpretation = false),
     )
   }
 
@@ -87,7 +93,7 @@ class InterpretationFunctionFlinkGraphSpec extends FlinkStreamGraphSpec {
   }
 
   private def prepareProcess(useAsyncInterpretation: Boolean) = ScenarioBuilder
-    .streaming(scenarioId)
+    .streaming(scenarioName.value)
     .useAsyncInterpretation(useAsyncInterpretation)
     .sources(
       GraphBuilder

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/ConsumerGroupDeterminer.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/ConsumerGroupDeterminer.scala
@@ -1,17 +1,18 @@
 package pl.touk.nussknacker.engine.kafka
 
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.flink.api.process.FlinkCustomNodeContext
 
 class ConsumerGroupDeterminer(consumerGroupNamingStrategy: ConsumerGroupNamingStrategy.Value) {
 
   def consumerGroup(nodeContext: FlinkCustomNodeContext): String = {
-    consumerGroup(nodeContext.metaData.id, nodeContext.nodeId)
+    consumerGroup(nodeContext.metaData.name, nodeContext.nodeId)
   }
 
-  def consumerGroup(processId: String, nodeId: String): String = {
+  def consumerGroup(processName: ProcessName, nodeId: String): String = {
     consumerGroupNamingStrategy match {
-      case ConsumerGroupNamingStrategy.ProcessId       => processId
-      case ConsumerGroupNamingStrategy.ProcessIdNodeId => processId + "-" + nodeId
+      case ConsumerGroupNamingStrategy.ProcessId       => processName.value
+      case ConsumerGroupNamingStrategy.ProcessIdNodeId => processName.value + "-" + nodeId
     }
   }
 

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/sharedproducer/KafkaSharedProducer.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/sharedproducer/KafkaSharedProducer.scala
@@ -22,7 +22,7 @@ object DefaultSharedKafkaProducerHolder
       creator: KafkaProducerCreator[Array[Byte], Array[Byte]],
       metaData: MetaData
   ): DefaultSharedKafkaProducer = {
-    val clientId = s"$name-${metaData.id}-${creator.hashCode()}"
+    val clientId = s"$name-${metaData.name}-${creator.hashCode()}"
     DefaultSharedKafkaProducer(creator, creator.createProducer(clientId))
   }
 

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSerializationSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSerializationSpec.scala
@@ -57,7 +57,7 @@ class KafkaExceptionConsumerSerializationSpec extends AnyFunSuite with Matchers 
     new String(message.key()) shouldBe "test-nodeId"
     val decodedPayload = CirceUtil.decodeJsonUnsafe[KafkaExceptionInfo](message.value())
 
-    decodedPayload.processName shouldBe metaData.id
+    decodedPayload.processName shouldBe metaData.name
     decodedPayload.nodeId shouldBe Some("nodeId")
     decodedPayload.exceptionInput shouldBe Some("input1")
     decodedPayload.message shouldBe Some("mess")

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSpec.scala
@@ -53,12 +53,12 @@ class KafkaExceptionConsumerSpec extends AnyFunSuite with FlinkSpec with KafkaSp
 
     val env = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(env, modelData)(process)
-    env.withJobRunning(process.id) {
+    env.withJobRunning(process.name.value) {
       val consumed = kafkaClient.createConsumer().consumeWithJson[KafkaExceptionInfo](topicName).take(1).head
       consumed.key() shouldBe "testProcess-shouldFail"
 
       consumed.message().nodeId shouldBe Some("shouldFail")
-      consumed.message().processName shouldBe "testProcess"
+      consumed.message().processName.value shouldBe "testProcess"
       consumed.message().message shouldBe Some("Expression [1/{0, 1}[0] != 10] evaluation failed, message: / by zero")
       consumed.message().exceptionInput shouldBe Some("1/{0, 1}[0] != 10")
       consumed.message().additionalData shouldBe Map("configurableKey" -> "sampleValue")

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/KafkaSourceFactoryProcessMixin.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/KafkaSourceFactoryProcessMixin.scala
@@ -44,7 +44,7 @@ trait KafkaSourceFactoryProcessMixin
   protected def run(process: CanonicalProcess)(action: => Unit): Unit = {
     val env = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(env, modelData)(process)
-    env.withJobRunning(process.id)(action)
+    env.withJobRunning(process.name.value)(action)
   }
 
   protected def runAndVerifyResult(

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/LoggingService.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/LoggingService.scala
@@ -23,7 +23,7 @@ object LoggingService extends EagerService {
     new ServiceInvoker {
 
       private lazy val logger = LoggerFactory.getLogger(
-        (rootLogger :: metaData.id :: nodeId.id :: Option(loggerName).toList).filterNot(_.isBlank).mkString(".")
+        (rootLogger :: metaData.name.value :: nodeId.id :: Option(loggerName).toList).filterNot(_.isBlank).mkString(".")
       )
 
       override def invokeService(params: Map[String, Any])(

--- a/engine/flink/management/dev-model/src/test/scala/pl/touk/nussknacker/engine/process/NamespacedKafkaSourceSinkTest.scala
+++ b/engine/flink/management/dev-model/src/test/scala/pl/touk/nussknacker/engine/process/NamespacedKafkaSourceSinkTest.scala
@@ -56,7 +56,7 @@ class NamespacedKafkaSourceSinkTest extends AnyFunSuite with FlinkSpec with Kafk
   private def run(process: CanonicalProcess)(action: => Unit): Unit = {
     val env = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(env, modelData)(process)
-    env.withJobRunning(process.id)(action)
+    env.withJobRunning(process.name.value)(action)
   }
 
 }

--- a/engine/flink/management/dev-model/src/test/scala/pl/touk/nussknacker/engine/process/SampleComponentProviderTest.scala
+++ b/engine/flink/management/dev-model/src/test/scala/pl/touk/nussknacker/engine/process/SampleComponentProviderTest.scala
@@ -35,7 +35,7 @@ class SampleComponentProviderTest extends AnyFunSuite with FlinkSpec with Matche
   private def run(process: CanonicalProcess)(action: => Unit): Unit = {
     val env = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(env, modelData)(process)
-    env.withJobRunning(process.id)(action)
+    env.withJobRunning(process.name.value)(action)
   }
 
 }

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -210,7 +210,7 @@ class SlickPeriodicProcessesRepository(
 
   override def findProcessData(processName: ProcessName): Action[Seq[PeriodicProcess]] = {
     PeriodicProcesses
-      .filter(p => p.active === true && p.processName === processName.value)
+      .filter(p => p.active === true && p.processName === processName)
       .result
       .map(_.map(PeriodicProcessesRepository.createPeriodicProcess))
   }
@@ -274,7 +274,7 @@ class SlickPeriodicProcessesRepository(
       processName: ProcessName,
       deploymentsPerScheduleMaxCount: Int
   ): Action[SchedulesState] = {
-    val activeProcessesQuery = PeriodicProcesses.filter(p => p.processName === processName.value && p.active)
+    val activeProcessesQuery = PeriodicProcesses.filter(p => p.processName === processName && p.active)
     getLatestDeploymentsForEachSchedule(activeProcessesQuery, deploymentsPerScheduleMaxCount)
   }
 
@@ -284,7 +284,7 @@ class SlickPeriodicProcessesRepository(
       deploymentsPerScheduleMaxCount: Int
   ): Action[SchedulesState] = {
     val filteredProcessesQuery = PeriodicProcesses
-      .filter(p => p.processName === processName.value && !p.active)
+      .filter(p => p.processName === processName && !p.active)
       .sortBy(_.createdAt.desc)
       .take(inactiveProcessesMaxCount)
     getLatestDeploymentsForEachSchedule(filteredProcessesQuery, deploymentsPerScheduleMaxCount)

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesTable.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesTable.scala
@@ -21,6 +21,12 @@ trait PeriodicProcessesTableFactory {
 
   import profile.api._
 
+  implicit val processNameMapping: BaseColumnType[ProcessName] =
+    MappedColumnType.base[ProcessName, String](_.value, ProcessName.apply)
+
+  implicit val versionIdMapping: BaseColumnType[VersionId] =
+    MappedColumnType.base[VersionId, Long](_.value, VersionId(_))
+
   implicit val ProcessActionIdTypedType: TypedType[ProcessActionId] =
     MappedColumnType.base[ProcessActionId, UUID](
       _.value,
@@ -31,9 +37,9 @@ trait PeriodicProcessesTableFactory {
 
     def id: Rep[PeriodicProcessId] = column[PeriodicProcessId]("id", O.PrimaryKey, O.AutoInc)
 
-    def processName: Rep[String] = column[String]("process_name", NotNull)
+    def processName: Rep[ProcessName] = column[ProcessName]("process_name", NotNull)
 
-    def processVersionId: Rep[Long] = column[Long]("process_version_id", NotNull)
+    def processVersionId: Rep[VersionId] = column[VersionId]("process_version_id", NotNull)
 
     def processingType: Rep[String] = column[String]("processing_type", NotNull)
 
@@ -82,8 +88,8 @@ trait PeriodicProcessesTableFactory {
               ) =>
             (
               id,
-              processName.value,
-              versionId.value,
+              processName,
+              versionId,
               processingType,
               processJson.asJson.noSpaces,
               inputConfigDuringExecutionJson,
@@ -106,8 +112,8 @@ object PeriodicProcessEntity {
 
   def create(
       id: PeriodicProcessId,
-      processName: String,
-      processVersionId: Long,
+      processName: ProcessName,
+      processVersionId: VersionId,
       processingType: String,
       processJson: String,
       inputConfigDuringExecutionJson: String,
@@ -119,8 +125,8 @@ object PeriodicProcessEntity {
   ): PeriodicProcessEntity =
     PeriodicProcessEntity(
       id,
-      ProcessName(processName),
-      VersionId(processVersionId),
+      processName,
+      processVersionId,
       processingType,
       ProcessMarshaller.fromJsonUnsafe(processJson),
       inputConfigDuringExecutionJson,

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/flink/FlinkJarManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/flink/FlinkJarManager.scala
@@ -65,7 +65,7 @@ private[periodic] class FlinkJarManager(
   private def copyJarToLocalDir(processVersion: ProcessVersion): Future[String] = Future {
     jarsDir.toFile.mkdirs()
     val jarFileName =
-      s"${processVersion.processName.value}-${processVersion.versionId.value}-${System.currentTimeMillis()}.jar"
+      s"${processVersion.processName}-${processVersion.versionId.value}-${System.currentTimeMillis()}.jar"
     val jarPath = jarsDir.resolve(jarFileName)
     Files.copy(modelJarProvider.getJobJar().toPath, jarPath)
     logger.info(s"Copied current model jar to $jarPath")
@@ -78,7 +78,7 @@ private[periodic] class FlinkJarManager(
   ): Future[Option[ExternalDeploymentId]] = {
     val processVersion = deploymentWithJarData.processVersion
     logger.info(
-      s"Deploying scenario ${processVersion.processName.value}, version id: ${processVersion.versionId} and jar: ${deploymentWithJarData.jarFileName}"
+      s"Deploying scenario ${processVersion.processName}, version id: ${processVersion.versionId} and jar: ${deploymentWithJarData.jarFileName}"
     )
     val jarFile = jarsDir.resolve(deploymentWithJarData.jarFileName).toFile
     val args = FlinkDeploymentManager.prepareProgramArgs(

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceTest.scala
@@ -103,7 +103,7 @@ class PeriodicProcessServiceTest
             EnrichedProcessConfig(
               initialScheduleData.inputConfigDuringExecution.withValue(
                 "processName",
-                ConfigValueFactory.fromAnyRef(initialScheduleData.canonicalProcess.metaData.id)
+                ConfigValueFactory.fromAnyRef(initialScheduleData.canonicalProcess.name.value)
               )
             )
           )

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSlotsCountSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSlotsCountSpec.scala
@@ -14,16 +14,16 @@ class FlinkStreamingDeploymentManagerSlotsCountSpec extends AnyFunSuite with Mat
   override lazy val taskManagerSlotCount: Int = 1
 
   test("deploy scenario with too low task manager slots counts") {
-    val processId = "processTestingTMSlots"
-    val version   = ProcessVersion(VersionId.initialVersionId, ProcessName(processId), ProcessId(12), "user1", Some(13))
+    val processName = ProcessName("processTestingTMSlots")
+    val version     = ProcessVersion(VersionId.initialVersionId, processName, ProcessId(12), "user1", Some(13))
     val parallelism = 2
-    val process     = SampleProcess.prepareProcess(processId, parallelism = Some(parallelism))
+    val process     = SampleProcess.prepareProcess(processName, parallelism = Some(parallelism))
 
     try {
       deploymentManager.deploy(version, DeploymentData.empty, process, None).failed.futureValue shouldEqual
         NotEnoughSlotsException(taskManagerSlotCount, taskManagerSlotCount, SlotsBalance(0, parallelism))
     } finally {
-      cancelProcess(processId)
+      cancelProcess(processName)
     }
   }
 

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
@@ -24,14 +24,14 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
   private val processId = ProcessId(765)
 
   test("deploy scenario in running flink") {
-    val processName = "runningFlink"
+    val processName = ProcessName("runningFlink")
 
-    val version = ProcessVersion(VersionId(15), ProcessName(processName), processId, "user1", Some(13))
+    val version = ProcessVersion(VersionId(15), processName, processId, "user1", Some(13))
     val process = SampleProcess.prepareProcess(processName)
 
     deployProcessAndWaitIfRunning(process, version)
     try {
-      processVersion(ProcessName(processName)) shouldBe List(version)
+      processVersion(processName) shouldBe List(version)
     } finally {
       cancelProcess(processName)
     }
@@ -40,9 +40,9 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
   // manual test because it is hard to make it automatic
   // to run this test you have to add Thread.sleep(over 1 minute) to FlinkProcessMain.main method
   ignore("continue on timeout exception during scenario deploy") {
-    val processName = "runningFlink"
+    val processName = ProcessName("runningFlink")
     val process     = SampleProcess.prepareProcess(processName)
-    val version     = ProcessVersion(VersionId(15), ProcessName(processName), processId, "user1", Some(13))
+    val version     = ProcessVersion(VersionId(15), processName, processId, "user1", Some(13))
 
     val deployedResponse = deploymentManager.deploy(version, defaultDeploymentData, process, None)
 
@@ -55,58 +55,58 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
   }
 
   test("be able verify&redeploy kafka scenario") {
-    val processId    = "verifyAndRedeploy"
-    val outTopic     = s"output-$processId"
-    val inTopic      = s"input-$processId"
-    val kafkaProcess = SampleProcess.kafkaProcess(processId, inTopic)
+    val processName  = ProcessName("verifyAndRedeploy")
+    val outTopic     = s"output-$processName"
+    val inTopic      = s"input-$processName"
+    val kafkaProcess = SampleProcess.kafkaProcess(processName, inTopic)
 
     kafkaClient.createTopic(outTopic, 1)
     kafkaClient.createTopic(inTopic, 1)
     logger.info("Kafka topics created, deploying scenario")
 
-    deployProcessAndWaitIfRunning(kafkaProcess, empty(processId))
+    deployProcessAndWaitIfRunning(kafkaProcess, empty(processName))
     try {
       kafkaClient.sendMessage(inTopic, "1").futureValue
       messagesFromTopic(outTopic, 1).head shouldBe "1"
 
-      deployProcessAndWaitIfRunning(kafkaProcess, empty(processId))
+      deployProcessAndWaitIfRunning(kafkaProcess, empty(processName))
 
       kafkaClient.sendMessage(inTopic, "2").futureValue
       messagesFromTopic(outTopic, 2).last shouldBe "2"
     } finally {
-      cancelProcess(kafkaProcess.id)
+      cancelProcess(kafkaProcess.name)
     }
   }
 
   test("save state when redeploying") {
-    val processId                           = "redeploy"
-    val outTopic                            = s"output-$processId"
-    val processEmittingOneElementAfterStart = StatefulSampleProcess.prepareProcess(processId)
+    val processName                         = ProcessName("redeploy")
+    val outTopic                            = s"output-$processName"
+    val processEmittingOneElementAfterStart = StatefulSampleProcess.prepareProcess(processName)
 
     kafkaClient.createTopic(outTopic, 1)
 
-    deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processId))
+    deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processName))
     try {
       // we wait for first element to appear in kafka to be sure it's processed, before we proceed to checkpoint
       messagesFromTopic(outTopic, 1) shouldBe List("List(One element)")
 
-      deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processId))
+      deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processName))
 
       val messages = messagesFromTopic(outTopic, 2)
       messages shouldBe List("List(One element)", "List(One element, One element)")
     } finally {
-      cancelProcess(processId)
+      cancelProcess(processName)
     }
   }
 
   test("snapshot state and be able to deploy using it") {
-    val processId                           = "snapshot"
-    val outTopic                            = s"output-$processId"
-    val processEmittingOneElementAfterStart = StatefulSampleProcess.prepareProcess(processId)
+    val processName                         = ProcessName("snapshot")
+    val outTopic                            = s"output-$processName"
+    val processEmittingOneElementAfterStart = StatefulSampleProcess.prepareProcess(processName)
 
     kafkaClient.createTopic(outTopic, 1)
 
-    deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processId))
+    deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processName))
     try {
       // we wait for first element to appear in kafka to be sure it's processed, before we proceed to checkpoint
       messagesFromTopic(outTopic, 1) shouldBe List("List(One element)")
@@ -114,99 +114,103 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
       val savepointDir = Files.createTempDirectory("customSavepoint")
       val savepointPathFuture = deploymentManager
         .savepoint(
-          ProcessName(processEmittingOneElementAfterStart.id),
+          processEmittingOneElementAfterStart.name,
           savepointDir = Some(savepointDir.toUri.toString)
         )
         .map(_.path)
       val savepointPath = new URI(savepointPathFuture.futureValue)
       Paths.get(savepointPath).startsWith(savepointDir) shouldBe true
 
-      cancelProcess(processId)
-      deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processId), Some(savepointPath.toString))
+      cancelProcess(processName)
+      deployProcessAndWaitIfRunning(
+        processEmittingOneElementAfterStart,
+        empty(processName),
+        Some(savepointPath.toString)
+      )
 
       val messages = messagesFromTopic(outTopic, 2)
       messages shouldBe List("List(One element)", "List(One element, One element)")
     } finally {
-      cancelProcess(processId)
+      cancelProcess(processName)
     }
   }
 
   test("should stop scenario and deploy it using savepoint") {
-    val processId                           = "stop"
-    val outTopic                            = s"output-$processId"
-    val processEmittingOneElementAfterStart = StatefulSampleProcess.prepareProcess(processId)
+    val processName                         = ProcessName("stop")
+    val outTopic                            = s"output-$processName"
+    val processEmittingOneElementAfterStart = StatefulSampleProcess.prepareProcess(processName)
 
     kafkaClient.createTopic(outTopic, 1)
 
-    deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processId))
+    deployProcessAndWaitIfRunning(processEmittingOneElementAfterStart, empty(processName))
     try {
       messagesFromTopic(outTopic, 1) shouldBe List("List(One element)")
 
       val savepointPath =
-        deploymentManager.stop(ProcessName(processId), savepointDir = None, user = userToAct).map(_.path)
+        deploymentManager.stop(processName, savepointDir = None, user = userToAct).map(_.path)
       eventually {
-        val status = deploymentManager.getProcessStates(ProcessName(processId)).futureValue
+        val status = deploymentManager.getProcessStates(processName).futureValue
         status.value.map(_.status) shouldBe List(SimpleStateStatus.Canceled)
       }
 
       deployProcessAndWaitIfRunning(
         processEmittingOneElementAfterStart,
-        empty(processId),
+        empty(processName),
         Some(savepointPath.futureValue)
       )
 
       val messages = messagesFromTopic(outTopic, 2)
       messages shouldBe List("List(One element)", "List(One element, One element)")
     } finally {
-      cancelProcess(processId)
+      cancelProcess(processName)
     }
   }
 
   test("fail to redeploy if old is incompatible") {
-    val processId = "redeployFail"
-    val outTopic  = s"output-$processId"
-    val process   = StatefulSampleProcess.prepareProcessStringWithStringState(processId)
+    val processName = ProcessName("redeployFail")
+    val outTopic    = s"output-$processName"
+    val process     = StatefulSampleProcess.prepareProcessStringWithStringState(processName)
 
     kafkaClient.createTopic(outTopic, 1)
 
-    deployProcessAndWaitIfRunning(process, empty(process.id))
+    deployProcessAndWaitIfRunning(process, empty(process.name))
     try {
       messagesFromTopic(outTopic, 1) shouldBe List("")
 
       logger.info("Starting to redeploy")
 
-      val statefullProcess = StatefulSampleProcess.prepareProcessWithLongState(processId)
+      val statefullProcess = StatefulSampleProcess.prepareProcessWithLongState(processName)
       val exception =
-        deploymentManager.deploy(empty(process.id), defaultDeploymentData, statefullProcess, None).failed.futureValue
+        deploymentManager.deploy(empty(process.name), defaultDeploymentData, statefullProcess, None).failed.futureValue
       exception.getMessage shouldBe "State is incompatible, please stop scenario and start again with clean state"
     } finally {
-      cancelProcess(processId)
+      cancelProcess(processName)
     }
   }
 
   test("fail to redeploy if result produced by aggregation is incompatible") {
-    val processId = "redeployFailAggregator"
-    val outTopic  = s"output-$processId"
-    val process   = StatefulSampleProcess.processWithAggregator(processId, "#AGG.set")
+    val processName = ProcessName("redeployFailAggregator")
+    val outTopic    = s"output-$processName"
+    val process     = StatefulSampleProcess.processWithAggregator(processName, "#AGG.set")
 
     kafkaClient.createTopic(outTopic, 1)
 
-    deployProcessAndWaitIfRunning(process, empty(process.id))
+    deployProcessAndWaitIfRunning(process, empty(process.name))
     try {
       messagesFromTopic(outTopic, 1) shouldBe List("test")
 
       logger.info("Starting to redeploy")
 
-      val statefulProcess = StatefulSampleProcess.processWithAggregator(processId, "#AGG.approxCardinality")
+      val statefulProcess = StatefulSampleProcess.processWithAggregator(processName, "#AGG.approxCardinality")
       val exception =
-        deploymentManager.deploy(empty(process.id), defaultDeploymentData, statefulProcess, None).failed.futureValue
+        deploymentManager.deploy(empty(process.name), defaultDeploymentData, statefulProcess, None).failed.futureValue
       exception.getMessage shouldBe "State is incompatible, please stop scenario and start again with clean state"
     } finally {
-      cancelProcess(processId)
+      cancelProcess(processName)
     }
   }
 
-  def empty(processId: String): ProcessVersion = ProcessVersion.empty.copy(processName = ProcessName(processId))
+  def empty(processName: ProcessName): ProcessVersion = ProcessVersion.empty.copy(processName = processName)
 
   test("extract scenario definition") {
     val modelData  = ModelData(processingTypeConfig)
@@ -222,6 +226,6 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
       .map(_.message())
       .toList
 
-  private def processVersion(processId: ProcessName): List[ProcessVersion] =
-    deploymentManager.getProcessStates(processId).futureValue.value.flatMap(_.version)
+  private def processVersion(name: ProcessName): List[ProcessVersion] =
+    deploymentManager.getProcessStates(name).futureValue.value.flatMap(_.version)
 }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
@@ -50,15 +50,15 @@ class FlinkStreamingProcessTestRunnerSpec extends AnyFlatSpec with Matchers with
   it should "run scenario in test mode" in {
     val deploymentManager = FlinkStreamingDeploymentManagerProvider.defaultDeploymentManager(config)
 
-    val processId = UUID.randomUUID().toString
+    val processName = ProcessName(UUID.randomUUID().toString)
 
-    val process = SampleProcess.prepareProcess(processId)
+    val process = SampleProcess.prepareProcess(processName)
 
-    whenReady(deploymentManager.test(ProcessName(processId), process, scenarioTestData)) { r =>
+    whenReady(deploymentManager.test(processName, process, scenarioTestData)) { r =>
       r.nodeResults shouldBe Map(
-        "startProcess" -> List(Context(s"$processId-startProcess-0-0", Map("input" -> "terefere"))),
-        "nightFilter"  -> List(Context(s"$processId-startProcess-0-0", Map("input" -> "terefere"))),
-        "endSend"      -> List(Context(s"$processId-startProcess-0-0", Map("input" -> "terefere")))
+        "startProcess" -> List(Context(s"$processName-startProcess-0-0", Map("input" -> "terefere"))),
+        "nightFilter"  -> List(Context(s"$processName-startProcess-0-0", Map("input" -> "terefere"))),
+        "endSend"      -> List(Context(s"$processName-startProcess-0-0", Map("input" -> "terefere")))
       )
     }
   }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/JavaConfigDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/JavaConfigDeploymentManagerSpec.scala
@@ -24,16 +24,16 @@ class JavaConfigDeploymentManagerSpec extends AnyFunSuite with Matchers with Str
 
     assert(
       deploymentManager
-        .deploy(ProcessVersion.empty.copy(processName = ProcessName(process.id)), DeploymentData.empty, process, None)
+        .deploy(ProcessVersion.empty.copy(processName = process.name), DeploymentData.empty, process, None)
         .isReadyWithin(100 seconds)
     )
 
     eventually {
-      val jobStatus = deploymentManager.getProcessStates(ProcessName(process.id)).futureValue.value
+      val jobStatus = deploymentManager.getProcessStates(process.name).futureValue.value
       jobStatus.map(_.status) shouldBe List(SimpleStateStatus.Running)
     }
 
-    assert(deploymentManager.cancel(ProcessName(process.id), user = userToAct).isReadyWithin(10 seconds))
+    assert(deploymentManager.cancel(process.name, user = userToAct).isReadyWithin(10 seconds))
   }
 
 }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/SampleProcess.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/SampleProcess.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.engine.management.streaming
 
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.graph.node.SubsequentNode
@@ -9,8 +10,8 @@ object SampleProcess {
 
   import spel.Implicits._
 
-  def prepareProcess(id: String, parallelism: Option[Int] = None): CanonicalProcess = {
-    val baseProcessBuilder = ScenarioBuilder.streaming(id)
+  def prepareProcess(name: ProcessName, parallelism: Option[Int] = None): CanonicalProcess = {
+    val baseProcessBuilder = ScenarioBuilder.streaming(name.value)
     parallelism
       .map(baseProcessBuilder.parallelism)
       .getOrElse(baseProcessBuilder)
@@ -19,11 +20,11 @@ object SampleProcess {
       .emptySink("endSend", "sendSms", "Value" -> "'message'")
   }
 
-  def kafkaProcess(id: String, topic: String): CanonicalProcess = {
+  def kafkaProcess(name: ProcessName, topic: String): CanonicalProcess = {
     ScenarioBuilder
-      .streaming(id)
+      .streaming(name.value)
       .source("startProcess", "real-kafka", "Topic" -> s"'$topic'")
-      .emptySink("end", "kafka-string", "Topic" -> s"'output-$id'", "Value" -> "#input")
+      .emptySink("end", "kafka-string", "Topic" -> s"'output-$name'", "Value" -> "#input")
   }
 
   private def endWithMessage(idSuffix: String, message: String): SubsequentNode = {

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/StatefulSampleProcess.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/StatefulSampleProcess.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.engine.management.streaming
 
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.spel
@@ -8,26 +9,24 @@ object StatefulSampleProcess {
 
   import spel.Implicits._
 
-  def prepareProcess(id: String): CanonicalProcess = {
-
+  def prepareProcess(name: ProcessName): CanonicalProcess = {
     ScenarioBuilder
-      .streaming(id)
+      .streaming(name.value)
       .source("state", "oneSource")
       .customNode("stateful", "stateVar", "stateful", "groupBy" -> "#input")
-      .emptySink("end", "kafka-string", "Topic" -> s"'output-$id'", "Value" -> "#stateVar")
+      .emptySink("end", "kafka-string", "Topic" -> s"'output-$name'", "Value" -> "#stateVar")
   }
 
-  def prepareProcessStringWithStringState(id: String): CanonicalProcess = {
-
+  def prepareProcessStringWithStringState(name: ProcessName): CanonicalProcess = {
     ScenarioBuilder
-      .streaming(id)
+      .streaming(name.value)
       .source("state", "oneSource")
       .customNode("stateful", "stateVar", "constantStateTransformer")
-      .emptySink("end", "kafka-string", "Topic" -> s"'output-$id'", "Value" -> "#stateVar")
+      .emptySink("end", "kafka-string", "Topic" -> s"'output-$name'", "Value" -> "#stateVar")
   }
 
-  def processWithAggregator(id: String, aggregatorExpression: String): CanonicalProcess = ScenarioBuilder
-    .streaming(id)
+  def processWithAggregator(name: ProcessName, aggregatorExpression: String): CanonicalProcess = ScenarioBuilder
+    .streaming(name.value)
     .source("state", "oneSource")
     .customNode(
       "transform",
@@ -41,15 +40,14 @@ object StatefulSampleProcess {
     )
     // Add enricher to force creating async operator which buffers elements emitted by aggregation. These elements can be incompatible.
     .enricher("enricher", "output", "paramService", "param" -> "'a'")
-    .emptySink("end", "kafka-string", "Topic" -> s"'output-$id'", "Value" -> "'test'")
+    .emptySink("end", "kafka-string", "Topic" -> s"'output-$name'", "Value" -> "'test'")
 
-  def prepareProcessWithLongState(id: String): CanonicalProcess = {
-
+  def prepareProcessWithLongState(name: ProcessName): CanonicalProcess = {
     ScenarioBuilder
-      .streaming(id)
+      .streaming(name.value)
       .source("state", "oneSource")
       .customNode("stateful", "stateVar", "constantStateTransformerLongValue")
-      .emptySink("end", "kafka-string", "Topic" -> s"'output-$id'", "Value" -> "#stateVar")
+      .emptySink("end", "kafka-string", "Topic" -> s"'output-$name'", "Value" -> "#stateVar")
   }
 
 }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/StreamingDockerTest.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/StreamingDockerTest.scala
@@ -52,8 +52,8 @@ trait StreamingDockerTest extends DockerTest with Matchers with OptionValues { s
   ): Assertion = {
     deployProcess(process, processVersion, savepointPath)
     eventually {
-      val jobStatuses = deploymentManager.getProcessStates(ProcessName(process.id)).futureValue.value
-      logger.debug(s"Waiting for deploy: ${process.id}, $jobStatuses")
+      val jobStatuses = deploymentManager.getProcessStates(process.name).futureValue.value
+      logger.debug(s"Waiting for deploy: ${process.name}, $jobStatuses")
 
       jobStatuses.map(_.status) should contain(SimpleStateStatus.Running)
     }
@@ -67,17 +67,17 @@ trait StreamingDockerTest extends DockerTest with Matchers with OptionValues { s
     deploymentManager.deploy(processVersion, DeploymentData.empty, process, savepointPath).futureValue
   }
 
-  protected def cancelProcess(processId: String): Unit = {
-    deploymentManager.cancel(ProcessName(processId), user = userToAct).futureValue
+  protected def cancelProcess(processName: ProcessName): Unit = {
+    deploymentManager.cancel(processName, user = userToAct).futureValue
     eventually {
       val statuses = deploymentManager
-        .getProcessStates(ProcessName(processId))
+        .getProcessStates(processName)
         .futureValue
         .value
       val runningOrDurringCancelJobs = statuses
         .filter(state => Set(SimpleStateStatus.Running, SimpleStateStatus.DuringCancel).contains(state.status))
 
-      logger.debug(s"waiting for jobs: $processId, $statuses")
+      logger.debug(s"waiting for jobs: $processName, $statuses")
       if (runningOrDurringCancelJobs.nonEmpty) {
         throw new IllegalStateException("Job still exists")
       }

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkRestManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkRestManager.scala
@@ -166,13 +166,13 @@ class FlinkRestManager(config: FlinkConfig, modelData: BaseModelData, mainClassN
     statuses.filterNot(details => SimpleStateStatus.isFinalStatus(details.status)) match {
       case Nil =>
         logger.warn(
-          s"Trying to cancel ${processName.value}${deploymentId.map(" with id: " + _).getOrElse("")} which is not present or finished on Flink."
+          s"Trying to cancel $processName${deploymentId.map(" with id: " + _).getOrElse("")} which is not present or finished on Flink."
         )
         Future.successful(())
       case single :: Nil => cancelJob(single)
       case moreThanOne @ (_ :: _ :: _) =>
         logger.warn(
-          s"Found duplicate jobs of ${processName.value}${deploymentId.map(" with id: " + _).getOrElse("")}: $moreThanOne. Cancelling all in non terminal state."
+          s"Found duplicate jobs of $processName${deploymentId.map(" with id: " + _).getOrElse("")}: $moreThanOne. Cancelling all in non terminal state."
         )
         Future.sequence(moreThanOne.map(cancelJob)).map(_ => ())
     }

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/helpers/KafkaAvroSpecMixin.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/helpers/KafkaAvroSpecMixin.scala
@@ -209,7 +209,7 @@ trait KafkaAvroSpecMixin
   protected def run(process: CanonicalProcess)(action: => Unit): Unit = {
     val env = flinkMiniCluster.createExecutionEnvironment()
     UnitTestsFlinkRunner.registerInEnvironmentWithModel(env, modelData)(process)
-    env.withJobRunning(process.id)(action)
+    env.withJobRunning(process.name.value)(action)
   }
 
   sealed trait SourceAvroParam {

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/FlinkWithKafkaSuite.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/FlinkWithKafkaSuite.scala
@@ -126,7 +126,7 @@ abstract class FlinkWithKafkaSuite
   protected def run(process: CanonicalProcess)(action: => Unit): Unit = {
     val env = flinkMiniCluster.createExecutionEnvironment()
     registrar.register(env, process, ProcessVersion.empty, DeploymentData.empty)
-    env.withJobRunning(process.id)(action)
+    env.withJobRunning(process.name.value)(action)
   }
 
   protected def sendAvro(obj: Any, topic: String, timestamp: java.lang.Long = null) = {

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/StateCompatibilityTest.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/StateCompatibilityTest.scala
@@ -160,11 +160,11 @@ class StateCompatibilityTest extends FlinkWithKafkaSuite with Eventually with La
     sendAvro(givenMatchingAvroObj, inputTopicConfig.input)
 
     val jobExecutionResult = env.execute(streamGraph)
-    env.waitForStart(jobExecutionResult.getJobID, process1.id)()
+    env.waitForStart(jobExecutionResult.getJobID, process1.name.value)()
     sendAvro(givenNotMatchingAvroObj, inputTopicConfig.input)
 
     verifyOutputEvent(outputTopicConfig.output, input = event2, previousInput = event1)
-    env.stopJob(process1.id, jobExecutionResult)
+    env.stopJob(process1.name.value, jobExecutionResult)
   }
 
   private def verifyOutputEvent(outTopic: String, input: InputEvent, previousInput: InputEvent): Unit = {
@@ -184,7 +184,7 @@ class StateCompatibilityTest extends FlinkWithKafkaSuite with Eventually with La
   private def run(process: CanonicalProcess, action: JobExecutionResult => Unit): Unit = {
     val env = flinkMiniCluster.createExecutionEnvironment()
     registrar.register(env, process, ProcessVersion.empty, DeploymentData.empty)
-    env.withJobRunning(process.id, action)
+    env.withJobRunning(process.name.value, action)
   }
 
 }

--- a/engine/lite/components-api/src/main/scala/pl/touk/nussknacker/engine/lite/api/runtimecontext/LiteEngineRuntimeContextPreparer.scala
+++ b/engine/lite/components-api/src/main/scala/pl/touk/nussknacker/engine/lite/api/runtimecontext/LiteEngineRuntimeContextPreparer.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.lite.api.runtimecontext
 
 import pl.touk.nussknacker.engine.api.JobData
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.runtimecontext.{ContextIdGenerator, EngineRuntimeContext, IncContextIdGenerator}
 import pl.touk.nussknacker.engine.util.metrics.{MetricsProviderForScenario, NoOpMetricsProviderForScenario}
 
@@ -15,10 +16,10 @@ object LiteEngineRuntimeContextPreparer {
 }
 
 class LiteEngineRuntimeContextPreparer(
-    metricRegistryForScenario: String => MetricsProviderForScenario with AutoCloseable
+    metricRegistryForScenario: ProcessName => MetricsProviderForScenario with AutoCloseable
 ) {
   def prepare(jobData: JobData): LiteEngineRuntimeContext =
-    LiteEngineRuntimeContext(jobData, metricRegistryForScenario(jobData.metaData.id))
+    LiteEngineRuntimeContext(jobData, metricRegistryForScenario(jobData.metaData.name))
 }
 
 case class LiteEngineRuntimeContext(jobData: JobData, metricsProvider: MetricsProviderForScenario with AutoCloseable)

--- a/engine/lite/components/request-response/src/main/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/jsonschema/sources/JsonSchemaRequestResponseSource.scala
+++ b/engine/lite/components/request-response/src/main/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/jsonschema/sources/JsonSchemaRequestResponseSource.scala
@@ -36,7 +36,7 @@ class JsonSchemaRequestResponseSource(
     with SourceTestSupport[Any]
     with TestWithParametersSupport[Any] {
 
-  protected val openApiDescription: String = s"**scenario name**: ${metaData.id}"
+  protected val openApiDescription: String = s"**scenario name**: ${metaData.name}"
 
   private val deserializer = new CirceJsonDeserializer(inputSchema)
 

--- a/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedRequestResponseScenarioValidator.scala
+++ b/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedRequestResponseScenarioValidator.scala
@@ -15,7 +15,7 @@ object EmbeddedRequestResponseScenarioValidator extends CustomProcessValidator {
   override def validate(scenario: CanonicalProcess): ValidatedNel[ProcessCompilationError, Unit] = {
     scenario.metaData.typeSpecificData match {
       case rrMetaData: RequestResponseMetaData =>
-        validateRequestResponse(ProcessName(scenario.id), rrMetaData)
+        validateRequestResponse(scenario.name, rrMetaData)
       case _: FragmentSpecificData =>
         Valid(())
       // should not happen

--- a/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/requestresponse/RequestResponseDeploymentStrategy.scala
+++ b/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/requestresponse/RequestResponseDeploymentStrategy.scala
@@ -40,7 +40,7 @@ object RequestResponseDeploymentStrategy {
 
   def slugForScenario(metaData: MetaData): Validated[NonEmptyList[FatalUnknownError], String] =
     metaData.typeSpecificData match {
-      case RequestResponseMetaData(slug) => Valid(slug.getOrElse(defaultSlug(ProcessName(metaData.id))))
+      case RequestResponseMetaData(slug) => Valid(slug.getOrElse(defaultSlug(metaData.name)))
       case _ => Invalid(NonEmptyList.of(FatalUnknownError(s"Wrong scenario metadata: ${metaData.typeSpecificData}")))
     }
 

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/BaseStreamingEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/BaseStreamingEmbeddedDeploymentManagerTest.scala
@@ -43,7 +43,7 @@ trait BaseStreamingEmbeddedDeploymentManagerTest
   ) {
 
     def deployScenario(scenario: CanonicalProcess): Unit = {
-      val version = ProcessVersion.empty.copy(processName = ProcessName(scenario.id))
+      val version = ProcessVersion.empty.copy(processName = scenario.name)
       deploymentManager.deploy(version, DeploymentData.empty, scenario, None).futureValue
     }
 

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/RequestResponseEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/RequestResponseEmbeddedDeploymentManagerTest.scala
@@ -61,7 +61,7 @@ class RequestResponseEmbeddedDeploymentManagerTest extends AnyFunSuite with Matc
   sealed case class FixtureParam(deploymentManager: DeploymentManager, modelData: ModelData, port: Int) {
 
     def deployScenario(scenario: CanonicalProcess): Unit = {
-      val version = ProcessVersion.empty.copy(processName = ProcessName(scenario.id))
+      val version = ProcessVersion.empty.copy(processName = scenario.name)
       deploymentManager.deploy(version, DeploymentData.empty, scenario, None).futureValue
     }
 

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeBinTest.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeBinTest.scala
@@ -43,7 +43,7 @@ class NuKafkaRuntimeBinTest
     kafkaContainer.start()          // must be started before prepareTestCaseFixture because it creates topic via api
     schemaRegistryContainer.start() // should be started after kafka
     fixture =
-      prepareTestCaseFixture(NuKafkaRuntimeTestSamples.pingPongScenarioId, NuKafkaRuntimeTestSamples.pingPongScenario)
+      prepareTestCaseFixture(NuKafkaRuntimeTestSamples.pingPongScenarioName, NuKafkaRuntimeTestSamples.pingPongScenario)
     registerSchemas()
     MultipleContainers(kafkaContainer, schemaRegistryContainer)
   }

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeDockerAvroTest.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeDockerAvroTest.scala
@@ -27,7 +27,7 @@ class NuKafkaRuntimeDockerAvroTest
     kafkaContainer.start()          // must be started before prepareTestCaseFixture because it creates topic via api
     schemaRegistryContainer.start() // should be started after kafka
     fixture =
-      prepareTestCaseFixture(NuKafkaRuntimeTestSamples.pingPongScenarioId, NuKafkaRuntimeTestSamples.pingPongScenario)
+      prepareTestCaseFixture(NuKafkaRuntimeTestSamples.pingPongScenarioName, NuKafkaRuntimeTestSamples.pingPongScenario)
     registerSchemas()
     startRuntimeContainer(fixture.scenarioFile)
     MultipleContainers(kafkaContainer, schemaRegistryContainer, runtimeContainer)

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeDockerJsonTest.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeDockerJsonTest.scala
@@ -21,7 +21,7 @@ class NuKafkaRuntimeDockerJsonTest
     kafkaContainer.start()          // must be started before prepareTestCaseFixture because it creates topic via api
     schemaRegistryContainer.start() // should be started after kafka
     fixture =
-      prepareTestCaseFixture(NuKafkaRuntimeTestSamples.pingPongScenarioId, NuKafkaRuntimeTestSamples.pingPongScenario)
+      prepareTestCaseFixture(NuKafkaRuntimeTestSamples.pingPongScenarioName, NuKafkaRuntimeTestSamples.pingPongScenario)
     registerSchemas()
     startRuntimeContainer(fixture.scenarioFile)
     MultipleContainers(kafkaContainer, schemaRegistryContainer, runtimeContainer)

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeDockerProbesTest.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeDockerProbesTest.scala
@@ -25,7 +25,7 @@ class NuKafkaRuntimeDockerProbesTest
     kafkaContainer.start()          // must be started before prepareTestCaseFixture because it creates topic via api
     schemaRegistryContainer.start() // should be started after kafka
     fixture =
-      prepareTestCaseFixture(NuKafkaRuntimeTestSamples.pingPongScenarioId, NuKafkaRuntimeTestSamples.pingPongScenario)
+      prepareTestCaseFixture(NuKafkaRuntimeTestSamples.pingPongScenarioName, NuKafkaRuntimeTestSamples.pingPongScenario)
     registerSchemas()
     startRuntimeContainer(fixture.scenarioFile, checkReady = false)
     MultipleContainers(kafkaContainer, schemaRegistryContainer, runtimeContainer)

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeTestMixin.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/NuKafkaRuntimeTestMixin.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.lite.kafka
 
 import org.scalatest.TestSuite
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.kafka.KafkaClient
 import pl.touk.nussknacker.engine.lite.utils.NuRuntimeTestUtils
@@ -12,10 +13,10 @@ trait NuKafkaRuntimeTestMixin { self: TestSuite =>
   protected def kafkaBoostrapServer: String
 
   protected def prepareTestCaseFixture(
-      scenarioId: String,
+      scenarioName: ProcessName,
       prepareScenario: (String, String) => CanonicalProcess
   ): NuKafkaRuntimeTestTestCaseFixture = {
-    val testCaseId  = NuRuntimeTestUtils.testCaseId(self.suiteName, scenarioId)
+    val testCaseId  = NuRuntimeTestUtils.testCaseId(self.suiteName, scenarioName)
     val inputTopic  = testCaseId + "-input"
     val outputTopic = testCaseId + "-output"
     val errorTopic  = testCaseId + "-error"

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/sample/NuKafkaRuntimeTestSamples.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/sample/NuKafkaRuntimeTestSamples.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.lite.kafka.sample
 import io.confluent.kafka.schemaregistry.json.JsonSchema
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -20,10 +21,10 @@ object NuKafkaRuntimeTestSamples {
 
   import pl.touk.nussknacker.engine.spel.Implicits._
 
-  val pingPongScenarioId = "universal-ping-pong"
+  val pingPongScenarioName = ProcessName("universal-ping-pong")
 
   def pingPongScenario(inputTopic: String, outputTopic: String): CanonicalProcess = ScenarioBuilder
-    .streamingLite(pingPongScenarioId)
+    .streamingLite(pingPongScenarioName.value)
     .source("source", "kafka", "Topic" -> s"'$inputTopic'", "Schema version" -> "'latest'")
     .emptySink(
       "sink",

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/utils/NuRuntimeTestUtils.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/utils/NuRuntimeTestUtils.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.lite.utils
 
 import io.circe.syntax._
 import org.apache.commons.io.FileUtils
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 
 import java.io.File
@@ -11,9 +12,9 @@ object NuRuntimeTestUtils {
 
   val deploymentDataFile: File = new File(getClass.getResource("/sampleDeploymentData.conf").getFile)
 
-  def testCaseId(suiteName: String, scenario: CanonicalProcess): String = testCaseId(suiteName, scenario.id)
+  def testCaseId(suiteName: String, scenario: CanonicalProcess): String = testCaseId(suiteName, scenario.name)
 
-  def testCaseId(suiteName: String, scenarioId: String): String = suiteName + "-" + scenarioId
+  def testCaseId(suiteName: String, scenarioName: ProcessName): String = suiteName + "-" + scenarioName
 
   def saveScenarioToTmp(scenario: CanonicalProcess, scenarioFilePrefix: String): File = {
     val jsonFile = File.createTempFile(scenarioFilePrefix, ".json")

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
@@ -223,7 +223,7 @@ class K8sDeploymentManager(
       )
     } yield {
       logger.info(
-        s"Deployed ${processVersion.processName.value}, with deployment: ${deployment.name}, configmap: ${configMap.name}${serviceOpt
+        s"Deployed ${processVersion.processName}, with deployment: ${deployment.name}, configmap: ${configMap.name}${serviceOpt
             .map(svc => s", service: ${svc.name}")
             .getOrElse("")}${ingressOpt.map(i => s", ingress: ${i.name}").getOrElse("")}"
       )
@@ -266,8 +266,7 @@ class K8sDeploymentManager(
           case Some(existing) =>
             parseVersionAnnotation(existing) match {
               case Some(existingServiceData) if existingServiceData.processId != processVersion.processId =>
-                val scenarioName = existingServiceData.processName.value
-                val message      = s"Slug is not unique, scenario $scenarioName is using it"
+                val message = s"Slug is not unique, scenario ${existingServiceData.processName} is using it"
                 Future.failed(new IllegalArgumentException(message))
               case _ => Future.successful(())
             }
@@ -293,7 +292,7 @@ class K8sDeploymentManager(
       secrets     <- k8sClient.deleteAllSelected[ListResource[Secret]](selector)
     } yield {
       logger.debug(
-        s"Canceled ${name.value}, ${ingresses.map(i => s"ingresses: ${i.itemNames}, ").getOrElse("")}services: ${services.itemNames}, deployments: ${deployments.itemNames}, configmaps: ${configMaps.itemNames}, secrets: ${secrets.itemNames}"
+        s"Canceled $name, ${ingresses.map(i => s"ingresses: ${i.itemNames}, ").getOrElse("")}services: ${services.itemNames}, deployments: ${deployments.itemNames}, configmaps: ${configMaps.itemNames}, secrets: ${secrets.itemNames}"
       )
       ()
     }
@@ -446,7 +445,7 @@ object K8sDeploymentManager {
   ): String = {
     // we simulate (more or less) --append-hash kubectl behaviour...
     val hashToAppend      = hashInput.map(input => "-" + shortHash(input)).getOrElse("")
-    val plainScenarioName = s"scenario-${processVersion.processId.value}-${processVersion.processName.value}"
+    val plainScenarioName = s"scenario-${processVersion.processId.value}-${processVersion.processName}"
     val scenarioName      = objectNamePrefixedWithNussknackerInstanceName(nussknackerInstanceName, plainScenarioName)
     sanitizeObjectName(scenarioName, hashToAppend)
   }

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/RequestResponseScenarioValidator.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/RequestResponseScenarioValidator.scala
@@ -15,7 +15,7 @@ class RequestResponseScenarioValidator(nussknackerInstanceName: Option[String]) 
   def validate(scenario: CanonicalProcess): ValidatedNel[ProcessCompilationError, Unit] = {
     scenario.metaData.typeSpecificData match {
       case rrMetaData: RequestResponseMetaData =>
-        validateRequestResponse(ProcessName(scenario.id), rrMetaData)
+        validateRequestResponse(scenario.name, rrMetaData)
       case _: FragmentSpecificData =>
         Valid(())
       // should not happen

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerKafkaTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerKafkaTest.scala
@@ -75,7 +75,7 @@ class K8sDeploymentManagerKafkaTest
           "Value"                 -> s"{ original: #input, version: $version }"
         )
 
-      val pversion = ProcessVersion(VersionId(version), ProcessName(scenario.id), ProcessId(1234), "testUser", Some(22))
+      val pversion = ProcessVersion(VersionId(version), scenario.name, ProcessId(1234), "testUser", Some(22))
       manager.deploy(pversion, DeploymentData.empty, scenario, None).futureValue
       pversion
     }
@@ -171,7 +171,7 @@ class K8sDeploymentManagerKafkaTest
     val f = createKafkaFixture()
 
     def withManager(manager: K8sDeploymentManager)(action: ProcessVersion => Unit): Unit = {
-      val version = ProcessVersion(VersionId(11), ProcessName(f.scenario.id), ProcessId(1234), "testUser", Some(22))
+      val version = ProcessVersion(VersionId(11), f.scenario.name, ProcessId(1234), "testUser", Some(22))
       manager.deploy(version, DeploymentData.empty, f.scenario, None).futureValue
 
       action(version)
@@ -410,8 +410,8 @@ class K8sDeploymentManagerKafkaTest
         "Value validation mode" -> "'strict'",
         "Value"                 -> "#input"
       )
-    logger.info(s"Running kafka test on ${scenario.id} $input - $output")
-    val version = ProcessVersion(VersionId(11), ProcessName(scenario.id), ProcessId(1234), "testUser", Some(22))
+    logger.info(s"Running kafka test on ${scenario.name} $input - $output")
+    val version = ProcessVersion(VersionId(11), scenario.name, ProcessId(1234), "testUser", Some(22))
     new KafkaTestFixture(
       inputTopic = input,
       outputTopic = output,

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerReqRespTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerReqRespTest.scala
@@ -279,9 +279,9 @@ class K8sDeploymentManagerReqRespTest
     val deployConfig = reqRespDeployConfig(givenServicePort, extraClasses, extraDeployConfig)
     val manager      = new K8sDeploymentManager(modelData, deployConfig, ConfigFactory.empty())
     val scenario     = preparePingPongScenario(givenScenarioName, givenVersion, givenSlug)
-    logger.info(s"Running req-resp test on ${scenario.id}")
+    logger.info(s"Running req-resp test on ${scenario.name}")
     val version =
-      ProcessVersion(VersionId(givenVersion), ProcessName(scenario.id), ProcessId(1234), "testUser", Some(22))
+      ProcessVersion(VersionId(givenVersion), scenario.name, ProcessId(1234), "testUser", Some(22))
     new ReqRespTestFixture(manager = manager, scenario = scenario, version = version, extraClasses)
   }
 

--- a/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaSingleScenarioTaskRun.scala
+++ b/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaSingleScenarioTaskRun.scala
@@ -53,7 +53,7 @@ class KafkaSingleScenarioTaskRun(
     extends Task
     with LazyLogging {
 
-  private val groupId = metaData.id
+  private val groupId = metaData.name.value
 
   private var consumer: KafkaConsumer[Array[Byte], Array[Byte]] = _
   private var producer: KafkaProducerRecordsHandler             = _
@@ -197,7 +197,7 @@ class KafkaSingleScenarioTaskRun(
     List(producer, consumer, producerMetricsRegistrar, consumerMetricsRegistrar)
       .filter(_ != null)
       .foreach(closeable => retryCloseOnInterrupt(closeable.close))
-    logger.info(s"Closed runner for ${metaData.id}")
+    logger.info(s"Closed runner for ${metaData.name}")
   }
 
   private def configSanityCheck(): Unit = {

--- a/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreter.scala
+++ b/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreter.scala
@@ -113,7 +113,7 @@ class KafkaTransactionalScenarioInterpreter private[kafka] (
   private val interpreterConfig = modelData.modelConfig.as[KafkaInterpreterConfig]
 
   private val taskRunner: TaskRunner = new TaskRunner(
-    scenario.id,
+    scenario.name.value,
     liteKafkaJobData.tasksCount,
     createScenarioTaskRun,
     interpreterConfig.shutdownTimeout,

--- a/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
+++ b/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
@@ -196,7 +196,7 @@ class KafkaTransactionalScenarioInterpreterTest
 
       val error = kafkaClient.createConsumer().consumeWithJson[KafkaExceptionInfo](errorTopic).take(1).head.message()
       error.nodeId shouldBe Some("throw on 0")
-      error.processName shouldBe scenario.id
+      error.processName shouldBe scenario.name
       error.exceptionInput shouldBe Some("1 / #input.length")
     }
   }
@@ -368,7 +368,7 @@ class KafkaTransactionalScenarioInterpreterTest
         kafkaClient.createConsumer().consumeWithJson[KafkaExceptionInfo](fixture.errorTopic).take(1).head.message()
 
       error.nodeId shouldBe Some("source")
-      error.processName shouldBe scenario.id
+      error.processName shouldBe scenario.name
       // shouldn't it be just in error.message?
       error.exceptionInput.value should include(TestComponentProvider.SourceFailure.getMessage)
     }

--- a/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseInterpreter.scala
+++ b/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseInterpreter.scala
@@ -10,7 +10,7 @@ import pl.touk.nussknacker.engine.Interpreter.InterpreterShape
 import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
-import pl.touk.nussknacker.engine.api.process.ComponentUseCase
+import pl.touk.nussknacker.engine.api.process.{ComponentUseCase, ProcessName}
 import pl.touk.nussknacker.engine.api.typed.typing
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.lite.ScenarioInterpreterFactory.ScenarioInterpreterWithLifecycle
@@ -76,7 +76,7 @@ object RequestResponseInterpreter {
     private lazy val outputSchemaString: Option[String] =
       context.jobData.metaData.additionalFields.properties.get(OutputSchemaProperty)
 
-    val id: String = context.jobData.metaData.id
+    val scenarioName: ProcessName = context.jobData.metaData.name
 
     val sinkTypes: Map[NodeId, typing.TypingResult] = statelessScenarioInterpreter.sinkTypes
 
@@ -118,7 +118,7 @@ object RequestResponseInterpreter {
     }
 
     def generateInfoOpenApiDefinitionPart(): OApiInfo = OApiInfo(
-      title = id,
+      title = scenarioName.value,
       version = context.jobData.processVersion.versionId.value.toString,
       description = context.jobData.metaData.additionalFields.description
     )
@@ -130,8 +130,8 @@ object RequestResponseInterpreter {
       } yield {
         // TODO: remove cyclic dependency: RequestResponseOpenApiGenerator -> RequestResponseScenarioInterpreter -> RequestResponseOpenApiGenerator
         RequestResponseOpenApiGenerator.generateScenarioDefinition(
-          id,
-          id,
+          scenarioName.value,
+          scenarioName.value,
           sourceDefinition.description,
           sourceDefinition.tags,
           sourceDefinition.definition,

--- a/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/ScenarioRouteSpec.scala
+++ b/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/ScenarioRouteSpec.scala
@@ -47,7 +47,7 @@ class ScenarioRouteSpec extends AnyFunSuite with ScalatestRouteTest with Matcher
   private val modelData =
     LocalModelData(ConfigFactory.load(), RequestResponseComponentProvider.Components)
 
-  private val scenarioName: ProcessName = ProcessName(scenario.metaData.id)
+  private val scenarioName: ProcessName = scenario.name
 
   private val interpreter = RequestResponseInterpreter[Future](
     scenario,

--- a/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/MetricsTest.scala
+++ b/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/MetricsTest.scala
@@ -5,6 +5,7 @@ import io.dropwizard.metrics5.{MetricFilter, MetricRegistry}
 import org.scalatest.LoneElement._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.graph.node.{Case, DeadEndingData, EndingNodeData}
@@ -80,7 +81,7 @@ class MetricsTest extends AnyFunSuite with Matchers {
 
   test("should unregister metrics") {
     val metricRegistry   = new MetricRegistry
-    val metricProvider   = new DropwizardMetricsProviderFactory(metricRegistry)("fooScenarioId")
+    val metricProvider   = new DropwizardMetricsProviderFactory(metricRegistry)(ProcessName("fooScenarioId"))
     val metricIdentifier = MetricIdentifier(NonEmptyList("foo", Nil), Map.empty)
     val someGauge = new Gauge[Int] {
       override def getValue: Int = 123

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/displayedgraph/DisplayableProcess.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/displayedgraph/DisplayableProcess.scala
@@ -9,22 +9,18 @@ import pl.touk.nussknacker.engine.api.process.{ProcessName, ProcessingType}
 import pl.touk.nussknacker.engine.api.{MetaData, ProcessAdditionalFields, TypeSpecificData}
 import pl.touk.nussknacker.engine.graph.node.NodeData
 
-//it would be better to have two classes but it would either to derive from each other, which is not easy for final case classes
-//or we'd have to do composition which would break many things in client
-// TODO: id type should be ProcessName
 @JsonCodec final case class DisplayableProcess(
-    id: String,
+    // TODO: remove - it is already available in ScenarioWithDetails
+    name: ProcessName,
     properties: ProcessProperties,
     nodes: List[NodeData],
     edges: List[Edge],
+    // TODO: remove both processingType and category - they are already available in ScenarioWithDetails
     processingType: ProcessingType,
-    // FIXME: remove from here
     category: String
 ) {
 
-  val processName: ProcessName = ProcessName(id)
-
-  val metaData: MetaData = properties.toMetaData(processName)
+  val metaData: MetaData = properties.toMetaData(name)
 
 }
 

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/AsyncExecutionContextPreparer.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/AsyncExecutionContextPreparer.scala
@@ -9,12 +9,7 @@ trait AsyncExecutionContextPreparer {
   def bufferSize: Int
 
   def defaultUseAsyncInterpretation: Option[Boolean]
-
-  @deprecated("Use 'prepare' instead", "1.13.0")
-  def prepareExecutionContext(processId: String, parallelism: Int): ExecutionContext =
-    prepare(processId).executionContext
-
-  def prepare(processId: String): ServiceExecutionContext
+  def prepare(processName: ProcessName): ServiceExecutionContext
 
   def close(): Unit
 }

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/FragmentResolver.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/FragmentResolver.scala
@@ -16,7 +16,7 @@ object FragmentResolver {
 
   // For easier testing purpose
   def apply(fragments: Iterable[CanonicalProcess]): FragmentResolver = {
-    val fragmentMap = fragments.map(a => ProcessName(a.metaData.id) -> a).toMap
+    val fragmentMap = fragments.map(a => a.metaData.name -> a).toMap
     FragmentResolver(fragmentMap.get _)
   }
 

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/IdValidator.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/IdValidator.scala
@@ -5,6 +5,7 @@ import cats.data.ValidatedNel
 import cats.implicits._
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 
 object IdValidator {
@@ -13,7 +14,7 @@ object IdValidator {
   private val nodeIdIllegalCharactersReadable = "Quotation mark (\"), dot (.) and apostrophe (')"
 
   def validate(process: CanonicalProcess): ValidatedNel[ProcessCompilationError, Unit] = {
-    val scenarioIdValidationResult = validateScenarioId(process.id, process.metaData.isFragment)
+    val scenarioIdValidationResult = validateScenarioName(process.name, process.metaData.isFragment)
     val nodesIdValidationResult = process.nodes
       .map(node => validateNodeId(node.data.id))
       .combineAll
@@ -21,8 +22,11 @@ object IdValidator {
     scenarioIdValidationResult.combine(nodesIdValidationResult)
   }
 
-  def validateScenarioId(scenarioId: String, isFragment: Boolean): ValidatedNel[ProcessCompilationError, Unit] =
-    validateId(scenarioId).leftMap(_.map(ScenarioIdError(_, scenarioId, isFragment)))
+  def validateScenarioName(
+      scenarioName: ProcessName,
+      isFragment: Boolean
+  ): ValidatedNel[ProcessCompilationError, Unit] =
+    validateId(scenarioName.value).leftMap(_.map(ScenarioNameError(_, scenarioName, isFragment)))
 
   def validateNodeId(nodeId: String): ValidatedNel[ProcessCompilationError, Unit] =
     validateId(nodeId, nodeIdIllegalCharacters, nodeIdIllegalCharactersReadable)

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
@@ -70,7 +70,7 @@ trait ProcessValidator extends LazyLogging {
       })
     } catch {
       case NonFatal(e) =>
-        logger.warn(s"Unexpected error during compilation of ${process.id}", e)
+        logger.warn(s"Unexpected error during compilation of ${process.name}", e)
         CompilationResult(Invalid(NonEmptyList.of(FatalUnknownError(e.getMessage))))
     }
   }

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/dict/ProcessDictSubstitutor.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/dict/ProcessDictSubstitutor.scala
@@ -41,7 +41,7 @@ class ProcessDictSubstitutor(
           val afterSubstitution = ExpressionSubstitutor.substitute(expr.expression, substitutions)
           if (substitutions.nonEmpty)
             logger.debug(
-              s"Found ${substitutions.size} substitutions in expression: ${process.metaData.id} > ${nodeExpressionId.nodeId.id} > ${nodeExpressionId.expressionId}. " +
+              s"Found ${substitutions.size} substitutions in expression: ${process.name} > ${nodeExpressionId.nodeId.id} > ${nodeExpressionId.expressionId}. " +
                 s"Expression: '${expr.expression}' replaced with '$afterSubstitution'"
             )
           afterSubstitution

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/variables/MetaVariables.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/variables/MetaVariables.scala
@@ -14,7 +14,7 @@ object MetaVariables {
 
   @Hidden
   def apply(metaData: MetaData): MetaVariables =
-    MetaVariables(metaData.id, properties(metaData))
+    MetaVariables(metaData.name.value, properties(metaData))
 
   @Hidden
   def typingResult(metaData: MetaData): TypingResult =

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/FragmentResolverSpec.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/FragmentResolverSpec.scala
@@ -1,23 +1,23 @@
 package pl.touk.nussknacker.engine.compile
 
-import cats.data.{NonEmptyList, ValidatedNel}
 import cats.data.Validated.{Invalid, Valid}
+import cats.data.{NonEmptyList, ValidatedNel}
 import org.scalatest.Inside
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.{FragmentSpecificData, MetaData}
 import pl.touk.nussknacker.engine.build.GraphBuilder.Creator
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
-import pl.touk.nussknacker.engine.canonicalgraph.{CanonicalProcess, canonicalnode}
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.{FlatNode, Fragment}
-import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
+import pl.touk.nussknacker.engine.canonicalgraph.{CanonicalProcess, canonicalnode}
 import pl.touk.nussknacker.engine.graph.evaluatedparam.{Parameter => NodeParameter}
 import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.graph.fragment.FragmentRef
 import pl.touk.nussknacker.engine.graph.node.FragmentInputDefinition.{FragmentClazzRef, FragmentParameter}
 import pl.touk.nussknacker.engine.graph.node._
 import pl.touk.nussknacker.engine.graph.sink.SinkRef
-import pl.touk.nussknacker.engine.graph.fragment.FragmentRef
 
 class FragmentResolverSpec extends AnyFunSuite with Matchers with Inside {
 

--- a/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/IdValidatorTest.scala
+++ b/interpreter/src/test/scala/pl/touk/nussknacker/engine/compile/IdValidatorTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks.{Table, forAll}
 import org.scalatest.prop.TableFor2
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 
@@ -58,7 +59,7 @@ class IdValidatorTest extends AnyFunSuite with Matchers {
     IdValidator.validate(scenarioWithEmptyIds) match {
       case Validated.Invalid(errors) =>
         errors.toList should contain theSameElementsAs List(
-          ScenarioIdError(EmptyValue, "", isFragment = false),
+          ScenarioNameError(EmptyValue, ProcessName(""), isFragment = false),
           NodeIdValidationError(EmptyValue, "")
         )
       case Validated.Valid(_) =>
@@ -102,15 +103,15 @@ object IdValidationTestData {
     Table(
       ("scenarioId", "errors"),
       ("validId", List.empty),
-      ("", List(ScenarioIdError(EmptyValue, "", forFragment))),
-      (" ", List(ScenarioIdError(BlankId, " ", forFragment))),
-      ("trailingSpace ", List(ScenarioIdError(TrailingSpacesId, "trailingSpace ", forFragment))),
-      (" leadingSpace", List(ScenarioIdError(LeadingSpacesId, " leadingSpace", forFragment))),
+      ("", List(ScenarioNameError(EmptyValue, ProcessName(""), forFragment))),
+      (" ", List(ScenarioNameError(BlankId, ProcessName(" "), forFragment))),
+      ("trailingSpace ", List(ScenarioNameError(TrailingSpacesId, ProcessName("trailingSpace "), forFragment))),
+      (" leadingSpace", List(ScenarioNameError(LeadingSpacesId, ProcessName(" leadingSpace"), forFragment))),
       (
         " leadingAndTrailingSpace ",
         List(
-          ScenarioIdError(LeadingSpacesId, " leadingAndTrailingSpace ", forFragment),
-          ScenarioIdError(TrailingSpacesId, " leadingAndTrailingSpace ", forFragment)
+          ScenarioNameError(LeadingSpacesId, ProcessName(" leadingAndTrailingSpace "), forFragment),
+          ScenarioNameError(TrailingSpacesId, ProcessName(" leadingAndTrailingSpace "), forFragment)
         )
       ),
     )

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/CanonicalProcess.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/CanonicalProcess.scala
@@ -6,6 +6,7 @@ import pl.touk.nussknacker.engine.api.MetaData
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.CanonicalNode
 import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.graph.node
 import pl.touk.nussknacker.engine.graph.node._
 import pl.touk.nussknacker.engine.marshall.ProcessMarshaller
 
@@ -15,7 +16,8 @@ sealed trait CanonicalTreeNode
 
 object CanonicalProcess {
 
-  val IdFieldName = "$id"
+  // On the FE side, scenario properties are treated as a special type of node, so field name have to be the same
+  val NameFieldName: String = node.IdFieldName
 
   private def isNodeDisabled(node: CanonicalNode): Boolean =
     node.data match {
@@ -84,7 +86,7 @@ case class CanonicalProcess(
 
   import CanonicalProcess._
 
-  lazy val id: String = metaData.id
+  def name: ProcessName = metaData.name
 
   def allStartNodes: NonEmptyList[List[CanonicalNode]] = NonEmptyList(nodes, additionalBranches)
 
@@ -97,7 +99,7 @@ case class CanonicalProcess(
     copy(nodes = head, additionalBranches = tail)
   }
 
-  def withProcessId(processName: ProcessName): CanonicalProcess =
+  def withProcessName(processName: ProcessName): CanonicalProcess =
     copy(metaData = metaData.copy(id = processName.value))
 
   lazy val withoutDisabledNodes: CanonicalProcess = mapAllNodes(withoutDisabled)

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/ProcessNodesRewriter.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/ProcessNodesRewriter.scala
@@ -165,7 +165,7 @@ trait ExpressionRewriter {
     } catch {
       case NonFatal(ex) =>
         throw new IllegalArgumentException(
-          s"Exception during expression rewriting: $e, with id: $expressionId in node: $nodeId in process: ${metaData.id}",
+          s"Exception during expression rewriting: $e, with id: $expressionId in node: $nodeId in process: ${metaData.name}",
           ex
         )
     }

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/graph/EspProcess.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/graph/EspProcess.scala
@@ -13,7 +13,5 @@ object EspProcess {
 }
 
 case class EspProcess(metaData: MetaData, roots: NonEmptyList[SourceNode]) {
-  def id: String = metaData.id
-
   def toCanonicalProcess: CanonicalProcess = ProcessCanonizer.canonize(this)
 }

--- a/scenario-api/src/test/scala/pl/touk/nussknacker/engine/ScenarioApiShowcasesTest.scala
+++ b/scenario-api/src/test/scala/pl/touk/nussknacker/engine/ScenarioApiShowcasesTest.scala
@@ -16,14 +16,14 @@ class ScenarioApiShowcasesTest extends AnyFunSuite with Matchers with EitherValu
 
   import pl.touk.nussknacker.engine.spel.Implicits._
 
-  private val scenarioId   = "fooId"
+  private val scenarioName = "fooId"
   private val sourceNodeId = "source"
   private val sourceType   = "source-type"
 
   private val scenarioJson =
     s"""{
        |  "metaData" : {
-       |    "id" : "$scenarioId",
+       |    "id" : "$scenarioName",
        |    "additionalFields" : {
        |      "properties" : {
        |        "parallelism" : "",
@@ -84,14 +84,14 @@ class ScenarioApiShowcasesTest extends AnyFunSuite with Matchers with EitherValu
 
   test("should be able to parse scenario and easily extract its fields") {
     val canonicalScenario = ProcessMarshaller.fromJson(scenarioJson).toEither.rightValue
-    canonicalScenario.metaData.id shouldEqual scenarioId
+    canonicalScenario.name.value shouldEqual scenarioName
     canonicalScenario.nodes.head.data.id shouldEqual sourceNodeId
     canonicalScenario.nodes.head.data.asInstanceOf[Source].ref.typ shouldEqual sourceType
   }
 
   test("should be able to create scenario using dsl and print it") {
     val scenarioDsl = ScenarioBuilder
-      .streaming(scenarioId)
+      .streaming(scenarioName)
       .source(sourceNodeId, sourceType, "foo" -> "'expression value'")
       .filter("filter", "#input != 123")
       .emptySink("sink", "sink-type", "bar" -> "#input")

--- a/scenario-api/src/test/scala/pl/touk/nussknacker/engine/marshall/ProcessMarshallerSpec.scala
+++ b/scenario-api/src/test/scala/pl/touk/nussknacker/engine/marshall/ProcessMarshallerSpec.scala
@@ -163,7 +163,7 @@ class ProcessMarshallerSpec
       val canonicalProcess = buildProcessJsonWithAdditionalFields(processAdditionalFields = Some(marshalled))
 
       inside(canonicalProcess) { case Valid(process) =>
-        process.metaData.id shouldBe "custom"
+        process.name.value shouldBe "custom"
         process.metaData.additionalFields.description shouldBe unmarshaled.description
         process.metaData.additionalFields.metaDataType shouldBe unmarshaled.metaDataType
         unmarshaled.properties.toSet.subsetOf(process.metaData.additionalFields.properties.toSet) shouldBe true
@@ -177,7 +177,7 @@ class ProcessMarshallerSpec
     )
 
     inside(canonicalProcess) { case Valid(process) =>
-      process.metaData.id shouldBe "custom"
+      process.name.value shouldBe "custom"
       process.nodes should have size 1
       process.nodes.head.data.additionalFields shouldBe Some(
         UserDefinedAdditionalNodeFields(description = Some("single node description"), None)
@@ -189,7 +189,7 @@ class ProcessMarshallerSpec
     val canonicalProcess = buildProcessJsonWithAdditionalFields()
 
     inside(canonicalProcess) { case Valid(process) =>
-      process.metaData.id shouldBe "custom"
+      process.name.value shouldBe "custom"
       process.metaData.additionalFields shouldBe ProcessAdditionalFields(
         None,
         testStreamMetaData.toMap,
@@ -208,7 +208,7 @@ class ProcessMarshallerSpec
     )
 
     inside(canonicalProcess) { case Valid(process) =>
-      process.metaData.id shouldBe "custom"
+      process.name.value shouldBe "custom"
       process.metaData.additionalFields shouldBe ProcessAdditionalFields(
         None,
         testStreamMetaData.toMap,

--- a/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/sharedservice/SharedService.scala
+++ b/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/sharedservice/SharedService.scala
@@ -21,13 +21,13 @@ abstract class SharedServiceHolder[CreationData, Service <: SharedService[Creati
   private var sharedServices = Map[CreationData, (Service, Int)]()
 
   def retrieveService(creationData: CreationData)(implicit metaData: MetaData): Service = synchronized {
-    val processId = metaData.id
+    val processName = metaData.name
     val newValue = sharedServices.get(creationData) match {
       case Some((currentInstance, counter)) =>
-        logger.debug(s"Retrieving $name from cache for config: $creationData and $processId")
+        logger.debug(s"Retrieving $name from cache for config: $creationData and $processName")
         (currentInstance, counter + 1)
       case None =>
-        logger.info(s"Creating new $name for config: $creationData for $processId")
+        logger.info(s"Creating new $name for config: $creationData for $processName")
         (createService(creationData, metaData), 1)
 
     }

--- a/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkTestScenarioRunner.scala
+++ b/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkTestScenarioRunner.scala
@@ -165,7 +165,7 @@ class FlinkTestScenarioRunner(
           testScenarioCollectorHandler.resultCollector
         )
 
-        env.executeAndWaitForFinished(scenario.id)()
+        env.executeAndWaitForFinished(scenario.name.value)()
 
         RunUnitResult(errors = testScenarioCollectorHandler.resultsCollectingListener.results.exceptions)
       }

--- a/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/sink/KafkaSinkFactory.scala
+++ b/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/sink/KafkaSinkFactory.scala
@@ -51,7 +51,7 @@ abstract class BaseKafkaSinkFactory(
     val preparedTopic = KafkaComponentsUtils.prepareKafkaTopic(topic, modelDependencies)
     KafkaComponentsUtils.validateTopicsExistence(List(preparedTopic), kafkaConfig)
     val serializationSchema = serializationSchemaFactory.create(preparedTopic.prepared, kafkaConfig)
-    val clientId            = s"${processMetaData.id}-${preparedTopic.prepared}"
+    val clientId            = s"${processMetaData.name}-${preparedTopic.prepared}"
     implProvider.prepareSink(preparedTopic, value, kafkaConfig, serializationSchema, clientId)
   }
 

--- a/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaConfig.scala
+++ b/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaConfig.scala
@@ -48,6 +48,7 @@ case class KafkaConfig(
 }
 
 object ConsumerGroupNamingStrategy extends Enumeration {
+  // TODO: Rename to processName and processName-nodeName
   val ProcessId: ConsumerGroupNamingStrategy.Value       = Value("processId")
   val ProcessIdNodeId: ConsumerGroupNamingStrategy.Value = Value("processId-nodeId")
 }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkFactory.scala
@@ -219,7 +219,7 @@ class UniversalKafkaSinkFactory(
       Option(finalState.schema),
       kafkaConfig
     )
-    val clientId = s"${TypedNodeDependency[MetaData].extract(dependencies).id}-${preparedTopic.prepared}"
+    val clientId = s"${TypedNodeDependency[MetaData].extract(dependencies).name}-${preparedTopic.prepared}"
     val validationMode = extractValidationMode(
       params.getOrElse(SinkValidationModeParameterName, ValidationMode.strict.name).asInstanceOf[String]
     )

--- a/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/LoggingListener.scala
+++ b/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/LoggingListener.scala
@@ -33,7 +33,7 @@ object LoggingListener extends ProcessListener with Serializable {
   }
 
   override def nodeEntered(nodeId: String, context: Context, metadata: MetaData): Unit = {
-    debug(List(metadata.id, nodeId), s"Node entered. Context: $context")
+    debug(List(metadata.name.value, nodeId), s"Node entered. Context: $context")
   }
 
   override def endEncountered(
@@ -42,11 +42,11 @@ object LoggingListener extends ProcessListener with Serializable {
       context: Context,
       metadata: MetaData
   ): Unit = {
-    debug(List(metadata.id, nodeId, "end", ref), s"End encountered. Context: $context")
+    debug(List(metadata.name.value, nodeId, "end", ref), s"End encountered. Context: $context")
   }
 
   override def deadEndEncountered(lastNodeId: String, context: Context, metadata: MetaData): Unit = {
-    debug(List(metadata.id, lastNodeId, "deadEnd"), s"Dead end encountered. Context: $context")
+    debug(List(metadata.name.value, lastNodeId, "deadEnd"), s"Dead end encountered. Context: $context")
   }
 
   override def expressionEvaluated(
@@ -57,7 +57,10 @@ object LoggingListener extends ProcessListener with Serializable {
       metadata: MetaData,
       result: Any
   ): Unit = {
-    debug(List(metadata.id, nodeId, "expression"), s"invoked expression: $expr with result $result. Context: $context")
+    debug(
+      List(metadata.name.value, nodeId, "expression"),
+      s"invoked expression: $expr with result $result. Context: $context"
+    )
   }
 
   override def serviceInvoked(
@@ -68,7 +71,10 @@ object LoggingListener extends ProcessListener with Serializable {
       params: Map[String, Any],
       result: Try[Any]
   ): Unit = {
-    debug(List(metadata.id, nodeId, "service", id), s"Invocation ended-up with result: $result. Context: $context")
+    debug(
+      List(metadata.name.value, nodeId, "service", id),
+      s"Invocation ended-up with result: $result. Context: $context"
+    )
   }
 
   override def exceptionThrown(exceptionInfo: NuExceptionInfo[_ <: Throwable]): Unit = {


### PR DESCRIPTION
## Describe your changes

- BE: `ProcessName` value class is used in most possible places - wrapping/unwrapping operations count was drastically reduced
- FE: `ProcessId` value class renamed to `ProcessName` for consistency with BE
- REST API:
  * `/process(Details)/**` endpoints:
    * `id` fields was removed (it had the same value as `name`)
    * `processId` fields return always `null`
    * `.json.id` fields was renamed to `.json.name`
  * `components/*/usages` endpoint:
    * `id` fields was removed (it had the same value as `name`)
    * `processId` fields was removed
  * `processes/**/activity/attachments` - `processId` fields was removed
  * `processes/**/activity/comments` - `processId` fields was removed
  * GET `processes/$name/$version/activity/attachments` - `$version` segment is removed now

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
