### PR TITLE
Add skipNodeResults parameter to API calls that return validated scenarios

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -91,13 +91,17 @@ class ProcessesResources(
           }
         }
       } ~ path("processesDetails") {
-        (get & processesQuery & skipValidateAndResolveParameter) { (query, skipValidateAndResolve) =>
-          complete {
-            processService.getLatestProcessesWithDetails(
-              query,
-              GetScenarioWithDetailsOptions(FetchScenarioGraph(!skipValidateAndResolve), fetchState = false)
-            )
-          }
+        (get & processesQuery & skipValidateAndResolveParameter & skipNodeResultsParameter) {
+          (query, skipValidateAndResolve, skipNodeResults) =>
+            complete {
+              processService.getLatestProcessesWithDetails(
+                query,
+                GetScenarioWithDetailsOptions(
+                  FetchScenarioGraph(validationFlagsToMode(skipValidateAndResolve, skipNodeResults)),
+                  fetchState = false
+                )
+              )
+            }
         }
       } ~ path("processes" / "status") {
         get {
@@ -150,13 +154,17 @@ class ProcessesResources(
                 }
               }
             }
-          } ~ (get & skipValidateAndResolveParameter) { skipValidateAndResolve =>
-            complete {
-              processService.getLatestProcessWithDetails(
-                processId,
-                GetScenarioWithDetailsOptions(FetchScenarioGraph(!skipValidateAndResolve), fetchState = true)
-              )
-            }
+          } ~ (get & skipValidateAndResolveParameter & skipNodeResultsParameter) {
+            (skipValidateAndResolve, skipNodeResults) =>
+              complete {
+                processService.getLatestProcessWithDetails(
+                  processId,
+                  GetScenarioWithDetailsOptions(
+                    FetchScenarioGraph(validationFlagsToMode(skipValidateAndResolve, skipNodeResults)),
+                    fetchState = true
+                  )
+                )
+              }
           }
         }
       } ~ path("processes" / ProcessNameSegment / "rename" / ProcessNameSegment) { (processName, newName) =>
@@ -170,15 +178,19 @@ class ProcessesResources(
           }
         }
       } ~ path("processes" / ProcessNameSegment / VersionIdSegment) { (processName, versionId) =>
-        (get & processId(processName) & skipValidateAndResolveParameter) { (processId, skipValidateAndResolve) =>
-          complete {
-            processService.getProcessWithDetails(
-              processId,
-              versionId,
-              // TODO: disable fetching state when FE is ready
-              GetScenarioWithDetailsOptions(FetchScenarioGraph(!skipValidateAndResolve), fetchState = true)
-            )
-          }
+        (get & processId(processName) & skipValidateAndResolveParameter & skipNodeResultsParameter) {
+          (processId, skipValidateAndResolve, skipNodeResults) =>
+            complete {
+              processService.getProcessWithDetails(
+                processId,
+                versionId,
+                // TODO: disable fetching state when FE is ready
+                GetScenarioWithDetailsOptions(
+                  FetchScenarioGraph(validationFlagsToMode(skipValidateAndResolve, skipNodeResults)),
+                  fetchState = true
+                )
+              )
+            }
         }
       } ~ path("processes" / ProcessNameSegment / Segment) { (processName, category) =>
         authorize(user.can(category, Permission.Write)) {
@@ -284,6 +296,15 @@ class ProcessesResources(
 
   private def skipValidateAndResolveParameter = {
     parameters(Symbol("skipValidateAndResolve").as[Boolean].withDefault(false))
+  }
+
+  private def skipNodeResultsParameter = {
+    parameters(Symbol("skipNodeResults").as[Boolean].withDefault(false))
+  }
+
+  private def validationFlagsToMode(skipValidateAndResolve: Boolean, skipNodeResults: Boolean) = {
+    if (skipValidateAndResolve) FetchScenarioGraph.DontValidate
+    else FetchScenarioGraph.ValidateAndResolve(!skipNodeResults)
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
@@ -60,7 +60,7 @@ object ProcessService {
       new GetScenarioWithDetailsOptions(SkipScenarioGraph, fetchState = false)
 
     val withsScenarioGraph: GetScenarioWithDetailsOptions =
-      new GetScenarioWithDetailsOptions(FetchScenarioGraph(validateAndResolve = false), fetchState = false)
+      new GetScenarioWithDetailsOptions(FetchScenarioGraph(), fetchState = false)
   }
 
   final case class GetScenarioWithDetailsOptions(fetchGraphOptions: ScenarioGraphOptions, fetchState: Boolean) {
@@ -68,7 +68,7 @@ object ProcessService {
     def withValidation: GetScenarioWithDetailsOptions = {
       val newFetchGraphOptions = fetchGraphOptions match {
         case SkipScenarioGraph => throw new IllegalStateException("withValidation used with SkipScenarioGraph option")
-        case fetch: FetchScenarioGraph => fetch.copy(validateAndResolve = true)
+        case fetch: FetchScenarioGraph => fetch.copy(validate = FetchScenarioGraph.ValidateAndResolve())
       }
       copy(fetchGraphOptions = newFetchGraphOptions)
     }
@@ -80,7 +80,16 @@ object ProcessService {
 
   case object SkipScenarioGraph extends ScenarioGraphOptions
 
-  case class FetchScenarioGraph(validateAndResolve: Boolean) extends ScenarioGraphOptions
+  case class FetchScenarioGraph(validate: FetchScenarioGraph.ValidationMode = FetchScenarioGraph.DontValidate)
+      extends ScenarioGraphOptions
+
+  object FetchScenarioGraph {
+    sealed trait ValidationMode {}
+
+    case object DontValidate extends ValidationMode
+
+    case class ValidateAndResolve(includeValidationNodeResults: Boolean = true) extends ValidationMode
+  }
 
 }
 
@@ -220,9 +229,9 @@ class DBProcessService(
       case SkipScenarioGraph =>
         fetchScenario[Unit]
           .map(_.map(ScenarioWithDetailsConversions.fromEntityIgnoringGraphAndValidationResult))
-      case FetchScenarioGraph(validateAndResolve) =>
+      case FetchScenarioGraph(validate) =>
         fetchScenario[CanonicalProcess]
-          .map(_.map(validateAndReverseResolve(_, validateAndResolve)))
+          .map(_.map(validateAndReverseResolve(_, validate)))
     }).flatMap { details =>
       if (options.fetchState)
         deploymentService.enrichDetailsWithProcessState(details)
@@ -239,12 +248,21 @@ class DBProcessService(
 
   private def validateAndReverseResolve(
       entity: ScenarioWithDetailsEntity[CanonicalProcess],
-      validateAndResolve: Boolean
+      validate: FetchScenarioGraph.ValidationMode
   )(implicit user: LoggedUser): ScenarioWithDetails = {
-    if (validateAndResolve) {
-      validateAndReverseResolve(entity)
-    } else {
-      toDisplayableProcessDetailsWithoutValidation(entity)
+    validate match {
+      case FetchScenarioGraph.ValidateAndResolve(true) =>
+        validateAndReverseResolve(entity)
+      case FetchScenarioGraph.ValidateAndResolve(false) =>
+        // reduce serialized response JSON by ~5-10 MB (typical typing information size in production use)
+        val result = validateAndReverseResolve(entity)
+        result.copy(json = result.json.map { validatedProcess =>
+          validatedProcess.copy(validationResult =
+            validatedProcess.validationResult.map(_.copy(nodeResults = Map.empty))
+          )
+        })
+      case FetchScenarioGraph.DontValidate =>
+        toDisplayableProcessDetailsWithoutValidation(entity)
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -10,6 +10,7 @@ import akka.http.scaladsl.{Http, HttpExt}
 import akka.stream.Materializer
 import cats.data.EitherT
 import cats.implicits._
+import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.Decoder
 import pl.touk.nussknacker.engine.api.displayedgraph.DisplayableProcess
@@ -84,6 +85,7 @@ class HttpRemoteEnvironment(
     val environmentId: String
 )(implicit as: ActorSystem, val materializer: Materializer, ec: ExecutionContext)
     extends StandardRemoteEnvironment
+    with LazyLogging
     with AutoCloseable {
   override val config: StandardRemoteEnvironmentConfig = httpConfig.remoteConfig
 
@@ -99,6 +101,7 @@ class HttpRemoteEnvironment(
       request: MessageEntity,
       headers: Seq[HttpHeader]
   ): Future[HttpResponse] = {
+    logger.debug("Sending request to remote environment: {} {}", method.value, uri)
     http.singleRequest(
       HttpRequest(
         uri = uri,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -263,6 +263,7 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
       Query(
         ("names", names.map(ns => URLEncoder.encode(ns.value, StandardCharsets.UTF_8)).mkString(",")),
         ("isArchived", "false"),
+        ("skipNodeResults", "true"),
       )
     )
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrations.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrations.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.ui.process.migrate
 
+import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.displayedgraph.DisplayableProcess
 import pl.touk.nussknacker.engine.api.process.{ProcessName, ProcessingType}
 import pl.touk.nussknacker.engine.migration.ProcessMigrations
@@ -23,14 +24,18 @@ import scala.concurrent.Future
 class TestModelMigrations(
     migrations: ProcessingTypeDataProvider[ProcessMigrations, _],
     processValidator: ProcessingTypeDataProvider[UIProcessValidator, _]
-) {
+) extends LazyLogging {
 
   def testMigrations(
       processes: List[ScenarioWithDetails],
       fragments: List[ScenarioWithDetails]
   )(implicit user: LoggedUser): List[TestMigrationResult] = {
+    logger.debug(
+      s"Testing scenario migrations (scenarios=${processes.count(_ => true)}, fragments=${fragments.count(_ => true)})"
+    )
     val migratedFragments = fragments.flatMap(migrateProcess)
     val migratedProcesses = processes.flatMap(migrateProcess)
+    logger.debug("Validating migrated scenarios")
     val validator = processValidator.mapValues(
       _.withFragmentResolver(
         new FragmentResolver(prepareFragmentRepository(migratedFragments.map(s => (s.newProcess, s.processCategory))))

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/services/AppApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/services/AppApiHttpService.scala
@@ -12,7 +12,7 @@ import pl.touk.nussknacker.engine.version.BuildInfo
 import pl.touk.nussknacker.engine.api.process.ProcessingType
 import pl.touk.nussknacker.ui.api.AppApiEndpoints.Dtos._
 import pl.touk.nussknacker.ui.api.AppApiEndpoints
-import pl.touk.nussknacker.ui.process.ProcessService.{FetchScenarioGraph, GetScenarioWithDetailsOptions}
+import pl.touk.nussknacker.ui.process.ProcessService.GetScenarioWithDetailsOptions
 import pl.touk.nussknacker.ui.process.processingtypedata.{ProcessingTypeDataProvider, ProcessingTypeDataReload}
 import pl.touk.nussknacker.ui.process.{ProcessCategoryService, ProcessService, ScenarioQuery, UserCategoryService}
 import pl.touk.nussknacker.ui.security.api.{AuthenticationResources, LoggedUser, NussknackerInternalUser}

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8,6 +8,7 @@
 * [#5271](https://github.com/TouK/nussknacker/pull/5271) Changed `AdditionalUIConfigProvider.getAllForProcessingType` API to be more in line with FragmentParameter
 * [#5278](https://github.com/TouK/nussknacker/pull/5278) Recreate assembled model JAR for Flink if it got removed (e.g. by systemd-tmpfiles)
 * [#5280](https://github.com/TouK/nussknacker/pull/5280) Security improvement: Checking if user has access rights to fragment's Category for fragments served by definitions API
+* [#5303](https://github.com/TouK/nussknacker/pull/5303) Added `skipNodeResults` parameter to API endpoints that return scenario validation results
 
 1.13.0 (Not released yet)
 -------------------------


### PR DESCRIPTION
## Describe your changes

Extends API to make it possible to fetch validation results without detailed typing information.

Example for `/api/processesDetails?names=...&skipNodeResults=true`:
* before: 796 kB (11,31 MB uncompressed) - our average production scenario has 5-10 MB of typing information
* after: 11,62 kB (68,65 kB uncompressed)

This allows us to reduce migration test time for 449 scenarios and 73 fragments from ~13,5 to ~11 minutes. I'm heavily averaging here, but assuming that an average scenario has 500 kB of JSON data (5 MB uncompressed) this gives us:
* 250 MB less sent between live application and CI server
* 2,5 GB less JSON data to parse

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [x] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
