### PR TITLE
Fix for: pallete didn't contain fragmentDefinition component group

### DIFF
--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/UIComponentGroupsPreparerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/component/UIComponentGroupsPreparerSpec.scala
@@ -8,6 +8,7 @@ import pl.touk.nussknacker.engine.api.component._
 import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.typed.typing.Unknown
 import pl.touk.nussknacker.engine.definition.component.bultin.BuiltInComponentsStaticDefinitionsPreparer
+import pl.touk.nussknacker.engine.definition.component.defaultconfig.DefaultsComponentGroupName
 import pl.touk.nussknacker.engine.definition.component.{
   ComponentDefinitionWithImplementation,
   CustomComponentSpecificData
@@ -33,7 +34,7 @@ class UIComponentGroupsPreparerSpec
 
   test("return groups sorted in order: inputs, base, other, outputs and then sorted by name within group") {
     val groups = ComponentGroupsPreparer.prepareComponentGroups(
-      prepareModelDefinition(
+      prepareModelDefinitionForTestData(
         Map(
           ComponentGroupName("custom") -> Some(ComponentGroupName("CUSTOM")),
           ComponentGroupName("sinks")  -> Some(ComponentGroupName("BAR"))
@@ -47,14 +48,14 @@ class UIComponentGroupsPreparerSpec
 
   test("return groups with hidden base group") {
     val groups = ComponentGroupsPreparer.prepareComponentGroups(
-      prepareModelDefinition(Map(ComponentGroupName("base") -> None))
+      prepareModelDefinitionForTestData(Map(ComponentGroupName("base") -> None))
     )
     groups.map(_.name) shouldBe List("sources", "custom", "enrichers", "optionalEndingCustom", "services", "sinks").map(
       ComponentGroupName(_)
     )
   }
 
-  test("return objects sorted by label case insensitive") {
+  test("return components sorted by label case insensitive") {
     val groups = prepareGroupForServices(List("foo", "alaMaKota", "BarFilter"))
     groups.map(_.components.map(n => n.label)) shouldBe List(
       List("choice", "filter", "record-variable", "split", "variable"),
@@ -62,9 +63,9 @@ class UIComponentGroupsPreparerSpec
     )
   }
 
-  test("return objects with mapped groups") {
+  test("return components with mapped groups") {
     val groups = ComponentGroupsPreparer.prepareComponentGroups(
-      prepareModelDefinition(
+      prepareModelDefinitionForTestData(
         Map(
           ComponentGroupName("custom")               -> Some(ComponentGroupName("base")),
           ComponentGroupName("optionalEndingCustom") -> Some(ComponentGroupName("base"))
@@ -88,7 +89,7 @@ class UIComponentGroupsPreparerSpec
 
   test("return custom component with correct group") {
     val definitionWithCustomComponentInSomeGroup =
-      prepareModelDefinition(Map.empty).transform {
+      prepareModelDefinitionForTestData(Map.empty).transform {
         case component if component.componentType == ComponentType.CustomComponent =>
           val updatedComponentConfig =
             component.componentConfig.copy(componentGroup = Some(ComponentGroupName("group1")))
@@ -121,6 +122,22 @@ class UIComponentGroupsPreparerSpec
     }
   }
 
+  test("return components for fragments") {
+    val model =
+      enrichModelDefinitionWithBuiltInComponents(ModelDefinitionBuilder.empty.build, Map.empty, forFragment = true)
+    val groups = ComponentGroupsPreparer.prepareComponentGroups(model)
+    groups.map(_.name) shouldEqual List(
+      DefaultsComponentGroupName.FragmentsDefinitionGroupName,
+      DefaultsComponentGroupName.BaseGroupName
+    )
+    val fragmentDefinitionComponentLabels =
+      groups.find(_.name == DefaultsComponentGroupName.FragmentsDefinitionGroupName).value.components.map(_.label)
+    fragmentDefinitionComponentLabels shouldEqual List(
+      BuiltInComponentInfo.FragmentInputDefinition.name,
+      BuiltInComponentInfo.FragmentOutputDefinition.name
+    )
+  }
+
   private def validateGroups(groups: List[UIComponentGroup], expectedSizeOfNotEmptyGroups: Int): Unit = {
     groups.filterNot(ng => ng.components.isEmpty) should have size expectedSizeOfNotEmptyGroups
   }
@@ -135,14 +152,17 @@ class UIComponentGroupsPreparerSpec
     ComponentGroupsPreparer.prepareComponentGroups(modelDefinition)
   }
 
-  private def prepareModelDefinition(groupNameMapping: Map[ComponentGroupName, Option[ComponentGroupName]]) = {
+  private def prepareModelDefinitionForTestData(
+      groupNameMapping: Map[ComponentGroupName, Option[ComponentGroupName]]
+  ) = {
     val modelDefinition = ProcessTestData.modelDefinition(groupNameMapping)
     enrichModelDefinitionWithBuiltInComponents(modelDefinition, groupNameMapping)
   }
 
   private def enrichModelDefinitionWithBuiltInComponents(
       modelDefinition: ModelDefinition[ComponentDefinitionWithImplementation],
-      groupNameMapping: Map[ComponentGroupName, Option[ComponentGroupName]]
+      groupNameMapping: Map[ComponentGroupName, Option[ComponentGroupName]],
+      forFragment: Boolean = false
   ) = {
     val modelDefinitionEnricher = new ModelDefinitionEnricher(
       new BuiltInComponentsStaticDefinitionsPreparer(new ComponentsUiConfig(Map.empty, groupNameMapping)),
@@ -152,7 +172,7 @@ class UIComponentGroupsPreparerSpec
     )
     modelDefinitionEnricher
       .modelDefinitionWithBuiltInComponentsAndFragments(
-        forFragment = false,
+        forFragment,
         fragmentScenarios = List.empty,
         TestProcessingTypes.Streaming
       )

--- a/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/component/defaultconfig/DefaultComponentConfigDeterminer.scala
+++ b/interpreter/src/main/scala/pl/touk/nussknacker/engine/definition/component/defaultconfig/DefaultComponentConfigDeterminer.scala
@@ -1,6 +1,11 @@
 package pl.touk.nussknacker.engine.definition.component.defaultconfig
 
-import pl.touk.nussknacker.engine.api.component.{ComponentGroupName, ComponentInfo, SingleComponentConfig}
+import pl.touk.nussknacker.engine.api.component.{
+  BuiltInComponentInfo,
+  ComponentGroupName,
+  ComponentInfo,
+  SingleComponentConfig
+}
 import pl.touk.nussknacker.engine.definition.component._
 
 object DefaultComponentConfigDeterminer {
@@ -40,14 +45,21 @@ object DefaultComponentConfigDeterminer {
     )
   }
 
-  def forBuiltInComponent(info: ComponentInfo): SingleComponentConfig = SingleComponentConfig(
-    params = None,
-    Some(DefaultsComponentIcon.forBuiltInComponent(info)),
-    // TODO: move from defaultModelConfig.conf to here + convention instead of code
-    docsUrl = None,
-    componentGroup = Some(DefaultsComponentGroupName.BaseGroupName),
-    componentId = None
-  )
+  def forBuiltInComponent(info: ComponentInfo): SingleComponentConfig = {
+    val componentGroup = if (BuiltInComponentInfo.FragmentDefinitionComponents.contains(info)) {
+      DefaultsComponentGroupName.FragmentsDefinitionGroupName
+    } else {
+      DefaultsComponentGroupName.BaseGroupName
+    }
+    SingleComponentConfig(
+      params = None,
+      Some(DefaultsComponentIcon.forBuiltInComponent(info)),
+      // TODO: move from defaultModelConfig.conf to here + convention instead of code
+      docsUrl = None,
+      componentGroup = Some(componentGroup),
+      componentId = None
+    )
+  }
 
   def forFragment(docsUrl: Option[String]): SingleComponentConfig = SingleComponentConfig(
     params = None,


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
