### PR TITLE
Fix for: outgoing edges from node that used fragment which lost outputs weren't automatically cleaned

### DIFF
--- a/designer/client/src/components/graph/NodeUtils.ts
+++ b/designer/client/src/components/graph/NodeUtils.ts
@@ -227,11 +227,15 @@ class NodeUtils {
     hasOutputs = (node: NodeType, processDefinitionData?: ProcessDefinitionData): boolean => {
         switch (node?.type) {
             case "FragmentInput": {
-                const outputParameters =
-                    processDefinitionData?.components["fragment-" + node.ref.id]?.outputParameters ||
-                    Object.keys(node.ref.outputVariableNames);
-                return outputParameters.length > 0;
+                const fragmentComponentId = ProcessUtils.determineComponentId(node);
+                const edgesFromDefinition = processDefinitionData?.edgesForNodes.find(
+                    (e) => e.componentId === fragmentComponentId && !e.isForInputDefinition,
+                )?.edges;
+                // Is this fallback is ok? This function is used for correctFetchedDetails. Why we prefer to
+                // clean edges when referred fragment lost all outputs but don't clean them when fragment was removed at all?
+                return (edgesFromDefinition || Object.keys(node.ref.outputVariableNames)).length > 0;
             }
+            // Can't we use processDefinitionData?.edgesForNodes for every node type?
             default: {
                 return !this.noOutputNodeTypes.includes(node?.type);
             }

--- a/designer/client/src/reducers/graph/correctFetchedDetails.ts
+++ b/designer/client/src/reducers/graph/correctFetchedDetails.ts
@@ -4,10 +4,13 @@ import { ProcessType } from "../../components/Process/types";
 
 function getEdgeValidator(processToDisplay: Process, processDefinitionData?: ProcessDefinitionData) {
     return ({ from }: Edge): boolean => {
+        // TODO: we could not only check if hasOutput for from, but also check if Edge.edgeType.name matches
+        //       available edges(name) from the definition
         return NodeUtils.hasOutputs(NodeUtils.getNodeById(from, processToDisplay), processDefinitionData);
     };
 }
 
+// TODO: This should be one on the BE side
 export function correctFetchedDetails(data: ProcessType, definitionData?: ProcessDefinitionData): ProcessType {
     const { json: processToDisplay } = data;
     const { edges } = processToDisplay;

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
@@ -69,8 +69,7 @@ package object definition {
       //    (see. ProcessUtils.findAvailableVariables). This heuristic is used when DisplayableProcess can't be translated
       //    to CanonicalProcess. When we replace CanonicalProcess by DisplayableProcess, it won't be needed anymore
       returnType: Option[TypingResult],
-      // This field is defined only for fragments. It is used to correct output edges from a node that uses fragment.
-      // See correctFetchedDetails.ts
+      // This field is defined only for fragments
       outputParameters: Option[List[String]]
   )
 

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
@@ -69,7 +69,8 @@ package object definition {
       //    (see. ProcessUtils.findAvailableVariables). This heuristic is used when DisplayableProcess can't be translated
       //    to CanonicalProcess. When we replace CanonicalProcess by DisplayableProcess, it won't be needed anymore
       returnType: Option[TypingResult],
-      // For fragments only
+      // This field is defined only for fragments. It is used to correct output edges from a node that uses fragment.
+      // See correctFetchedDetails.ts
       outputParameters: Option[List[String]]
   )
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionsService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionsService.scala
@@ -4,7 +4,7 @@ import pl.touk.nussknacker.engine.api.component._
 import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.api.deployment.DeploymentManager
 import pl.touk.nussknacker.engine.api.process.ProcessingType
-import pl.touk.nussknacker.engine.definition.component.ComponentStaticDefinition
+import pl.touk.nussknacker.engine.definition.component.{ComponentStaticDefinition, FragmentSpecificData}
 import pl.touk.nussknacker.engine.definition.model.ModelDefinition
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.modelconfig.ComponentsUiConfigParser
@@ -94,7 +94,9 @@ class DefinitionsService(
     UIComponentDefinition(
       parameters = componentDefinition.parameters.map(createUIParameter),
       returnType = componentDefinition.returnType,
-      outputParameters = None
+      outputParameters = Option(componentDefinition.componentTypeSpecificData).collect {
+        case FragmentSpecificData(outputNames) => outputNames
+      }
     )
   }
 


### PR DESCRIPTION
… on the FE side due to changes in the definition api

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
