### PR TITLE
Make default timeout of RichKafkaConsumer methods public

### DIFF
--- a/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/RichKafkaConsumer.scala
+++ b/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/RichKafkaConsumer.scala
@@ -76,7 +76,7 @@ class RichKafkaConsumer[K, M](consumer: Consumer[K, M]) extends LazyLogging {
 }
 
 object RichKafkaConsumer {
-  private val DefaultSecondsToWait = 30
+  val DefaultSecondsToWait: Int = 30
 }
 
 case class KeyMessage[K, V](k: K, msg: V, timestamp: Long) {


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
