### PR TITLE
[Draft] refactor to add context in kafka sources

### DIFF
--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkSource.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkSource.scala
@@ -31,7 +31,7 @@ trait FlinkSourceTestSupport[Raw] extends SourceTestSupport[Raw] { self: Source 
   // TODO: design better way of handling test data in generic FlinkSource
   // Probably we *still* want to use CollectionSource (and have some custom logic in parser if needed), but timestamps
   // have to be handled here for now
-  def timestampAssignerForTest: Option[TimestampWatermarkHandler[Raw]]
+  def timestampAssignerForTest: Option[TimestampWatermarkHandler[Context]]
 
   def typeInformation: TypeInformation[Raw]
 

--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/timestampwatermark/TimestampWatermarkHandler.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/timestampwatermark/TimestampWatermarkHandler.scala
@@ -77,19 +77,3 @@ object StandardTimestampWatermarkHandler {
   }
 
 }
-
-@silent("deprecated")
-class LegacyTimestampWatermarkHandler[T](timestampAssigner: TimestampAssigner[T]) extends TimestampWatermarkHandler[T] {
-
-  override def assignTimestampAndWatermarks(dataStream: DataStream[T]): DataStream[T] = {
-    timestampAssigner match {
-      case periodic: AssignerWithPeriodicWatermarks[T @unchecked] =>
-        dataStream.assignTimestampsAndWatermarks(periodic)
-      case punctuated: AssignerWithPunctuatedWatermarks[T @unchecked] =>
-        dataStream.assignTimestampsAndWatermarks(punctuated)
-    }
-  }
-
-  def extractTimestamp(element: T, recordTimestamp: Long): Long =
-    timestampAssigner.extractTimestamp(element, recordTimestamp)
-}

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/CollectionSource.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/CollectionSource.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.flink.util.source
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.functions.source.FromElementsFunction
+import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.typed.ReturningType
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.flink.api.process.BasicFlinkSource
@@ -11,7 +12,7 @@ import scala.jdk.CollectionConverters._
 
 case class CollectionSource[T: TypeInformation](
     list: List[T],
-    timestampAssigner: Option[TimestampWatermarkHandler[T]],
+    timestampAssigner: Option[TimestampWatermarkHandler[Context]],
     returnType: TypingResult
 ) extends BasicFlinkSource[T]
     with ReturningType {

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/EmptySource.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/source/EmptySource.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.flink.util.source
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.functions.source.SourceFunction
+import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.typed.ReturningType
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.flink.api.process.BasicFlinkSource
@@ -13,7 +14,7 @@ case class EmptySource[T: TypeInformation](returnType: TypingResult) extends Bas
 
   override val typeInformation: TypeInformation[T] = implicitly[TypeInformation[T]]
 
-  override def timestampAssigner: Option[TimestampWatermarkHandler[T]] = None
+  override def timestampAssigner: Option[TimestampWatermarkHandler[Context]] = None
 
 }
 

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFragmentSourceDefinitionPreparer.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFragmentSourceDefinitionPreparer.scala
@@ -51,13 +51,13 @@ class StubbedFragmentSourceDefinitionPreparer(
       with FlinkIntermediateRawSource[Map[String, Any]]
       with FlinkSourceTestSupport[Map[String, Any]]
       with TestWithParametersSupport[Map[String, Any]] {
-      override def timestampAssignerForTest: Option[TimestampWatermarkHandler[Map[String, Any]]] = None
+      override def timestampAssignerForTest: Option[TimestampWatermarkHandler[Context]] = None
 
       override def typeInformation: TypeInformation[Map[String, Any]] = TypeInformation.of(classOf[Map[String, Any]])
 
       override def testRecordParser: TestRecordParser[Map[String, Any]] = ???
 
-      override def timestampAssigner: Option[TimestampWatermarkHandler[Map[String, Any]]] = None
+      override def timestampAssigner: Option[TimestampWatermarkHandler[Context]] = None
 
       override def testParametersDefinition: List[Parameter] = inputParameters
 

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFlinkProcessCompilerDataFactoryTest.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/compiler/StubbedFlinkProcessCompilerDataFactoryTest.scala
@@ -11,7 +11,7 @@ import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.process.{SourceFactory, TestWithParametersSupport}
 import pl.touk.nussknacker.engine.api.test._
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
-import pl.touk.nussknacker.engine.api.{CirceUtil, NodeId, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{CirceUtil, Context, NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.compiledgraph.part.SourcePart
@@ -166,7 +166,7 @@ class StubbedFlinkProcessCompilerDataFactoryTest extends AnyFunSuite with Matche
       extends CollectionSource[Int](List.empty, None, Typed.fromDetailedType[Int])
       with FlinkSourceTestSupport[Int]
       with TestWithParametersSupport[Int] {
-    override def timestampAssignerForTest: Option[TimestampWatermarkHandler[Int]] = None
+    override def timestampAssignerForTest: Option[TimestampWatermarkHandler[Context]] = None
 
     override def testRecordParser: TestRecordParser[Int] = (testRecord: TestRecord) =>
       CirceUtil.decodeJsonUnsafe[Int](testRecord.json)
@@ -179,7 +179,7 @@ class StubbedFlinkProcessCompilerDataFactoryTest extends AnyFunSuite with Matche
   object SampleTestSupportSource
       extends CollectionSource[Int](List.empty, None, Typed.fromDetailedType[Int])
       with FlinkSourceTestSupport[Int] {
-    override def timestampAssignerForTest: Option[TimestampWatermarkHandler[Int]] = None
+    override def timestampAssignerForTest: Option[TimestampWatermarkHandler[Context]] = None
     override def testRecordParser: TestRecordParser[Int] = (testRecord: TestRecord) =>
       CirceUtil.decodeJsonUnsafe[Int](testRecord.json)
   }

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/generic/DelayedFlinkKafkaConsumer.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/generic/DelayedFlinkKafkaConsumer.scala
@@ -24,7 +24,6 @@ import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
 import pl.touk.nussknacker.engine.flink.api.exception.ExceptionHandler
 import pl.touk.nussknacker.engine.flink.api.process.FlinkCustomNodeContext
 import pl.touk.nussknacker.engine.flink.api.timestampwatermark.{
-  LegacyTimestampWatermarkHandler,
   StandardTimestampWatermarkHandler,
   TimestampWatermarkHandler
 }
@@ -68,17 +67,6 @@ object DelayedFlinkKafkaConsumer {
       NodeId(flinkNodeContext.nodeId)
     )
     timestampAssigner match {
-      case Some(lth: LegacyTimestampWatermarkHandler[T]) =>
-        new DelayedFlinkKafkaConsumer[T](
-          topics,
-          schema,
-          props,
-          delayCalculator,
-          (_, e, t) => lth.extractTimestamp(e, t),
-          flinkNodeContext.exceptionHandlerPreparer,
-          flinkNodeContext.convertToEngineRuntimeContext,
-          NodeId(flinkNodeContext.nodeId)
-        )
       case Some(sth: StandardTimestampWatermarkHandler[T]) =>
         defaultConsumer.assignTimestampsAndWatermarks(sth.strategy)
       case None => defaultConsumer

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/generic/GenericTimestampAssigner.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/generic/GenericTimestampAssigner.scala
@@ -1,0 +1,10 @@
+package pl.touk.nussknacker.engine.kafka.generic
+
+import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import pl.touk.nussknacker.engine.api.Context
+
+trait GenericTimestampAssigner {
+  def conumerRecordAssigner[K, V]: SerializableTimestampAssigner[ConsumerRecord[K, V]]
+  def contextAssigner: SerializableTimestampAssigner[Context]
+}

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/flink/FlinkKafkaSourceImplFactory.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/flink/FlinkKafkaSourceImplFactory.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.kafka.source.flink
 
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.context.transformation.NodeDependencyValue
 import pl.touk.nussknacker.engine.api.process.{ContextInitializer, Source}
 import pl.touk.nussknacker.engine.flink.api.timestampwatermark.TimestampWatermarkHandler
@@ -9,7 +10,7 @@ import pl.touk.nussknacker.engine.kafka.source.KafkaSourceFactory.{KafkaSourceIm
 import pl.touk.nussknacker.engine.kafka.{KafkaConfig, PreparedKafkaTopic, RecordFormatter}
 
 class FlinkKafkaSourceImplFactory[K, V](
-    protected val timestampAssigner: Option[TimestampWatermarkHandler[ConsumerRecord[K, V]]]
+    protected val timestampAssigner: Option[TimestampWatermarkHandler[Context]]
 ) extends KafkaSourceImplFactory[K, V]
     with Serializable {
 

--- a/engine/flink/management/dev-model-java/src/main/scala/pl/touk/nussknacker/engine/management/javasample/Objects.scala
+++ b/engine/flink/management/dev-model-java/src/main/scala/pl/touk/nussknacker/engine/management/javasample/Objects.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.management.javasample
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.functions.source.SourceFunction
+import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.process.{SinkFactory, SourceFactory, WithCategories}
 import pl.touk.nussknacker.engine.flink.api.process.BasicFlinkSource
 import pl.touk.nussknacker.engine.flink.api.timestampwatermark.TimestampWatermarkHandler
@@ -26,7 +27,7 @@ class Objects extends Serializable {
 
       override val typeInformation: TypeInformation[Model] = TypeInformation.of(classOf[Model])
 
-      override def timestampAssigner: Option[TimestampWatermarkHandler[Model]] = None
+      override def timestampAssigner: Option[TimestampWatermarkHandler[Context]] = None
     }))
 
   def sink = WithCategories.anyCategory(SinkFactory.noParam(EmptySink))

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/CsvSource.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/CsvSource.scala
@@ -2,11 +2,10 @@ package pl.touk.nussknacker.engine.management.sample.source
 
 import io.circe.Json
 
-import java.nio.charset.StandardCharsets
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
-import pl.touk.nussknacker.engine.api.CirceUtil
+import pl.touk.nussknacker.engine.api.{CirceUtil, Context}
 import pl.touk.nussknacker.engine.api.process.TestDataGenerator
 import pl.touk.nussknacker.engine.api.test.{TestData, TestRecord, TestRecordParser}
 import pl.touk.nussknacker.engine.flink.api.process.{BasicFlinkSource, FlinkSourceTestSupport}
@@ -34,5 +33,5 @@ class CsvSource extends BasicFlinkSource[CsvRecord] with FlinkSourceTestSupport[
 
   override def timestampAssigner: Option[Nothing] = None
 
-  override def timestampAssignerForTest: Option[TimestampWatermarkHandler[CsvRecord]] = timestampAssigner
+  override def timestampAssignerForTest: Option[TimestampWatermarkHandler[Context]] = timestampAssigner
 }

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/GenericSourceWithCustomVariablesSample.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/GenericSourceWithCustomVariablesSample.scala
@@ -88,7 +88,7 @@ object GenericSourceWithCustomVariablesSample extends SourceFactory with SingleI
       override def testRecordParser: TestRecordParser[String] = (testRecord: TestRecord) =>
         CirceUtil.decodeJsonUnsafe[String](testRecord.json)
 
-      override def timestampAssignerForTest: Option[TimestampWatermarkHandler[String]] = timestampAssigner
+      override def timestampAssignerForTest: Option[TimestampWatermarkHandler[Context]] = timestampAssigner
     }
   }
 

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/NoEndingSource.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/NoEndingSource.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
-import pl.touk.nussknacker.engine.api.CirceUtil
+import pl.touk.nussknacker.engine.api.{CirceUtil, Context}
 import pl.touk.nussknacker.engine.api.test.{TestRecord, TestRecordParser}
 import pl.touk.nussknacker.engine.flink.api.process.{BasicFlinkSource, FlinkSourceTestSupport}
 import pl.touk.nussknacker.engine.flink.api.timestampwatermark.{
@@ -17,12 +17,12 @@ import pl.touk.nussknacker.engine.flink.api.timestampwatermark.{
 class NoEndingSource extends BasicFlinkSource[String] with FlinkSourceTestSupport[String] {
   override val typeInformation: TypeInformation[String] = TypeInformation.of(classOf[String])
 
-  override def timestampAssigner: Option[TimestampWatermarkHandler[String]] = Option(
+  override def timestampAssigner: Option[TimestampWatermarkHandler[Context]] = Option(
     StandardTimestampWatermarkHandler
-      .boundedOutOfOrderness[String]((_: String) => System.currentTimeMillis(), Duration.ofMinutes(10))
+      .boundedOutOfOrderness[Context]((_: Context) => System.currentTimeMillis(), Duration.ofMinutes(10))
   )
 
-  override def timestampAssignerForTest: Option[TimestampWatermarkHandler[String]] = timestampAssigner
+  override def timestampAssignerForTest: Option[TimestampWatermarkHandler[Context]] = timestampAssigner
 
   override def testRecordParser: TestRecordParser[String] = (testRecord: TestRecord) =>
     CirceUtil.decodeJsonUnsafe[String](testRecord.json)

--- a/engine/flink/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/UniversalTimestampFieldAssigner.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/UniversalTimestampFieldAssigner.scala
@@ -3,22 +3,36 @@ package pl.touk.nussknacker.engine.schemedkafka.source.flink
 import org.apache.avro.generic.GenericRecord
 import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.VariableConstants.InputVariableName
+import pl.touk.nussknacker.engine.kafka.generic.GenericTimestampAssigner
 import pl.touk.nussknacker.engine.util.TimestampUtils.supportedTypeToMillis
 
-object UniversalTimestampFieldAssigner {
+case class UniversalTimestampFieldAssigner(fieldName: String) extends GenericTimestampAssigner {
 
-  def apply[K, V](fieldName: String): SerializableTimestampAssigner[ConsumerRecord[K, V]] =
+  override def conumerRecordAssigner[K, V]: SerializableTimestampAssigner[ConsumerRecord[K, V]] =
     new SerializableTimestampAssigner[ConsumerRecord[K, V]] {
 
-      override def extractTimestamp(element: ConsumerRecord[K, V], recordTimestamp: Long): Long = {
-        val timestampOpt: Option[Long] = Option(element.value() match {
-          case genericRecord: GenericRecord                    => genericRecord.get(fieldName)
-          case typedMap: java.util.Map[String, Any] @unchecked => typedMap.get(fieldName)
-        }).map(v => supportedTypeToMillis(v, fieldName))
-
-        timestampOpt.getOrElse(0L) // explicit null to 0L conversion (instead of implicit unboxing)
-      }
+      override def extractTimestamp(element: ConsumerRecord[K, V], recordTimestamp: Long): Long =
+        calculateTimestamp(Option(element.value()), fieldName)
 
     }
+
+  override def contextAssigner: SerializableTimestampAssigner[Context] =
+    new SerializableTimestampAssigner[Context] {
+
+      override def extractTimestamp(element: Context, recordTimestamp: Long): Long =
+        calculateTimestamp(element.get[Any](InputVariableName), fieldName)
+
+    }
+
+  private def calculateTimestamp[A](ctx: Option[A], fieldName: String) =
+    ctx
+      .flatMap {
+        case genericRecord: GenericRecord                    => Option(genericRecord.get(fieldName))
+        case typedMap: java.util.Map[String, Any] @unchecked => Option(typedMap.get(fieldName))
+      }
+      .map(v => supportedTypeToMillis(v, fieldName))
+      .getOrElse(0L)
 
 }

--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/CorrectExceptionHandlingSpec.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/CorrectExceptionHandlingSpec.scala
@@ -5,6 +5,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.scalatest.Suite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ModelData
+import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
@@ -79,9 +80,9 @@ object SamplesComponent extends Serializable {
         .toList
       CollectionSource(
         samples,
-        Some(StandardTimestampWatermarkHandler.afterEachEvent[AnyRef]((_: AnyRef) => 1L)),
+        Some(StandardTimestampWatermarkHandler.afterEachEvent[Context]((_: Context) => 1L)),
         Typed.fromDetailedType[java.util.List[Int]]
-      )(TypeInformation.of(classOf[AnyRef]))
+      )(TypeInformation.of(classOf[java.util.List[Int]]))
     }
     SourceFactory.noParam(createSource, Typed.fromDetailedType[java.util.List[Int]])
   }

--- a/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
+++ b/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
@@ -443,7 +443,7 @@ class KafkaTransactionalScenarioInterpreterTest
       val result = interpreter.run()
       (result, action)
     }
-    Await.result(runResult, 10 seconds)
+    Await.result(runResult, 30 seconds)
     output
   }
 

--- a/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkTestScenarioRunner.scala
+++ b/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkTestScenarioRunner.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.flink.util.test
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import pl.touk.nussknacker.defaultmodel.DefaultConfigCreator
-import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.{Context, ProcessVersion}
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.process.{ComponentUseCase, SourceFactory}
 import pl.touk.nussknacker.engine.api.typed.typing
@@ -32,7 +32,7 @@ private object testComponents {
 
   def testDataSourceComponent[T: ClassTag: TypeInformation](
       data: List[T],
-      timestampAssigner: Option[TimestampWatermarkHandler[T]]
+      timestampAssigner: Option[TimestampWatermarkHandler[Context]]
   ): ComponentDefinition = {
     ComponentDefinition(
       TestScenarioRunner.testDataSource,
@@ -74,7 +74,7 @@ class FlinkTestScenarioRunner(
   def runWithDataAndTimestampAssigner[I: ClassTag, R](
       scenario: CanonicalProcess,
       data: List[I],
-      timestampAssigner: TimestampWatermarkHandler[I]
+      timestampAssigner: TimestampWatermarkHandler[Context]
   ): RunnerListResult[R] = {
     implicit val typeInf: TypeInformation[I] =
       TypeInformation.of(implicitly[ClassTag[I]].runtimeClass.asInstanceOf[Class[I]])


### PR DESCRIPTION
## Describe your changes
allows one to use  nu context in timestampAssigners in kafka sources

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
