### PR TITLE
[NU-1466] ScenarioAction: commands (ADT, sum types) instead of methods

### DIFF
--- a/common-api/src/main/scala/pl/touk/nussknacker/engine/api/ProcessVersion.scala
+++ b/common-api/src/main/scala/pl/touk/nussknacker/engine/api/ProcessVersion.scala
@@ -3,9 +3,7 @@ package pl.touk.nussknacker.engine.api
 import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId}
 
-// This class holds all necessary for scenario running, scenario metadata. It is passed next to the scenario graph
-// into DeploymentManager during deploy
-// TODO: It should be called ScenarioRuntimeMetadata (See TODO in MetaData)
+// We should split this class - see TODO in ScenarioAction
 @JsonCodec case class ProcessVersion(
     versionId: VersionId,
     processName: ProcessName,

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/BaseDeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/BaseDeploymentManager.scala
@@ -1,46 +1,16 @@
 package pl.touk.nussknacker.engine.api.deployment
 
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleProcessStateDefinitionManager
-import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.deployment.{
-  CustomActionDefinition,
-  CustomActionRequest,
-  CustomActionResult,
-  DeploymentId,
-  User
-}
+import pl.touk.nussknacker.engine.deployment.CustomActionDefinition
 
 import scala.concurrent.Future
 
 trait BaseDeploymentManager extends DeploymentManager {
 
-  override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] = {
-    Future.failed(new UnsupportedOperationException(s"Making of savepoint is not supported"))
-  }
-
-  override def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] = {
-    Future.failed(new UnsupportedOperationException(s"Stopping of scenario is not supported"))
-  }
-
-  override def stop(
-      name: ProcessName,
-      deploymentId: DeploymentId,
-      savepointDir: Option[String],
-      user: User
-  ): Future[SavepointResult] =
-    Future.failed(new UnsupportedOperationException(s"Stopping of deployment is not supported"))
-
   override def processStateDefinitionManager: ProcessStateDefinitionManager = SimpleProcessStateDefinitionManager
 
   override def close(): Unit = {}
 
-  override def customActions: List[CustomActionDefinition] = List.empty
-
-  override def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
-  ): Future[CustomActionResult] =
-    Future.failed(new NotImplementedError())
+  override def customActionsDefinitions: List[CustomActionDefinition] = List.empty
 
 }

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
@@ -7,7 +7,6 @@ import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{
   CustomActionDefinition,
-  CustomActionRequest,
   CustomActionResult,
   DeploymentData,
   DeploymentId,
@@ -44,35 +43,7 @@ trait DeploymentManagerInconsistentStateHandlerMixIn {
 
 trait DeploymentManager extends AutoCloseable {
 
-  /**
-    * This method is invoked separately before deploy, to be able to give user quick feedback, as deploy (e.g. on Flink) may take long time
-    */
-  def validate(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess
-  ): Future[Unit]
-
-  /**
-    * TODO: savepointPath is very flink specific, we should handle this mode via custom action
-    * We assume that validate was already called and was successful
-    */
-  def deploy(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess,
-      savepointPath: Option[String]
-  ): Future[Option[ExternalDeploymentId]]
-
-  def cancel(name: ProcessName, user: User): Future[Unit]
-
-  def cancel(name: ProcessName, deploymentId: DeploymentId, user: User): Future[Unit]
-
-  def test(
-      name: ProcessName,
-      canonicalProcess: CanonicalProcess,
-      scenarioTestData: ScenarioTestData
-  ): Future[TestResults]
+  def processCommand[Result](command: ScenarioCommand[Result]): Future[Result]
 
   final def getProcessState(idWithName: ProcessIdWithName, lastStateAction: Option[ProcessAction])(
       implicit freshnessPolicy: DataFreshnessPolicy
@@ -105,24 +76,9 @@ trait DeploymentManager extends AutoCloseable {
 
   def processStateDefinitionManager: ProcessStateDefinitionManager
 
-  def customActions: List[CustomActionDefinition]
+  def customActionsDefinitions: List[CustomActionDefinition]
 
-  def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
-  ): Future[CustomActionResult]
-
-  // TODO: this is very flink specific, we should handle it via custom action
-  def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult]
-
-  // TODO: savepointPath is very flink specific, we should handle it via custom action
-  def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult]
-
-  def stop(
-      name: ProcessName,
-      deploymentId: DeploymentId,
-      savepointDir: Option[String],
-      user: User
-  ): Future[SavepointResult]
+  protected final def notImplemented: Future[Nothing] =
+    Future.failed(new NotImplementedError())
 
 }

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ScenarioCommand.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ScenarioCommand.scala
@@ -1,0 +1,84 @@
+package pl.touk.nussknacker.engine.api.deployment
+
+import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.process.ProcessName
+import pl.touk.nussknacker.engine.api.test.ScenarioTestData
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.deployment.{
+  CustomActionResult,
+  DeploymentData,
+  DeploymentId,
+  ExternalDeploymentId,
+  User
+}
+import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
+
+// TODO: We should try to unify all commands below to the form:
+//       ScenarioCommand[Result](scenarioVersionData, actionInvocationContext, commandSpecificData) where
+//        - scenarioDeploymentData - should contain: scenarioMetadata, scenarioVersionData, scenarioGraph, deploymentId
+//        - actionInvocationContext - should contain: user invoking current action and other audit data
+//       Currently:
+//        - ProcessVersion has some part of scenarioMetadata (processName, processId, user (I guess)) and some part of scenarioVersionData (versionId, modelVersion)
+//        - scenarioGraph is represented as CanonicalProcess and is laying separately
+//        - user is laying separately
+//       After we do this, we can consider replacing them by one common case class and only the commandSpecificData will be a sealed trait
+sealed trait ScenarioCommand[Result]
+
+/**
+  * This command is invoked separately before deploy, to be able to give user quick feedback, as deploy (e.g. on Flink) may take long time
+  */
+case class ValidateScenarioCommand(
+    processVersion: ProcessVersion,
+    deploymentData: DeploymentData,
+    canonicalProcess: CanonicalProcess
+) extends ScenarioCommand[Unit]
+
+/**
+  * We assume that validate was already called and was successful, currently savepointPath is flink specific, but we could
+  * leverage this concept also for other engines
+  */
+case class RunDeploymentCommand(
+    processVersion: ProcessVersion,
+    deploymentData: DeploymentData,
+    canonicalProcess: CanonicalProcess,
+    savepointPath: Option[String]
+) extends ScenarioCommand[Option[ExternalDeploymentId]]
+
+case class CancelDeploymentCommand(scenarioName: ProcessName, deploymentId: DeploymentId, user: User)
+    extends ScenarioCommand[Unit]
+
+// TODO: We should merge it with CancelDeploymentCommand
+case class StopDeploymentCommand(
+    scenarioName: ProcessName,
+    deploymentId: DeploymentId,
+    savepointDir: Option[String],
+    user: User
+) extends ScenarioCommand[SavepointResult]
+
+// TODO: Custom is a bad name. We should expose in the name the fact that it is for the purpose of commands that leveraging
+//       the power of our "generic" Parameter's concept that allows to change FE side without need to write
+//       a dedicated code on the FE side. Not every new command need to be a custom scenario command.
+//       We should also describe it in some scaladoc
+case class CustomActionCommand(
+    scenarioName: ScenarioActionName,
+    processVersion: ProcessVersion,
+    canonicalProcess: CanonicalProcess,
+    user: User,
+    params: Map[String, String]
+) extends ScenarioCommand[CustomActionResult]
+
+// TODO Commands below will be legacy in some future because they operate on the scenario level instead of deployment level -
+//      we should replace them by commands operating on deployment
+case class TestScenarioCommand(
+    scenarioName: ProcessName,
+    canonicalProcess: CanonicalProcess,
+    scenarioTestData: ScenarioTestData
+) extends ScenarioCommand[TestResults]
+
+case class MakeAScenarioSavepointCommand(scenarioName: ProcessName, savepointDir: Option[String])
+    extends ScenarioCommand[SavepointResult]
+
+case class CancelScenarioCommand(scenarioName: ProcessName, user: User) extends ScenarioCommand[Unit]
+
+case class StopScenarioCommand(scenarioName: ProcessName, savepointDir: Option[String], user: User)
+    extends ScenarioCommand[SavepointResult]

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ScenarioCommand.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ScenarioCommand.scala
@@ -60,7 +60,7 @@ case class StopDeploymentCommand(
 //       a dedicated code on the FE side. Not every new command need to be a custom scenario command.
 //       We should also describe it in some scaladoc
 case class CustomActionCommand(
-    scenarioName: ScenarioActionName,
+    actionName: ScenarioActionName,
     processVersion: ProcessVersion,
     canonicalProcess: CanonicalProcess,
     user: User,
@@ -75,7 +75,7 @@ case class TestScenarioCommand(
     scenarioTestData: ScenarioTestData
 ) extends ScenarioCommand[TestResults]
 
-case class MakeAScenarioSavepointCommand(scenarioName: ProcessName, savepointDir: Option[String])
+case class MakeScenarioSavepointCommand(scenarioName: ProcessName, savepointDir: Option[String])
     extends ScenarioCommand[SavepointResult]
 
 case class CancelScenarioCommand(scenarioName: ProcessName, user: User) extends ScenarioCommand[Unit]

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/cache/CachingProcessStateDeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/cache/CachingProcessStateDeploymentManager.scala
@@ -3,21 +3,9 @@ package pl.touk.nussknacker.engine.api.deployment.cache
 import com.github.benmanes.caffeine.cache.{AsyncCache, Caffeine}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
-import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName}
-import pl.touk.nussknacker.engine.api.test.ScenarioTestData
-import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.deployment.{
-  CustomActionDefinition,
-  CustomActionRequest,
-  CustomActionResult,
-  DeploymentData,
-  DeploymentId,
-  ExternalDeploymentId,
-  User
-}
-import pl.touk.nussknacker.engine.testmode.TestProcess
+import pl.touk.nussknacker.engine.deployment.CustomActionDefinition
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext.Implicits._
@@ -60,57 +48,12 @@ class CachingProcessStateDeploymentManager(delegate: DeploymentManager, cacheTTL
     }
   }
 
-  override def validate(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess
-  ): Future[Unit] =
-    delegate.validate(processVersion, deploymentData, canonicalProcess)
-
-  override def deploy(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess,
-      savepointPath: Option[String]
-  ): Future[Option[ExternalDeploymentId]] =
-    delegate.deploy(processVersion, deploymentData, canonicalProcess, savepointPath)
-
-  override def cancel(name: ProcessName, user: User): Future[Unit] =
-    delegate.cancel(name, user)
-
-  override def cancel(name: ProcessName, deploymentId: DeploymentId, user: User): Future[Unit] =
-    delegate.cancel(name, deploymentId, user)
-
-  override def test(
-      name: ProcessName,
-      canonicalProcess: CanonicalProcess,
-      scenarioTestData: ScenarioTestData
-  ): Future[TestProcess.TestResults] =
-    delegate.test(name, canonicalProcess, scenarioTestData)
+  override def processCommand[Result](command: ScenarioCommand[Result]): Future[Result] =
+    delegate.processCommand(command)
 
   override def processStateDefinitionManager: ProcessStateDefinitionManager = delegate.processStateDefinitionManager
 
-  override def customActions: List[CustomActionDefinition] = delegate.customActions
-
-  override def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
-  ): Future[CustomActionResult] =
-    delegate.invokeCustomAction(actionRequest, canonicalProcess)
-
-  override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] =
-    delegate.savepoint(name, savepointDir)
-
-  override def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] =
-    delegate.stop(name, savepointDir, user)
-
-  override def stop(
-      name: ProcessName,
-      deploymentId: DeploymentId,
-      savepointDir: Option[String],
-      user: User
-  ): Future[SavepointResult] =
-    delegate.stop(name, deploymentId, savepointDir, user)
+  override def customActionsDefinitions: List[CustomActionDefinition] = delegate.customActionsDefinitions
 
   override def close(): Unit = delegate.close()
 

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
@@ -2,24 +2,13 @@ package pl.touk.nussknacker.engine.testing
 
 import cats.data.{Validated, ValidatedNel}
 import com.typesafe.config.Config
+import pl.touk.nussknacker.engine.api.StreamMetaData
 import pl.touk.nussknacker.engine.api.component.ScenarioPropertyConfig
 import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessStateDefinitionManager, SimpleStateStatus}
 import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName}
-import pl.touk.nussknacker.engine.api.test.ScenarioTestData
-import pl.touk.nussknacker.engine.api.{ProcessVersion, StreamMetaData}
-import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.deployment.{
-  CustomActionDefinition,
-  CustomActionRequest,
-  CustomActionResult,
-  DeploymentData,
-  DeploymentId,
-  ExternalDeploymentId,
-  User
-}
-import pl.touk.nussknacker.engine.testmode.TestProcess
+import pl.touk.nussknacker.engine.deployment.CustomActionDefinition
 import pl.touk.nussknacker.engine.{
   BaseModelData,
   DeploymentManagerDependencies,
@@ -27,45 +16,10 @@ import pl.touk.nussknacker.engine.{
   MetaDataInitializer
 }
 
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 
-class DeploymentManagerStub extends DeploymentManager {
-
-  override def validate(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess
-  ): Future[Unit] = Future.successful(())
-
-  override def deploy(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess,
-      savepointPath: Option[String]
-  ): Future[Option[ExternalDeploymentId]] =
-    Future.successful(None)
-
-  override def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] =
-    Future.successful(SavepointResult(""))
-
-  override def stop(
-      name: ProcessName,
-      deploymentId: DeploymentId,
-      savepointDir: Option[String],
-      user: User
-  ): Future[SavepointResult] =
-    Future.successful(SavepointResult(""))
-
-  override def cancel(name: ProcessName, user: User): Future[Unit] = Future.successful(())
-
-  override def cancel(name: ProcessName, deploymentId: DeploymentId, user: User): Future[Unit] = Future.successful(())
-
-  override def test(
-      name: ProcessName,
-      canonicalProcess: CanonicalProcess,
-      scenarioTestData: ScenarioTestData
-  ): Future[TestProcess.TestResults] = ???
+class DeploymentManagerStub extends BaseDeploymentManager with StubbingCommands {
 
   // We map lastStateAction to state to avoid some corner/blocking cases with the deleting/canceling scenario on tests..
   override def resolve(
@@ -92,20 +46,26 @@ class DeploymentManagerStub extends DeploymentManager {
     )
   }
 
-  override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] =
-    Future.successful(SavepointResult(""))
-
   override def processStateDefinitionManager: ProcessStateDefinitionManager = SimpleProcessStateDefinitionManager
 
-  override def customActions: List[CustomActionDefinition] = Nil
-
-  override def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
-  ): Future[CustomActionResult] =
-    Future.failed(new NotImplementedError())
+  override def customActionsDefinitions: List[CustomActionDefinition] = Nil
 
   override def close(): Unit = {}
+
+}
+
+trait StubbingCommands { self: DeploymentManager =>
+
+  override def processCommand[Result](command: ScenarioCommand[Result]): Future[Result] = command match {
+    case _: ValidateScenarioCommand                      => Future.successful(())
+    case _: RunDeploymentCommand                         => Future.successful(None)
+    case _: StopDeploymentCommand                        => Future.successful(SavepointResult(""))
+    case _: StopScenarioCommand                          => Future.successful(SavepointResult(""))
+    case _: CancelDeploymentCommand                      => Future.successful(())
+    case _: CancelScenarioCommand                        => Future.successful(())
+    case _: MakeAScenarioSavepointCommand                => Future.successful(SavepointResult(""))
+    case _: CustomActionCommand | _: TestScenarioCommand => notImplemented
+  }
 
 }
 

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
@@ -63,7 +63,7 @@ trait StubbingCommands { self: DeploymentManager =>
     case _: StopScenarioCommand                          => Future.successful(SavepointResult(""))
     case _: CancelDeploymentCommand                      => Future.successful(())
     case _: CancelScenarioCommand                        => Future.successful(())
-    case _: MakeAScenarioSavepointCommand                => Future.successful(SavepointResult(""))
+    case _: MakeScenarioSavepointCommand                 => Future.successful(SavepointResult(""))
     case _: CustomActionCommand | _: TestScenarioCommand => notImplemented
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -137,7 +137,7 @@ class ManagementResources(
               convertSavepointResultToResponse(
                 dispatcher
                   .deploymentManagerUnsafe(processId)(ec, user)
-                  .flatMap(_.savepoint(processId.name, savepointDir))
+                  .flatMap(_.processCommand(MakeAScenarioSavepointCommand(processId.name, savepointDir)))
               )
             }
           }
@@ -150,7 +150,7 @@ class ManagementResources(
                 convertSavepointResultToResponse(
                   dispatcher
                     .deploymentManagerUnsafe(processId)(ec, user)
-                    .flatMap(_.stop(processId.name, savepointDir, user.toManagerUser))
+                    .flatMap(_.processCommand(StopScenarioCommand(processId.name, savepointDir, user.toManagerUser)))
                 )
               }
             }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -137,7 +137,7 @@ class ManagementResources(
               convertSavepointResultToResponse(
                 dispatcher
                   .deploymentManagerUnsafe(processId)(ec, user)
-                  .flatMap(_.processCommand(MakeAScenarioSavepointCommand(processId.name, savepointDir)))
+                  .flatMap(_.processCommand(MakeScenarioSavepointCommand(processId.name, savepointDir)))
               )
             }
           }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionsService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionsService.scala
@@ -76,7 +76,7 @@ class DefinitionsService(
         (if (forFragment) FragmentPropertiesConfig.properties else finalizedScenarioPropertiesConfig)
           .mapValuesNow(createUIScenarioPropertyConfig),
       edgesForNodes = EdgeTypesPreparer.prepareEdgeTypes(components.map(_.component)),
-      customActions = deploymentManager.customActions.map(UICustomAction(_))
+      customActions = deploymentManager.customActionsDefinitions.map(UICustomAction(_))
     )
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ScenarioTestExecutorService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ScenarioTestExecutorService.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.ui.process.deployment
 
-import pl.touk.nussknacker.engine.api.deployment.DeploymentManager
+import pl.touk.nussknacker.engine.api.deployment.{DeploymentManager, TestScenarioCommand}
 import pl.touk.nussknacker.engine.api.process.ProcessIdWithName
 import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -29,7 +29,7 @@ class ScenarioTestExecutorServiceImpl(scenarioResolver: ScenarioResolver, deploy
   )(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[TestResults] = {
     for {
       resolvedProcess <- Future.fromTry(scenarioResolver.resolveScenario(canonicalProcess))
-      testResult      <- deploymentManager.test(id.name, resolvedProcess, scenarioTestData)
+      testResult <- deploymentManager.processCommand(TestScenarioCommand(id.name, resolvedProcess, scenarioTestData))
     } yield testResult
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/InvalidDeploymentManagerStub.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/InvalidDeploymentManagerStub.scala
@@ -1,22 +1,10 @@
 package pl.touk.nussknacker.ui.process.processingtype
 
-import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleProcessStateDefinitionManager
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus.ProblemStateStatus
-import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName}
-import pl.touk.nussknacker.engine.api.test.ScenarioTestData
-import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.deployment
-import pl.touk.nussknacker.engine.deployment.{
-  CustomActionDefinition,
-  CustomActionRequest,
-  CustomActionResult,
-  DeploymentId,
-  ExternalDeploymentId,
-  User
-}
-import pl.touk.nussknacker.engine.testmode.TestProcess
+import pl.touk.nussknacker.engine.deployment.CustomActionDefinition
 import pl.touk.nussknacker.ui.process.exception.ProcessIllegalAction
 
 import scala.concurrent.Future
@@ -47,50 +35,13 @@ object InvalidDeploymentManagerStub extends DeploymentManager {
 
   override def processStateDefinitionManager: ProcessStateDefinitionManager = SimpleProcessStateDefinitionManager
 
-  override def validate(
-      processVersion: ProcessVersion,
-      deploymentData: deployment.DeploymentData,
-      canonicalProcess: CanonicalProcess
-  ): Future[Unit] =
-    Future.unit
+  override def processCommand[Result](command: ScenarioCommand[Result]): Future[Result] = command match {
+    case _: ValidateScenarioCommand => Future.unit
+    case _                          => stubbedActionResponse
 
-  override def deploy(
-      processVersion: ProcessVersion,
-      deploymentData: deployment.DeploymentData,
-      canonicalProcess: CanonicalProcess,
-      savepointPath: Option[String]
-  ): Future[Option[ExternalDeploymentId]] =
-    stubbedActionResponse
+  }
 
-  override def cancel(name: ProcessName, user: User): Future[Unit] = stubbedActionResponse
-
-  override def cancel(name: ProcessName, deploymentId: DeploymentId, user: User): Future[Unit] = stubbedActionResponse
-
-  override def test(
-      name: ProcessName,
-      canonicalProcess: CanonicalProcess,
-      scenarioTestData: ScenarioTestData
-  ): Future[TestProcess.TestResults] = stubbedActionResponse
-
-  override def customActions: List[CustomActionDefinition] = List.empty
-
-  override def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
-  ): Future[CustomActionResult] = stubbedActionResponse
-
-  override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] =
-    stubbedActionResponse
-
-  override def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] =
-    stubbedActionResponse
-
-  override def stop(
-      name: ProcessName,
-      deploymentId: DeploymentId,
-      savepointDir: Option[String],
-      user: User
-  ): Future[SavepointResult] = stubbedActionResponse
+  override def customActionsDefinitions: List[CustomActionDefinition] = List.empty
 
   override def close(): Unit = ()
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
@@ -231,7 +231,7 @@ class MockDeploymentManager(
   }
 
   override protected def processCustomAction(command: CustomActionCommand): Future[CustomActionResult] =
-    command.scenarioName.value match {
+    command.actionName.value match {
       case "hello" | "invalid-status" => Future.successful(CustomActionResult("Hi"))
       case _                          => Future.failed(new NotImplementedError())
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
@@ -12,25 +12,16 @@ import pl.touk.nussknacker.engine.api.{ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{
   CustomActionDefinition,
-  CustomActionRequest,
   CustomActionResult,
-  DeploymentData,
   DeploymentId,
-  ExternalDeploymentId,
-  User
+  ExternalDeploymentId
 }
 import pl.touk.nussknacker.engine.management.{FlinkDeploymentManager, FlinkStreamingDeploymentManagerProvider}
-import pl.touk.nussknacker.engine.{
-  BaseModelData,
-  DeploymentManagerDependencies,
-  ModelData,
-  ProcessingTypeConfig,
-  deployment
-}
+import pl.touk.nussknacker.engine._
 import pl.touk.nussknacker.test.config.ConfigWithScalaVersion
 import pl.touk.nussknacker.test.utils.domain.TestFactory
 import shapeless.syntax.typeable.typeableOps
-import sttp.client3.testing.SttpBackendStub
+import _root_.sttp.client3.testing.SttpBackendStub
 
 import java.util.UUID
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue}
@@ -90,15 +81,11 @@ class MockDeploymentManager(
     }
   }
 
-  override def deploy(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess,
-      savepoint: Option[String]
-  ): Future[Option[ExternalDeploymentId]] = {
+  override protected def runDeployment(command: RunDeploymentCommand): Future[Option[ExternalDeploymentId]] = {
+    import command._
     logger.debug(s"Adding deploy for ${processVersion.processName}")
     deploys.add(processVersion.processName)
-    synchronized {
+    this.synchronized {
       Option(deployResult.get(processVersion.processName))
         .map(_.toArray(Array.empty[Future[Option[ExternalDeploymentId]]]))
         .getOrElse(Array.empty)
@@ -228,7 +215,7 @@ class MockDeploymentManager(
       savepointPath: Option[String]
   ): Future[Option[ExternalDeploymentId]] = ???
 
-  override def customActions: List[CustomActionDefinition] = {
+  override def customActionsDefinitions: List[CustomActionDefinition] = {
     import SimpleStateStatus._
     List(
       deployment.CustomActionDefinition(
@@ -243,22 +230,19 @@ class MockDeploymentManager(
     )
   }
 
-  override def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
-  ): Future[CustomActionResult] =
-    actionRequest.name.value match {
+  override protected def processCustomAction(command: CustomActionCommand): Future[CustomActionResult] =
+    command.scenarioName.value match {
       case "hello" | "invalid-status" => Future.successful(CustomActionResult("Hi"))
       case _                          => Future.failed(new NotImplementedError())
     }
 
   override def close(): Unit = {}
 
-  override def cancel(name: ProcessName, user: User): Future[Unit] = cancelResult
+  override def cancelDeployment(command: CancelDeploymentCommand): Future[Unit] = Future.successful(())
 
-  override protected def cancel(deploymentId: ExternalDeploymentId): Future[Unit] = Future.successful(())
+  override def cancelScenario(command: CancelScenarioCommand): Future[Unit] = cancelResult
 
-  override def cancel(name: ProcessName, deploymentId: DeploymentId, user: User): Future[Unit] = Future.successful(())
+  override protected def cancelFlinkJob(deploymentId: ExternalDeploymentId): Future[Unit] = Future.successful(())
 
   override protected def checkRequiredSlotsExceedAvailableSlots(
       canonicalProcess: CanonicalProcess,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/notifications/NotificationServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/notifications/NotificationServiceTest.scala
@@ -7,17 +7,16 @@ import org.scalatest.OptionValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessStateDefinitionManager, SimpleStateStatus}
 import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, DeploymentId, ExternalDeploymentId}
-import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, PatientScalaFutures}
 import pl.touk.nussknacker.test.base.db.WithHsqlDbTesting
-import pl.touk.nussknacker.test.utils.scalas.DBIOActionValues
 import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory}
+import pl.touk.nussknacker.test.utils.scalas.DBIOActionValues
+import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, PatientScalaFutures}
 import pl.touk.nussknacker.ui.listener.ProcessChangeListener
 import pl.touk.nussknacker.ui.process.deployment.LoggedUserConversions._
 import pl.touk.nussknacker.ui.process.deployment.{DeploymentManagerDispatcher, DeploymentServiceImpl, ScenarioResolver}
@@ -77,7 +76,7 @@ class NotificationServiceTest
         user: LoggedUser
     ): Option[ExternalDeploymentId] = {
       when(
-        deploymentManager.deploy(any[ProcessVersion], any[DeploymentData], any[CanonicalProcess], any[Option[String]])
+        deploymentManager.processCommand(any[RunDeploymentCommand])
       ).thenReturn(Future.fromTry(givenDeployResult))
       when(deploymentManager.processStateDefinitionManager).thenReturn(SimpleProcessStateDefinitionManager)
       deploymentService.deployProcessAsync(processIdWithName, None, None)(user, global).flatten.futureValue
@@ -117,9 +116,9 @@ class NotificationServiceTest
         user: LoggedUser
     ): Option[ExternalDeploymentId] = {
       when(
-        deploymentManager.deploy(any[ProcessVersion], any[DeploymentData], any[CanonicalProcess], any[Option[String]])
+        deploymentManager.processCommand(any[RunDeploymentCommand])
       ).thenAnswer { invocation =>
-        passedDeploymentId = Some(invocation.getArgument[DeploymentData](1).deploymentId)
+        passedDeploymentId = Some(invocation.getArgument[RunDeploymentCommand](0).deploymentData.deploymentId)
         Future.fromTry(givenDeployResult)
       }
       when(deploymentManager.processStateDefinitionManager).thenReturn(SimpleProcessStateDefinitionManager)

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -20,7 +20,7 @@ To see the biggest differences please consult the [changelog](Changelog.md).
     * `cancel` without `deploymentId` argument - `CancelScenarioCommand`
     * `stop` with `deploymentId` argument - `StopDeploymentCommand`
     * `stop` without `deploymentId` argument - `StopScenarioCommand`
-    * `savepoint` - `MakeAScenarioSavepointCommand`
+    * `savepoint` - `MakeScenarioSavepointCommand`
     * `test` - `TestScenarioCommand`
 
 ### Other changes

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -7,9 +7,21 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 ### Code API changes
 
 * [#5609](https://github.com/TouK/nussknacker/pull/5609) Refactoring around DeploymentManager's actions:
-  * `CustomAction`, `CustomActionParameter` and `CustomActionResult` moved from `extension-api` to `deployment-manager-api` module
-  * `CustomActionResult.req` was removed
-  * `CustomAction` was renamed to `CustomActionDefinition`
+  * Custom Actions
+    * `CustomAction`, `CustomActionParameter` and `CustomActionResult` moved from `extension-api` to `deployment-manager-api` module
+    * `CustomActionResult.req` was removed
+    * `CustomAction` was renamed to `CustomActionDefinition`
+    * `CustomActionRequest` (from the `extension-api`) was renamed to `CustomActionCommand`
+  * Other "action" methods - all methods operating on a scenario (or its deployment) were replaced by case classes and
+    one method handling them all: `processCommand(command)`:
+    * `validate` - `ValidateScenarioCommand`
+    * `deploy` - `RunDeploymentCommand`
+    * `cancel` with `deploymentId` argument - `CancelDeploymentCommand`
+    * `cancel` without `deploymentId` argument - `CancelScenarioCommand`
+    * `stop` with `deploymentId` argument - `StopDeploymentCommand`
+    * `stop` without `deploymentId` argument - `StopScenarioCommand`
+    * `savepoint` - `MakeAScenarioSavepointCommand`
+    * `test` - `TestScenarioCommand`
 
 ### Other changes
 

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentDeploymentManagerProvider.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/DevelopmentDeploymentManagerProvider.scala
@@ -84,10 +84,10 @@ class DevelopmentDeploymentManager(actorSystem: ActorSystem)
     case CancelDeploymentCommand(name, _, user) =>
       // TODO: cancelling specific deployment
       cancelScenario(CancelScenarioCommand(name, user))
-    case command: CancelScenarioCommand   => cancelScenario(command)
-    case command: CustomActionCommand     => invokeCustomAction(command)
-    case _: MakeAScenarioSavepointCommand => Future.successful(SavepointResult(""))
-    case _: TestScenarioCommand           => notImplemented
+    case command: CancelScenarioCommand  => cancelScenario(command)
+    case command: CustomActionCommand    => invokeCustomAction(command)
+    case _: MakeScenarioSavepointCommand => Future.successful(SavepointResult(""))
+    case _: TestScenarioCommand          => notImplemented
   }
 
   private def description(canonicalProcess: CanonicalProcess) = {
@@ -153,12 +153,12 @@ class DevelopmentDeploymentManager(actorSystem: ActorSystem)
   private def invokeCustomAction(command: CustomActionCommand): Future[CustomActionResult] = {
     val processName = command.processVersion.processName
     val statusOpt = customActionStatusMapping
-      .collectFirst { case (customAction, status) if customAction.name == command.scenarioName => status }
+      .collectFirst { case (customAction, status) if customAction.name == command.actionName => status }
 
     statusOpt match {
       case Some(newStatus) =>
         asyncChangeState(processName, newStatus)
-        Future.successful(CustomActionResult(s"Done ${command.scenarioName}"))
+        Future.successful(CustomActionResult(s"Done ${command.actionName}"))
       case _ =>
         Future.failed(new NotImplementedError())
     }

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
@@ -4,23 +4,12 @@ import cats.data.Validated.valid
 import cats.data.ValidatedNel
 import com.typesafe.config.Config
 import pl.touk.nussknacker.development.manager.MockableDeploymentManagerProvider.MockableDeploymentManager
-import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessStateDefinitionManager, SimpleStateStatus}
 import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName}
-import pl.touk.nussknacker.engine.api.test.ScenarioTestData
-import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.deployment.{
-  CustomActionDefinition,
-  CustomActionRequest,
-  CustomActionResult,
-  DeploymentData,
-  DeploymentId,
-  ExternalDeploymentId,
-  User
-}
+import pl.touk.nussknacker.engine.deployment.CustomActionDefinition
 import pl.touk.nussknacker.engine.management.FlinkStreamingPropertiesConfig
-import pl.touk.nussknacker.engine.testmode.TestProcess
+import pl.touk.nussknacker.engine.testing.StubbingCommands
 import pl.touk.nussknacker.engine.{
   BaseModelData,
   DeploymentManagerDependencies,
@@ -54,7 +43,7 @@ object MockableDeploymentManagerProvider {
 
   // note: At the moment this manager cannot be used in tests which are executed in parallel. It can be obviously
   //       improved, but there is no need to do it ATM.
-  object MockableDeploymentManager extends DeploymentManager {
+  object MockableDeploymentManager extends DeploymentManager with StubbingCommands {
 
     private val scenarioStatuses = new AtomicReference[Map[ScenarioName, StateStatus]](Map.empty)
 
@@ -66,44 +55,6 @@ object MockableDeploymentManagerProvider {
       this.scenarioStatuses.set(Map.empty)
     }
 
-    override def validate(
-        processVersion: ProcessVersion,
-        deploymentData: DeploymentData,
-        canonicalProcess: CanonicalProcess
-    ): Future[Unit] =
-      Future.successful(())
-
-    override def deploy(
-        processVersion: ProcessVersion,
-        deploymentData: DeploymentData,
-        canonicalProcess: CanonicalProcess,
-        savepointPath: Option[String]
-    ): Future[Option[ExternalDeploymentId]] =
-      Future.successful(None)
-
-    override def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] =
-      Future.successful(SavepointResult(""))
-
-    override def stop(
-        name: ProcessName,
-        deploymentId: DeploymentId,
-        savepointDir: Option[String],
-        user: User
-    ): Future[SavepointResult] =
-      Future.successful(SavepointResult(""))
-
-    override def cancel(name: ProcessName, user: User): Future[Unit] =
-      Future.successful(())
-
-    override def cancel(name: ProcessName, deploymentId: DeploymentId, user: User): Future[Unit] =
-      Future.successful(())
-
-    override def test(
-        name: ProcessName,
-        canonicalProcess: CanonicalProcess,
-        scenarioTestData: ScenarioTestData
-    ): Future[TestProcess.TestResults] = ???
-
     override def resolve(
         idWithName: ProcessIdWithName,
         statusDetails: List[StatusDetails],
@@ -112,19 +63,10 @@ object MockableDeploymentManagerProvider {
       Future.successful(processStateDefinitionManager.processState(statusDetails.head))
     }
 
-    override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] =
-      Future.successful(SavepointResult(""))
-
     override def processStateDefinitionManager: ProcessStateDefinitionManager =
       SimpleProcessStateDefinitionManager
 
-    override def customActions: List[CustomActionDefinition] = Nil
-
-    override def invokeCustomAction(
-        actionRequest: CustomActionRequest,
-        canonicalProcess: CanonicalProcess
-    ): Future[CustomActionResult] =
-      Future.failed(new NotImplementedError())
+    override def customActionsDefinitions: List[CustomActionDefinition] = Nil
 
     override def getProcessStates(name: ProcessName)(
         implicit freshnessPolicy: DataFreshnessPolicy

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicCustomActionsProviderFactory.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicCustomActionsProviderFactory.scala
@@ -1,7 +1,8 @@
 package pl.touk.nussknacker.engine.management.periodic
 
+import pl.touk.nussknacker.engine.api.deployment.CustomActionCommand
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.deployment.{CustomActionDefinition, CustomActionRequest, CustomActionResult}
+import pl.touk.nussknacker.engine.deployment.{CustomActionDefinition, CustomActionResult}
 import pl.touk.nussknacker.engine.management.periodic.db.PeriodicProcessesRepository
 
 import scala.concurrent.Future
@@ -24,8 +25,7 @@ trait PeriodicCustomActionsProvider {
   def customActions: List[CustomActionDefinition]
 
   def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
+      actionRequest: CustomActionCommand
   ): Future[CustomActionResult]
 
 }
@@ -34,8 +34,7 @@ object EmptyPeriodicCustomActionsProvider extends PeriodicCustomActionsProvider 
   override def customActions: List[CustomActionDefinition] = Nil
 
   override def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
+      actionRequest: CustomActionCommand
   ): Future[CustomActionResult] =
     Future.failed(new NotImplementedError())
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -116,7 +116,7 @@ class PeriodicDeploymentManager private[periodic] (
       case command: StopScenarioCommand     => stopScenario(command)
       case command: CustomActionCommand     => customActionsProvider.invokeCustomAction(command)
       case _: TestScenarioCommand | _: CancelDeploymentCommand | _: StopDeploymentCommand |
-          _: MakeAScenarioSavepointCommand | _: CustomActionCommand =>
+          _: MakeScenarioSavepointCommand | _: CustomActionCommand =>
         delegate.processCommand(command)
     }
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -9,7 +9,6 @@ import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{
   CustomActionDefinition,
-  CustomActionRequest,
   CustomActionResult,
   DeploymentData,
   DeploymentId,
@@ -109,24 +108,29 @@ class PeriodicDeploymentManager private[periodic] (
     extends DeploymentManager
     with LazyLogging {
 
-  override def validate(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess
-  ): Future[Unit] = {
+  override def processCommand[Result](command: ScenarioCommand[Result]): Future[Result] =
+    command match {
+      case command: ValidateScenarioCommand => validate(command)
+      case command: RunDeploymentCommand    => runDeployment(command)
+      case command: CancelScenarioCommand   => cancelScenario(command)
+      case command: StopScenarioCommand     => stopScenario(command)
+      case command: CustomActionCommand     => customActionsProvider.invokeCustomAction(command)
+      case _: TestScenarioCommand | _: CancelDeploymentCommand | _: StopDeploymentCommand |
+          _: MakeAScenarioSavepointCommand | _: CustomActionCommand =>
+        delegate.processCommand(command)
+    }
+
+  private def validate(command: ValidateScenarioCommand): Future[Unit] = {
+    import command._
     for {
       scheduledProperty <- extractScheduleProperty(canonicalProcess)
       _                 <- Future.fromTry(service.prepareInitialScheduleDates(scheduledProperty).toTry)
-      _                 <- delegate.validate(processVersion, deploymentData, canonicalProcess)
+      _ <- delegate.processCommand(ValidateScenarioCommand(processVersion, deploymentData, canonicalProcess))
     } yield ()
   }
 
-  override def deploy(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess,
-      savepointPath: Option[String]
-  ): Future[Option[ExternalDeploymentId]] = {
+  private def runDeployment(command: RunDeploymentCommand): Future[Option[ExternalDeploymentId]] = {
+    import command._
     extractScheduleProperty(canonicalProcess).flatMap { scheduleProperty =>
       logger.info(s"About to (re)schedule ${processVersion.processName} in version ${processVersion.versionId}")
       // PeriodicProcessStateDefinitionManager do not allow to redeploy (so doesn't GUI),
@@ -139,7 +143,7 @@ class PeriodicDeploymentManager private[periodic] (
           deploymentData.deploymentId.toActionIdOpt.getOrElse(
             throw new IllegalArgumentException(s"deploymentData.deploymentId should be valid ProcessActionId")
           ),
-          cancel(processVersion.processName, deploymentData.user)
+          cancelScenario(CancelScenarioCommand(processVersion.processName, deploymentData.user))
         )
         .map(_ => None)
     }
@@ -154,40 +158,34 @@ class PeriodicDeploymentManager private[periodic] (
     }
   }
 
-  override def stop(name: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] = {
-    service.deactivate(name).flatMap { deploymentIdsToStop =>
+  private def stopScenario(command: StopScenarioCommand): Future[SavepointResult] = {
+    import command._
+    service.deactivate(scenarioName).flatMap { deploymentIdsToStop =>
       // TODO: should return List of SavepointResult
       Future
-        .sequence(deploymentIdsToStop.map(delegate.stop(name, _, savepointDir, user)))
+        .sequence(
+          deploymentIdsToStop
+            .map(deploymentId =>
+              delegate.processCommand(StopDeploymentCommand(scenarioName, deploymentId, savepointDir, user))
+            )
+        )
         .map(_.headOption.getOrElse {
-          throw new IllegalStateException(s"No running deployment for scenario: $name found")
+          throw new IllegalStateException(s"No running deployment for scenario: $scenarioName found")
         })
     }
   }
 
-  override def stop(
-      name: ProcessName,
-      deploymentId: DeploymentId,
-      savepointDir: Option[String],
-      user: User
-  ): Future[SavepointResult] =
-    Future.failed(new UnsupportedOperationException(s"Stopping of deployment is not supported"))
-
-  override def cancel(name: ProcessName, user: User): Future[Unit] = {
-    service.deactivate(name).flatMap { deploymentIdsToCancel =>
-      Future.sequence(deploymentIdsToCancel.map(delegate.cancel(name, _, user))).map(_ => ())
+  private def cancelScenario(command: CancelScenarioCommand): Future[Unit] = {
+    import command._
+    service.deactivate(scenarioName).flatMap { deploymentIdsToCancel =>
+      Future
+        .sequence(
+          deploymentIdsToCancel
+            .map(deploymentId => delegate.processCommand(CancelDeploymentCommand(scenarioName, deploymentId, user)))
+        )
+        .map(_ => ())
     }
   }
-
-  override def cancel(name: ProcessName, deploymentId: DeploymentId, user: User): Future[Unit] =
-    Future.failed(new UnsupportedOperationException(s"Cancelling of deployment it not supported"))
-
-  override def test(
-      name: ProcessName,
-      canonicalProcess: CanonicalProcess,
-      scenarioTestData: ScenarioTestData
-  ): Future[TestProcess.TestResults] =
-    delegate.test(name, canonicalProcess, scenarioTestData)
 
   override def getProcessStates(
       name: ProcessName
@@ -212,22 +210,12 @@ class PeriodicDeploymentManager private[periodic] (
   override def processStateDefinitionManager: ProcessStateDefinitionManager =
     new PeriodicProcessStateDefinitionManager(delegate.processStateDefinitionManager)
 
-  override def savepoint(name: ProcessName, savepointDir: Option[String]): Future[SavepointResult] = {
-    delegate.savepoint(name, savepointDir)
-  }
-
   override def close(): Unit = {
     logger.info("Closing periodic process manager")
     toClose()
     delegate.close()
   }
 
-  override def customActions: List[CustomActionDefinition] = customActionsProvider.customActions
-
-  override def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
-  ): Future[CustomActionResult] =
-    customActionsProvider.invokeCustomAction(actionRequest, canonicalProcess)
+  override def customActionsDefinitions: List[CustomActionDefinition] = customActionsProvider.customActions
 
 }

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
@@ -1,18 +1,15 @@
 package pl.touk.nussknacker.engine.management.periodic
 
-import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName}
-import pl.touk.nussknacker.engine.api.test.ScenarioTestData
-import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.deployment.{DeploymentData, DeploymentId, ExternalDeploymentId, User}
+import pl.touk.nussknacker.engine.deployment.{DeploymentId, ExternalDeploymentId}
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeploymentId
-import pl.touk.nussknacker.engine.testmode.TestProcess
+import pl.touk.nussknacker.engine.testing.StubbingCommands
 
 import scala.concurrent.Future
 
-class DeploymentManagerStub extends BaseDeploymentManager {
+class DeploymentManagerStub extends BaseDeploymentManager with StubbingCommands {
 
   var jobStatus: Option[StatusDetails] = None
 
@@ -30,23 +27,6 @@ class DeploymentManagerStub extends BaseDeploymentManager {
     )
   }
 
-  override def deploy(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess,
-      savepointPath: Option[String]
-  ): Future[Option[ExternalDeploymentId]] = ???
-
-  override def cancel(name: ProcessName, user: User): Future[Unit] = Future.successful(())
-
-  override def cancel(name: ProcessName, deploymentId: DeploymentId, user: User): Future[Unit] = Future.successful(())
-
-  override def test(
-      name: ProcessName,
-      canonicalProcess: CanonicalProcess,
-      scenarioTestData: ScenarioTestData
-  ): Future[TestProcess.TestResults] = ???
-
   override def resolve(
       idWithName: ProcessIdWithName,
       statusDetails: List[StatusDetails],
@@ -63,11 +43,5 @@ class DeploymentManagerStub extends BaseDeploymentManager {
   )(implicit freshnessPolicy: DataFreshnessPolicy): Future[WithDataFreshnessStatus[List[StatusDetails]]] = {
     Future.successful(WithDataFreshnessStatus.fresh(jobStatus.toList))
   }
-
-  override def validate(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess
-  ): Future[Unit] = Future.successful(())
 
 }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSlotsCountSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSlotsCountSpec.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.management.streaming
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.deployment.RunDeploymentCommand
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId}
 import pl.touk.nussknacker.engine.deployment.DeploymentData
 import pl.touk.nussknacker.engine.management.FlinkSlotsChecker.{NotEnoughSlotsException, SlotsBalance}
@@ -20,7 +21,10 @@ class FlinkStreamingDeploymentManagerSlotsCountSpec extends AnyFunSuite with Mat
     val process     = SampleProcess.prepareProcess(processName, parallelism = Some(parallelism))
 
     try {
-      deploymentManager.deploy(version, DeploymentData.empty, process, None).failed.futureValue shouldEqual
+      deploymentManager
+        .processCommand(RunDeploymentCommand(version, DeploymentData.empty, process, None))
+        .failed
+        .futureValue shouldEqual
         NotEnoughSlotsException(taskManagerSlotCount, taskManagerSlotCount, SlotsBalance(0, parallelism))
     } finally {
       cancelProcess(processName)

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
@@ -7,7 +7,7 @@ import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.component.{ComponentId, ComponentType, DesignerWideComponentId}
 import pl.touk.nussknacker.engine.api.deployment.{
   CancelScenarioCommand,
-  MakeAScenarioSavepointCommand,
+  MakeScenarioSavepointCommand,
   RunDeploymentCommand,
   StopScenarioCommand
 }
@@ -123,7 +123,7 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
       val savepointDir = Files.createTempDirectory("customSavepoint")
       val savepointPathFuture = deploymentManager
         .processCommand(
-          MakeAScenarioSavepointCommand(
+          MakeScenarioSavepointCommand(
             processEmittingOneElementAfterStart.name,
             savepointDir = Some(savepointDir.toUri.toString)
           )

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
@@ -5,6 +5,12 @@ import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.{ModelData, ModelDependencies}
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.component.{ComponentId, ComponentType, DesignerWideComponentId}
+import pl.touk.nussknacker.engine.api.deployment.{
+  CancelScenarioCommand,
+  MakeAScenarioSavepointCommand,
+  RunDeploymentCommand,
+  StopScenarioCommand
+}
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId}
 import pl.touk.nussknacker.engine.deployment.DeploymentData
@@ -44,14 +50,17 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
     val process     = SampleProcess.prepareProcess(processName)
     val version     = ProcessVersion(VersionId(15), processName, processId, "user1", Some(13))
 
-    val deployedResponse = deploymentManager.deploy(version, defaultDeploymentData, process, None)
+    val deployedResponse =
+      deploymentManager.processCommand(RunDeploymentCommand(version, defaultDeploymentData, process, None))
 
     deployedResponse.futureValue
   }
 
   // this is for the case where e.g. we manually cancel flink job, or it fail and didn't restart...
   test("cancel of not existing job should not fail") {
-    deploymentManager.cancel(ProcessName("not existing job"), user = userToAct).futureValue shouldBe (())
+    deploymentManager
+      .processCommand(CancelScenarioCommand(ProcessName("not existing job"), user = userToAct))
+      .futureValue shouldBe (())
   }
 
   test("be able verify&redeploy kafka scenario") {
@@ -113,9 +122,11 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
 
       val savepointDir = Files.createTempDirectory("customSavepoint")
       val savepointPathFuture = deploymentManager
-        .savepoint(
-          processEmittingOneElementAfterStart.name,
-          savepointDir = Some(savepointDir.toUri.toString)
+        .processCommand(
+          MakeAScenarioSavepointCommand(
+            processEmittingOneElementAfterStart.name,
+            savepointDir = Some(savepointDir.toUri.toString)
+          )
         )
         .map(_.path)
       val savepointPath = new URI(savepointPathFuture.futureValue)
@@ -147,7 +158,9 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
       messagesFromTopic(outTopic, 1) shouldBe List("List(One element)")
 
       val savepointPath =
-        deploymentManager.stop(processName, savepointDir = None, user = userToAct).map(_.path)
+        deploymentManager
+          .processCommand(StopScenarioCommand(processName, savepointDir = None, user = userToAct))
+          .map(_.path)
       eventually {
         val status = deploymentManager.getProcessStates(processName).futureValue
         status.value.map(_.status) shouldBe List(SimpleStateStatus.Canceled)
@@ -181,7 +194,10 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
 
       val statefullProcess = StatefulSampleProcess.prepareProcessWithLongState(processName)
       val exception =
-        deploymentManager.deploy(empty(process.name), defaultDeploymentData, statefullProcess, None).failed.futureValue
+        deploymentManager
+          .processCommand(RunDeploymentCommand(empty(process.name), defaultDeploymentData, statefullProcess, None))
+          .failed
+          .futureValue
       exception.getMessage shouldBe "State is incompatible, please stop scenario and start again with clean state"
     } finally {
       cancelProcess(processName)
@@ -203,7 +219,10 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
 
       val statefulProcess = StatefulSampleProcess.processWithAggregator(processName, "#AGG.approxCardinality")
       val exception =
-        deploymentManager.deploy(empty(process.name), defaultDeploymentData, statefulProcess, None).failed.futureValue
+        deploymentManager
+          .processCommand(RunDeploymentCommand(empty(process.name), defaultDeploymentData, statefulProcess, None))
+          .failed
+          .futureValue
       exception.getMessage shouldBe "State is incompatible, please stop scenario and start again with clean state"
     } finally {
       cancelProcess(processName)

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingProcessTestRunnerSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ConfigWithUnresolvedVersion
 import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.deployment.TestScenarioCommand
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, ScenarioTestJsonRecord}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
@@ -43,7 +44,7 @@ class FlinkStreamingProcessTestRunnerSpec extends AnyFlatSpec with Matchers with
 
     val process = SampleProcess.prepareProcess(processName)
 
-    whenReady(deploymentManager.test(processName, process, scenarioTestData)) { r =>
+    whenReady(deploymentManager.processCommand(TestScenarioCommand(processName, process, scenarioTestData))) { r =>
       r.nodeResults shouldBe Map(
         "startProcess" -> List(Context(s"$processName-startProcess-0-0", Map("input" -> "terefere"))),
         "nightFilter"  -> List(Context(s"$processName-startProcess-0-0", Map("input" -> "terefere"))),
@@ -64,7 +65,7 @@ class FlinkStreamingProcessTestRunnerSpec extends AnyFlatSpec with Matchers with
 
     val caught = intercept[IllegalArgumentException] {
       Await.result(
-        deploymentManager.test(ProcessName(processId), process, scenarioTestData),
+        deploymentManager.processCommand(TestScenarioCommand(ProcessName(processId), process, scenarioTestData)),
         patienceConfig.timeout
       )
     }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/JavaConfigDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/JavaConfigDeploymentManagerSpec.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.management.streaming
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.deployment.{CancelScenarioCommand, RunDeploymentCommand}
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
@@ -24,7 +25,14 @@ class JavaConfigDeploymentManagerSpec extends AnyFunSuite with Matchers with Str
 
     assert(
       deploymentManager
-        .deploy(ProcessVersion.empty.copy(processName = process.name), DeploymentData.empty, process, None)
+        .processCommand(
+          RunDeploymentCommand(
+            ProcessVersion.empty.copy(processName = process.name),
+            DeploymentData.empty,
+            process,
+            None
+          )
+        )
         .isReadyWithin(100 seconds)
     )
 
@@ -33,7 +41,9 @@ class JavaConfigDeploymentManagerSpec extends AnyFunSuite with Matchers with Str
       jobStatus.map(_.status) shouldBe List(SimpleStateStatus.Running)
     }
 
-    assert(deploymentManager.cancel(process.name, user = userToAct).isReadyWithin(10 seconds))
+    assert(
+      deploymentManager.processCommand(CancelScenarioCommand(process.name, user = userToAct)).isReadyWithin(10 seconds)
+    )
   }
 
 }

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
@@ -13,7 +13,6 @@ import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{
   CustomActionDefinition,
-  CustomActionRequest,
   CustomActionResult,
   DeploymentData,
   DeploymentId,
@@ -96,23 +95,40 @@ abstract class FlinkDeploymentManager(
     }
   }
 
-  override def validate(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess
-  ): Future[Unit] = {
+  override def processCommand[Result](command: ScenarioCommand[Result]): Future[Result] =
+    command match {
+      case command: ValidateScenarioCommand => validate(command)
+      case command: RunDeploymentCommand    => runDeployment(command)
+      case command: CancelDeploymentCommand => cancelDeployment(command)
+      case command: CancelScenarioCommand   => cancelScenario(command)
+      case StopDeploymentCommand(processName, deploymentId, savepointDir, _) =>
+        requireSingleRunningJob(processName, _.deploymentId.contains(deploymentId)) {
+          stop(_, savepointDir)
+        }
+      case StopScenarioCommand(processName, savepointDir, _) =>
+        requireSingleRunningJob(processName, _ => true) {
+          stop(_, savepointDir)
+        }
+      case MakeAScenarioSavepointCommand(processName, savepointDir) =>
+        // TODO: savepoint for given deployment id
+        requireSingleRunningJob(processName, _ => true) {
+          makeSavepoint(_, savepointDir)
+        }
+      case TestScenarioCommand(_, canonicalProcess, scenarioTestData) =>
+        testRunner.test(canonicalProcess, scenarioTestData)
+      case command: CustomActionCommand => processCustomAction(command)
+    }
+
+  private def validate(command: ValidateScenarioCommand): Future[Unit] = {
+    import command._
     for {
       oldJob <- oldJobsToStop(processVersion)
       _      <- checkRequiredSlotsExceedAvailableSlots(canonicalProcess, oldJob.flatMap(_.externalDeploymentId))
     } yield ()
   }
 
-  override def deploy(
-      processVersion: ProcessVersion,
-      deploymentData: DeploymentData,
-      canonicalProcess: CanonicalProcess,
-      savepointPath: Option[String]
-  ): Future[Option[ExternalDeploymentId]] = {
+  protected def runDeployment(command: RunDeploymentCommand): Future[Option[ExternalDeploymentId]] = {
+    import command._
     val processName = processVersion.processName
 
     val stoppingResult = for {
@@ -160,45 +176,7 @@ abstract class FlinkDeploymentManager(
       currentlyDeployedJobsIds: List[ExternalDeploymentId]
   ): Future[Unit]
 
-  override def savepoint(processName: ProcessName, savepointDir: Option[String]): Future[SavepointResult] = {
-    // TODO: savepoint for given deployment id
-    requireSingleRunningJob(processName, _ => true) {
-      makeSavepoint(_, savepointDir)
-    }
-  }
-
-  override def stop(processName: ProcessName, savepointDir: Option[String], user: User): Future[SavepointResult] = {
-    requireSingleRunningJob(processName, _ => true) {
-      stop(_, savepointDir)
-    }
-  }
-
-  override def stop(
-      processName: ProcessName,
-      deploymentId: DeploymentId,
-      savepointDir: Option[String],
-      user: User
-  ): Future[SavepointResult] = {
-    requireSingleRunningJob(processName, _.deploymentId.contains(deploymentId)) {
-      stop(_, savepointDir)
-    }
-  }
-
-  override def test(
-      processName: ProcessName,
-      canonicalProcess: CanonicalProcess,
-      scenarioTestData: ScenarioTestData
-  ): Future[TestResults] = {
-    testRunner.test(canonicalProcess, scenarioTestData)
-  }
-
-  override def customActions: List[CustomActionDefinition] = List.empty
-
-  override def invokeCustomAction(
-      actionRequest: CustomActionRequest,
-      canonicalProcess: CanonicalProcess
-  ): Future[CustomActionResult] =
-    Future.failed(new NotImplementedError())
+  override def customActionsDefinitions: List[CustomActionDefinition] = List.empty
 
   private def requireSingleRunningJob[T](processName: ProcessName, statusDetailsPredicate: StatusDetails => Boolean)(
       action: ExternalDeploymentId => Future[T]
@@ -238,11 +216,17 @@ abstract class FlinkDeploymentManager(
       savepointResult <- makeSavepoint(deploymentId, savepointDir = None)
       savepointPath = savepointResult.path
       _ <- checkIfJobIsCompatible(savepointPath, canonicalProcess, processVersion)
-      _ <- cancel(deploymentId)
+      _ <- cancelFlinkJob(deploymentId)
     } yield savepointPath
   }
 
-  protected def cancel(deploymentId: ExternalDeploymentId): Future[Unit]
+  protected def processCustomAction(command: CustomActionCommand): Future[CustomActionResult] = notImplemented
+
+  protected def cancelScenario(command: CancelScenarioCommand): Future[Unit]
+
+  protected def cancelDeployment(command: CancelDeploymentCommand): Future[Unit]
+
+  protected def cancelFlinkJob(deploymentId: ExternalDeploymentId): Future[Unit]
 
   protected def makeSavepoint(deploymentId: ExternalDeploymentId, savepointDir: Option[String]): Future[SavepointResult]
 

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
@@ -109,7 +109,7 @@ abstract class FlinkDeploymentManager(
         requireSingleRunningJob(processName, _ => true) {
           stop(_, savepointDir)
         }
-      case MakeAScenarioSavepointCommand(processName, savepointDir) =>
+      case MakeScenarioSavepointCommand(processName, savepointDir) =>
         // TODO: savepoint for given deployment id
         requireSingleRunningJob(processName, _ => true) {
           makeSavepoint(_, savepointDir)

--- a/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
+++ b/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
@@ -217,7 +217,7 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
     val manager     = createManager(List(buildRunningJobOverview(processName)), acceptSavepoint = true)
 
     manager
-      .processCommand(MakeAScenarioSavepointCommand(processName, savepointDir = None))
+      .processCommand(MakeScenarioSavepointCommand(processName, savepointDir = None))
       .futureValue shouldBe SavepointResult(path = savepointPath)
   }
 

--- a/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
+++ b/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
@@ -150,11 +150,13 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
     statuses = List(JobOverview("2343", "p1", 10L, 10L, JobStatus.FAILED.name(), tasksOverview(failed = 1)))
 
     createManager(statuses, acceptDeploy = true, exceptionOnDeploy = Some(new TimeoutException("tooo looong")))
-      .deploy(
-        defaultVersion,
-        defaultDeploymentData,
-        canonicalProcess,
-        None
+      .processCommand(
+        RunDeploymentCommand(
+          defaultVersion,
+          defaultDeploymentData,
+          canonicalProcess,
+          None
+        )
       )
       .futureValue shouldBe None
   }
@@ -164,11 +166,13 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
     val manager =
       createManager(statuses, acceptDeploy = true, exceptionOnDeploy = Some(new NoRouteToHostException("heeelo?")))
 
-    val result = manager.deploy(
-      defaultVersion,
-      defaultDeploymentData,
-      canonicalProcess,
-      None
+    val result = manager.processCommand(
+      RunDeploymentCommand(
+        defaultVersion,
+        defaultDeploymentData,
+        canonicalProcess,
+        None
+      )
     )
     expectException(result, "Exception when sending request: POST http://test.pl/jars/file/run")
     result.failed.futureValue.getCause.getMessage shouldBe "heeelo?"
@@ -182,15 +186,21 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
 
     val message =
       "Not enough free slots on Flink cluster. Available slots: 0, requested: 1. Extend resources of Flink cluster resources"
-    expectException(manager.validate(defaultVersion, defaultDeploymentData, canonicalProcess), message)
-    expectException(manager.deploy(defaultVersion, defaultDeploymentData, canonicalProcess, None), message)
+    expectException(
+      manager.processCommand(ValidateScenarioCommand(defaultVersion, defaultDeploymentData, canonicalProcess)),
+      message
+    )
+    expectException(
+      manager.processCommand(RunDeploymentCommand(defaultVersion, defaultDeploymentData, canonicalProcess, None)),
+      message
+    )
   }
 
   test("allow deploy if process is failed") {
     statuses = List(JobOverview("2343", "p1", 10L, 10L, JobStatus.FAILED.name(), tasksOverview(failed = 1)))
 
     createManager(statuses, acceptDeploy = true)
-      .deploy(defaultVersion, defaultDeploymentData, canonicalProcess, None)
+      .processCommand(RunDeploymentCommand(defaultVersion, defaultDeploymentData, canonicalProcess, None))
       .futureValue shouldBe Some(ExternalDeploymentId(returnedJobId))
   }
 
@@ -198,7 +208,7 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
     statuses = List(JobOverview("2343", "p1", 10L, 10L, JobStatus.RUNNING.name(), tasksOverview(running = 1)))
 
     createManager(statuses, acceptDeploy = true, acceptSavepoint = true)
-      .deploy(defaultVersion, defaultDeploymentData, canonicalProcess, None)
+      .processCommand(RunDeploymentCommand(defaultVersion, defaultDeploymentData, canonicalProcess, None))
       .futureValue shouldBe Some(ExternalDeploymentId(returnedJobId))
   }
 
@@ -206,7 +216,9 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
     val processName = ProcessName("p1")
     val manager     = createManager(List(buildRunningJobOverview(processName)), acceptSavepoint = true)
 
-    manager.savepoint(processName, savepointDir = None).futureValue shouldBe SavepointResult(path = savepointPath)
+    manager
+      .processCommand(MakeAScenarioSavepointCommand(processName, savepointDir = None))
+      .futureValue shouldBe SavepointResult(path = savepointPath)
   }
 
   test("should stop") {
@@ -214,7 +226,7 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
     val manager     = createManager(List(buildRunningJobOverview(processName)), acceptStop = true)
 
     manager
-      .stop(processName, savepointDir = None, user = User("user1", "user"))
+      .processCommand(StopScenarioCommand(processName, savepointDir = None, user = User("user1", "user")))
       .futureValue shouldBe SavepointResult(path = savepointPath)
   }
 
@@ -235,7 +247,7 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
 
     cancellableStatuses
       .map(status => ProcessName(s"process_$status"))
-      .map(manager.cancel(_, User("test_id", "Jack")))
+      .map(deploymentId => manager.processCommand(CancelScenarioCommand(deploymentId, User("test_id", "Jack"))))
       .foreach(_.futureValue shouldBe (()))
 
     statuses.map(_.jid).foreach(id => history should contain(HistoryEntry("cancel", Some(id))))
@@ -266,7 +278,9 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
 
     val (manager, history) = createManagerWithHistory(statuses)
 
-    manager.cancel(processName, fooDeploymentId, User("user1", "user1")).futureValue shouldBe (())
+    manager
+      .processCommand(CancelDeploymentCommand(processName, fooDeploymentId, User("user1", "user1")))
+      .futureValue shouldBe (())
 
     history should contain(HistoryEntry("cancel", Some(fooDeploymentId.value)))
     history should not contain HistoryEntry("cancel", Some(barDeploymentId.value))
@@ -283,7 +297,9 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
 
     val (manager, history) = createManagerWithHistory(statuses)
 
-    manager.cancel(ProcessName("test"), User("test_id", "Jack")).futureValue shouldBe (())
+    manager.processCommand(CancelScenarioCommand(ProcessName("test"), User("test_id", "Jack"))).futureValue shouldBe (
+      ()
+    )
 
     history.filter(_.operation == "cancel").map(_.jobId.get) should contain theSameElementsAs
       statuses.filter(_.state == JobStatus.RUNNING.name()).map(_.jid)
@@ -293,7 +309,7 @@ class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFu
     statuses = List(JobOverview("2343", "p1", 10L, 10L, JobStatus.FAILED.name(), tasksOverview(failed = 1)))
     val (manager, history) = createManagerWithHistory(statuses, acceptCancel = false)
 
-    manager.cancel(ProcessName("p1"), User("test_id", "Jack")).futureValue shouldBe (())
+    manager.processCommand(CancelScenarioCommand(ProcessName("p1"), User("test_id", "Jack"))).futureValue shouldBe (())
     history.filter(_.operation == "cancel") shouldBe Nil
   }
 

--- a/engine/lite/deploymentManager/src/main/scala/pl/touk/nussknacker/lite/manager/LiteDeploymentManager.scala
+++ b/engine/lite/deploymentManager/src/main/scala/pl/touk/nussknacker/lite/manager/LiteDeploymentManager.scala
@@ -2,10 +2,7 @@ package pl.touk.nussknacker.lite.manager
 
 import pl.touk.nussknacker.engine.BaseModelData
 import pl.touk.nussknacker.engine.ModelData.BaseModelDataExt
-import pl.touk.nussknacker.engine.api.deployment.BaseDeploymentManager
-import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.api.test.ScenarioTestData
-import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.api.deployment.{BaseDeploymentManager, TestScenarioCommand}
 import pl.touk.nussknacker.engine.lite.kafka.KafkaTransactionalScenarioInterpreter
 import pl.touk.nussknacker.engine.testmode.TestProcess
 
@@ -17,18 +14,14 @@ trait LiteDeploymentManager extends BaseDeploymentManager {
 
   protected implicit def executionContext: ExecutionContext
 
-  override def test(
-      name: ProcessName,
-      canonicalProcess: CanonicalProcess,
-      scenarioTestData: ScenarioTestData,
-  ): Future[TestProcess.TestResults] = {
+  protected def processTestActionCommand(command: TestScenarioCommand): Future[TestProcess.TestResults] = {
     Future {
       modelData.asInvokableModelData.withThisAsContextClassLoader {
         // TODO: handle scenario testing in RR as well
         KafkaTransactionalScenarioInterpreter.testRunner.runTest(
           modelData.asInvokableModelData,
-          scenarioTestData,
-          canonicalProcess
+          command.scenarioTestData,
+          command.canonicalProcess
         )
       }
     }

--- a/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedDeploymentManager.scala
+++ b/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedDeploymentManager.scala
@@ -102,7 +102,7 @@ class EmbeddedDeploymentManager(
       case command: CancelDeploymentCommand => cancelDeployment(command)
       case command: CancelScenarioCommand   => cancelScenario(command)
       case command: TestScenarioCommand     => processTestActionCommand(command)
-      case _: StopDeploymentCommand | _: StopScenarioCommand | _: MakeAScenarioSavepointCommand |
+      case _: StopDeploymentCommand | _: StopScenarioCommand | _: MakeScenarioSavepointCommand |
           _: CustomActionCommand =>
         notImplemented
     }

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/BaseStreamingEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/BaseStreamingEmbeddedDeploymentManagerTest.scala
@@ -10,7 +10,8 @@ import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.{
   DeployedScenarioData,
   DeploymentManager,
-  ProcessingTypeDeploymentServiceStub
+  ProcessingTypeDeploymentServiceStub,
+  RunDeploymentCommand
 }
 import pl.touk.nussknacker.engine.api.process.ProcessObjectDependencies
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -44,7 +45,7 @@ trait BaseStreamingEmbeddedDeploymentManagerTest
 
     def deployScenario(scenario: CanonicalProcess): Unit = {
       val version = ProcessVersion.empty.copy(processName = scenario.name)
-      deploymentManager.deploy(version, DeploymentData.empty, scenario, None).futureValue
+      deploymentManager.processCommand(RunDeploymentCommand(version, DeploymentData.empty, scenario, None)).futureValue
     }
 
   }

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/RequestResponseEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/RequestResponseEmbeddedDeploymentManagerTest.scala
@@ -9,10 +9,12 @@ import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.cache.ScenarioStateCachingConfig
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.deployment.{
+  CancelScenarioCommand,
   DataFreshnessPolicy,
   DeployedScenarioData,
   DeploymentManager,
-  ProcessingTypeDeploymentServiceStub
+  ProcessingTypeDeploymentServiceStub,
+  RunDeploymentCommand
 }
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
@@ -71,7 +73,7 @@ class RequestResponseEmbeddedDeploymentManagerTest
 
     def deployScenario(scenario: CanonicalProcess): Unit = {
       val version = ProcessVersion.empty.copy(processName = scenario.name)
-      deploymentManager.deploy(version, DeploymentData.empty, scenario, None).futureValue
+      deploymentManager.processCommand(RunDeploymentCommand(version, DeploymentData.empty, scenario, None)).futureValue
     }
 
   }
@@ -131,7 +133,7 @@ class RequestResponseEmbeddedDeploymentManagerTest
       .toOption
       .get should include("\"openapi\"")
 
-    manager.cancel(name, User("a", "b")).futureValue
+    manager.processCommand(CancelScenarioCommand(name, User("a", "b"))).futureValue
 
     manager.getProcessStates(name).futureValue.value shouldBe List.empty
     request.body("""{ productId: 15 }""").send(backend).code shouldBe StatusCode.NotFound

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
@@ -60,7 +60,7 @@ class StreamingEmbeddedDeploymentManagerTest
     kafkaClient.createConsumer().consumeWithJson[Json](outputTopic).take(1).head.message() shouldBe input
 
     wrapInFailingLoader {
-      manager.cancel(name, User("a", "b")).futureValue
+      manager.processCommand(CancelScenarioCommand(name, User("a", "b"))).futureValue
     }
     manager.getProcessStates(name).futureValue.value shouldBe List.empty
   }
@@ -96,7 +96,7 @@ class StreamingEmbeddedDeploymentManagerTest
 
     kafkaClient.createConsumer().consumeWithJson[Json](outputTopic).take(1).head.message() shouldBe input
 
-    manager.cancel(name, User("a", "b")).futureValue
+    manager.processCommand(CancelScenarioCommand(name, User("a", "b"))).futureValue
     manager.getProcessStates(name).futureValue.value shouldBe List.empty
   }
 
@@ -212,7 +212,7 @@ class StreamingEmbeddedDeploymentManagerTest
     kafkaClient.sendMessage(inputTopic, message("3")).futureValue
     consumer.take(3) shouldBe List(prefixMessage("start", "1"), prefixMessage("next", "2"), prefixMessage("next", "3"))
 
-    manager.cancel(name, User("a", "b")).futureValue
+    manager.processCommand(CancelScenarioCommand(name, User("a", "b"))).futureValue
 
     manager.getProcessStates(name).futureValue.value shouldBe List.empty
   }
@@ -262,7 +262,7 @@ class StreamingEmbeddedDeploymentManagerTest
 
     val testData = testInfoProvider.prepareTestData(preliminaryTestData, scenario).rightValue
     val results = wrapInFailingLoader {
-      manager.test(name, scenario, testData).futureValue
+      manager.processCommand(TestScenarioCommand(name, scenario, testData)).futureValue
     }
     results.nodeResults("sink") should have length 2
     val idGenerator       = IncContextIdGenerator.withProcessIdNodeIdPrefix(scenario.metaData, "source")

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
@@ -114,7 +114,7 @@ class K8sDeploymentManager(
       case command: CancelScenarioCommand   => cancelScenario(command)
       case command: TestScenarioCommand     => processTestActionCommand(command)
       case _: CancelDeploymentCommand | _: StopDeploymentCommand | _: StopScenarioCommand |
-          _: MakeAScenarioSavepointCommand | _: CustomActionCommand =>
+          _: MakeScenarioSavepointCommand | _: CustomActionCommand =>
         notImplemented
     }
 

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/BaseK8sDeploymentManagerTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/BaseK8sDeploymentManagerTest.scala
@@ -8,7 +8,12 @@ import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.ProcessVersion
-import pl.touk.nussknacker.engine.api.deployment.{DataFreshnessPolicy, ProcessingTypeDeploymentServiceStub}
+import pl.touk.nussknacker.engine.api.deployment.{
+  CancelScenarioCommand,
+  DataFreshnessPolicy,
+  ProcessingTypeDeploymentServiceStub,
+  RunDeploymentCommand
+}
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.DeploymentData
@@ -118,7 +123,7 @@ class BaseK8sDeploymentManagerTest
       with LazyLogging {
 
     def withRunningScenario(action: => Unit): Unit = {
-      manager.deploy(version, DeploymentData.empty, scenario, None).futureValue
+      manager.processCommand(RunDeploymentCommand(version, DeploymentData.empty, scenario, None)).futureValue
       try {
         waitForRunning(version)
         action
@@ -129,7 +134,7 @@ class BaseK8sDeploymentManagerTest
           }
           throw ex
       } finally {
-        manager.cancel(version.processName, DeploymentData.systemUser).futureValue
+        manager.processCommand(CancelScenarioCommand(version.processName, DeploymentData.systemUser)).futureValue
         eventually {
           manager.getProcessStates(version.processName).futureValue shouldBe List.empty
         }

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/deployment/CustomActionDefinition.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/deployment/CustomActionDefinition.scala
@@ -29,11 +29,4 @@ case class CustomActionDefinition(
 //TODO: validators, defaultValue, hint, labelOpt?
 case class CustomActionParameter(name: String, editor: ParameterEditor)
 
-case class CustomActionRequest(
-    name: ScenarioActionName,
-    processVersion: ProcessVersion,
-    user: User,
-    params: Map[String, String]
-)
-
 case class CustomActionResult(msg: String)


### PR DESCRIPTION
## Describe your changes
DeploymentManager's "action" methods - (methods operating on a scenario or its deployment) were replaced by case classes and one method handling them all: `processCommand(command)`:
* `validate` - `ValidateScenarioCommand`
* `deploy` - `RunDeploymentCommand`
* `cancel` with `deploymentId` argument - `CancelDeploymentCommand`
* `cancel` without `deploymentId` argument - `CancelScenarioCommand`
* `stop` with `deploymentId` argument - `StopDeploymentCommand`
* `stop` without `deploymentId` argument - `StopScenarioCommand`
* `savepoint` - `MakeScenarioSavepointCommand`
* `test` - `TestScenarioCommand`

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
