### PR TITLE
Add fixed values parameter editor for timestampField in kafka source

### DIFF
--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/DelayedUniversalKafkaSourceAvroPayloadIntegrationSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/DelayedUniversalKafkaSourceAvroPayloadIntegrationSpec.scala
@@ -1,12 +1,68 @@
 package pl.touk.nussknacker.engine.schemedkafka.source.flink
 
+import org.apache.avro.Schema
+import org.scalatest.LoneElement
+import pl.touk.nussknacker.engine.api.context.ValidationContext
+import pl.touk.nussknacker.engine.api.definition.{
+  DualParameterEditor,
+  FixedExpressionValue,
+  FixedValuesParameterEditor,
+  StringParameterEditor
+}
+import pl.touk.nussknacker.engine.api.editor.DualEditorMode
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.compile.FragmentResolver
+import pl.touk.nussknacker.engine.compile.nodecompilation.{NodeDataValidator, ValidationPerformed}
 import pl.touk.nussknacker.engine.kafka.source.InputMeta
 import pl.touk.nussknacker.engine.process.helpers.TestResultsHolder
 import pl.touk.nussknacker.engine.schemedkafka.schema._
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.ExistingSchemaVersion
 
-class DelayedUniversalKafkaSourceAvroPayloadIntegrationSpec extends DelayedUniversalKafkaSourceIntegrationMixinSpec {
+class DelayedUniversalKafkaSourceAvroPayloadIntegrationSpec
+    extends DelayedUniversalKafkaSourceIntegrationMixinSpec
+    with LoneElement {
+
+  test("timestampField editor should be set to simple if schema does not contain eligible fields") {
+    val timestampFieldParameter =
+      prepareTestForTimestampField("simple-topic-without-timestamp-fields", FullNameV1.schema)
+
+    timestampFieldParameter.editor shouldBe Some(DualParameterEditor(StringParameterEditor, DualEditorMode.RAW))
+  }
+
+  test("timestampField editor should contain long field") {
+    val timestampFieldParameter =
+      prepareTestForTimestampField("simple-topic-with-single-timestamp-fields", LongFieldV1.schema)
+
+    timestampFieldParameter.editor shouldBe Some(
+      DualParameterEditor(
+        FixedValuesParameterEditor(
+          List(
+            FixedExpressionValue("", ""),
+            FixedExpressionValue("'field'", "field")
+          )
+        ),
+        DualEditorMode.SIMPLE
+      )
+    )
+  }
+
+  test("timestampField editor should contain all eligible fields") {
+    val timestampFieldParameter =
+      prepareTestForTimestampField("simple-topic-with-multiple-timestamp-fields", PaymentDate.schema)
+
+    timestampFieldParameter.editor shouldBe Some(
+      DualParameterEditor(
+        FixedValuesParameterEditor(
+          List(
+            FixedExpressionValue("", ""),
+            FixedExpressionValue("'dateTime'", "dateTime"),
+            FixedExpressionValue("'vat'", "vat")
+          )
+        ),
+        DualEditorMode.SIMPLE
+      )
+    )
+  }
 
   test("properly process data using kafka-generic-delayed source") {
     val topicConfig = createAndRegisterTopicConfig("simple-topic-with-long-field", LongFieldV1.schema)
@@ -48,6 +104,14 @@ class DelayedUniversalKafkaSourceAvroPayloadIntegrationSpec extends DelayedUnive
     runAndVerify(topicConfig, process, IntFieldV1.record)
   }
 
+  test("raise an error when timestamp field set to string field") {
+    val topicConfig = createAndRegisterTopicConfig("simple-topic-with-Fullname-schema", FullNameV1.schema)
+    val process     = createProcessWithDelayedSource(topicConfig.input, ExistingSchemaVersion(1), "'first'", "123L")
+    intercept[IllegalArgumentException] {
+      runAndVerify(topicConfig, process, FullNameV1.record)
+    }.getMessage should include("'first' has invalid type: String.")
+  }
+
   test("handle timestamp field in TimestampMillis format") {
     val topicConfig =
       createAndRegisterTopicConfig("simple-topic-with-timestamp-millis-field", TimestampMillisFieldV1.schema)
@@ -84,6 +148,22 @@ class DelayedUniversalKafkaSourceAvroPayloadIntegrationSpec extends DelayedUnive
     }.getMessage should include(
       "LowerThanRequiredParameter(This field value has to be a number greater than or equal to 0,Please fill field with proper number,delayInMillis,start)"
     )
+  }
+
+  private def prepareTestForTimestampField(topicName: String, schema: Schema) = {
+    val topicConfig   = createAndRegisterTopicConfig(topicName, schema)
+    val process       = createProcessWithDelayedSource(topicConfig.input, ExistingSchemaVersion(1), "'field'", "1L")
+    val nodeValidator = new NodeDataValidator(modelData)
+
+    val result = nodeValidator.validate(
+      process.nodes.head.data,
+      ValidationContext(),
+      Map.empty,
+      List.empty,
+      FragmentResolver(_ => None)
+    )(process.metaData)
+
+    result.asInstanceOf[ValidationPerformed].parameters.getOrElse(Nil).filter(_.name == "timestampField").loneElement
   }
 
   private def runAndVerify(topicConfig: TopicConfig, process: CanonicalProcess, givenObj: AnyRef): Unit = {

--- a/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/delayed/DelayedKafkaSourceFactory.scala
+++ b/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/delayed/DelayedKafkaSourceFactory.scala
@@ -19,12 +19,33 @@ object DelayedKafkaSourceFactory {
 
   final val TimestampFieldParamName = "timestampField"
 
-  // TODO: consider changing to lazy parameter and add the same parameter also in "not delayed" kafka sources
-  final val TimestampFieldParameter = Parameter
+  final val fallbackTimestampFieldParameter = Parameter
     .optional(TimestampFieldParamName, Typed[String])
     .copy(
       editor = Some(DualParameterEditor(simpleEditor = StringParameterEditor, defaultMode = DualEditorMode.RAW))
     )
+
+  // TODO this is simple way to provide better UX for timestampField usage. But probably instead of taking this further
+  // one should try to allow using spel expression here. As it requires some changes in SourceFunction for Kafka, it must wait
+  // until sources will be migrated to non-deprecated Source APi.
+  def timestampFieldParameter(kafkaRecordValueType: Option[TypingResult]): Parameter = {
+    val editorOpt = kafkaRecordValueType
+      .collect { case TypedObjectTypingResult(fields, _, _) => fields.toList }
+      .map(_.collect {
+        case (paramName, typing) if TimestampUtils.supportedTimestampTypes.contains(typing) =>
+          FixedExpressionValue(s"'${paramName}'", paramName)
+      })
+      .filter(_.nonEmpty)
+      .map(_.sortBy(_.label))
+      .map(FixedExpressionValue("", "") :: _)
+      .map(FixedValuesParameterEditor(_))
+      .map(DualParameterEditor(_, DualEditorMode.SIMPLE))
+      .orElse(Some(DualParameterEditor(simpleEditor = StringParameterEditor, defaultMode = DualEditorMode.RAW)))
+
+    Parameter
+      .optional(TimestampFieldParamName, Typed[String])
+      .copy(editor = editorOpt)
+  }
 
   def extractTimestampField(params: Params): String = params.extract[String](TimestampFieldParamName).getOrElse("")
 

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaUniversalComponentTransformer.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaUniversalComponentTransformer.scala
@@ -151,18 +151,18 @@ trait KafkaUniversalComponentTransformer[T]
       NextParameters(parameters = topicParam.value, errors = topicParam.written)
   }
 
-  protected def schemaParamStep(implicit nodeId: NodeId): ContextTransformationDefinition = {
+  protected def schemaParamStep(nextParams: List[Parameter])(implicit nodeId: NodeId): ContextTransformationDefinition = {
     case TransformationStep((topicParamName, DefinedEagerParameter(topic: String, _)) :: Nil, _) =>
       val preparedTopic = prepareTopic(topic)
       val versionParam  = getVersionParam(preparedTopic)
       val topicValidationErrors =
         validateTopic(preparedTopic.prepared).swap.toList.map(_.toCustomNodeError(nodeId.id, Some(topicParamName)))
       NextParameters(
-        versionParam.value :: paramsDeterminedAfterSchema,
+        versionParam.value :: nextParams,
         errors = versionParam.written ++ topicValidationErrors
       )
     case TransformationStep((topicParamName, _) :: Nil, _) =>
-      NextParameters(parameters = fallbackVersionOptionParam :: paramsDeterminedAfterSchema)
+      NextParameters(parameters = fallbackVersionOptionParam :: nextParams)
   }
 
   def paramsDeterminedAfterSchema: List[Parameter]

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkFactory.scala
@@ -196,7 +196,7 @@ class UniversalKafkaSinkFactory(
       implicit nodeId: NodeId
   ): ContextTransformationDefinition =
     topicParamStep orElse
-      schemaParamStep orElse
+      schemaParamStep(paramsDeterminedAfterSchema) orElse
       rawEditorParameterStep(context) orElse
       valueEditorParamStep(context)
 

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/delayed/DelayedUniversalKafkaSourceFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/delayed/DelayedUniversalKafkaSourceFactory.scala
@@ -1,6 +1,5 @@
 package pl.touk.nussknacker.engine.schemedkafka.source.delayed
 
-import cats.data.Validated.{Invalid, Valid}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.context.transformation.{DefinedEagerParameter, NodeDependencyValue}
@@ -11,8 +10,7 @@ import pl.touk.nussknacker.engine.kafka.source.delayed.DelayedKafkaSourceFactory
 import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransformer.SchemaVersionParamName
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{SchemaBasedSerdeProvider, SchemaRegistryClientFactory}
 import pl.touk.nussknacker.engine.schemedkafka.source.UniversalKafkaSourceFactory
-
-import scala.reflect.ClassTag
+import pl.touk.nussknacker.engine.schemedkafka.source.UniversalKafkaSourceFactory.PrecalculatedValueSchemaUniversalKafkaSourceFactoryState
 
 class DelayedUniversalKafkaSourceFactory(
     schemaRegistryClientFactory: SchemaRegistryClientFactory,
@@ -27,18 +25,49 @@ class DelayedUniversalKafkaSourceFactory(
     ) {
 
   override def paramsDeterminedAfterSchema: List[Parameter] = super.paramsDeterminedAfterSchema ++ List(
-    TimestampFieldParameter,
     DelayParameter
   )
 
-  override protected def nextSteps(context: ValidationContext, dependencies: List[NodeDependencyValue])(
+  override def contextTransformation(context: ValidationContext, dependencies: List[NodeDependencyValue])(
+      implicit nodeId: NodeId
+  ): ContextTransformationDefinition =
+    topicParamStep orElse
+      schemaParamStep(Nil) orElse
+      timestampFieldParamStep orElse
+      validateTimestampFieldStep orElse
+      nextSteps(context, dependencies)
+
+  protected def validateTimestampFieldStep(
       implicit nodeId: NodeId
   ): ContextTransformationDefinition = {
-    case step @ TransformationStep(
+    case TransformationStep(
           (`topicParamName`, DefinedEagerParameter(topic: String, _)) ::
           (SchemaVersionParamName, DefinedEagerParameter(version: String, _)) ::
-          (TimestampFieldParamName, DefinedEagerParameter(field, _)) ::
-          (DelayParameterName, DefinedEagerParameter(delay, _)) :: Nil,
+          (TimestampFieldParamName, DefinedEagerParameter(field, _)) :: Nil,
+          state @ Some(PrecalculatedValueSchemaUniversalKafkaSourceFactoryState(valueValidationResult))
+        ) =>
+      val timestampValidation = valueValidationResult.toOption
+        .map(_._2)
+        .flatMap(typingResult => Option(field.asInstanceOf[String]).map(f => validateTimestampField(f, typingResult)))
+        .getOrElse(Nil)
+
+      NextParameters(
+        paramsDeterminedAfterSchema,
+        state = state,
+        errors = timestampValidation
+      )
+
+    case TransformationStep(
+          (`topicParamName`, _) :: (SchemaVersionParamName, _) :: (TimestampFieldParamName, _) :: Nil,
+          _
+        ) =>
+      NextParameters(parameters = fallbackTimestampFieldParameter :: paramsDeterminedAfterSchema)
+  }
+
+  protected def timestampFieldParamStep(implicit nodeId: NodeId): ContextTransformationDefinition = {
+    case TransformationStep(
+          (`topicParamName`, DefinedEagerParameter(topic: String, _)) ::
+          (SchemaVersionParamName, DefinedEagerParameter(version: String, _)) :: Nil,
           _
         ) =>
       val preparedTopic = prepareTopic(topic)
@@ -48,29 +77,12 @@ class DelayedUniversalKafkaSourceFactory(
         Some(SchemaVersionParamName)
       )
 
-      valueValidationResult match {
-        case Valid((valueRuntimeSchema, typingResult)) =>
-          val timestampValidationErrors =
-            Option(field.asInstanceOf[String]).map(f => validateTimestampField(f, typingResult)).getOrElse(Nil)
-          prepareSourceFinalResults(
-            preparedTopic,
-            valueValidationResult,
-            context,
-            dependencies,
-            step.parameters,
-            timestampValidationErrors
-          )
-        case Invalid(exc) =>
-          prepareSourceFinalErrors(context, dependencies, step.parameters, List(exc))
-      }
-    case step @ TransformationStep(
-          (`topicParamName`, _) :: (SchemaVersionParamName, _) :: (TimestampFieldParamName, _) :: (
-            DelayParameterName,
-            _
-          ) :: Nil,
-          _
-        ) =>
-      prepareSourceFinalErrors(context, dependencies, step.parameters, errors = Nil)
+      NextParameters(
+        timestampFieldParameter(valueValidationResult.map(_._2).toOption) :: Nil,
+        state = Some(PrecalculatedValueSchemaUniversalKafkaSourceFactoryState(valueValidationResult))
+      )
+    case TransformationStep((topicParamName, _) :: (schemaVersionParamName, _) :: Nil, _) =>
+      NextParameters(parameters = fallbackTimestampFieldParameter :: paramsDeterminedAfterSchema)
   }
 
 }


### PR DESCRIPTION
…(#5534)

* Adds fixedValuesEditor for timestampField in kafkaSource

* sorts values in editor

* changes after CR:
- empty value in FixedValuesParameterEditor
- storing schemaValidationResults in GenericNodeTransformation.State
- some tests if ParameterEditor sets correctly

* changes after CR:
- rename and new TODOs

* removing some code duplication from DelayedUniversalKafkaSourceFactory

* fixed missed during rebase

---------

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
