### PR TITLE
[5615] Fix for eventhub naming convention with Azure Schema Registry

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -350,6 +350,8 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_EVENT_HUBS_SHARED_ACCESS_KEY_NAME: ${{ secrets.AZURE_EVENT_HUBS_SHARED_ACCESS_KEY_NAME }}
+          AZURE_EVENT_HUBS_SHARED_ACCESS_KEY: ${{ secrets.AZURE_EVENT_HUBS_SHARED_ACCESS_KEY }}
         shell: bash
 #        run: ./ciRunSbt.sh designer/Slow/test liteK8sDeploymentManager/ExternalDepsTests/test schemedKafkaComponentsUtils/ExternalDepsTests/test liteKafkaComponentsTests/ExternalDepsTests/test
         run: ./ciRunSbt.sh designer/Slow/test schemedKafkaComponentsUtils/ExternalDepsTests/test liteKafkaComponentsTests/ExternalDepsTests/test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,7 +209,10 @@ For other clusters you can select other image tag using `dockerTagName` system e
 Azure integration tests are not run by default using `sbt test`. You need to run tests in `ExternalDepsTests` scope e.g. `sbt schemedKafkaComponentsUtils/ExternalDepsTests/test`.
 To run them you should have configured one of authentication options described here:
 https://github.com/Azure/azure-sdk-for-java/wiki/Azure-Identity-Examples#authenticating-with-defaultazurecredential e.g. Intellij plugin, Azure CLI or environment variables.
-Tests connect to schema registry registered in Event Hubs Namespace from AZURE_EVENT_HUBS_NAMESPACE environment variable (by default nu-cloud).
+To run the tests set up environment variables:
+- AZURE_EVENT_HUBS_NAMESPACE, that is Event Hubs Namespace where schema registry is registered (by default nu-cloud).
+- AZURE_EVENT_HUBS_SHARED_ACCESS_KEY_NAME and AZURE_EVENT_HUBS_SHARED_ACCESS_KEY, to configure Kafka admin client that uses "sasl.jaas.config" to authenticate
+(see properties configuration in https://nussknacker.io/documentation/cloud/azure/#setting-up-nussknacker-cloud)
 
 ### Using logs in tests
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -48,6 +48,7 @@
   [#5515](https://github.com/TouK/nussknacker/pull/5515) [#5474](https://github.com/TouK/nussknacker/pull/5474) Processing mode and engine available in the GUI
 * [#5566](https://github.com/TouK/nussknacker/pull/5566) `DEFAULT_SCENARIO_TYPE` environment variable is not supported anymore 
 * [#5272](https://github.com/TouK/nussknacker/pull/5272) [#5145](https://github.com/TouK/nussknacker/pull/5145) Added: Decision Table component
+* [#5657](https://github.com/TouK/nussknacker/pull/5657) Improved heuristic for eventhub to Azure's schema name mapping.
 
 1.13.1 (Not released yet)
 ------------------------

--- a/docs/integration/KafkaIntegration.md
+++ b/docs/integration/KafkaIntegration.md
@@ -39,7 +39,7 @@ To properly present information about topics and version and to recognize which 
   It means that it looks for schemas available at `<topic-name>-(key or value)` *subject*. For example for topic `transactions`, it looks for schemas at `transactions-key` *subject* for key and `transactions-value` *subject* for value
 - In the Azure Schema Registry, *subject* concept doesn't exist - schemas are grouped by the same *schema name*. Because of that, Nussknacker introduces
   own convention for association between schema and topic: *schema name* should be in format: `CamelCasedTopicNameKey` for keys and `CamelCasedTopicNameValue` for values.
-  For example for `input-events` topic, schema name should be named `InputEventsKey` for key or `InputEventsValue` for value. Be aware that it may require change of schema name
+  For example for `input-events` (or `input.events`) topic, schema name should be named `InputEventsKey` for key or `InputEventsValue` for value. Be aware that it may require change of schema name
   not only in Azure portal but also inside schema content - those names should be the same to make serialization works correctly
 
 ## Connection and Authentication Configuration

--- a/docs/integration/KafkaIntegration.md
+++ b/docs/integration/KafkaIntegration.md
@@ -111,6 +111,8 @@ Regarding authentication, a couple of options can be used - you can provide cred
 by Azure's [DefaultAzureCredential](https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme?view=azure-java-stable#defaultazurecredential).
 For example via Azure CLI or Azure PowerShell.
 
+Integration with Azure Schema Registry requires Kafka connection, make sure you have provided proper [configuration](#kafka---authentication).
+
 ## Messaging
 
 You can use standard kafka-cli commands like `kafka-console-consumer`, `kafka-console-producer`, [kcat](https://github.com/edenhill/kcat), Confluent's

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/AzureSchemaRegistryClientFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/AzureSchemaRegistryClientFactory.scala
@@ -126,7 +126,7 @@ class AzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) extends
       admin.listTopics().names().get().asScala.toList
     }
     val matchStrategy = SchemaNameTopicMatchStrategy(topics)
-    getAllFullSchemaNames.map(matchStrategy.matchAllTopics(_, isKey = false))
+    getAllFullSchemaNames.map(matchStrategy.getAllMatchingTopics(_, isKey = false))
   }
 
   override def getAllVersions(topicName: String, isKey: Boolean): Validated[SchemaRegistryError, List[Integer]] = {
@@ -135,8 +135,7 @@ class AzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) extends
 
   private def getOneMatchingSchemaName(topicName: String, isKey: Boolean): Validated[SchemaRegistryError, String] = {
     getAllFullSchemaNames.andThen { fullSchemaNames =>
-      val matchStrategy           = SchemaNameTopicMatchStrategy(List(topicName))
-      val matchingFullSchemaNames = matchStrategy.matchAllSchemas(fullSchemaNames, isKey)
+      val matchingFullSchemaNames = SchemaNameTopicMatchStrategy.getMatchingSchemas(topicName, fullSchemaNames, isKey)
       matchingFullSchemaNames match {
         case one :: Nil =>
           Valid(one)

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/SchemaNameTopicMatchStrategy.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/SchemaNameTopicMatchStrategy.scala
@@ -1,19 +1,46 @@
 package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure
 
-import com.google.common.base.CaseFormat
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.SchemaNameTopicMatchStrategy.{
+  FullSchemaNameDecomposed,
+  sanitize
+}
 
 // TODO: It probable should be configurable: e.g would be nice to have possibility to define static topic -> schemaName map in config
-//       Thanks to that would be possible to use existing schemas that not follow our convention in Nussknacker.
+//       Thanks to that it would be possible to use existing schemas that not follow our convention in Nussknacker.
 //       Also in case of ambiguity (>1 schemas with only different namespaces), we could pick the correct one schema.
+// TODO: Return validated matches: reject duplicate matches, e.g. schema FooBarValue matches topics foo-bar and foo.baz
+class SchemaNameTopicMatchStrategy(referenceTopicList: List[String]) {
+
+  /**
+    * List all reference topics matching schema names.
+    */
+  def matchAllTopics(fullSchemaNames: List[String], isKey: Boolean): List[String] = {
+    fullSchemaNames.collect { case _ @FullSchemaNameDecomposed(coreName, _, `isKey`) =>
+      referenceTopicList.collectFirst { case topicName if sanitize(topicName) == coreName => topicName }
+    }.flatten
+  }
+
+  /**
+    * List all schemas matching reference topics.
+    */
+  def matchAllSchemas(fullSchemaNames: List[String], isKey: Boolean): List[String] = {
+    fullSchemaNames.collect {
+      case fullSchemaName @ FullSchemaNameDecomposed(coreName, _, `isKey`)
+          if referenceTopicList.map(sanitize).contains(coreName) =>
+        fullSchemaName
+    }
+  }
+
+}
+
 object SchemaNameTopicMatchStrategy {
 
   val KeySuffix   = "Key"
   val ValueSuffix = "Value"
-  def topicNameFromKeySchemaName(schemaName: String): Option[String] =
-    FullSchemaNameDecomposed.unapply(schemaName).filter(_._3).map(_._1)
 
-  def topicNameFromValueSchemaName(schemaName: String): Option[String] =
-    FullSchemaNameDecomposed.unapply(schemaName).filterNot(_._3).map(_._1)
+  def apply(referenceTopicList: List[String] = Nil): SchemaNameTopicMatchStrategy = new SchemaNameTopicMatchStrategy(
+    referenceTopicList
+  )
 
   def keySchemaNameFromTopicName(topicName: String): String = schemaNameFromTopicName(topicName, isKey = true)
 
@@ -21,40 +48,42 @@ object SchemaNameTopicMatchStrategy {
 
   def schemaNameFromTopicName(topicName: String, isKey: Boolean): String = {
     val suffix = if (isKey) KeySuffix else ValueSuffix
-    CaseFormat.LOWER_HYPHEN.to(CaseFormat.UPPER_CAMEL, topicName) + suffix
+    sanitize(topicName) + suffix
   }
+
+  def sanitize(name: String): String = name.replaceAll("\\W", " ").toLowerCase.split(" ").map(_.capitalize).mkString("")
 
   object FullSchemaNameDecomposed {
 
-    private val fullyQualifiedRegex = "^(.*)\\.[^.]*$".r
+    private def fullSchemaNamePattern(suffix: String) = ("^(.*\\.)?([^.]*)" + suffix + "$").r
+    private val namespaceAndNameKey                   = fullSchemaNamePattern(KeySuffix)
+    private val namespaceAndNameValue                 = fullSchemaNamePattern(ValueSuffix)
 
-    // Decompose schema (full) name to: topicName, namespace and isKey
-    def unapply(schemaFullName: String): Option[(String, Option[String], Boolean)] = {
-      // Only schemas ends with Key or Value will be recognized - we assume that other schemas are for other purpose
-      // and won't appear on any Nussknacker lists.
-      if (schemaFullName.endsWith(KeySuffix)) {
-        val (topicName, namespace) = extractTopicNameAndNamespace(schemaFullName, KeySuffix)
-        Some(topicName, namespace, true)
-      } else if (schemaFullName.endsWith(ValueSuffix)) {
-        val (topicName, namespace) = extractTopicNameAndNamespace(schemaFullName, ValueSuffix)
-        Some(topicName, namespace, false)
-      } else {
-        None
+    /**
+      * Decompose schema (full) name to: topicName, namespace (optional) and isKey.
+      *
+      * Only schemas ends with Key or Value will be recognized - we assume that other schemas are for other purpose
+      * and won't appear on any Nussknacker lists.
+      * We remove namespace from topic name because we don't want to force ppl to create technically looking event hub names
+      * Also event hubs already has dedicated namespaces.
+      * Topics (event hubs) can have capital letters but generally it is a good rule to not use them in topic names to avoid
+      * mistakes in interpretation shortcuts and so on - similar like with sql tables.
+      *
+      * For example: full schema name "some.optional.namespace.CoreSchemaNameValue" is decomposed into
+      * <ul>
+      * <li>name = CoreSchemaName</li>
+      * <li>namespace = some.optional.namespace</li>
+      * <li>"isKey" flag = true</li>
+      * </ul>
+      */
+    def unapply(fullSchemaName: String): Option[(String, Option[String], Boolean)] = {
+      fullSchemaName match {
+        case namespaceAndNameKey(null, core)        => Some((core, None, true))
+        case namespaceAndNameKey(namespace, core)   => Some((core, Some(namespace.replaceAll("\\.$", "")), true))
+        case namespaceAndNameValue(null, core)      => Some((core, None, false))
+        case namespaceAndNameValue(namespace, core) => Some((core, Some(namespace.replaceAll("\\.$", "")), false))
+        case _                                      => None
       }
-    }
-
-    private def extractTopicNameAndNamespace(schemaFullName: String, suffix: String): (String, Option[String]) = {
-      val schemaFullNameWithoutSuffix = schemaFullName.replaceFirst(suffix + "$", "")
-      // We remove namespace from topic name because we don't want to force ppl to create technically looking event hub names
-      // Also event hubs already has dedicated namespaces
-      val cleanedSchemaName = schemaFullNameWithoutSuffix.replaceFirst("^.*\\.", "")
-      // Topics (event hubs) can have capital letters but generally it is a good rule to not use them in topic names to avoid
-      // mistakes in interpretation shortcuts and so on - similar like with sql tables
-      val topicName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, cleanedSchemaName)
-      val namespace = fullyQualifiedRegex.findFirstMatchIn(schemaFullNameWithoutSuffix).map { m =>
-        m.group(1)
-      }
-      (topicName, namespace)
     }
 
   }

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/AzureSchemaRegistryClientIntegrationTest.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/AzureSchemaRegistryClientIntegrationTest.scala
@@ -53,7 +53,8 @@ class AzureSchemaRegistryClientIntegrationTest
 
     val value  = new NuCloudIntegrationTestValue
     val schema = createReflectSchema(value)
-    SchemaNameTopicMatchStrategy(List(givenTopic)).matchAllTopics(List(schema.name()), isKey = false) shouldEqual List(
+    SchemaNameTopicMatchStrategy(List(givenTopic))
+      .getAllMatchingTopics(List(schema.name()), isKey = false) shouldEqual List(
       givenTopic
     )
     schemaRegistryClient.registerSchemaVersionIfNotExists(schema)

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/AzureSchemaRegistryClientIntegrationTest.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/AzureSchemaRegistryClientIntegrationTest.scala
@@ -38,7 +38,7 @@ class AzureSchemaRegistryClientIntegrationTest
       "bootstrap.servers" -> s"$eventHubsNamespace.servicebus.windows.net:9093",
       "security.protocol" -> "SASL_SSL",
       "sasl.mechanism"    -> "PLAIN",
-      "sasl.jaas.config" -> s"org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$$ConnectionString\" password=\"Endpoint=sb://$eventHubsNamespace.servicebus.windows.net/;SharedAccessKeyName=$eventHubsSharedAccessKeyName;SharedAccessKey=$eventHubsSharedAccessKey\";",
+      "sasl.jaas.config" -> s"""org.apache.kafka.common.security.plain.PlainLoginModule required username="$$ConnectionString" password="Endpoint=sb://$eventHubsNamespace.servicebus.windows.net/;SharedAccessKeyName=$eventHubsSharedAccessKeyName;SharedAccessKey=$eventHubsSharedAccessKey";""",
       "schema.registry.url" -> s"https://$eventHubsNamespace.servicebus.windows.net",
       "schema.group"        -> "test-group",
     )

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/SchemaNameTopicMatchStrategyTest.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/SchemaNameTopicMatchStrategyTest.scala
@@ -7,27 +7,63 @@ import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.SchemaNameTo
 
 class SchemaNameTopicMatchStrategyTest extends AnyFunSuite with Matchers with OptionValues {
 
-  test("schema name extraction") {
-    FullSchemaNameDecomposed.unapply("some.namespace.FooBarKey").value shouldEqual ("foo-bar", Some(
+  test("should decompose full schema name") {
+    FullSchemaNameDecomposed.unapply("some.namespace.FooBarKey").value shouldEqual ("FooBar", Some(
       "some.namespace"
     ), true)
-    FullSchemaNameDecomposed.unapply("some.namespace.FooBarValue").value shouldEqual ("foo-bar", Some(
+    FullSchemaNameDecomposed.unapply("some.namespace.FooBarValue").value shouldEqual ("FooBar", Some(
       "some.namespace"
     ), false)
     FullSchemaNameDecomposed.unapply("some.namespace.FooBar") should be(empty)
-    FullSchemaNameDecomposed.unapply("FooBarKey").value shouldEqual ("foo-bar", None, true)
-
-    SchemaNameTopicMatchStrategy.topicNameFromKeySchemaName("some.namespace.FooBarKey").value shouldEqual "foo-bar"
-    SchemaNameTopicMatchStrategy.topicNameFromValueSchemaName("some.namespace.FooBarKey") should be(empty)
-    SchemaNameTopicMatchStrategy.topicNameFromKeySchemaName("some.namespace.FooBarValue") should be(empty)
-    SchemaNameTopicMatchStrategy.topicNameFromValueSchemaName("some.namespace.FooBarValue").value shouldEqual "foo-bar"
+    FullSchemaNameDecomposed.unapply("FooBarKey").value shouldEqual ("FooBar", None, true)
+    FullSchemaNameDecomposed.unapply("FooBar") should be(empty)
   }
 
-  test("topic to schema name conversion") {
+  test("should convert topic to schema name") {
     SchemaNameTopicMatchStrategy.keySchemaNameFromTopicName("foo") shouldEqual "FooKey"
     SchemaNameTopicMatchStrategy.keySchemaNameFromTopicName("foo-bar") shouldEqual "FooBarKey"
+    SchemaNameTopicMatchStrategy.keySchemaNameFromTopicName("foo.bar") shouldEqual "FooBarKey"
     SchemaNameTopicMatchStrategy.valueSchemaNameFromTopicName("foo") shouldEqual "FooValue"
     SchemaNameTopicMatchStrategy.valueSchemaNameFromTopicName("foo-bar") shouldEqual "FooBarValue"
+    SchemaNameTopicMatchStrategy.valueSchemaNameFromTopicName("foo.bar") shouldEqual "FooBarValue"
+  }
+
+  test("should list topics matching schemas") {
+    val referenceTopics = List(
+      "foo.bar",
+      "foo-baz",
+      "without.schema"
+    )
+    val schemasToMatch = List(
+      "some.namespace.FooBarKey",
+      "some.namespace.FooBarValue",
+      "some.namespace.FooBazValue",
+      "some.namespace.WithoutTopicValue"
+    )
+    val matchStrategy = SchemaNameTopicMatchStrategy(referenceTopics)
+    matchStrategy.matchAllTopics(schemasToMatch, isKey = false) shouldEqual List(
+      "foo.bar",
+      "foo-baz"
+    )
+  }
+
+  test("should list schemas matching reference topics") {
+    val referenceTopics = List(
+      "foo.bar",
+      "foo-baz",
+      "without.schema"
+    )
+    val schemasToMatch = List(
+      "some.namespace.FooBarKey",
+      "some.namespace.FooBarValue",
+      "some.namespace.FooBazValue",
+      "some.namespace.WithoutTopicValue"
+    )
+    val matchStrategy = SchemaNameTopicMatchStrategy(referenceTopics)
+    matchStrategy.matchAllSchemas(schemasToMatch, isKey = false) shouldEqual List(
+      "some.namespace.FooBarValue",
+      "some.namespace.FooBazValue"
+    )
   }
 
 }

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/SchemaNameTopicMatchStrategyTest.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/SchemaNameTopicMatchStrategyTest.scala
@@ -8,21 +8,14 @@ import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.SchemaNameTo
 class SchemaNameTopicMatchStrategyTest extends AnyFunSuite with Matchers with OptionValues {
 
   test("should decompose full schema name") {
-    FullSchemaNameDecomposed.unapply("some.namespace.FooBarKey").value shouldEqual ("FooBar", Some(
-      "some.namespace"
-    ), true)
-    FullSchemaNameDecomposed.unapply("some.namespace.FooBarValue").value shouldEqual ("FooBar", Some(
-      "some.namespace"
-    ), false)
+    FullSchemaNameDecomposed.unapply("some.namespace.FooBarKey").value shouldEqual ("FooBar", true)
+    FullSchemaNameDecomposed.unapply("some.namespace.FooBarValue").value shouldEqual ("FooBar", false)
     FullSchemaNameDecomposed.unapply("some.namespace.FooBar") should be(empty)
-    FullSchemaNameDecomposed.unapply("FooBarKey").value shouldEqual ("FooBar", None, true)
+    FullSchemaNameDecomposed.unapply("FooBarKey").value shouldEqual ("FooBar", true)
     FullSchemaNameDecomposed.unapply("FooBar") should be(empty)
   }
 
   test("should convert topic to schema name") {
-    SchemaNameTopicMatchStrategy.keySchemaNameFromTopicName("foo") shouldEqual "FooKey"
-    SchemaNameTopicMatchStrategy.keySchemaNameFromTopicName("foo-bar") shouldEqual "FooBarKey"
-    SchemaNameTopicMatchStrategy.keySchemaNameFromTopicName("foo.bar") shouldEqual "FooBarKey"
     SchemaNameTopicMatchStrategy.valueSchemaNameFromTopicName("foo") shouldEqual "FooValue"
     SchemaNameTopicMatchStrategy.valueSchemaNameFromTopicName("foo-bar") shouldEqual "FooBarValue"
     SchemaNameTopicMatchStrategy.valueSchemaNameFromTopicName("foo.bar") shouldEqual "FooBarValue"
@@ -41,29 +34,27 @@ class SchemaNameTopicMatchStrategyTest extends AnyFunSuite with Matchers with Op
       "some.namespace.WithoutTopicValue"
     )
     val matchStrategy = SchemaNameTopicMatchStrategy(referenceTopics)
-    matchStrategy.matchAllTopics(schemasToMatch, isKey = false) shouldEqual List(
+    matchStrategy.getAllMatchingTopics(schemasToMatch, isKey = false) shouldEqual List(
       "foo.bar",
       "foo-baz"
     )
   }
 
   test("should list schemas matching reference topics") {
-    val referenceTopics = List(
-      "foo.bar",
-      "foo-baz",
-      "without.schema"
-    )
     val schemasToMatch = List(
       "some.namespace.FooBarKey",
       "some.namespace.FooBarValue",
       "some.namespace.FooBazValue",
       "some.namespace.WithoutTopicValue"
     )
-    val matchStrategy = SchemaNameTopicMatchStrategy(referenceTopics)
-    matchStrategy.matchAllSchemas(schemasToMatch, isKey = false) shouldEqual List(
-      "some.namespace.FooBarValue",
-      "some.namespace.FooBazValue"
+
+    SchemaNameTopicMatchStrategy.getMatchingSchemas("foo.bar", schemasToMatch, isKey = false) shouldEqual List(
+      "some.namespace.FooBarValue"
     )
+    SchemaNameTopicMatchStrategy.getMatchingSchemas("foo-bar", schemasToMatch, isKey = false) shouldEqual List(
+      "some.namespace.FooBarValue"
+    )
+    SchemaNameTopicMatchStrategy.getMatchingSchemas("without.schema", schemasToMatch, isKey = false) shouldEqual Nil
   }
 
 }


### PR DESCRIPTION
## Describe your changes
`SchemaNameTopicMatchStrategy` uses reference topic (or eventhub) list to match topic (or eventhub) name with schema name. It is still an estimation/guess but it doesn't rely on strict topic name convention and allows to loosen topic naming restrictions (see https://nussknacker.io/documentation/docs/integration/KafkaIntegration/#association-between-schema-with-topic).
Reference topic list is fetched in `AzureSchemaRegistryClient` by kafka admin client, therefore both schema registry and kafka client properties must be provided (see https://nussknacker.io/documentation/cloud/azure/#setting-up-nussknacker-cloud).

Schema `FooBarValue` is used to describe data in topics (eventhubs):
- foo.bar
- foo-bar

Documentation to update:
https://nussknacker.io/documentation/docs/integration/KafkaIntegration/#association-between-schema-with-topic

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [x] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [x] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
