### PR TITLE
Modify TestValue textArea height calculation

### DIFF
--- a/designer/client/src/components/graph/node-modal/NodeDetailsContent/NodeTableStyled.tsx
+++ b/designer/client/src/components/graph/node-modal/NodeDetailsContent/NodeTableStyled.tsx
@@ -1,7 +1,7 @@
 import { css, styled } from "@mui/material";
 import { customCheckbox } from "./CustomCheckbox";
 
-export const HiddenTextareaPixelHeight = 100;
+export const HIDDEN_TEXTAREA_PIXEL_HEIGHT = 100;
 export const NodeTableStyled = styled("div")(
     ({ theme }) => css`
         font-size: 11px;
@@ -50,7 +50,7 @@ export const NodeTableStyled = styled("div")(
             }
             &.partly-hidden {
                 textarea {
-                    height: ${HiddenTextareaPixelHeight}px !important;
+                    height: ${HIDDEN_TEXTAREA_PIXEL_HEIGHT}px !important;
                 }
             }
             &.node-value-type-select {

--- a/designer/client/src/components/graph/node-modal/NodeDetailsContent/NodeTableStyled.tsx
+++ b/designer/client/src/components/graph/node-modal/NodeDetailsContent/NodeTableStyled.tsx
@@ -1,6 +1,7 @@
 import { css, styled } from "@mui/material";
 import { customCheckbox } from "./CustomCheckbox";
 
+export const HiddenTextareaPixelHeight = 100;
 export const NodeTableStyled = styled("div")(
     ({ theme }) => css`
         font-size: 11px;
@@ -49,7 +50,7 @@ export const NodeTableStyled = styled("div")(
             }
             &.partly-hidden {
                 textarea {
-                    height: 100px !important;
+                    height: ${HiddenTextareaPixelHeight}px !important;
                 }
             }
             &.node-value-type-select {

--- a/designer/client/src/components/graph/node-modal/tests/ExpressionTestResults.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/ExpressionTestResults.tsx
@@ -5,7 +5,7 @@ import TestValue from "./TestValue";
 import { NodeResultsForContext } from "../../../../common/TestResultUtils";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import { FormControl, FormLabel } from "@mui/material";
-import { HiddenTextareaPixelHeight } from "../NodeDetailsContent/NodeTableStyled";
+import { HIDDEN_TEXTAREA_PIXEL_HEIGHT } from "../NodeDetailsContent/NodeTableStyled";
 
 interface ExpressionTestResultsProps {
     fieldName: string;
@@ -14,18 +14,11 @@ interface ExpressionTestResultsProps {
 
 export default function ExpressionTestResults(props: PropsWithChildren<ExpressionTestResultsProps>): JSX.Element {
     const { fieldName, resultsToShow } = props;
-    const [hideTestResults, toggleTestResults] = useState(false);
-    const [fitsMaxHeight, setFitsMaxHeight] = useState(true);
     const testValueRef: React.Ref<HTMLTextAreaElement> = useRef(null);
-    useEffect(() => {
-        if (testValueRef.current && testValueRef.current.scrollHeight > HiddenTextareaPixelHeight) {
-            toggleTestResults((s) => !s);
-            setFitsMaxHeight(false);
-        }
-    }, []);
-
+    const fitsMaxHeight = testValueRef?.current ? testValueRef.current.scrollHeight <= HIDDEN_TEXTAREA_PIXEL_HEIGHT : true;
+    const [collapsedTestResults, setCollapsedTestResults] = useState(true);
     const testValue = fieldName ? resultsToShow && resultsToShow.expressionResults[fieldName] : null;
-    const PrettyIconComponent = hideTestResults ? VisibilityOff : Visibility;
+    const PrettyIconComponent = collapsedTestResults ? VisibilityOff : Visibility;
 
     return testValue ? (
         <div>
@@ -37,10 +30,10 @@ export default function ExpressionTestResults(props: PropsWithChildren<Expressio
                         icon={<InfoIcon sx={(theme) => ({ color: theme.custom.colors.info, alignSelf: "center" })} />}
                     />
                     {testValue.pretty && !fitsMaxHeight ? (
-                        <PrettyIconComponent sx={{ cursor: "pointer" }} onClick={() => toggleTestResults((s) => !s)} />
+                        <PrettyIconComponent sx={{ cursor: "pointer" }} onClick={() => setCollapsedTestResults((s) => !s)} />
                     ) : null}
                 </FormLabel>
-                <TestValue ref={testValueRef} value={testValue} shouldHideTestResults={hideTestResults} />
+                <TestValue ref={testValueRef} value={testValue} shouldHideTestResults={collapsedTestResults && !fitsMaxHeight} />
             </FormControl>
         </div>
     ) : (

--- a/designer/client/src/components/graph/node-modal/tests/ExpressionTestResults.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/ExpressionTestResults.tsx
@@ -1,10 +1,11 @@
-import React, { PropsWithChildren, useState } from "react";
+import React, { PropsWithChildren, useEffect, useRef, useState } from "react";
 import InfoIcon from "@mui/icons-material/Info";
 import NodeTip from "../NodeTip";
 import TestValue from "./TestValue";
 import { NodeResultsForContext } from "../../../../common/TestResultUtils";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import { FormControl, FormLabel } from "@mui/material";
+import { HiddenTextareaPixelHeight } from "../NodeDetailsContent/NodeTableStyled";
 
 interface ExpressionTestResultsProps {
     fieldName: string;
@@ -14,6 +15,14 @@ interface ExpressionTestResultsProps {
 export default function ExpressionTestResults(props: PropsWithChildren<ExpressionTestResultsProps>): JSX.Element {
     const { fieldName, resultsToShow } = props;
     const [hideTestResults, toggleTestResults] = useState(false);
+    const [fitsMaxHeight, setFitsMaxHeight] = useState(true);
+    const testValueRef: React.Ref<HTMLTextAreaElement> = useRef(null);
+    useEffect(() => {
+        if (testValueRef.current && testValueRef.current.scrollHeight > HiddenTextareaPixelHeight) {
+            toggleTestResults((s) => !s);
+            setFitsMaxHeight(false);
+        }
+    }, []);
 
     const testValue = fieldName ? resultsToShow && resultsToShow.expressionResults[fieldName] : null;
     const PrettyIconComponent = hideTestResults ? VisibilityOff : Visibility;
@@ -27,11 +36,11 @@ export default function ExpressionTestResults(props: PropsWithChildren<Expressio
                         title={"Value evaluated in test case"}
                         icon={<InfoIcon sx={(theme) => ({ color: theme.custom.colors.info, alignSelf: "center" })} />}
                     />
-                    {testValue.pretty ? (
+                    {testValue.pretty && !fitsMaxHeight ? (
                         <PrettyIconComponent sx={{ cursor: "pointer" }} onClick={() => toggleTestResults((s) => !s)} />
                     ) : null}
                 </FormLabel>
-                <TestValue value={testValue} shouldHideTestResults={hideTestResults} />
+                <TestValue ref={testValueRef} value={testValue} shouldHideTestResults={hideTestResults} />
             </FormControl>
         </div>
     ) : (

--- a/designer/client/src/components/graph/node-modal/tests/TestValue.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/TestValue.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import { Variable } from "../../../../common/TestResultUtils";
 import { cx } from "@emotion/css";
 
@@ -11,18 +11,26 @@ function prettyPrint(obj: unknown) {
     return JSON.stringify(obj, null, 2);
 }
 
-export default function TestValue(props: Props) {
+export default forwardRef<HTMLTextAreaElement, Props>(function TestValue(props: Props, ref: React.Ref<HTMLTextAreaElement>) {
     const { value, shouldHideTestResults } = props;
-
     return (
         <div className={cx("node-value", shouldHideTestResults && "partly-hidden")}>
-            {value?.original ? <ReadonlyTextarea value={value.original} /> : null}
-            <ReadonlyTextarea value={prettyPrint(value?.pretty)} />
+            {value?.original ? <ReadonlyTextarea ref={ref} value={value.original} /> : null}
+            <ReadonlyTextarea ref={ref} value={prettyPrint(value?.pretty)} />
             {shouldHideTestResults ? <div className="fadeout" /> : null}
         </div>
     );
-}
+});
 
-function ReadonlyTextarea({ value = "" }: { value: string }) {
-    return <textarea className="node-input" readOnly value={value} rows={value.split("\n").length} />;
-}
+const ReadonlyTextarea = forwardRef<HTMLTextAreaElement, { value: string }>(function ReadonlyTextarea(
+    { value = "" }: { value: string },
+    outerRef: React.Ref<HTMLTextAreaElement>,
+) {
+    const innerRef = useRef<HTMLTextAreaElement>(null);
+    useImperativeHandle(outerRef, () => innerRef.current, []);
+    useEffect(() => {
+        innerRef.current.style.height = innerRef.current.scrollHeight + "px";
+    }, []);
+
+    return <textarea ref={innerRef} className="node-input" readOnly value={value} rows={value.split("\n").length} />;
+});

--- a/designer/client/src/components/graph/node-modal/tests/TestValue.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/TestValue.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import React, { forwardRef, useImperativeHandle, useRef } from "react";
 import { Variable } from "../../../../common/TestResultUtils";
 import { cx } from "@emotion/css";
 
@@ -28,9 +28,15 @@ const ReadonlyTextarea = forwardRef<HTMLTextAreaElement, { value: string }>(func
 ) {
     const innerRef = useRef<HTMLTextAreaElement>(null);
     useImperativeHandle(outerRef, () => innerRef.current, []);
-    useEffect(() => {
-        innerRef.current.style.height = innerRef.current.scrollHeight + "px";
-    }, []);
-
-    return <textarea ref={innerRef} className="node-input" readOnly value={value} rows={value.split("\n").length} />;
+    const textAreaFullHeight = innerRef?.current?.scrollHeight;
+    return (
+        <textarea
+            ref={innerRef}
+            style={{ height: textAreaFullHeight }}
+            className="node-input"
+            readOnly
+            value={value}
+            rows={value.split("\n").length}
+        />
+    );
 });


### PR DESCRIPTION
## Describe your changes

Currently during scenario testing with 'ad hoc' tests and tests from file there is an issue with presenting longer contents of textAreas. The problem exists because of how textArea's rows dictate its height. 
```
function ReadonlyTextarea({ value = "" }: { value: string }) {
    return <textarea className="node-input" readOnly value={value} rows={value.split("\n").length} />;
```
Row count is based on number of new line characters in the contents. This approach has an issue when we have a longer string content without new line characters as it is presented in a textArea that has only one row. As a result the hide/show content "eye" icon is not working as intended. It 'shrinks' the textArea to 100px and fades its the bottom as it assumes the textArea's height is set to its full content size. (Disregard random string data - it's just to present the problems on actual data)

![showHideOld](https://github.com/TouK/nussknacker/assets/30436981/fad9a24a-55bb-4b07-9a19-25bc308d9edf)

To solve the issue with presenting test data I changed the textArea's height to fit its content.
```
useEffect(() => {
    innerRef.current.style.height = innerRef.current.scrollHeight + 'px';
}, []);
```
I also changed how by default, if content is longer than defined hidden height, the 'eye' icon will be active and the rest of contents will be hidden. Clicking it will show the whole content

![showHideBetter](https://github.com/TouK/nussknacker/assets/30436981/34eb57d2-2b7a-4f1b-88f1-d6e76b8829d8)

Also the hide/show "eye" icon won't be present when textArea's content fits the maxium defined content height. 

![noEye](https://github.com/TouK/nussknacker/assets/30436981/08899e02-955e-4941-9442-83b23d55c39d)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
