### PR TITLE
Fixed NPE when ForEachTransformer is invoked with null elements parmeter

### DIFF
--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformerSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformerSpec.scala
@@ -74,6 +74,16 @@ class ForEachTransformerSpec extends AnyFunSuite with FlinkSpec with Matchers wi
     results.nodeResults shouldNot contain key sinkId
   }
 
+  test("should not produce any results when elements parameter is null") {
+    val collectingListener = initializeListener
+    val model              = modelData(List(TestRecord()), collectingListener)
+
+    val testProcess = aProcessWithForEachNode(elements = "null")
+
+    val results = collectTestResults[String](model, testProcess, collectingListener)
+    results.nodeResults shouldNot contain key sinkId
+  }
+
   private def initializeListener = ResultsCollectingListenerHolder.registerListener
 
   private def modelData(

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
@@ -27,11 +27,13 @@ object ForEachTransformer extends CustomStreamTransformer with Serializable {
           .flatMap(ctx.lazyParameterHelper.lazyMapFunction(elements))
           .flatMap(
             (valueWithContext: ValueWithContext[util.Collection[AnyRef]], c: Collector[ValueWithContext[AnyRef]]) => {
-              valueWithContext.value.asScala.zipWithIndex
-                .map { case (partToRun, index) =>
-                  new ValueWithContext[AnyRef](partToRun, valueWithContext.context.appendIdSuffix(index.toString))
-                }
-                .foreach(c.collect)
+              Option(valueWithContext.value).foreach(
+                _.asScala.zipWithIndex
+                  .map { case (partToRun, index) =>
+                    new ValueWithContext[AnyRef](partToRun, valueWithContext.context.appendIdSuffix(index.toString))
+                  }
+                  .foreach(c.collect)
+              )
             },
             ctx.valueWithContextInfo.forType[AnyRef](returnType(elements))
           )


### PR DESCRIPTION
## Describe your changes

Before:
When ForEachTransformer is invoked with `elements = null` null pointer exception is raised (transient exception, it is not handled via ExceptionHandler/ExceptionConsumer, leads to scenario failure and restart).

After:
When `elements = null` the component does not emit any data, just like when elements is an empty list.

Alternative solution:
When `elements = null` the component raises non-transient exception to make clear to the user that something erroneous happend (via EspExceptionConsumer) without restarting the whole scenario. WDYT?

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
