### PR TITLE
Explicit defaults for scenario properties

### DIFF
--- a/common-api/src/main/scala/pl/touk/nussknacker/engine/api/TypeSpecificData.scala
+++ b/common-api/src/main/scala/pl/touk/nussknacker/engine/api/TypeSpecificData.scala
@@ -44,10 +44,10 @@ object FragmentSpecificData {
 
 // TODO: rename to FlinkStreamMetaData
 case class StreamMetaData(
-    parallelism: Option[Int] = None,
+    parallelism: Option[Int] = Some(1),
     // we assume it's safer to spill state to disk and fix performance than to fix heap problems...
     spillStateToDisk: Option[Boolean] = Some(true),
-    useAsyncInterpretation: Option[Boolean] = None,
+    useAsyncInterpretation: Option[Boolean] = Some(false),
     checkpointIntervalInSeconds: Option[Long] = None
 ) extends ScenarioSpecificData {
 

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.testing
 import cats.data.{Validated, ValidatedNel}
 import com.typesafe.config.Config
 import pl.touk.nussknacker.engine.api.StreamMetaData
+import pl.touk.nussknacker.engine.api.async.DefaultAsyncInterpretationValueDeterminer
 import pl.touk.nussknacker.engine.api.component.ScenarioPropertyConfig
 import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.api.deployment._
@@ -96,27 +97,25 @@ object FlinkStreamingPropertiesConfig {
 
   private val parallelismConfig: (String, ScenarioPropertyConfig) = StreamMetaData.parallelismName ->
     ScenarioPropertyConfig(
-      defaultValue = None,
+      defaultValue = Some("1"),
       editor = Some(StringParameterEditor),
       validators = Some(List(LiteralIntegerValidator, MinimalNumberValidator(1))),
       label = Some("Parallelism")
     )
 
   private val spillStatePossibleValues = List(
-    FixedExpressionValue("", "Server default"),
     FixedExpressionValue("false", "False"),
     FixedExpressionValue("true", "True")
   )
 
   private val asyncPossibleValues = List(
-    FixedExpressionValue("", "Server default"),
     FixedExpressionValue("false", "Synchronous"),
     FixedExpressionValue("true", "Asynchronous")
   )
 
   private val spillStateConfig: (String, ScenarioPropertyConfig) = StreamMetaData.spillStateToDiskName ->
     ScenarioPropertyConfig(
-      defaultValue = None,
+      defaultValue = Some("true"),
       editor = Some(FixedValuesParameterEditor(spillStatePossibleValues)),
       validators = Some(List(FixedValuesValidator(spillStatePossibleValues))),
       label = Some("Spill state to disk")
@@ -125,7 +124,9 @@ object FlinkStreamingPropertiesConfig {
   private val asyncInterpretationConfig: (String, ScenarioPropertyConfig) =
     StreamMetaData.useAsyncInterpretationName ->
       ScenarioPropertyConfig(
-        defaultValue = None,
+        defaultValue = Some(
+          DefaultAsyncInterpretationValueDeterminer.DefaultValue.toString
+        ), // config -> asyncExecutionConfig.defaultUseAsyncInterpretation
         editor = Some(FixedValuesParameterEditor(asyncPossibleValues)),
         validators = Some(List(FixedValuesValidator(asyncPossibleValues))),
         label = Some("IO mode")
@@ -144,7 +145,7 @@ object FlinkStreamingPropertiesConfig {
 
   val metaDataInitializer: MetaDataInitializer = MetaDataInitializer(
     metadataType = StreamMetaData.typeName,
-    overridingProperties = Map(StreamMetaData.parallelismName -> "1", StreamMetaData.spillStateToDiskName -> "true")
+    overridingProperties = Map.empty
   )
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/ExplicitDefaultPropertiesMigration.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/ExplicitDefaultPropertiesMigration.scala
@@ -1,0 +1,51 @@
+package pl.touk.nussknacker.ui.process.migrate
+
+import pl.touk.nussknacker.engine.api.{LiteStreamMetaData, StreamMetaData}
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.migration.ProcessMigration
+
+class ExplicitDefaultPropertiesMigration extends ProcessMigration {
+
+  override def description: String = "Set explicit values for default scenario properties"
+
+  override def migrateProcess(canonicalProcess: CanonicalProcess, category: String): CanonicalProcess = {
+    val metaData = canonicalProcess.metaData
+    metaData.additionalFields.metaDataType match {
+      case StreamMetaData.typeName =>
+        setDefaultsIfEmpty(
+          canonicalProcess,
+          Map(
+            StreamMetaData.parallelismName            -> "1",
+            StreamMetaData.spillStateToDiskName       -> "true",
+            StreamMetaData.useAsyncInterpretationName -> "false"
+          )
+        )
+      case LiteStreamMetaData.typeName =>
+        setDefaultsIfEmpty(
+          canonicalProcess,
+          Map(
+            LiteStreamMetaData.parallelismName -> "1"
+          )
+        )
+      case _ => canonicalProcess
+    }
+  }
+
+  def setDefaultsIfEmpty(canonicalProcess: CanonicalProcess, defaultValues: Map[String, String]): CanonicalProcess = {
+    val oldProperties = canonicalProcess.metaData.additionalFields.properties
+    val newProperties = oldProperties.map { case (k, v) =>
+      if (defaultValues.contains(k) && v.isEmpty) {
+        k -> defaultValues(k)
+      } else {
+        k -> v
+      }
+
+    }
+    canonicalProcess.copy(metaData =
+      canonicalProcess.metaData.copy(additionalFields =
+        canonicalProcess.metaData.additionalFields.copy(properties = newProperties)
+      )
+    )
+  }
+
+}

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkProcessCompilerDataFactory.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkProcessCompilerDataFactory.scala
@@ -66,14 +66,9 @@ class FlinkProcessCompilerDataFactory(
     // TODO: this should be somewhere else?
     val timeout = modelConfig.as[FiniteDuration]("timeout")
 
-    // TODO: should this be the default?
-    val asyncExecutionContextPreparer = creator
-      .asyncExecutionContextPreparer(modelDependencies)
-      .getOrElse(
-        modelConfig.as[DefaultServiceExecutionContextPreparer]("asyncExecutionConfig")
-      )
-    val defaultListeners = prepareDefaultListeners(usedNodes) ++ creator.listeners(modelDependencies)
-    val listenersToUse   = adjustListeners(defaultListeners, modelDependencies)
+    val asyncExecutionContextPreparer = modelConfig.as[DefaultServiceExecutionContextPreparer]("asyncExecutionConfig")
+    val defaultListeners              = prepareDefaultListeners(usedNodes) ++ creator.listeners(modelDependencies)
+    val listenersToUse                = adjustListeners(defaultListeners, modelDependencies)
 
     val (definitionWithTypes, dictRegistry) = definitions(modelDependencies, userCodeClassLoader)
 

--- a/engine/lite/deploymentManager/src/main/scala/pl/touk/nussknacker/lite/manager/LiteDeploymentManagerProvider.scala
+++ b/engine/lite/deploymentManager/src/main/scala/pl/touk/nussknacker/lite/manager/LiteDeploymentManagerProvider.scala
@@ -16,7 +16,7 @@ trait LiteDeploymentManagerProvider extends DeploymentManagerProvider {
 
   override def metaDataInitializer(config: Config): MetaDataInitializer = {
     forMode(config)(
-      MetaDataInitializer(LiteStreamMetaData.typeName, Map(LiteStreamMetaData.parallelismName -> "1")),
+      MetaDataInitializer(LiteStreamMetaData.typeName, _ => Map.empty),
       MetaDataInitializer(
         RequestResponseMetaData.typeName,
         scenarioName => Map(RequestResponseMetaData.slugName -> defaultRequestResponseSlug(scenarioName, config))
@@ -47,7 +47,7 @@ object LitePropertiesConfig {
 
   private val parallelismConfig: (String, ScenarioPropertyConfig) = LiteStreamMetaData.parallelismName ->
     ScenarioPropertyConfig(
-      defaultValue = None,
+      defaultValue = Some("1"),
       editor = Some(StringParameterEditor),
       validators = Some(List(LiteralIntegerValidator, MinimalNumberValidator(1))),
       label = Some("Parallelism")

--- a/extensions-api/src/main/java/pl/touk/nussknacker/engine/javaapi/process/ProcessConfigCreator.java
+++ b/extensions-api/src/main/java/pl/touk/nussknacker/engine/javaapi/process/ProcessConfigCreator.java
@@ -19,9 +19,6 @@ public interface ProcessConfigCreator extends Serializable {
     Collection<ProcessListener> listeners(ProcessObjectDependencies processObjectDependencies);
     ExpressionConfig expressionConfig(ProcessObjectDependencies processObjectDependencies);
     Map<String, String> buildInfo();
-    default Optional<AsyncExecutionContextPreparer> asyncExecutionContextPreparer(ProcessObjectDependencies processObjectDependencies) {
-      return Optional.empty();
-    }
     default ClassExtractionSettings classExtractionSettings(ProcessObjectDependencies processObjectDependencies) {
         return ClassExtractionSettings.DEFAULT;
     }

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/conversion/ProcessConfigCreatorMapping.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/conversion/ProcessConfigCreatorMapping.scala
@@ -51,11 +51,6 @@ object ProcessConfigCreatorMapping {
       override def buildInfo(): Map[String, String] = {
         jcreator.buildInfo().asScala.toMap
       }
-      override def asyncExecutionContextPreparer(
-          modelDependencies: ProcessObjectDependencies
-      ): Option[AsyncExecutionContextPreparer] = {
-        Option(jcreator.asyncExecutionContextPreparer(modelDependencies).orElse(null))
-      }
       override def classExtractionSettings(
           modelDependencies: ProcessObjectDependencies
       ): ClassExtractionSettings = {

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/ProcessConfigCreator.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/ProcessConfigCreator.scala
@@ -25,10 +25,6 @@ trait ProcessConfigCreator extends Serializable {
   // TODO: Rename to modelInfo or similar, as it can contain any information related to model, not only build info
   def buildInfo(): Map[String, String]
 
-  def asyncExecutionContextPreparer(
-      modelDependencies: ProcessObjectDependencies
-  ): Option[AsyncExecutionContextPreparer] = None
-
   def classExtractionSettings(modelDependencies: ProcessObjectDependencies): ClassExtractionSettings =
     ClassExtractionSettings.Default
 


### PR DESCRIPTION
## Describe your changes

AS IS:
Default values for scenario properties are introduced in several places: 
1. in `DeploymentManagerProvider.scenarioPropertiesConfig` (e.g. FlinkStreamingPropertiesConfig.properties)
2. via configuration `scenarioPropertiesConfig`
3. in `DeploymentManagerProvider.metaDataInitializer` there are some static overwrites (e.g. `overridingProperties = Map(StreamMetaData.parallelismName -> "1", StreamMetaData.spillStateToDiskName -> "true")`)
4. in TypeSpecificData (e.g. `StreamMetaData.spillStateToDisk = Some(true)` which by accident corresponds to metaDataInitializer)
5. in some places in code (e.g. `DefaultAsyncInterpretationValueDeterminer.DefaultValue` and `ProcessConfigCreator.asyncExecutionContextPreparer`)

Implicit defaults lead to 3-state logic of "IO mode" and "Spill state to disk", true / false / server default, where server default is burried somewhere in those places above.
Some scenario properties are used to initialize scenario metaData (with typeSpecificData).
MetaData control the behaviour of scenario.

Comments:
1. MetaDataInitializer: "TODO: set the defaults in one place without overriding"
2. DefaultAsyncInterpretationValueDeterminer: // ... in the future this default will be changed to true

Purpose of the change:
Introduce explicit default values for scenario properties:
- to avoid confusing 3-state logic
- user knows what is the configuration of scenario
- the explicit configuration is imprinted into scenario version

TO BE:
**1. Remove "server default" option from "IO mode" and "Spill state to disk". It seems to be redundant to other two options.
2. Migrate all implicit properties (stored as empty string) to explicit values.**
3. Remove `DefaultAsyncInterpretationValueDeterminer`, it duplicates MetaDataInitializer.create
4. Move `asyncExecutionConfig.defaultUseAsyncInterpretation` to scenarioPropertiesConfig
5. Remove `ProcessConfigCreator.asyncExecutionContextPreparer`
6. `TypeSpecificData` keeps property names and default values.
7. `DeploymentManagerProvider.scenarioPropertiesConfig` defines explicit static default values.
8. `ProcessingTypeData.createDeploymentData` combines DeploymentManagerProvider.scenarioPropertiesConfig and config to build DeploymentData (to display in UI and use inside deployment)
9. `MetaDataInitializer.overrideDefaultProperties` should not override, it is more like "evaluate some initial MD values that cannot be statically defined (like slug in request-response)"

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
