### PR TITLE
[NU-1544] change of scenario name to the same value force user to save scenario

### DIFF
--- a/designer/client/src/actions/nk/calculateProcessAfterChange.ts
+++ b/designer/client/src/actions/nk/calculateProcessAfterChange.ts
@@ -30,9 +30,12 @@ export function calculateProcessAfterChange(
             if (after.id !== before.id) {
                 dispatch({ type: "PROCESS_RENAME", name: after.id });
             }
+
+            const { id, ...properties } = after;
+
             return {
                 processName: after.id,
-                scenarioGraph: { ...processWithNewFragmentSchema, properties: after },
+                scenarioGraph: { ...processWithNewFragmentSchema, properties },
             };
         }
 

--- a/designer/client/src/common/ProcessUtils.ts
+++ b/designer/client/src/common/ProcessUtils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable i18next/no-literal-string */
-import { flatten, isEmpty, isEqual, map, omit, pickBy, transform } from "lodash";
+import { flatten, isEmpty, isEqual, omit, pickBy, transform } from "lodash";
 import {
     ComponentDefinition,
     NodeId,

--- a/designer/client/src/components/graph/NodeUtils.ts
+++ b/designer/client/src/components/graph/NodeUtils.ts
@@ -22,7 +22,7 @@ class NodeUtils {
         return !isEmpty(obj) && has(obj, "id") && has(obj, "type");
     };
 
-    nodeType = (node: NodeType) => {
+    nodeType = (node: UINodeType) => {
         return node.type ? node.type : "Properties";
     };
 
@@ -31,7 +31,7 @@ class NodeUtils {
         return type === "Properties";
     };
 
-    nodeIsFragment = (node): node is FragmentNodeType => {
+    nodeIsFragment = (node: UINodeType): node is FragmentNodeType => {
         return this.nodeType(node) === "FragmentInput";
     };
 

--- a/designer/client/src/components/graph/node-modal/DescriptionField.tsx
+++ b/designer/client/src/components/graph/node-modal/DescriptionField.tsx
@@ -2,13 +2,13 @@
 import { NodeField } from "./NodeField";
 import { FieldType } from "./editors/field/Field";
 import React from "react";
-import { NodeType, NodeValidationError } from "../../../types";
+import { NodeType, NodeValidationError, UINodeType } from "../../../types";
 
 interface DescriptionFieldProps {
     autoFocus?: boolean;
     defaultValue?: string;
     isEditMode?: boolean;
-    node: NodeType;
+    node: UINodeType;
     readonly?: boolean;
     renderFieldLabel: (paramName: string) => JSX.Element;
     setProperty: <K extends keyof NodeType>(property: K, newValue: NodeType[K], defaultValue?: NodeType[K]) => void;

--- a/designer/client/src/components/graph/node-modal/IdField.tsx
+++ b/designer/client/src/components/graph/node-modal/IdField.tsx
@@ -2,7 +2,7 @@ import { extendErrors, getValidationErrorsForField, uniqueScenarioValueValidator
 import Field, { FieldType } from "./editors/field/Field";
 import React, { useMemo } from "react";
 import { useDiffMark } from "./PathsToMark";
-import { NodeType, NodeValidationError } from "../../../types";
+import { NodeType, NodeValidationError, UINodeType } from "../../../types";
 import { useSelector } from "react-redux";
 import { getProcessNodesIds } from "../../../reducers/selectors/graph";
 import NodeUtils from "../NodeUtils";
@@ -10,7 +10,7 @@ import { isEmpty } from "lodash";
 
 interface IdFieldProps {
     isEditMode?: boolean;
-    node: NodeType;
+    node: UINodeType;
     renderFieldLabel: (paramName: string) => JSX.Element;
     setProperty?: <K extends keyof NodeType>(property: K, newValue: NodeType[K], defaultValue?: NodeType[K]) => void;
     showValidation?: boolean;

--- a/designer/client/src/components/graph/node-modal/NodeField.tsx
+++ b/designer/client/src/components/graph/node-modal/NodeField.tsx
@@ -3,7 +3,7 @@ import { getValidationErrorsForField } from "./editors/Validators";
 import { get, isEmpty } from "lodash";
 import React from "react";
 import { useDiffMark } from "./PathsToMark";
-import { NodeType, NodeValidationError } from "../../../types";
+import { NodeType, NodeValidationError, UINodeType } from "../../../types";
 
 type NodeFieldProps<N extends string, V> = {
     autoFocus?: boolean;
@@ -12,7 +12,7 @@ type NodeFieldProps<N extends string, V> = {
     fieldName: N;
     fieldType: FieldType;
     isEditMode?: boolean;
-    node: NodeType;
+    node: UINodeType;
     readonly?: boolean;
     renderFieldLabel: (paramName: string) => JSX.Element;
     setProperty: <K extends keyof NodeType>(property: K, newValue: NodeType[K], defaultValue?: NodeType[K]) => void;

--- a/designer/client/src/components/graph/node-modal/ScenarioProperty.tsx
+++ b/designer/client/src/components/graph/node-modal/ScenarioProperty.tsx
@@ -17,7 +17,11 @@ interface Props {
     propertyName: string;
     propertyConfig: ScenarioPropertyConfig;
     editedNode: PropertiesType;
-    onChange: <K extends keyof PropertiesType>(property: K, newValue: PropertiesType[K], defaultValue?: PropertiesType[K]) => void;
+    onChange: <K extends keyof PropertiesType["additionalFields"]["properties"]>(
+        property: K,
+        newValue: PropertiesType["additionalFields"]["properties"][K],
+        defaultValue?: PropertiesType["additionalFields"]["properties"][K],
+    ) => void;
     renderFieldLabel: (paramName: string) => JSX.Element;
     readOnly: boolean;
     errors: NodeValidationError[];

--- a/designer/client/src/types/node.ts
+++ b/designer/client/src/types/node.ts
@@ -38,7 +38,7 @@ export type NodeType<F extends Field = Field> = {
         id: string;
         parameters?: $TodoType[];
     };
-    nodeType: string;
+    nodeType?: string;
     [key: string]: any;
 };
 
@@ -59,12 +59,13 @@ export interface Expression {
     expression: string;
 }
 
-//TODO: Add other process properties...
-export type PropertiesType = Omit<NodeType, "id"> & {
+export type PropertiesType = {
+    // FE applies fake id as name, but it's not send by/to BE
+    id?: string;
     type: "Properties";
     additionalFields: ProcessAdditionalFields;
 };
 
 export type NodeId = NodeType["id"];
 
-export type UINodeType = NodeType;
+export type UINodeType = NodeType | PropertiesType;

--- a/designer/client/src/types/node.ts
+++ b/designer/client/src/types/node.ts
@@ -60,7 +60,7 @@ export interface Expression {
 }
 
 //TODO: Add other process properties...
-export type PropertiesType = NodeType & {
+export type PropertiesType = Omit<NodeType, "id"> & {
     type: "Properties";
     additionalFields: ProcessAdditionalFields;
 };


### PR DESCRIPTION
## Describe your changes
- We made some changes to the FE and BE related to the scenario state.Now, after performing the EDIT_NODE action, which changes the scenario state, we added a redundant scenario id to the scenarioGraph.properties. That's why, our mechanism to detect whether the Save button should be enabled or disabled is now detecting changes even when there aren't any.

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
