### PR TITLE
Optimize Delay component

### DIFF
--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
@@ -15,7 +15,6 @@ import pl.touk.nussknacker.engine.flink.util.keyed.StringKeyOnlyMapper
 
 import java.time.Duration
 import java.util
-import java.util.Collections
 import javax.annotation.Nullable
 
 object DelayTransformer extends DelayTransformer
@@ -81,7 +80,7 @@ class DelayFunction(nodeCtx: FlinkCustomNodeContext, delay: Duration)
     val fireTime = ctx.timestamp() + delay.toMillis
 
     val currentState = readStateValueOrInitial(fireTime)
-    currentState.add(0, value.context)
+    currentState.add(value.context)
     state.put(fireTime, currentState)
 
     ctx.timerService().registerEventTimeTimer(fireTime)
@@ -89,7 +88,6 @@ class DelayFunction(nodeCtx: FlinkCustomNodeContext, delay: Duration)
 
   override def onTimer(timestamp: Long, funCtx: FlinkTimerCtx, out: Collector[ValueWithContext[AnyRef]]): Unit = {
     val currentState = readStateValueOrInitial(timestamp)
-    Collections.reverse(currentState)
     currentState.forEach(emitValue(out, _))
     state.remove(timestamp)
   }


### PR DESCRIPTION
## Describe your changes

* ~~remove state descriptor from component's fields - it doesn't belong there~~
  * or not, if it's not a class-level `val` then closure cleaner complains about `nodeCtx.contextTypeInfo`
* replace element prepending with appending, making it cheaper and removing the need for list reversal when emitting elements

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
