### PR TITLE
Fix Scala case class with fields in body serialization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1155,6 +1155,7 @@ lazy val flinkScalaUtils = (project in flink("scala-utils"))
       ) ++ flinkLibScalaDeps(scalaVersion.value, Some("provided"))
     }
   )
+  .dependsOn(testUtils % Test)
 
 lazy val flinkTestUtils = (project in flink("test-utils"))
   .settings(commonSettings)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,6 +7,7 @@
   * openapi-circe-yaml: 0.6.0 -> 0.7.4 
 * [#5438](https://github.com/TouK/nussknacker/pull/5438) [#5495](https://github.com/TouK/nussknacker/pull/5495) Improvement in DeploymentManager API:
     * Alignment in the api of primary (deploy/cancel) actions and the experimental api of custom actions.
+* [#5780](https://github.com/TouK/nussknacker/pull/5780) Modified `CaseClassTypeInfoFactory` so Scala case classes are serialized properly
 
 1.14.0 (21 Mar 2024)
 -------------------------

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,7 +7,7 @@
   * openapi-circe-yaml: 0.6.0 -> 0.7.4 
 * [#5438](https://github.com/TouK/nussknacker/pull/5438) [#5495](https://github.com/TouK/nussknacker/pull/5495) Improvement in DeploymentManager API:
     * Alignment in the api of primary (deploy/cancel) actions and the experimental api of custom actions.
-* [#5780](https://github.com/TouK/nussknacker/pull/5780) Modified `CaseClassTypeInfoFactory` so Scala case classes are serialized properly
+* [#5780](https://github.com/TouK/nussknacker/pull/5780) Fixed Scala case classes serialization when a class has additional fields in its body
 
 1.14.0 (21 Mar 2024)
 -------------------------

--- a/engine/flink/scala-utils/src/test/scala/pl/touk/nussknacker/engine/flink/api/typeinfo/caseclass/CaseClassSerializationTest.scala
+++ b/engine/flink/scala-utils/src/test/scala/pl/touk/nussknacker/engine/flink/api/typeinfo/caseclass/CaseClassSerializationTest.scala
@@ -1,0 +1,92 @@
+package pl.touk.nussknacker.engine.flink.api.typeinfo.caseclass
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.TypeInfo
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.java.typeutils.TypeExtractor
+import org.apache.flink.core.memory.{DataInputViewStreamWrapper, DataOutputViewStreamWrapper}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
+import pl.touk.nussknacker.test.ProcessUtils.convertToAnyShouldWrapper
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import scala.reflect.{ClassTag, classTag}
+
+class CaseClassSerializationTest extends AnyFunSuite with Matchers {
+
+  private val executionConfig = new ExecutionConfig()
+
+  private val bufferSize = 1024
+
+  test("Simple case class should be the same after serialization and deserialization") {
+    val input = SimpleCaseClass("value")
+
+    val serializer   = getSerializer[SimpleCaseClass]
+    val deserialized = serializeAndDeserialize(serializer, input)
+
+    serializer shouldBe a[ScalaCaseClassSerializer[_]]
+    deserialized shouldEqual input
+  }
+
+  test("Case class with field in body should be the same after serialization and deserialization") {
+    val input = SimpleCaseClassWithAdditionalField("value")
+
+    val serializer   = getSerializer[SimpleCaseClassWithAdditionalField]
+    val deserialized = serializeAndDeserialize(serializer, input)
+
+    serializer shouldBe a[ScalaCaseClassSerializer[_]]
+    deserialized shouldEqual input
+  }
+
+  test("Case class with secondary constructor should be the same after serialization and deserialization") {
+    val input = SimpleCaseClassWithMultipleConstructors("value", 2.2)
+
+    val serializer   = getSerializer[SimpleCaseClassWithMultipleConstructors]
+    val deserialized = serializeAndDeserialize(serializer, input)
+
+    serializer shouldBe a[ScalaCaseClassSerializer[_]]
+    deserialized shouldEqual input
+  }
+
+  private def getSerializer[T: ClassTag] =
+    TypeExtractor.getForClass(classTag[T].runtimeClass.asInstanceOf[Class[T]]).createSerializer(executionConfig)
+
+  private def serializeAndDeserialize[T](serializer: TypeSerializer[T], in: T): T = {
+    val outStream  = new ByteArrayOutputStream(bufferSize)
+    val outWrapper = new DataOutputViewStreamWrapper(outStream)
+
+    serializer.serialize(in, outWrapper)
+    serializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(outStream.toByteArray)))
+  }
+
+}
+
+@TypeInfo(classOf[SimpleCaseClass.TypeInfoFactory])
+final case class SimpleCaseClass(constructorField: String)
+
+object SimpleCaseClass {
+  class TypeInfoFactory extends CaseClassTypeInfoFactory[SimpleCaseClass]
+}
+
+@TypeInfo(classOf[SimpleCaseClassWithAdditionalField.TypeInfoFactory])
+final case class SimpleCaseClassWithAdditionalField(constructorField: String) {
+  val bodyField: String = "body " + constructorField
+}
+
+object SimpleCaseClassWithAdditionalField {
+  class TypeInfoFactory extends CaseClassTypeInfoFactory[SimpleCaseClassWithAdditionalField]
+}
+
+@TypeInfo(classOf[SimpleCaseClassWithMultipleConstructors.TypeInfoFactory])
+final case class SimpleCaseClassWithMultipleConstructors(firstField: String, secondField: Double) {
+  val bodyField: String = "body " + firstField
+
+  def this(someField: Int, someSecondField: String) = {
+    this(someSecondField, someField)
+  }
+
+}
+
+object SimpleCaseClassWithMultipleConstructors {
+  class TypeInfoFactory extends CaseClassTypeInfoFactory[SimpleCaseClassWithMultipleConstructors]
+}

--- a/engine/flink/scala-utils/src/test/scala/pl/touk/nussknacker/engine/flink/api/typeinfo/caseclass/CaseClassSerializationTest.scala
+++ b/engine/flink/scala-utils/src/test/scala/pl/touk/nussknacker/engine/flink/api/typeinfo/caseclass/CaseClassSerializationTest.scala
@@ -39,7 +39,7 @@ class CaseClassSerializationTest extends AnyFunSuite with Matchers {
   }
 
   test("Case class with secondary constructor should be the same after serialization and deserialization") {
-    val input = SimpleCaseClassWithMultipleConstructors("value", 2.2)
+    val input = new SimpleCaseClassWithMultipleConstructors(2, "value")
 
     val serializer   = getSerializer[SimpleCaseClassWithMultipleConstructors]
     val deserialized = serializeAndDeserialize(serializer, input)
@@ -82,6 +82,10 @@ final case class SimpleCaseClassWithMultipleConstructors(firstField: String, sec
   val bodyField: String = "body " + firstField
 
   def this(someField: Int, someSecondField: String) = {
+    this(someSecondField, someField)
+  }
+
+  def this(someField: Int, someSecondField: String, toIgnore: String) = {
     this(someSecondField, someField)
   }
 


### PR DESCRIPTION
## Describe your changes

Currently when we try to serialize `@TypeInfo` case class with fields defined inside of its body we get `IndexOutOfBoundsException`. 
For example serializing case class:
```
@TypeInfo(classOf[SimpleCaseClassWithAdditionalField.TypeInfoFactory])
final case class SimpleCaseClassWithAdditionalField(constructorField: String) {
  val bodyField: String = "body " + constructorField
}

object SimpleCaseClassWithAdditionalField {
  class TypeInfoFactory extends CaseClassTypeInfoFactory[SimpleCaseClassWithAdditionalField]
}
```

Will throw the following exception:

```
1
java.lang.IndexOutOfBoundsException: 1
	at scala.runtime.Statics.ioobe(Statics.java:196)
	at pl.touk.nussknacker.engine.flink.api.typeinfo.caseclass.SimpleCaseClassWithAdditionalField.productElement(CaseClassSerializationTest.scala:61)
	at pl.touk.nussknacker.engine.flink.api.typeinfo.caseclass.CaseClassSerializer.serialize(CaseClassSerializer.scala:102)
	at pl.touk.nussknacker.engine.flink.api.typeinfo.caseclass.CaseClassSerializer.serialize(CaseClassSerializer.scala:32)
	at pl.touk.nussknacker.engine.flink.api.typeinfo.caseclass.CaseClassSerializationTest.serializeAndDeserialize(CaseClassSerializationTest.scala:47)
	at pl.touk.nussknacker.engine.flink.api.typeinfo.caseclass.CaseClassSerializationTest.$anonfun$new$2(CaseClassSerializationTest.scala:35)
	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
...
```

It happens because serializers are created for all of the class fields, including the ones defined inside of its body. However when values are actually passed to the serializer it serializes values only for the primary constructor.
With the proposed changes we create serializers for the primary constructor fields that should actually be serialized.


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [x] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [x] Showcase in dev-application.conf added to demonstrate the feature
- [x] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [x] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [x] Verify that PR will be squashed during merge
