### PR TITLE
Add show and hide option for variables in test case

### DIFF
--- a/designer/client/src/components/graph/node-modal/NodeDetailsContent/NodeTableStyled.tsx
+++ b/designer/client/src/components/graph/node-modal/NodeDetailsContent/NodeTableStyled.tsx
@@ -65,8 +65,9 @@ export const NodeTableStyled = styled("div")(
                 width: 70%;
             }
             .fadeout {
-                position: relative;
-                bottom: 4em;
+                position: absolute;
+                bottom: 0;
+                width: 100%;
                 height: 4em;
                 background: -webkit-linear-gradient(rgba(20, 20, 20, 0) 0%, rgba(20, 20, 20, 1) 100%);
                 background-image: -moz-linear-gradient(rgba(20, 20, 20, 0) 0%, rgba(20, 20, 20, 1) 100%);

--- a/designer/client/src/components/graph/node-modal/tests/TestResults.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/TestResults.tsx
@@ -2,11 +2,11 @@ import { isEmpty, isObject, join } from "lodash";
 import React from "react";
 import InfoIcon from "@mui/icons-material/Info";
 import NodeTip from "../NodeTip";
-import TestValue from "./TestValue";
 import { useTestResults } from "../TestResultsWrapper";
 import { NodeId } from "../../../../types";
 import { Box, FormControl, FormLabel } from "@mui/material";
 import { useTranslation } from "react-i18next";
+import TestResultsVariables from "./TestResultsVariables";
 
 export default function TestResults({ nodeId }: { nodeId: NodeId }): JSX.Element {
     const { t } = useTranslation();
@@ -28,11 +28,8 @@ export default function TestResults({ nodeId }: { nodeId: NodeId }): JSX.Element
             </FormControl>
             {Object.keys(results.testResultsToShow.context.variables)
                 .sort((a, b) => a.localeCompare(b))
-                .map((key, ikey) => (
-                    <FormControl key={ikey}>
-                        <FormLabel>{key}:</FormLabel>
-                        <TestValue value={results.testResultsToShow.context.variables[key]} shouldHideTestResults={false} />
-                    </FormControl>
+                .map((key, index) => (
+                    <TestResultsVariables key={index} labelText={key} result={results.testResultsToShow.context.variables[key]} />
                 ))}
             {results.testResultsToShow && !isEmpty(results.testResultsToShow.externalInvocationResultsForCurrentContext)
                 ? results.testResultsToShow.externalInvocationResultsForCurrentContext.map((mockedValue, index) => (

--- a/designer/client/src/components/graph/node-modal/tests/TestResultsVariables.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/TestResultsVariables.tsx
@@ -1,0 +1,33 @@
+import { FormControl, FormLabel } from "@mui/material";
+import TestValue from "./TestValue";
+import React, { useRef, useState } from "react";
+import { HIDDEN_TEXTAREA_PIXEL_HEIGHT } from "../NodeDetailsContent/NodeTableStyled";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
+import { Variable } from "../../../../common/TestResultUtils";
+
+interface TestResultsVariablesProps {
+    labelText: string;
+    result: Variable;
+}
+
+export default function TestResultsVariables(props: TestResultsVariablesProps): JSX.Element {
+    const { labelText, result } = props;
+    const testValueRef: React.Ref<HTMLTextAreaElement> = useRef(null);
+    const fitsMaxHeight = testValueRef?.current ? testValueRef.current.scrollHeight <= HIDDEN_TEXTAREA_PIXEL_HEIGHT : true;
+    const [collapsedTestResults, setCollapsedTestResults] = useState(true);
+    const PrettyIconComponent = collapsedTestResults ? VisibilityOff : Visibility;
+
+    return (
+        <FormControl>
+            <FormLabel sx={{ flexDirection: "column" }}>
+                {labelText}:
+                {!fitsMaxHeight ? (
+                    <FormLabel>
+                        <PrettyIconComponent sx={{ cursor: "pointer" }} onClick={() => setCollapsedTestResults((s) => !s)} />
+                    </FormLabel>
+                ) : null}
+            </FormLabel>
+            <TestValue ref={testValueRef} value={result} shouldHideTestResults={collapsedTestResults && !fitsMaxHeight} />
+        </FormControl>
+    );
+}

--- a/designer/client/src/components/graph/node-modal/tests/TestValue.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/TestValue.tsx
@@ -17,7 +17,11 @@ export default forwardRef<HTMLTextAreaElement, Props>(function TestValue(props: 
         <div className={cx("node-value", shouldHideTestResults && "partly-hidden")}>
             {value?.original ? <ReadonlyTextarea ref={ref} value={value.original} /> : null}
             <ReadonlyTextarea ref={ref} value={prettyPrint(value?.pretty)} />
-            {shouldHideTestResults ? <div className="fadeout" /> : null}
+            {shouldHideTestResults ? (
+                <div style={{ position: "relative" }}>
+                    <div className="fadeout" />
+                </div>
+            ) : null}
         </div>
     );
 });


### PR DESCRIPTION
## Describe your changes

Currently, when we test a scenario with ad hoc tests or tests from a file we get textAreas with contents displayed fully as shown on the screen.

![Zrzut ekranu z 2024-03-26 12-09-45](https://github.com/TouK/nussknacker/assets/30436981/a1c73fb5-bd5e-4092-9014-126713e7e057)

When contents are large it becomes cumbersome to scroll to find the variable that actually interests us, and generally it's not too pleasant to read.
To solve this I added mechanism with the "eye" symbol similar to the one introduced in this merged PR: https://github.com/TouK/nussknacker/pull/5690

If a variable's contents fit into 4 lines of text in textArea we do not show the "eye" icon.
Else, we render the icon in its "active" form hiding large content as shown on the screen below.

![Zrzut ekranu z 2024-03-26 11-10-20](https://github.com/TouK/nussknacker/assets/30436981/6e4790a7-f7b6-4a90-902a-d84007a1ede9)

Additionally, I removed the unused space that occurred when the fade effect was active on a textArea (screen below). Currently, it takes the same space as other textAreas (screen above).

![pusteMiejsce](https://github.com/TouK/nussknacker/assets/30436981/235973ab-d1ca-4a3f-b857-f96b9e47681b)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [x] Verify that PR will be squashed during merge
