### PR TITLE
Temporary fix for unintelligible exception raised when category field is missing

### DIFF
--- a/designer/client/src/components/useProcessFormDataOptions.test.ts
+++ b/designer/client/src/components/useProcessFormDataOptions.test.ts
@@ -398,39 +398,40 @@ describe("useProcessFormDataOptions", () => {
         });
     });
 
-    it("should return isCategoryFieldVisible false when there is only one category available", () => {
-        const jsonDataOneUnique: ScenarioParametersCombination[] = [
-            { processingMode: ProcessingMode.streaming, category: "Category1", engineSetupName: "Engine1" },
-            { processingMode: ProcessingMode.streaming, category: "Category1", engineSetupName: "Engine1" },
-            { processingMode: ProcessingMode.batch, category: "Category1", engineSetupName: "Engine2" },
-        ];
-
-        const value: Record<string, string> = {
-            processingMode: "",
-            processCategory: "",
-            processEngine: "",
-        };
-
-        const { result } = renderHook(() =>
-            useProcessFormDataOptions({
-                allCombinations: jsonDataOneUnique,
-                value,
-            }),
-        );
-
-        expect(result.current).toEqual({
-            categories: [
-                {
-                    disabled: false,
-                    value: "Category1",
-                },
-            ],
-            engines: ["Engine1", "Engine2"],
-            isCategoryFieldVisible: false,
-            isProcessingModeBatchAvailable: true,
-            isEngineFieldVisible: false,
-
-            processingModes: ["Unbounded-Stream", "Bounded-Stream"],
-        });
-    });
+    // TODO: Uncomment when temporary fix is removed. See useProcessFormDataOptions
+    // it("should return isCategoryFieldVisible false when there is only one category available", () => {
+    //     const jsonDataOneUnique: ScenarioParametersCombination[] = [
+    //         { processingMode: ProcessingMode.streaming, category: "Category1", engineSetupName: "Engine1" },
+    //         { processingMode: ProcessingMode.streaming, category: "Category1", engineSetupName: "Engine1" },
+    //         { processingMode: ProcessingMode.batch, category: "Category1", engineSetupName: "Engine2" },
+    //     ];
+    //
+    //     const value: Record<string, string> = {
+    //         processingMode: "",
+    //         processCategory: "",
+    //         processEngine: "",
+    //     };
+    //
+    //     const { result } = renderHook(() =>
+    //         useProcessFormDataOptions({
+    //             allCombinations: jsonDataOneUnique,
+    //             value,
+    //         }),
+    //     );
+    //
+    //     expect(result.current).toEqual({
+    //         categories: [
+    //             {
+    //                 disabled: false,
+    //                 value: "Category1",
+    //             },
+    //         ],
+    //         engines: ["Engine1", "Engine2"],
+    //         isCategoryFieldVisible: false,
+    //         isProcessingModeBatchAvailable: true,
+    //         isEngineFieldVisible: false,
+    //
+    //         processingModes: ["Unbounded-Stream", "Bounded-Stream"],
+    //     });
+    // });
 });

--- a/designer/client/src/components/useProcessFormDataOptions.ts
+++ b/designer/client/src/components/useProcessFormDataOptions.ts
@@ -68,6 +68,7 @@ export const useProcessFormDataOptions = ({ allCombinations, value }: Props) => 
         return multipleEnginesSelectable;
     }, [allCombinations]);
 
+    // TODO: Remove this temporary fix. When category field is hidden the request is incomplete and backend raises unintelligible exception.
     const isCategoryFieldVisible = true; // QUICK-BUG-FIX categories.length > 1;
 
     const isProcessingModeBatchAvailable = allCombinations.some((allCombination) => allCombination.processingMode === ProcessingMode.batch);


### PR DESCRIPTION
## Describe your changes

Temporary fix for unintelligible exception raised when category field is missing

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
