### PR TITLE
Add comment username override mechanism for technical users

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TapirCodecs.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TapirCodecs.scala
@@ -6,7 +6,7 @@ import pl.touk.nussknacker.engine.api.component.ProcessingMode
 import pl.touk.nussknacker.engine.api.process.{ProcessName, VersionId}
 import pl.touk.nussknacker.engine.deployment.EngineSetupName
 import pl.touk.nussknacker.ui.api.description.MigrationApiEndpoints.Dtos.MigrateScenarioRequest
-import pl.touk.nussknacker.ui.server.HeadersSupport.{ContentDisposition, FileName}
+import pl.touk.nussknacker.ui.server.HeadersSupport.{ContentDisposition, FileName, ForwardedUsername}
 import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.CodecFormat.TextPlain
 import sttp.tapir.{Codec, CodecFormat, DecodeResult, Schema}
@@ -64,6 +64,19 @@ object TapirCodecs {
         override def format: TextPlain = CodecFormat.TextPlain()
       }
 
+  }
+
+  object ForwardedUsernameCodec {
+    def encode(forwardedUsername: ForwardedUsername): String = forwardedUsername.value
+
+    def decode(s: String): DecodeResult[ForwardedUsername] = {
+      val scenarioName = ForwardedUsername(s)
+      DecodeResult.Value(scenarioName)
+    }
+
+    implicit val forwardedUsernameCodec: PlainCodec[ForwardedUsername] = Codec.string.mapDecode(decode)(encode)
+
+    implicit val schema: Schema[ForwardedUsername] = Schema.string
   }
 
   object HeaderCodec {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/ScenarioActivityApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/ScenarioActivityApiEndpoints.scala
@@ -7,8 +7,12 @@ import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions
 import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions.SecuredEndpoint
 import pl.touk.nussknacker.security.AuthCredentials
 import pl.touk.nussknacker.ui.api.TapirCodecs
-import pl.touk.nussknacker.ui.process.repository.DbProcessActivityRepository.{Attachment => DbAttachment, Comment => DbComment, ProcessActivity => DbProcessActivity}
-import pl.touk.nussknacker.ui.server.HeadersSupport.FileName
+import pl.touk.nussknacker.ui.process.repository.DbProcessActivityRepository.{
+  Attachment => DbAttachment,
+  Comment => DbComment,
+  ProcessActivity => DbProcessActivity
+}
+import pl.touk.nussknacker.ui.server.HeadersSupport.{FileName, ForwardedUsername}
 import pl.touk.nussknacker.ui.api.BaseHttpService.CustomAuthorizationError
 import sttp.model.StatusCode.{InternalServerError, NotFound, Ok}
 import sttp.model.{HeaderNames, MediaType}
@@ -25,6 +29,7 @@ class ScenarioActivityApiEndpoints(auth: EndpointInput[AuthCredentials]) extends
   import ScenarioActivityApiEndpoints.Dtos.ScenarioActivityError._
   import ScenarioActivityApiEndpoints.Dtos._
   import TapirCodecs.ContentDispositionCodec._
+  import TapirCodecs.ForwardedUsernameCodec._
   import TapirCodecs.HeaderCodec._
   import TapirCodecs.ScenarioNameCodec._
   import TapirCodecs.VersionIdCodec._
@@ -74,7 +79,8 @@ class ScenarioActivityApiEndpoints(auth: EndpointInput[AuthCredentials]) extends
       .post
       .in(
         ("processes" / path[ProcessName]("scenarioName") / path[VersionId]("versionId") / "activity"
-          / "comments" / stringBody).mapTo[AddCommentRequest]
+          / "comments" / stringBody / header[Option[ForwardedUsername]](ForwardedUsername.headerName))
+          .mapTo[AddCommentRequest]
       )
       .out(statusCode(Ok))
       .errorOut(scenarioNotFoundErrorOutput)
@@ -232,7 +238,12 @@ object ScenarioActivityApiEndpoints {
 
     }
 
-    final case class AddCommentRequest(scenarioName: ProcessName, versionId: VersionId, commentContent: String)
+    final case class AddCommentRequest(
+        scenarioName: ProcessName,
+        versionId: VersionId,
+        commentContent: String,
+        forwardedUsername: Option[ForwardedUsername]
+    )
 
     final case class DeleteCommentRequest(scenarioName: ProcessName, commentId: Long)
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/db/entity/CommentEntityFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/db/entity/CommentEntityFactory.scala
@@ -61,7 +61,12 @@ trait CommentActions {
     Sequence[Long]("process_comments_id_sequence").next.result
   }
 
-  def newCommentAction(processId: ProcessId, processVersionId: => VersionId, comment: Option[Comment])(
+  def newCommentAction(
+      processId: ProcessId,
+      processVersionId: => VersionId,
+      comment: Option[Comment],
+      overriddenUsername: Option[String] = Option.empty
+  )(
       implicit ec: ExecutionContext,
       loggedUser: LoggedUser
   ): DB[Option[CommentEntityData]] = {
@@ -74,7 +79,10 @@ trait CommentActions {
             processId = processId,
             processVersionId = processVersionId,
             content = c.value,
-            user = loggedUser.username,
+            user = overriddenUsername match {
+              case Some(username) => username
+              case _              => loggedUser.username
+            },
             createDate = Timestamp.from(Instant.now())
           )
           _ <- commentsTable += entityData

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DbProcessActivityRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DbProcessActivityRepository.scala
@@ -16,7 +16,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait ProcessActivityRepository {
 
-  def addComment(processId: ProcessId, processVersionId: VersionId, comment: CommentValue)(
+  def addComment(
+      processId: ProcessId,
+      processVersionId: VersionId,
+      comment: CommentValue,
+      overriddenUsername: Option[String]
+  )(
       implicit ec: ExecutionContext,
       loggedUser: LoggedUser
   ): Future[Unit]
@@ -43,11 +48,16 @@ final case class DbProcessActivityRepository(protected val dbRef: DbRef)
 
   import profile.api._
 
-  override def addComment(processId: ProcessId, processVersionId: VersionId, comment: CommentValue)(
+  override def addComment(
+      processId: ProcessId,
+      processVersionId: VersionId,
+      comment: CommentValue,
+      overriddenUsername: Option[String]
+  )(
       implicit ec: ExecutionContext,
       loggedUser: LoggedUser
   ): Future[Unit] = {
-    run(newCommentAction(processId, processVersionId, Option(comment))).map(_ => ())
+    run(newCommentAction(processId, processVersionId, Option(comment), overriddenUsername)).map(_ => ())
   }
 
   override def deleteComment(commentId: Long)(implicit ec: ExecutionContext): Future[Either[Exception, Unit]] = {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/HeadersSupport.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/HeadersSupport.scala
@@ -24,4 +24,10 @@ object HeadersSupport {
       new ContentDisposition(Some(FileName(fileName)))
   }
 
+  final case class ForwardedUsername(value: String)
+
+  object ForwardedUsername {
+    val headerName = "forwarded-username"
+  }
+
 }

--- a/designer/server/src/test/resources/config/business-cases/basicauth-users.conf
+++ b/designer/server/src/test/resources/config/business-cases/basicauth-users.conf
@@ -33,7 +33,7 @@ rules: [
   },
   {
     role: "AllPermissions"
-    permissions: ["Read", "Write", "Deploy"]
+    permissions: ["Read", "Write", "Deploy", "OverrideUsername"]
     globalPermissions: []
     categories: ["Category1"]
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/UserApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/UserApiHttpServiceBusinessSpec.scala
@@ -31,7 +31,7 @@ class UserApiHttpServiceBusinessSpec
              |  "isAdmin": false,
              |  "categories": [ "Category1" ],
              |  "categoryPermissions": {
-             |      "Category1": [ "Deploy", "Read", "Write" ]
+             |      "Category1": [ "Deploy", "OverrideUsername", "Read", "Write" ]
              |    },
              |  "globalPermissions": []
              |}""".stripMargin)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/ScenarioAttachmentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/ScenarioAttachmentServiceSpec.scala
@@ -43,7 +43,12 @@ class ScenarioAttachmentServiceSpec extends AnyFunSuite with Matchers with Scala
 
 private object TestProcessActivityRepository extends ProcessActivityRepository {
 
-  override def addComment(processId: ProcessId, processVersionId: VersionId, comment: Comment)(
+  override def addComment(
+      processId: ProcessId,
+      processVersionId: VersionId,
+      comment: Comment,
+      overriddenUsername: Option[String]
+  )(
       implicit ec: ExecutionContext,
       loggedUser: LoggedUser
   ): Future[Unit] = ???

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -1550,6 +1550,11 @@ paths:
         schema:
           type: integer
           format: int64
+      - name: forwarded-username
+        in: header
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           text/plain:
@@ -1561,7 +1566,7 @@ paths:
           description: ''
         '400':
           description: 'Invalid value for: path parameter versionId, Invalid value
-            for: body'
+            for: body, Invalid value for: header forwarded-username'
           content:
             text/plain:
               schema:

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -14,6 +14,7 @@
 * [#5780](https://github.com/TouK/nussknacker/pull/5780) Fixed Scala case classes serialization when a class has additional fields in its body
 * [#5853](https://github.com/TouK/nussknacker/pull/5853) Add processing mode information and filtering to the components table
 * [#5843](https://github.com/TouK/nussknacker/pull/5843) Added new endpoint to provide statistics URL
+* [#5879](https://github.com/TouK/nussknacker/pull/5879) Added username override mechanism for adding comments
 
 1.14.0 (21 Mar 2024)
 -------------------------


### PR DESCRIPTION
## Describe your changes

Currently, when a technical user tries to add a comment (as a result of some action taken by a regular user) he becomes the author of the comment. Sometimes it would be useful to make an actual user triggering the action the author.

That's why in these changes I introduced a mechanism that enables overriding username for comments. If request contains optional header `forwarded-username` and the user has appropriate permission (`OverrideUsername`) the username passed in the header will become the author of the comment.

If header is not present the user who sent the request will become an author.
If the optional header is present and user does not have the permission 403 status code will be returned.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
