### PR TITLE
[NU-1609] fixed: Nu runtime memory leak 

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -15,6 +15,7 @@
 * [#5853](https://github.com/TouK/nussknacker/pull/5853) Add processing mode information and filtering to the components table
 * [#5843](https://github.com/TouK/nussknacker/pull/5843) Added new endpoint to provide statistics URL
 * [#5873](https://github.com/TouK/nussknacker/pull/5873) Handle list of the anonymous statistic URLs, and send them in the interval
+* [#5898](https://github.com/TouK/nussknacker/pull/5898) fixed Nu runtime memory leak
 
 1.14.0 (21 Mar 2024)
 -------------------------

--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/SynchronousExecutionContextAndIORuntime.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/SynchronousExecutionContextAndIORuntime.scala
@@ -53,7 +53,8 @@ object SynchronousExecutionContextAndIORuntime extends LazyLogging {
 
   // note: even if the provided by us IORuntime is dummy, it registers MBean for a sake of monitoring fibers. We don't
   //       need it, so we just disable it. There is no other way to do it by setting system property. After IORuntime
-  //       creation we clear the property (to not affect creating other /not existing currently/ IORuntimes)
+  //       creation we clear the property (to not affect creating other /not existing currently/ IORuntimes). Note that
+  //       we change here the global state, so this is not a bullet proof solution.
   private def withDisableCatsTracingMode(create: => IORuntime): IORuntime = synchronized {
     val tracingModePropertyName = "cats.effect.tracing.mode"
     val originalTracingMode     = Option(System.getProperty(tracingModePropertyName))

--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/SynchronousExecutionContextAndIORuntime.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/SynchronousExecutionContextAndIORuntime.scala
@@ -55,11 +55,16 @@ object SynchronousExecutionContextAndIORuntime extends LazyLogging {
   //       need it, so we just disable it. There is no other way to do it by setting system property. After IORuntime
   //       creation we clear the property (to not affect creating other /not existing currently/ IORuntimes)
   private def withDisableCatsTracingMode(create: => IORuntime): IORuntime = synchronized {
-    System.setProperty("cats.effect.tracing.mode", "NONE")
+    val tracingModePropertyName = "cats.effect.tracing.mode"
+    val originalTracingMode     = Option(System.getProperty(tracingModePropertyName))
+    System.setProperty(tracingModePropertyName, "NONE")
     try {
       create
     } finally {
-      System.clearProperty("cats.effect.tracing.mode")
+      originalTracingMode match {
+        case Some(mode) => System.setProperty(tracingModePropertyName, mode)
+        case None       => System.clearProperty(tracingModePropertyName)
+      }
     }
   }
 

--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/SynchronousExecutionContextAndIORuntime.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/SynchronousExecutionContextAndIORuntime.scala
@@ -19,13 +19,15 @@ object SynchronousExecutionContextAndIORuntime extends LazyLogging {
   })
 
   private def createSyncIORuntime(): IORuntime = {
-    IORuntime(
-      compute = syncEc,
-      blocking = syncEc,
-      scheduler = DummyScheduler,
-      shutdown = () => {},
-      config = IORuntimeConfig()
-    )
+    withDisableCatsTracingMode {
+      IORuntime(
+        compute = syncEc,
+        blocking = syncEc,
+        scheduler = DummyScheduler,
+        shutdown = () => {},
+        config = IORuntimeConfig()
+      )
+    }
   }
 
   // note: we provide a dummy implementation of scheduler, because IORuntime requires some. We don't want to use real
@@ -47,6 +49,18 @@ object SynchronousExecutionContextAndIORuntime extends LazyLogging {
     }
 
     override def monotonicNanos(): Long = System.nanoTime()
+  }
+
+  // note: even if the provided by us IORuntime is dummy, it registers MBean for a sake of monitoring fibers. We don't
+  //       need it, so we just disable it. There is no other way to do it by setting system property. After IORuntime
+  //       creation we clear the property (to not affect creating other /not existing currently/ IORuntimes)
+  private def withDisableCatsTracingMode(create: => IORuntime): IORuntime = synchronized {
+    System.setProperty("cats.effect.tracing.mode", "NONE")
+    try {
+      create
+    } finally {
+      System.clearProperty("cats.effect.tracing.mode")
+    }
   }
 
 }


### PR DESCRIPTION
## Describe your changes

`SynchronousExecutionContextAndIORuntime` provides sync IORuntime. The runtime is rather dummy and there is no simple way to close it properly. We thought that there was no simple way to close it, but the closing is not required because it's a dummy. It figures out that it's not so true, because by default, during creation, MBean is registered. We don't need the monitoring functionality provided by the MBean, so we simply disable it before creating the sync IORuntime. Now, we consider it really a dummy one.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
