### PR TITLE
Make CustomFicusInstances extendable

### DIFF
--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/config/CustomFicusInstances.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/config/CustomFicusInstances.scala
@@ -8,8 +8,15 @@ import net.ceedubs.ficus.readers._
 import java.util.UUID
 import scala.language.implicitConversions
 
-// We exclude URLReader because of our own implementation with fallback to a File url
-object CustomFicusInstances
+/**
+ * Configuration extending default Ficus decoding.
+ *
+ * Customizations:
+ *
+ *  - [[URLReader]] is modified to default to the `file://` scheme
+ *  - String values can be read as [[UUID]] instances
+ */
+trait CustomFicusInstances
     extends AnyValReaders
     with StringReader
     with SymbolReader
@@ -36,3 +43,5 @@ object CustomFicusInstances
   implicit def toFicusConfig(config: Config): FicusConfig = SimpleFicusConfig(config)
 
 }
+
+object CustomFicusInstances extends CustomFicusInstances

--- a/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/config/CustomFicusInstancesSpec.scala
+++ b/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/config/CustomFicusInstancesSpec.scala
@@ -1,0 +1,32 @@
+package pl.touk.nussknacker.engine.util.config
+
+import com.typesafe.config.ConfigValueFactory.fromAnyRef
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import CustomFicusInstances._
+
+import java.io.File
+import java.net.URL
+import java.util.UUID
+
+class CustomFicusInstancesSpec extends AnyFlatSpec with Matchers {
+
+  it should "decode URL using custom decoder" in {
+    case class Container(url: URL)
+
+    val config = ConfigFactory.empty().withValue("url", fromAnyRef("/absolute/path"))
+
+    config.as[Container].url shouldBe new File("/absolute/path").toURI.toURL
+  }
+
+  it should "decode UUID" in {
+    case class Container(uuid: UUID)
+
+    val config = ConfigFactory.empty().withValue("uuid", fromAnyRef("a0cddbd7-0f2d-4c86-8434-8811c45f18dd"))
+
+    config.as[Container].uuid shouldBe UUID.fromString("a0cddbd7-0f2d-4c86-8434-8811c45f18dd")
+  }
+
+}


### PR DESCRIPTION
## Describe your changes

We hit few cases of [Lightbend Config string length limitations](https://github.com/lightbend/config/issues/627), so I'm proposing a generic decoder that can make working with a workaround (basically writing long strings as lists of shorter strings) a bit easier.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
