### PR TITLE
Use explicit readers in CustomFicusInstances

### DIFF
--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/config/CustomFicusInstances.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/config/CustomFicusInstances.scala
@@ -35,10 +35,10 @@ trait CustomFicusInstances
     with URIExtensions {
 
   implicit val urlValueReader: ValueReader[URL] =
-    javaURIReader.map(uri => uri.withFileSchemeDefault.toURL)
+    URIReaders.javaURIReader.map(uri => uri.withFileSchemeDefault.toURL)
 
-  implicit val uuidValueReader: ValueReader[UUID] = ValueReader[String]
-    .map(value => UUID.fromString(value))
+  implicit val uuidValueReader: ValueReader[UUID] =
+    StringReader.stringValueReader.map(value => UUID.fromString(value))
 
   implicit def toFicusConfig(config: Config): FicusConfig = SimpleFicusConfig(config)
 


### PR DESCRIPTION
## Describe your changes

Follow-up to #5913, allows for overriding of `ValueReader[String]`.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
