### PR TITLE
Fix search node qualifier (selector) for variable node

### DIFF
--- a/designer/client/src/components/toolbars/search/utils.ts
+++ b/designer/client/src/components/toolbars/search/utils.ts
@@ -34,11 +34,11 @@ const fieldsSelectors: FilterSelector = [
     },
     {
         name: "paramValue",
-        selector: (node) => [node.expression, node.exprVal],
+        selector: (node) => [node.expression, node.exprVal, node.value],
     },
     {
         name: "outputValue",
-        selector: (node) => [node.outputName, node.output, node.outputVar, node.varName, node.value],
+        selector: (node) => [node.outputName, node.output, node.outputVar, node.varName],
     },
     {
         name: "paramValue",


### PR DESCRIPTION
## Describe your changes

Variable expression value was qualified as "Output" category in search results:
![obraz](https://github.com/TouK/nussknacker/assets/2381222/a6aeebc7-d4a6-420f-b3cc-a94e606990ad)

Fixed, expression value goes into "Value" category:
![Zrzut ekranu z 2024-04-24 00-06-47](https://github.com/TouK/nussknacker/assets/2381222/90ae462d-674f-41e0-8838-20fd1c1ddc73)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
