### PR TITLE
Bring back deploymentCommentSettings validation

### DIFF
--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/config/FeatureTogglesConfigTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/config/FeatureTogglesConfigTest.scala
@@ -1,0 +1,36 @@
+package pl.touk.nussknacker.ui.config
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory.fromMap
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.ui.api.EmptyDeploymentCommentSettingsError
+
+import scala.jdk.CollectionConverters._
+
+class FeatureTogglesConfigTest extends AnyFunSuite with Matchers {
+
+  test("should be ok with no deploymentCommentSettings") {
+    val config = ConfigFactory
+      .parseResources("config/business-cases/simple-streaming-use-case-designer.conf")
+    val parsedFeatures = FeatureTogglesConfig.create(config)
+    parsedFeatures.deploymentCommentSettings shouldBe None
+  }
+
+  test("should raise exception when invalid deploymentCommentSettings config") {
+    val config = ConfigFactory
+      .parseResources("config/business-cases/simple-streaming-use-case-designer.conf")
+      .withValue(
+        "deploymentCommentSettings",
+        fromMap(
+          Map[String, String](
+            "validationPattern" -> ""
+          ).asJava
+        )
+      )
+    intercept[EmptyDeploymentCommentSettingsError] {
+      FeatureTogglesConfig.create(config)
+    }
+  }
+
+}


### PR DESCRIPTION
## Describe your changes

`object DeploymentCommentSettings` was never used in "production" code. It was only used (tested) in tests. I see two ways:

1. remove `object DeploymentCommentSettings`
2. use it to validate configuration

And here I go with the latter option.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
