### PR TITLE
[NU-1657] Fixup to async DefaultAsyncExecutionContextPreparer

### DIFF
--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/async/DefaultServiceExecutionContextPreparer.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/async/DefaultServiceExecutionContextPreparer.scala
@@ -40,7 +40,7 @@ object DefaultServiceExecutionContextPreparer extends LazyLogging {
     }
   }
 
-  private[DefaultAsyncExecutionConfigPreparer] def close(): Unit = synchronized {
+  private[DefaultServiceExecutionContextPreparer] def close(): Unit = synchronized {
     logger.info(s"Closing asyncExecutor for ${asyncExecutionContext.map(_._1)}")
     asyncExecutionContext.foreach { case (_, executorService) => executorService.shutdownNow() }
     asyncExecutionContext = None

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/async/DefaultServiceExecutionContextPreparer.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/async/DefaultServiceExecutionContextPreparer.scala
@@ -13,8 +13,6 @@ object DefaultServiceExecutionContextPreparer extends LazyLogging {
 
   private final var asyncExecutionContext: Option[(ProcessName, ExecutionContextExecutorService)] = None
 
-  private final val counter = new AtomicLong(0)
-
   private val executorServiceCreator: (Int, ThreadFactory) => ExecutorService =
     (workers, threadFactory) => {
       val ex =
@@ -28,8 +26,7 @@ object DefaultServiceExecutionContextPreparer extends LazyLogging {
       workers: Int,
       processName: ProcessName
   ): ServiceExecutionContext = synchronized {
-    counter.incrementAndGet()
-    logger.info(s"Creating asyncExecutor for $processName, with $workers workers, counter is ${counter.get()}")
+    logger.info(s"Creating asyncExecutor for $processName, with $workers workers")
     ServiceExecutionContext {
       asyncExecutionContext match {
         case Some((_, ec)) => ec
@@ -43,12 +40,10 @@ object DefaultServiceExecutionContextPreparer extends LazyLogging {
     }
   }
 
-  private[DefaultServiceExecutionContextPreparer] def close(): Unit = {
-    logger.info(s"Closing asyncExecutor for ${asyncExecutionContext.map(_._1)} counter is ${counter.get()}")
-    if (counter.decrementAndGet() == 0) {
-      asyncExecutionContext.foreach(_._2.shutdownNow())
-      asyncExecutionContext = None
-    }
+  private[DefaultAsyncExecutionConfigPreparer] def close(): Unit = synchronized {
+    logger.info(s"Closing asyncExecutor for ${asyncExecutionContext.map(_._1)}")
+    asyncExecutionContext.foreach { case (_, executorService) => executorService.shutdownNow() }
+    asyncExecutionContext = None
   }
 
 }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
@@ -37,6 +37,15 @@ private[registrar] class AsyncInterpretationFunction(
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
+
+    getRuntimeContext.registerUserCodeClassLoaderReleaseHookIfAbsent(
+      "closeAsyncExecutionContext",
+      () => {
+        logger.info("User class loader release hook called - closing async execution context")
+        serviceExecutionContextPreparer.close()
+      }
+    )
+
     serviceExecutionContext = serviceExecutionContextPreparer.prepare(compilerData.metaData.name)
   }
 


### PR DESCRIPTION
## Describe your changes

We've run into the problem a few times now with the scenario getting a closed (Terminated) pool of threads from before the restart.
The idea is to remove the mechanism of atomic counting of the number of calls to open/close the pool. Instead, we use the "closeAsyncExecutionContext" hook and in the case of pool closure, we simply unregister user's class loader from Flink and reset the static variable: DefaultServiceExecutionContextPreparer#asyncExecutionContext.

BEWARE:  Asynchronous tests can still have this problem, because the tests share the same class loader, and in parallel execution that class loader is not unloaded - resulting in the pool not being closed!

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
