### PR TITLE
added `spacerBefore` prop in menu element to allow adding separators

### DIFF
--- a/designer/client/src/components/MenuBar/TabElement.tsx
+++ b/designer/client/src/components/MenuBar/TabElement.tsx
@@ -1,28 +1,46 @@
 import { DynamicTabData } from "../../containers/DynamicTab";
 import { NavLink } from "react-router-dom";
 import React from "react";
-import { Typography } from "@mui/material";
+import { styled } from "@mui/material";
 
-export function TabElement({ tab, className }: { tab: DynamicTabData; className?: string }): JSX.Element {
+function UnstyledTabElement({ tab, ...props }: { tab: DynamicTabData; className?: string }): JSX.Element {
     const { id, type, url, title } = tab;
     switch (type) {
         case "Local":
             return (
-                <Typography component={NavLink} className={className} to={url}>
+                <NavLink to={url} {...props}>
                     {title}
-                </Typography>
+                </NavLink>
             );
         case "Url":
             return (
-                <Typography component={"a"} className={className} href={url} target={"_blank"} rel="noreferrer">
+                <a href={url} target={"_blank"} rel="noreferrer" {...props}>
                     {title}
-                </Typography>
+                </a>
             );
         default:
             return (
-                <Typography component={NavLink} className={className} to={`/${id}`}>
+                <NavLink to={`/${id}`} {...props}>
                     {title}
-                </Typography>
+                </NavLink>
             );
     }
 }
+
+export const TabElement = styled(UnstyledTabElement)(({ theme }) => ({
+    padding: ".8em 1.2em",
+    whiteSpace: "nowrap",
+
+    "&, &:hover, &:focus": {
+        color: "inherit",
+        textDecoration: "none",
+    },
+
+    "&:hover": {
+        background: theme.palette.action.hover,
+    },
+
+    "&.active": {
+        background: theme.palette.action.active,
+    },
+}));

--- a/designer/client/src/components/MenuBar/menu.tsx
+++ b/designer/client/src/components/MenuBar/menu.tsx
@@ -1,4 +1,4 @@
-import { styled } from "@mui/material";
+import { styled, Typography } from "@mui/material";
 import { useStateWithRevertTimeout } from "./useStateWithRevertTimeout";
 import { useSelector } from "react-redux";
 import { getLoggedUser, getTabs } from "../../reducers/selectors/settings";
@@ -20,16 +20,6 @@ const PlainButton = styled("button")({
         outline: "unset",
     },
 });
-
-export const PlainLink = styled(TabElement)(({ theme }) => ({
-    "&, &:hover, &:focus": {
-        color: "inherit",
-        textDecoration: "none",
-    },
-    "&:hover": {
-        background: theme.palette.action.hover,
-    },
-}));
 
 const List = styled(TruncatedList)({
     // make sure to override global classname
@@ -110,6 +100,16 @@ function ExpandButton({ children }: PropsWithChildren<unknown>) {
     );
 }
 
+const Spacer = styled("span")(({ theme }) => ({
+    color: theme.palette.action.disabled,
+    border: "1px solid",
+    alignSelf: "stretch",
+    "li &": {
+        marginBlock: theme.spacing(1.5),
+        marginInline: theme.spacing(1),
+    },
+}));
+
 export function Menu(): JSX.Element {
     const tabs = useSelector(getTabs);
     const loggedUser = useSelector(getLoggedUser);
@@ -120,17 +120,10 @@ export function Menu(): JSX.Element {
                 .filter((t) => !t.requiredPermission || loggedUser.hasGlobalPermission(t.requiredPermission))
                 .filter((t) => !!t.title)
                 .map((tab) => (
-                    <PlainLink
-                        sx={(theme) => ({
-                            fontWeight: 400,
-                            padding: ".8em 1.2em",
-                            "&.active": {
-                                background: theme.palette.action.active,
-                            },
-                        })}
-                        key={tab.id}
-                        tab={tab}
-                    />
+                    <React.Fragment key={tab.id}>
+                        {tab.spacerBefore ? <Spacer /> : null}
+                        <Typography component={TabElement} tab={tab} />
+                    </React.Fragment>
                 )),
         [loggedUser, tabs],
     );

--- a/designer/client/src/containers/DynamicTab.tsx
+++ b/designer/client/src/containers/DynamicTab.tsx
@@ -31,6 +31,7 @@ export type DynamicTabData = BaseTabData & {
     title: string;
     id: string;
     requiredPermission?: string;
+    spacerBefore?: boolean;
 };
 
 export interface RemoteComponentProps {


### PR DESCRIPTION
replace this <img width="438" alt="Zrzut ekranu 2024-05-22 o 11 43 51" src="https://github.com/TouK/nussknacker/assets/965924/3ba317c4-a394-4cec-80c9-b60d265a8601"> with some civilized version


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
