### PR TITLE
Fixed width for actions dialogs when error message is too long

### DIFF
--- a/designer/client/src/components/modals/CustomActionDialog.tsx
+++ b/designer/client/src/components/modals/CustomActionDialog.tsx
@@ -110,7 +110,7 @@ export function CustomActionDialog(props: WindowContentProps<WindowKind, CustomA
 
     const [value, setValue] = useState<UnknownRecord>();
 
-    const confirm = useCallback(async () => {
+    const confirmAction = useCallback(async () => {
         await HttpService.customAction(processName, action.name, value, comment).then((response) => {
             if (response.isSuccess) {
                 dispatch(loadProcessState(processName));
@@ -124,10 +124,10 @@ export function CustomActionDialog(props: WindowContentProps<WindowKind, CustomA
     const { t } = useTranslation();
     const buttons: WindowButtonProps[] = useMemo(
         () => [
-            { title: t("dialog.button.cancel", "cancel"), action: () => props.close(), classname: LoadingButtonTypes.secondaryButton },
-            { title: t("dialog.button.confirm", "confirm"), action: () => confirm() },
+            { title: t("dialog.button.cancel", "Cancel"), action: () => props.close(), classname: LoadingButtonTypes.secondaryButton },
+            { title: t("dialog.button.confirm", "Ok"), action: () => confirmAction() },
         ],
-        [confirm, props, t],
+        [confirmAction, props, t],
     );
 
     return (

--- a/designer/client/src/components/toolbarSettings/actions.ts
+++ b/designer/client/src/components/toolbarSettings/actions.ts
@@ -1,3 +1,3 @@
 /* eslint-disable i18next/no-literal-string */
 
-export const ACTION_DIALOG_WIDTH = 636;
+export const ACTION_DIALOG_WIDTH = 652;

--- a/designer/client/src/components/toolbarSettings/actions.ts
+++ b/designer/client/src/components/toolbarSettings/actions.ts
@@ -1,3 +1,0 @@
-/* eslint-disable i18next/no-literal-string */
-
-export const ACTION_DIALOG_WIDTH = 652;

--- a/designer/client/src/components/toolbarSettings/actions.ts
+++ b/designer/client/src/components/toolbarSettings/actions.ts
@@ -1,0 +1,3 @@
+/* eslint-disable i18next/no-literal-string */
+
+export const ACTION_DIALOG_WIDTH = 636;

--- a/designer/client/src/components/toolbars/actions/buttons/CustomActionButton.tsx
+++ b/designer/client/src/components/toolbars/actions/buttons/CustomActionButton.tsx
@@ -7,6 +7,7 @@ import { StatusType } from "../../../Process/types";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
 import { ToolbarButtonProps } from "../../types";
 import UrlIcon from "../../../UrlIcon";
+import { ACTION_DIALOG_WIDTH } from "../../../toolbarSettings/actions";
 
 type CustomActionProps = {
     action: CustomAction;
@@ -39,6 +40,7 @@ export default function CustomActionButton(props: CustomActionProps) {
                 open<CustomAction>({
                     title: action.name,
                     kind: WindowKind.customAction,
+                    width: ACTION_DIALOG_WIDTH,
                     meta: action,
                 })
             }

--- a/designer/client/src/components/toolbars/actions/buttons/CustomActionButton.tsx
+++ b/designer/client/src/components/toolbars/actions/buttons/CustomActionButton.tsx
@@ -7,7 +7,7 @@ import { StatusType } from "../../../Process/types";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
 import { ToolbarButtonProps } from "../../types";
 import UrlIcon from "../../../UrlIcon";
-import { ACTION_DIALOG_WIDTH } from "../../../toolbarSettings/actions";
+import { ACTION_DIALOG_WIDTH } from "../../../../stylesheets/variables";
 
 type CustomActionProps = {
     action: CustomAction;

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/CancelDeployButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/CancelDeployButton.tsx
@@ -10,6 +10,7 @@ import { WindowKind, useWindows } from "../../../../windowManager";
 import { ToggleProcessActionModalData } from "../../../modals/DeployProcessDialog";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
 import { ToolbarButtonProps } from "../../types";
+import { ACTION_DIALOG_WIDTH } from "../../../toolbarSettings/actions";
 
 export default function CancelDeployButton(props: ToolbarButtonProps) {
     const { t } = useTranslation();
@@ -33,6 +34,7 @@ export default function CancelDeployButton(props: ToolbarButtonProps) {
                 open<ToggleProcessActionModalData>({
                     title: message,
                     kind: WindowKind.deployProcess,
+                    width: ACTION_DIALOG_WIDTH,
                     meta: { action },
                 })
             }

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/CancelDeployButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/CancelDeployButton.tsx
@@ -10,7 +10,7 @@ import { WindowKind, useWindows } from "../../../../windowManager";
 import { ToggleProcessActionModalData } from "../../../modals/DeployProcessDialog";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
 import { ToolbarButtonProps } from "../../types";
-import { ACTION_DIALOG_WIDTH } from "../../../toolbarSettings/actions";
+import { ACTION_DIALOG_WIDTH } from "../../../../stylesheets/variables";
 
 export default function CancelDeployButton(props: ToolbarButtonProps) {
     const { t } = useTranslation();

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/CustomActionButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/CustomActionButton.tsx
@@ -7,6 +7,7 @@ import { StatusType } from "../../../Process/types";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
 import { ToolbarButtonProps } from "../../types";
 import UrlIcon from "../../../UrlIcon";
+import { ACTION_DIALOG_WIDTH } from "../../../toolbarSettings/actions";
 
 type CustomActionProps = {
     action: CustomAction;
@@ -39,6 +40,7 @@ export default function CustomActionButton(props: CustomActionProps) {
                 open<CustomAction>({
                     title: action.name,
                     kind: WindowKind.customAction,
+                    width: ACTION_DIALOG_WIDTH,
                     meta: action,
                 })
             }

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/CustomActionButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/CustomActionButton.tsx
@@ -7,7 +7,7 @@ import { StatusType } from "../../../Process/types";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
 import { ToolbarButtonProps } from "../../types";
 import UrlIcon from "../../../UrlIcon";
-import { ACTION_DIALOG_WIDTH } from "../../../toolbarSettings/actions";
+import { ACTION_DIALOG_WIDTH } from "../../../../stylesheets/variables";
 
 type CustomActionProps = {
     action: CustomAction;

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/DeployButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/DeployButton.tsx
@@ -11,6 +11,7 @@ import { WindowKind } from "../../../../windowManager";
 import { ToggleProcessActionModalData } from "../../../modals/DeployProcessDialog";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
 import { ToolbarButtonProps } from "../../types";
+import { ACTION_DIALOG_WIDTH } from "../../../toolbarSettings/actions";
 
 export default function DeployButton(props: ToolbarButtonProps) {
     const dispatch = useDispatch();
@@ -49,6 +50,7 @@ export default function DeployButton(props: ToolbarButtonProps) {
                 open<ToggleProcessActionModalData>({
                     title: message,
                     kind: WindowKind.deployProcess,
+                    width: ACTION_DIALOG_WIDTH,
                     meta: { action, displayWarnings: true },
                 })
             }

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/DeployButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/DeployButton.tsx
@@ -11,7 +11,7 @@ import { WindowKind } from "../../../../windowManager";
 import { ToggleProcessActionModalData } from "../../../modals/DeployProcessDialog";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
 import { ToolbarButtonProps } from "../../types";
-import { ACTION_DIALOG_WIDTH } from "../../../toolbarSettings/actions";
+import { ACTION_DIALOG_WIDTH } from "../../../../stylesheets/variables";
 
 export default function DeployButton(props: ToolbarButtonProps) {
     const dispatch = useDispatch();

--- a/designer/client/src/stylesheets/variables.ts
+++ b/designer/client/src/stylesheets/variables.ts
@@ -6,3 +6,5 @@ export const PANEL_BUTTON_SIZE = SIDEBAR_WIDTH / 4;
 export const PANEL_BUTTON_SMALL_SIZE = SIDEBAR_WIDTH / 6;
 
 export const MODAL_HEADER_HEIGHT = 30;
+
+export const ACTION_DIALOG_WIDTH = 652;


### PR DESCRIPTION
## Describe your changes

Two problems (staging, v1.16):
1) When comment validation fails error message expands action dialog box. 
~2) Inconsistent position of actions buttons: deploy and cancel are centered, custom actions are aligned to the right~

![obraz](https://github.com/TouK/nussknacker/assets/2381222/391b7b22-3e0c-4c13-9d49-d74b49b6d7c0)
![obraz](https://github.com/TouK/nussknacker/assets/2381222/5f6336b2-2beb-4629-8d28-43352dbcd266)
![obraz](https://github.com/TouK/nussknacker/assets/2381222/2d2bacde-c92d-4a27-a9a2-8dece07a0f13)

Fix:
1) Long error message does not change the width of the dialog
~2) For all actions footer buttons are centered.~
![obraz](https://github.com/TouK/nussknacker/assets/2381222/7aa054a3-ce28-41a5-96e3-0749a4854c5a)


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
