### PR TITLE
Fix last action data determining

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
@@ -76,11 +76,17 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](
         actionRepository
           .getLastActionPerProcess(ProcessActionState.FinishedStates, Some(ScenarioActionName.StateActions))
       )
-      // for last deploy action we are not interested in ExecutionFinished deploys - we don't want to show them in the history
+      // For last deploy action we are not interested in Deploys that are Finished, but not ExecutionFinished, and that are not Cancelled
+      // so that the presence of such an action means that the process is currently deployed
       lastDeployedActionPerProcess <- fetchActionsOrEmpty(
         actionRepository
-          .getLastActionPerProcess(ProcessActionState.FinishedStates, Some(Set(ScenarioActionName.Deploy)))
-      ).map(_.filter { case (_, action) => action.state == ProcessActionState.Finished })
+          .getLastActionPerProcess(
+            ProcessActionState.FinishedStates,
+            Some(Set(ScenarioActionName.Deploy, ScenarioActionName.Cancel))
+          )
+      ).map(_.filter { case (_, action) =>
+        action.actionName == ScenarioActionName.Deploy && action.state == ProcessActionState.Finished
+      })
 
       latestProcesses <- fetchLatestProcessesQuery(query, lastDeployedActionPerProcess.keySet, isDeployed).result
     } yield latestProcesses
@@ -182,9 +188,13 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](
       processVersion = processVersion,
       lastActionData = actions.headOption,
       lastStateActionData = actions.find(a => ScenarioActionName.StateActions.contains(a.actionName)),
-      // for last deploy action we are not interested in ExecutionFinished deploys - we don't want to show them in the history
-      lastDeployedActionData =
-        actions.find(_.actionName == ScenarioActionName.Deploy).filter(_.state == ProcessActionState.Finished),
+      // For last deploy action we are not interested in Deploys that are Finished, but not ExecutionFinished, and that are not Cancelled
+      // so that the presence of such an action means that the process is currently deployed
+      lastDeployedActionData = actions
+        .find(action => Set(ScenarioActionName.Deploy, ScenarioActionName.Cancel).contains(action.actionName))
+        .filter(action =>
+          action.actionName == ScenarioActionName.Deploy && action.state == ProcessActionState.Finished
+        ),
       isLatestVersion = isLatestVersion,
       tags = Some(tags),
       history = Some(

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
@@ -77,9 +77,10 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](
           .getLastActionPerProcess(ProcessActionState.FinishedStates, Some(ScenarioActionName.StateActions))
       )
       // for last deploy action we are not interested in ExecutionFinished deploys - we don't want to show them in the history
-      lastDeployedActionPerProcess <- fetchActionsOrEmpty(
-        actionRepository.getLastActionPerProcess(Set(ProcessActionState.Finished), Some(Set(ScenarioActionName.Deploy)))
-      )
+      lastDeployedActionPerProcess = lastActionPerProcess.filter { case (_, action) =>
+        action.actionName == ScenarioActionName.Deploy && action.state == ProcessActionState.Finished
+      }
+
       latestProcesses <- fetchLatestProcessesQuery(query, lastDeployedActionPerProcess.keySet, isDeployed).result
     } yield latestProcesses
       .map { case ((_, processVersion), process) =>

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/DBFetchingProcessRepository.scala
@@ -76,7 +76,7 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](
         actionRepository
           .getLastActionPerProcess(ProcessActionState.FinishedStates, Some(ScenarioActionName.StateActions))
       )
-      // For last deploy action we are not interested in Deploys that are Finished, but not ExecutionFinished, and that are not Cancelled
+      // For last deploy action we are interested in Deploys that are Finished (not ExecutionFinished) and that are not Cancelled
       // so that the presence of such an action means that the process is currently deployed
       lastDeployedActionPerProcess <- fetchActionsOrEmpty(
         actionRepository
@@ -188,7 +188,7 @@ abstract class DBFetchingProcessRepository[F[_]: Monad](
       processVersion = processVersion,
       lastActionData = actions.headOption,
       lastStateActionData = actions.find(a => ScenarioActionName.StateActions.contains(a.actionName)),
-      // For last deploy action we are not interested in Deploys that are Finished, but not ExecutionFinished, and that are not Cancelled
+      // For last deploy action we are interested in Deploys that are Finished (not ExecutionFinished) and that are not Cancelled
       // so that the presence of such an action means that the process is currently deployed
       lastDeployedActionData = actions
         .find(action => Set(ScenarioActionName.Deploy, ScenarioActionName.Cancel).contains(action.actionName))

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessDBQueryRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/ProcessDBQueryRepository.scala
@@ -33,7 +33,7 @@ trait ProcessDBQueryRepository[F[_]] extends Repository[F] with NuTables {
 
   protected def fetchLatestProcessesQuery(
       query: ProcessEntityFactory#ProcessEntity => Rep[Boolean],
-      lastDeployedActionPerProcess: Set[ProcessId],
+      deployedProcesses: Set[ProcessId],
       isDeployed: Option[Boolean]
   )(implicit fetchShape: ScenarioShapeFetchStrategy[_], loggedUser: LoggedUser): Query[
     (
@@ -55,7 +55,7 @@ trait ProcessDBQueryRepository[F[_]] extends Repository[F] with NuTables {
       .filter { case ((_, _), process) =>
         isDeployed match {
           case None      => true: Rep[Boolean]
-          case Some(dep) => process.id.inSet(lastDeployedActionPerProcess) === dep
+          case Some(dep) => process.id.inSet(deployedProcesses) === dep
         }
       }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/WithAccessControlCheckingConfigScenarioHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/WithAccessControlCheckingConfigScenarioHelper.scala
@@ -50,4 +50,8 @@ trait WithAccessControlCheckingConfigScenarioHelper {
     rawScenarioHelper.createDeployedCanceledExampleScenario(scenarioName, category.stringify, isFragment = false)
   }
 
+  def createDeployedWithCustomActionScenario(scenarioName: ProcessName, category: TestCategory): ProcessId = {
+    rawScenarioHelper.createDeployedWithCustomActionScenario(scenarioName, category.stringify, isFragment = false)
+  }
+
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
@@ -96,6 +96,18 @@ private[test] class ScenarioHelper(dbRef: DbRef, designerConfig: Config)(implici
     } yield id).futureValue
   }
 
+  def createDeployedWithCustomActionScenario(
+      scenarioName: ProcessName,
+      category: String,
+      isFragment: Boolean
+  ): ProcessId = {
+    (for {
+      id <- prepareValidScenario(scenarioName, category, isFragment)
+      _  <- prepareDeploy(id, processingTypeBy(category))
+      _  <- prepareCustomAction(id)
+    } yield id).futureValue
+  }
+
   def createArchivedExampleScenario(scenarioName: ProcessName, category: String, isFragment: Boolean): ProcessId = {
     (for {
       id <- prepareValidScenario(scenarioName, category, isFragment)
@@ -125,6 +137,14 @@ private[test] class ScenarioHelper(dbRef: DbRef, designerConfig: Config)(implici
   private def prepareCancel(scenarioId: ProcessId): Future[_] = {
     val actionName = ScenarioActionName.Cancel
     val comment    = DeploymentComment.unsafe(UserComment("Cancel comment")).toComment(actionName)
+    dbioRunner.run(
+      actionRepository.addInstantAction(scenarioId, VersionId.initialVersionId, actionName, Some(comment), None)
+    )
+  }
+
+  private def prepareCustomAction(scenarioId: ProcessId): Future[_] = {
+    val actionName = ScenarioActionName("Custom")
+    val comment    = DeploymentComment.unsafe(UserComment("Execute custom action")).toComment(actionName)
     dbioRunner.run(
       actionRepository.addInstantAction(scenarioId, VersionId.initialVersionId, actionName, Some(comment), None)
     )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -828,6 +828,52 @@ class ProcessesResourcesSpec
     }
   }
 
+  test("should provide the same proper scenario state when fetching all scenarios and one scenario") {
+    createDeployedWithCustomActionScenario(processName, category = Category1)
+
+    Get(s"/api/processes") ~> withReaderUser() ~> applicationRoute ~> check {
+      status shouldEqual StatusCodes.OK
+      val loadedProcess = responseAs[List[ScenarioWithDetails]]
+
+      loadedProcess.head.lastAction should matchPattern {
+        case Some(
+              ProcessAction(_, _, _, _, _, _, ScenarioActionName("Custom"), ProcessActionState.Finished, _, _, _, _)
+            ) =>
+      }
+      loadedProcess.head.lastStateAction should matchPattern {
+        case Some(
+              ProcessAction(_, _, _, _, _, _, ScenarioActionName("DEPLOY"), ProcessActionState.Finished, _, _, _, _)
+            ) =>
+      }
+      loadedProcess.head.lastDeployedAction should matchPattern {
+        case Some(
+              ProcessAction(_, _, _, _, _, _, ScenarioActionName("DEPLOY"), ProcessActionState.Finished, _, _, _, _)
+            ) =>
+      }
+    }
+
+    Get(s"/api/processes/$processName") ~> withReaderUser() ~> applicationRoute ~> check {
+      status shouldEqual StatusCodes.OK
+      val loadedProcess = responseAs[ScenarioWithDetails]
+
+      loadedProcess.lastAction should matchPattern {
+        case Some(
+              ProcessAction(_, _, _, _, _, _, ScenarioActionName("Custom"), ProcessActionState.Finished, _, _, _, _)
+            ) =>
+      }
+      loadedProcess.lastStateAction should matchPattern {
+        case Some(
+              ProcessAction(_, _, _, _, _, _, ScenarioActionName("DEPLOY"), ProcessActionState.Finished, _, _, _, _)
+            ) =>
+      }
+      loadedProcess.lastDeployedAction should matchPattern {
+        case Some(
+              ProcessAction(_, _, _, _, _, _, ScenarioActionName("DEPLOY"), ProcessActionState.Finished, _, _, _, _)
+            ) =>
+      }
+    }
+  }
+
   test("not allow to save process if already exists") {
     val processName = ProcessName("p1")
     saveProcess(processName, ProcessTestData.sampleScenarioGraph, category = Category1) {

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+1.15.2 (7 June 2024)
+-------------------------
+* [#6134](https://github.com/TouK/nussknacker/pull/6134) Fixes in determining `lastStateActionData` and `lastDeployedActionData` for Scenario.
+  * Deployed version of scenario is now shown properly even if other actions followed deploy.
+  * Scenario state is now not impacted by actions that don't actually change it.
+
 1.15.1 (5 June 2024)
 -------------------------
 * [#6126](https://github.com/TouK/nussknacker/pull/6126) Fix statistics configuration.


### PR DESCRIPTION
## Describe your changes
This PR fixes the discrepant (and in the case of `lastDeployedActionData` incorrect in both cases) behaviour of `lastStateActionData/lastDeployedActionData` determining between `fetchLatestProcessDetailsByQueryAction` and `fetchProcessDetailsForVersion`


Here are the behaviours BEFORE the changes in this PR: ('list' is `fetchLatestProcessDetailsByQueryAction`, 'single' is `fetchProcessDetailsForVersion`)

lastActionData:
 - 'single' and 'list' - latest action out of those that are `Finished/ExecutionFinished`

lastStateActionData:
- 'single' - latest action out of those that (are `Finished/ExecutionFinished` _**AND**_ are state actions)
- 'list' - latest action out of those that (are `Finished/ExecutionFinished`) **_IF IT IS_** a state action

lastDeployedActionData (could be renamed to currentlyDeployedActionData IMO):
- 'single' - latest action out of those that are `Finished/ExecutionFinished` if it is `name==Deploy` and `state==Finished`
- 'list' - latest action out of those that are `Finished` if it is `name==Deploy`


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
