### PR TITLE
[NU-1649] Fix situation where no credentials were provided and anonymous access is not permitted

### DIFF
--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NuDesignerApiAvailableToExposeYamlSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NuDesignerApiAvailableToExposeYamlSpec.scala
@@ -166,7 +166,7 @@ object NuDesignerApiAvailableToExpose {
     val basicAuth = auth
       .basic[Option[String]]()
       .map(_.map(PassedAuthCredentials))(_.map(_.value))
-      .withPossibleImpersonation()
+      .withPossibleImpersonation(false)
 
     Try(clazz.getConstructor(classOf[EndpointInput[PassedAuthCredentials]]))
       .map(_.newInstance(basicAuth))


### PR DESCRIPTION
## Describe your changes

After [impersonation changes](https://github.com/TouK/nussknacker/pull/6053) when anonymous access was not configured and user tried to access main page he was getting authentication error.
It happend beacuse regardless of whether anonymous access was configured or not `NoCredentialsProvided` were passed further in the Authentication.

To fix that i added one check which was present before impersonation changes:
`case (None, None) if !anonymousAccessEnabled => DecodeResult.Missing`
With that when user enters the main page he gets possibility to log in with basic auth.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
