### PR TITLE
[NU-1712] Passing deployment ID as a Flink's job's ID

### DIFF
--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
@@ -79,7 +79,9 @@ sealed trait DeploymentSynchronisationSupport
 
 trait DeploymentSynchronisationSupported extends DeploymentSynchronisationSupport {
 
-  def getDeploymentStatusesToUpdate: Future[Map[newdeployment.DeploymentId, DeploymentStatus]]
+  def getDeploymentStatusesToUpdate(
+      deploymentIdsToCheck: Set[newdeployment.DeploymentId]
+  ): Future[Map[newdeployment.DeploymentId, DeploymentStatus]]
 
 }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
@@ -221,7 +221,8 @@ class MockDeploymentManager(
       processName: ProcessName,
       mainClass: String,
       args: List[String],
-      savepointPath: Option[String]
+      savepointPath: Option[String],
+      deploymentId: Option[newdeployment.DeploymentId]
   ): Future[Option[ExternalDeploymentId]] = ???
 
   override def customActionsDefinitions: List[CustomActionDefinition] = {

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/FlinkClientStub.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/FlinkClientStub.scala
@@ -14,6 +14,8 @@ class FlinkClientStub extends FlinkClient {
       implicit freshnessPolicy: DataFreshnessPolicy
   ): Future[WithDataFreshnessStatus[List[flinkRestModel.JobOverview]]] = ???
 
+  override def getJobDetails(jobId: String): Future[Option[flinkRestModel.JobDetails]] = ???
+
   override def getJobConfig(jobId: String): Future[flinkRestModel.ExecutionConfig] = ???
 
   override def cancel(deploymentId: ExternalDeploymentId): Future[Unit] = ???
@@ -29,7 +31,8 @@ class FlinkClientStub extends FlinkClient {
       jarFile: File,
       mainClass: String,
       args: List[String],
-      savepointPath: Option[String]
+      savepointPath: Option[String],
+      jobId: Option[String]
   ): Future[Option[ExternalDeploymentId]] = ???
 
   override def deleteJarIfExists(jarFileName: String): Future[Unit] = Future.successful(())

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
@@ -7,6 +7,7 @@ import pl.touk.nussknacker.engine.ModelData._
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.DeploymentUpdateStrategy.StateRestoringStrategy
 import pl.touk.nussknacker.engine.api.deployment._
+import pl.touk.nussknacker.engine.newdeployment
 import pl.touk.nussknacker.engine.api.deployment.inconsistency.InconsistentStateDetector
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName}
@@ -176,7 +177,8 @@ abstract class FlinkDeploymentManager(
           deploymentData,
           canonicalProcess
         ),
-        savepointPath
+        savepointPath,
+        command.deploymentData.deploymentId.toNewDeploymentIdOpt
       )
       _ <- runResult.map(waitForDuringDeployFinished(processName, _)).getOrElse(Future.successful(()))
     } yield runResult
@@ -255,7 +257,9 @@ abstract class FlinkDeploymentManager(
       processName: ProcessName,
       mainClass: String,
       args: List[String],
-      savepointPath: Option[String]
+      savepointPath: Option[String],
+      // TODO: make it mandatory - see TODO in newdeployment.DeploymentService
+      deploymentId: Option[newdeployment.DeploymentId]
   ): Future[Option[ExternalDeploymentId]]
 
   override def processStateDefinitionManager: ProcessStateDefinitionManager = FlinkProcessStateDefinitionManager

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/rest/CachedFlinkClient.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/rest/CachedFlinkClient.scala
@@ -5,7 +5,7 @@ import org.apache.flink.configuration.Configuration
 import pl.touk.nussknacker.engine.api.deployment.DataFreshnessPolicy.{CanBeCached, Fresh}
 import pl.touk.nussknacker.engine.api.deployment.{DataFreshnessPolicy, SavepointResult, WithDataFreshnessStatus}
 import pl.touk.nussknacker.engine.deployment.ExternalDeploymentId
-import pl.touk.nussknacker.engine.management.rest.flinkRestModel.{ExecutionConfig, JobOverview}
+import pl.touk.nussknacker.engine.management.rest.flinkRestModel.{ExecutionConfig, JobDetails, JobOverview}
 
 import java.io.File
 import scala.compat.java8.FutureConverters._
@@ -69,6 +69,8 @@ class CachedFlinkClient(delegate: FlinkClient, jobsOverviewCacheTTL: FiniteDurat
         }
       )
 
+  override def getJobDetails(jobId: String): Future[Option[JobDetails]] = delegate.getJobDetails(jobId)
+
   override def cancel(deploymentId: ExternalDeploymentId): Future[Unit] =
     delegate.cancel(deploymentId)
 
@@ -85,9 +87,10 @@ class CachedFlinkClient(delegate: FlinkClient, jobsOverviewCacheTTL: FiniteDurat
       jarFile: File,
       mainClass: String,
       args: List[String],
-      savepointPath: Option[String]
+      savepointPath: Option[String],
+      jobId: Option[String]
   ): Future[Option[ExternalDeploymentId]] =
-    delegate.runProgram(jarFile, mainClass, args, savepointPath)
+    delegate.runProgram(jarFile, mainClass, args, savepointPath, jobId)
 
   // TODO: Do we need cache here?
   override def getClusterOverview: Future[flinkRestModel.ClusterOverview] =

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/rest/FlinkClient.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/rest/FlinkClient.scala
@@ -6,7 +6,7 @@ import org.apache.flink.configuration.Configuration
 import pl.touk.nussknacker.engine.api.deployment.{DataFreshnessPolicy, SavepointResult, WithDataFreshnessStatus}
 import pl.touk.nussknacker.engine.deployment.ExternalDeploymentId
 import pl.touk.nussknacker.engine.management.FlinkConfig
-import pl.touk.nussknacker.engine.management.rest.flinkRestModel.{ClusterOverview, JobOverview}
+import pl.touk.nussknacker.engine.management.rest.flinkRestModel.{ClusterOverview, JobDetails, JobOverview}
 import sttp.client3.SttpBackend
 
 import java.io.File
@@ -20,6 +20,8 @@ trait FlinkClient {
   def getJobsOverviews()(
       implicit freshnessPolicy: DataFreshnessPolicy
   ): Future[WithDataFreshnessStatus[List[JobOverview]]]
+
+  def getJobDetails(jobId: String): Future[Option[JobDetails]]
 
   def getJobConfig(jobId: String): Future[flinkRestModel.ExecutionConfig]
 
@@ -37,7 +39,8 @@ trait FlinkClient {
       jarFile: File,
       mainClass: String,
       args: List[String],
-      savepointPath: Option[String]
+      savepointPath: Option[String],
+      jobId: Option[String]
   ): Future[Option[ExternalDeploymentId]]
 
 }

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/rest/HttpFlinkClient.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/rest/HttpFlinkClient.scala
@@ -9,6 +9,7 @@ import pl.touk.nussknacker.engine.deployment.ExternalDeploymentId
 import pl.touk.nussknacker.engine.management.rest.flinkRestModel._
 import pl.touk.nussknacker.engine.management.{FlinkArgsEncodeHack, FlinkConfig}
 import pl.touk.nussknacker.engine.sttp.SttpJson
+import pl.touk.nussknacker.engine.sttp.SttpJson.asOptionalJson
 import pl.touk.nussknacker.engine.util.exception.DeeplyCheckingExceptionExtractor
 import sttp.client3._
 import sttp.client3.circe._
@@ -103,6 +104,15 @@ class HttpFlinkClient(config: FlinkConfig, flinkUrl: Uri)(
       .recoverWith(recoverWithMessage("retrieve Flink jobs"))
   }
 
+  override def getJobDetails(jobId: String): Future[Option[JobDetails]] = {
+    basicRequest
+      .get(flinkUrl.addPath("jobs", jobId))
+      .response(asOptionalJson[JobDetails])
+      .send(backend)
+      .flatMap(SttpJson.failureToFuture)
+      .recoverWith(recoverWithMessage("retrieve Flink job details"))
+  }
+
   override def getJobConfig(jobId: String): Future[flinkRestModel.ExecutionConfig] = {
     basicRequest
       .get(flinkUrl.addPath("jobs", jobId, "config"))
@@ -192,13 +202,15 @@ class HttpFlinkClient(config: FlinkConfig, flinkUrl: Uri)(
       jarFile: File,
       mainClass: String,
       args: List[String],
-      savepointPath: Option[String]
+      savepointPath: Option[String],
+      jobId: Option[String]
   ): Future[Option[ExternalDeploymentId]] = {
     val program =
       DeployProcessRequest(
         entryClass = mainClass,
         savepointPath = savepointPath,
-        programArgs = FlinkArgsEncodeHack.prepareProgramArgs(args).mkString(" ")
+        programArgs = FlinkArgsEncodeHack.prepareProgramArgs(args).mkString(" "),
+        jobId = jobId
       )
     uploadJarFileIfNotExists(jarFile).flatMap { flinkJarFile =>
       basicRequest

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/rest/flinkRestModel.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/rest/flinkRestModel.scala
@@ -15,7 +15,8 @@ object flinkRestModel {
       savepointPath: Option[String],
       programArgs: String,
       parallelism: Int = common.ExecutionConfig.PARALLELISM_DEFAULT,
-      allowNonRestoredState: Boolean = true
+      allowNonRestoredState: Boolean = true,
+      jobId: Option[String]
   )
 
   @JsonCodec(encodeOnly = true) case class SavepointTriggerRequest(
@@ -65,19 +66,54 @@ object flinkRestModel {
       tasks: JobTasksOverview
   )
 
+  @JsonCodec(decodeOnly = true) case class JobDetails(
+      state: String,
+      `status-counts`: JobStatusCounts
+  )
+
   @JsonCodec(decodeOnly = true) case class JobTasksOverview(
-      total: Int,
+      override val total: Int,
       created: Int,
       scheduled: Int,
       deploying: Int,
-      running: Int,
-      finished: Int,
+      override val running: Int,
+      override val finished: Int,
       canceling: Int,
       canceled: Int,
       failed: Int,
       reconciling: Int,
       initializing: Option[Int]
-  )
+  ) extends BaseJobStatusCounts
+
+  @JsonCodec(decodeOnly = true) case class JobStatusCounts(
+      CREATED: Int,
+      SCHEDULED: Int,
+      DEPLOYING: Int,
+      RUNNING: Int,
+      FINISHED: Int,
+      CANCELING: Int,
+      CANCELED: Int,
+      FAILED: Int,
+      RECONCILING: Int,
+      INITIALIZING: Option[Int]
+  ) extends BaseJobStatusCounts {
+    override def running: Int = RUNNING
+
+    override def finished: Int = FINISHED
+
+    override def total: Int =
+      CREATED + SCHEDULED + DEPLOYING + RUNNING + FINISHED + CANCELING + CANCELED + FAILED + RECONCILING + INITIALIZING
+        .getOrElse(0)
+
+  }
+
+  trait BaseJobStatusCounts {
+    def running: Int
+
+    def finished: Int
+
+    def total: Int
+  }
 
   @JsonCodec(decodeOnly = true) case class JobConfig(jid: String, `execution-config`: ExecutionConfig)
 

--- a/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
+++ b/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkRestManagerSpec.scala
@@ -13,7 +13,6 @@ import pl.touk.nussknacker.engine.DeploymentManagerDependencies
 import pl.touk.nussknacker.engine.api.component.NodesDeploymentData
 import pl.touk.nussknacker.engine.api.deployment.DeploymentUpdateStrategy.StateRestoringStrategy
 import pl.touk.nussknacker.engine.api.deployment._
-import pl.touk.nussknacker.engine.api.deployment.cache.ScenarioStateCachingConfig
 import pl.touk.nussknacker.engine.api.deployment.inconsistency.InconsistentStateDetector
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus.ProblemStateStatus
@@ -21,7 +20,7 @@ import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId
 import pl.touk.nussknacker.engine.api.{MetaData, ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{DeploymentData, DeploymentId, ExternalDeploymentId, User}
-import pl.touk.nussknacker.engine.management.rest.{FlinkClient, HttpFlinkClient}
+import pl.touk.nussknacker.engine.management.rest.HttpFlinkClient
 import pl.touk.nussknacker.engine.management.rest.flinkRestModel._
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.test.{AvailablePortFinder, PatientScalaFutures}
@@ -34,9 +33,9 @@ import java.net.NoRouteToHostException
 import java.util.concurrent.TimeoutException
 import java.util.{Collections, UUID}
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 //TODO move some tests to FlinkHttpClientTest
 class FlinkRestManagerSpec extends AnyFunSuite with Matchers with PatientScalaFutures {

--- a/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/rest/FlinkHttpClientTest.scala
+++ b/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/rest/FlinkHttpClientTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.time.Span.convertSpanToDuration
 import pl.touk.nussknacker.engine.deployment.ExternalDeploymentId
 import pl.touk.nussknacker.engine.management.FlinkConfig
 import pl.touk.nussknacker.engine.management.rest.flinkRestModel.{JarFile, JarsResponse, UploadJarResponse}
+import pl.touk.nussknacker.engine.newdeployment.DeploymentId
 import pl.touk.nussknacker.engine.sttp.HttpClientError
 import pl.touk.nussknacker.test.PatientScalaFutures
 import sttp.client3.testing.SttpBackendStub
@@ -134,7 +135,7 @@ class FlinkHttpClientTest extends AnyFunSuite with Matchers with ScalaFutures wi
     }
 
     checkIfWrapped(flinkClient.cancel(deploymentId))
-    checkIfWrapped(flinkClient.runProgram(jarFile, "any", Nil, None))
+    checkIfWrapped(flinkClient.runProgram(jarFile, "any", Nil, None, Some(DeploymentId.generate.toString)))
   }
 
 }

--- a/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedDeploymentManager.scala
+++ b/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedDeploymentManager.scala
@@ -226,7 +226,9 @@ class EmbeddedDeploymentManager(
   override def deploymentSynchronisationSupport: DeploymentSynchronisationSupport =
     new DeploymentSynchronisationSupported {
 
-      override def getDeploymentStatusesToUpdate: Future[Map[newdeployment.DeploymentId, DeploymentStatus]] =
+      override def getDeploymentStatusesToUpdate(
+          deploymentIdsToCheck: Set[newdeployment.DeploymentId]
+      ): Future[Map[newdeployment.DeploymentId, DeploymentStatus]] =
         Future.successful(
           (
             for {


### PR DESCRIPTION
 + synchronisation of statuses uses job details endpoint instead of jobs overview + job config endpoints

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
