### PR TITLE
Fix FE ScenarioPropertyConfig's attribute to align to the BE response

### DIFF
--- a/designer/client/src/components/graph/node-modal/ScenarioProperty.tsx
+++ b/designer/client/src/components/graph/node-modal/ScenarioProperty.tsx
@@ -2,13 +2,13 @@ import { get } from "lodash";
 import EditableEditor from "./editors/EditableEditor";
 import React, { useCallback } from "react";
 import { ExpressionLang } from "./editors/expression/types";
-import { getValidationErrorsForField, PossibleValue } from "./editors/Validators";
+import { getValidationErrorsForField } from "./editors/Validators";
 import { NodeValidationError, PropertiesType } from "../../../types";
 
 export interface ScenarioPropertyConfig {
     editor: any;
     label: string;
-    values: Array<PossibleValue>;
+    defaultValue: string | null;
 }
 
 interface Props {

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
@@ -120,6 +120,8 @@ package object definition {
   )
 
   @JsonCodec final case class UiScenarioPropertyConfig(
+      // This attribute is deprecated on BE and FE as it's not used anywhere.
+      // Right now it's only kept because an external project uses it but it will be removed in the future.
       defaultValue: Option[String],
       editor: ParameterEditor,
       label: Option[String]


### PR DESCRIPTION
## Describe your changes

Currently there is a missmatch between what FE expects and BE provides while fetching `ProcessDefinitionData`.
Frontend's `ScenarioPropertiesConfig` contains attribute `values: Array<PossibleValue>` however backend does not return that. Instead it returns `defaultValue: Option[String]` which is ignored by the FE.

The `values` attribute isn't utilized on Frontend so I aligned the attribute to the BE response:
```  
@JsonCodec final case class UiScenarioPropertyConfig(
      defaultValue: Option[String],
      editor: ParameterEditor,
      label: Option[String]
  )
````
![Zrzut ekranu z 2024-06-21 09-24-17](https://github.com/TouK/nussknacker/assets/30436981/72a5db35-01fe-4187-a399-b7066e6752f9)

I noticed that mismatch when I had to use the `defaultValue` in an external project. 

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
