### PR TITLE
[NU-1719] Component statistics without restmodel

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/component/ComponentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/component/ComponentService.scala
@@ -32,6 +32,11 @@ trait ComponentService {
       implicit user: LoggedUser
   ): Future[XError[List[ComponentUsagesInScenario]]]
 
+  def getUsagesPerDesignerWideComponentId(
+      implicit loggedUser: LoggedUser,
+      ec: ExecutionContext
+  ): Future[Map[DesignerWideComponentId, Long]]
+
 }
 
 object DefaultComponentService {
@@ -139,6 +144,11 @@ class DefaultComponentService(
         )
       }
   }
+
+  override def getUsagesPerDesignerWideComponentId(
+      implicit loggedUser: LoggedUser,
+      ec: ExecutionContext
+  ): Future[Map[DesignerWideComponentId, Long]] = getUserAccessibleComponentUsages
 
   private def getUserAccessibleComponentUsages(
       implicit loggedUser: LoggedUser,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
@@ -478,7 +478,6 @@ class AkkaHttpBasedRouteProvider(
         processingTypeDataProvider.mapValues(_.deploymentData.deploymentManagerType),
         fingerprintService,
         processActivityRepository,
-        componentService,
         feStatisticsRepository,
         processingTypeDataProvider
           .mapValues { processingTypeData =>

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
@@ -478,6 +478,7 @@ class AkkaHttpBasedRouteProvider(
         processingTypeDataProvider.mapValues(_.deploymentData.deploymentManagerType),
         fingerprintService,
         processActivityRepository,
+        componentService,
         feStatisticsRepository,
         processingTypeDataProvider
           .mapValues { processingTypeData =>

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
@@ -27,6 +27,8 @@ object ScenarioStatistics {
 
   private val nameForCustom = "Custom"
 
+  private val nameForFragment = "Fragment"
+
   private def fromNussknackerPackage(component: ComponentDefinitionWithImplementation): Boolean =
     component.component.getClass.getPackageName.startsWith("pl.touk.nussknacker")
 
@@ -191,11 +193,12 @@ object ScenarioStatistics {
               if (fromNussknackerPackage(componentDefinition)) {
                 componentDefinition.id.toString
               } else nameForCustom
-            case None => nameForCustom
+            case None => nameForFragment
           }
           (componentIdOrCustom, usages)
         }
         .groupBy(_._1)
+        .removed(nameForFragment)
         .mapValuesNow(list => list.map(_._2).sum)
         .map { case (k, v) => (mapNameToStat(k), v.toString) }
     }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
@@ -177,7 +177,7 @@ object ScenarioStatistics {
       components
         .groupBy(_.id)
         .map { case (componentId, list) =>
-          if (fromNussknackerPackage(list.head)) {
+          if (list.forall(fromNussknackerPackage)) {
             componentId.toString
           } else nameForCustom
         }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
@@ -184,7 +184,7 @@ object ScenarioStatistics {
         .size
 
     val componentUsages = {
-      designerWideUsage
+      designerWideUsage.toList
         .map { case (designerWideId, usages) =>
           val componentIdOrCustom = components.find(_.designerWideId == designerWideId) match {
             case Some(componentDefinition) =>
@@ -196,7 +196,7 @@ object ScenarioStatistics {
           (componentIdOrCustom, usages)
         }
         .groupBy(_._1)
-        .mapValuesNow(_.values.sum)
+        .mapValuesNow(list => list.map(_._2).sum)
         .map { case (k, v) => (mapNameToStat(k), v.toString) }
     }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
@@ -84,8 +84,22 @@ object ScenarioStatistics {
       scenariosInputData: List[ScenarioStatisticsInputData],
       components: List[ComponentDefinitionWithImplementation]
   ): Map[String, String] = {
+    // Components are available independently from created scenarios
+    val componentsCount =
+      components
+        .groupBy(_.id)
+        .map { case (componentId, list) =>
+          if (list.head.component.getClass.getPackageName.startsWith("pl.touk.nussknacker")) {
+            componentId.toString
+          } else "Custom"
+        }
+        .toSet
+        .size
+
     if (scenariosInputData.isEmpty) {
-      emptyGeneralStatistics
+      emptyGeneralStatistics ++
+      Map(ComponentsCount -> componentsCount)
+        .map { case (k, v) => (k.toString, v.toString) }
     } else {
       //        Nodes stats
       val sortedNodes  = scenariosInputData.map(_.nodesCount).sorted
@@ -131,12 +145,19 @@ object ScenarioStatistics {
         .map(_.componentsAndFragmentsUsedCount)
         .flatMap(_.toList)
         .filterNot(_._1.`type` == ComponentType.Fragment)
+        .map { case (componentId, usages) =>
+          if (components.exists(component => component.id == componentId)) {
+            (componentId.toString, usages)
+          } else {
+            ("Custom", usages)
+          }
+        }
         .groupBy(_._1)
         .map { case (componentId, listOfUsages) =>
-          val usages = listOfUsages.map { case (componentId, usage) =>
+          val usages = listOfUsages.map { case (_, usage) =>
             usage
           }.sum
-          (mapNameToStat(componentId.toString), usages)
+          (mapNameToStat(componentId), usages)
         }
         .mapValuesNow(_.toString)
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
@@ -198,7 +198,7 @@ object ScenarioStatistics {
           (componentIdOrCustom, usages)
         }
         .groupBy(_._1)
-        .removed(nameForFragment)
+        .-(nameForFragment)
         .mapValuesNow(list => list.map(_._2).sum)
         .map { case (k, v) => (mapNameToStat(k), v.toString) }
     }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
@@ -25,6 +25,9 @@ object ScenarioStatistics {
 
   private val componentStatisticPrefix = "c_"
 
+  private def fromNussknackerPackage(component: ComponentDefinitionWithImplementation): Boolean =
+    component.component.getClass.getPackageName.startsWith("pl.touk.nussknacker")
+
   private[statistics] val emptyScenarioStatistics: Map[String, String] = Map(
     ScenarioCount        -> 0,
     FragmentCount        -> 0,
@@ -89,7 +92,7 @@ object ScenarioStatistics {
       components
         .groupBy(_.id)
         .map { case (componentId, list) =>
-          if (list.head.component.getClass.getPackageName.startsWith("pl.touk.nussknacker")) {
+          if (fromNussknackerPackage(list.head)) {
             componentId.toString
           } else "Custom"
         }
@@ -146,7 +149,10 @@ object ScenarioStatistics {
         .flatMap(_.toList)
         .filterNot(_._1.`type` == ComponentType.Fragment)
         .map { case (componentId, usages) =>
-          if (components.exists(component => component.id == componentId)) {
+          if (components.exists(component =>
+              component.id == componentId &&
+                fromNussknackerPackage(component)
+            )) {
             (componentId.toString, usages)
           } else {
             ("Custom", usages)
@@ -157,9 +163,8 @@ object ScenarioStatistics {
           val usages = listOfUsages.map { case (_, usage) =>
             usage
           }.sum
-          (mapNameToStat(componentId), usages)
+          (mapNameToStat(componentId), usages.toString)
         }
-        .mapValuesNow(_.toString)
 
       val componentsCount =
         components

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
@@ -140,7 +140,7 @@ object ScenarioStatistics {
           ).map { case (k, v) => (k.toString, v.toString) }
         }
       }
-      // Components stats
+      // Components usage stat
       val componentsUsedMap = scenariosInputData
         .map(_.componentsAndFragmentsUsedCount)
         .flatMap(_.toList)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsService.scala
@@ -3,11 +3,12 @@ package pl.touk.nussknacker.ui.statistics
 import cats.data.EitherT
 import cats.implicits.toTraverseOps
 import com.typesafe.scalalogging.LazyLogging
-import pl.touk.nussknacker.engine.api.component.ProcessingMode
+import pl.touk.nussknacker.engine.api.component.{BuiltInComponentId, ComponentId, ComponentType, ProcessingMode}
 import pl.touk.nussknacker.engine.api.deployment.{ProcessAction, StateStatus}
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.process.{ProcessId, VersionId}
 import pl.touk.nussknacker.engine.definition.component.ComponentDefinitionWithImplementation
+import pl.touk.nussknacker.engine.graph.node
 import pl.touk.nussknacker.engine.graph.node.FragmentInput
 import pl.touk.nussknacker.engine.version.BuildInfo
 import pl.touk.nussknacker.restmodel.component.ComponentListElement
@@ -56,7 +57,7 @@ object UsageStatisticsReportsSettingsService extends LazyLogging {
         )(user)
         .map { scenariosDetails =>
           Right(
-            scenariosDetails.map(scenario =>
+            scenariosDetails.map(scenario => {
               ScenarioStatisticsInputData(
                 isFragment = scenario.isFragment,
                 processingMode = scenario.processingMode,
@@ -66,11 +67,11 @@ object UsageStatisticsReportsSettingsService extends LazyLogging {
                 scenarioCategory = scenario.processCategory,
                 scenarioVersion = scenario.processVersionId,
                 createdBy = scenario.createdBy,
-                fragmentsUsedCount = getFragmentsUsedInScenario(scenario.scenarioGraph),
+                componentsAndFragmentsUsedCount = getComponentsUsedInScenario(scenario.scenarioGraph),
                 lastDeployedAction = scenario.lastDeployedAction,
                 scenarioId = scenario.processId
               )
-            )
+            })
           )
         }
     }
@@ -101,14 +102,31 @@ object UsageStatisticsReportsSettingsService extends LazyLogging {
 
   }
 
-  private def getFragmentsUsedInScenario(scenarioGraph: Option[ScenarioGraph]): Int = {
+  private def getComponentsUsedInScenario(scenarioGraph: Option[ScenarioGraph]): Map[ComponentId, Int] = {
     scenarioGraph match {
       case Some(graph) =>
-        graph.nodes.map {
-          case _: FragmentInput => 1
-          case _                => 0
-        }.sum
-      case None => 0
+        graph.nodes
+          .map {
+            case data: node.CustomNodeData           => ComponentId(ComponentType.CustomComponent, data.componentId)
+            case data: node.Source                   => ComponentId(ComponentType.Source, data.componentId)
+            case data: node.Sink                     => ComponentId(ComponentType.Sink, data.componentId)
+            case data: node.VariableBuilder          => BuiltInComponentId.RecordVariable
+            case data: node.Variable                 => BuiltInComponentId.Variable
+            case data: node.Enricher                 => ComponentId(ComponentType.Service, data.componentId)
+            case data: node.Processor                => ComponentId(ComponentType.Service, data.componentId)
+            case data: FragmentInput                 => ComponentId(ComponentType.Fragment, "fragment")
+            case data: node.FragmentUsageOutput      => ComponentId(ComponentType.Fragment, "fragment")
+            case data: node.Filter                   => BuiltInComponentId.Filter
+            case data: node.Switch                   => BuiltInComponentId.Choice
+            case data: node.Split                    => BuiltInComponentId.Split
+            case data: node.FragmentInputDefinition  => BuiltInComponentId.FragmentInputDefinition
+            case data: node.FragmentOutputDefinition => BuiltInComponentId.FragmentOutputDefinition
+            case data: node.BranchEndData            => ComponentId(ComponentType.Sink, data.id)
+          }
+          .filterNot(comp => comp.`type` == ComponentType.BuiltIn && (comp.name == "input" || comp.name == "output"))
+          .groupBy(identity)
+          .map { case (id, list) => (id, list.size) }
+      case None => Map.empty
     }
   }
 
@@ -151,18 +169,18 @@ class UsageStatisticsReportsSettingsService(
       scenariosInputData <- new EitherT(fetchNonArchivedScenariosInputData())
       scenariosStatistics = ScenarioStatistics.getScenarioStatistics(scenariosInputData)
       basicStatistics     = determineBasicStatistics(config)
-      generalStatistics   = ScenarioStatistics.getGeneralStatistics(scenariosInputData)
+      generalStatistics   = ScenarioStatistics.getGeneralStatistics(scenariosInputData, components)
       activity <- new EitherT(fetchActivity(scenariosInputData))
       activityStatistics = ScenarioStatistics.getActivityStatistics(activity)
       componentList <- new EitherT(fetchComponentList())
-      componentStatistics = ScenarioStatistics.getComponentStatistic(componentList, components)
+//      componentStatistics = ScenarioStatistics.getComponentStatistic(componentList, components)
       feStatistics <- EitherT.liftF(fetchFeStatistics())
       designerUptimeStatistics = getDesignerUptimeStatistics
     } yield basicStatistics ++
       scenariosStatistics ++
       generalStatistics ++
       activityStatistics ++
-      componentStatistics ++
+//      componentStatistics ++
       designerUptimeStatistics ++
       feStatistics.map { case (k, v) =>
         k -> v.toString
@@ -198,7 +216,7 @@ private[statistics] case class ScenarioStatisticsInputData(
     scenarioCategory: String,
     scenarioVersion: VersionId,
     createdBy: String,
-    fragmentsUsedCount: Int,
+    componentsAndFragmentsUsedCount: Map[ComponentId, Int],
     lastDeployedAction: Option[ProcessAction],
     scenarioId: Option[ProcessId]
 )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsService.scala
@@ -83,18 +83,12 @@ object UsageStatisticsReportsSettingsService extends LazyLogging {
       scenarioIds.map(scenarioId => scenarioActivityRepository.findActivity(scenarioId)).sequence.map(Right(_))
     }
 
-    def fetchComponentList(): Future[Either[StatisticError, List[ComponentListElement]]] = {
-      componentService.getComponentsList
-        .map(Right(_))
-    }
-
     new UsageStatisticsReportsSettingsService(
       config,
       urlConfig,
       fingerprintService,
       fetchNonArchivedScenarioParameters,
       fetchActivity,
-      fetchComponentList,
       () => ignoringErrorsFEStatisticsRepository.read(),
       componentList,
       designerClock
@@ -140,7 +134,6 @@ class UsageStatisticsReportsSettingsService(
     fetchActivity: List[ScenarioStatisticsInputData] => Future[
       Either[StatisticError, List[DbProcessActivityRepository.ProcessActivity]]
     ],
-    fetchComponentList: () => Future[Either[StatisticError, List[ComponentListElement]]],
     fetchFeStatistics: () => Future[Map[String, Long]],
     components: List[ComponentDefinitionWithImplementation],
     designerClock: Clock
@@ -172,7 +165,7 @@ class UsageStatisticsReportsSettingsService(
       generalStatistics   = ScenarioStatistics.getGeneralStatistics(scenariosInputData, components)
       activity <- new EitherT(fetchActivity(scenariosInputData))
       activityStatistics = ScenarioStatistics.getActivityStatistics(activity)
-      componentList <- new EitherT(fetchComponentList())
+//      componentList <- new EitherT(fetchComponentList())
 //      componentStatistics = ScenarioStatistics.getComponentStatistic(componentList, components)
       feStatistics <- EitherT.liftF(fetchFeStatistics())
       designerUptimeStatistics = getDesignerUptimeStatistics

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsService.scala
@@ -11,10 +11,8 @@ import pl.touk.nussknacker.engine.definition.component.ComponentDefinitionWithIm
 import pl.touk.nussknacker.engine.graph.node
 import pl.touk.nussknacker.engine.graph.node.FragmentInput
 import pl.touk.nussknacker.engine.version.BuildInfo
-import pl.touk.nussknacker.restmodel.component.ComponentListElement
 import pl.touk.nussknacker.ui.config.UsageStatisticsReportsConfig
 import pl.touk.nussknacker.ui.db.timeseries.{FEStatisticsRepository, ReadFEStatisticsRepository}
-import pl.touk.nussknacker.ui.definition.component.ComponentService
 import pl.touk.nussknacker.ui.process.ProcessService.GetScenarioWithDetailsOptions
 import pl.touk.nussknacker.ui.process.processingtype.{DeploymentManagerType, ProcessingTypeDataProvider}
 import pl.touk.nussknacker.ui.process.repository.{DbProcessActivityRepository, ProcessActivityRepository}
@@ -37,8 +35,6 @@ object UsageStatisticsReportsSettingsService extends LazyLogging {
       deploymentManagerTypes: ProcessingTypeDataProvider[DeploymentManagerType, _],
       fingerprintService: FingerprintService,
       scenarioActivityRepository: ProcessActivityRepository,
-      // TODO: Should not depend on DTO, need to extract usageCount and check if all available components are present using processingTypeDataProvider
-      componentService: ComponentService,
       statisticsRepository: FEStatisticsRepository[Future],
       componentList: List[ComponentDefinitionWithImplementation],
       designerClock: Clock
@@ -57,7 +53,7 @@ object UsageStatisticsReportsSettingsService extends LazyLogging {
         )(user)
         .map { scenariosDetails =>
           Right(
-            scenariosDetails.map(scenario => {
+            scenariosDetails.map(scenario =>
               ScenarioStatisticsInputData(
                 isFragment = scenario.isFragment,
                 processingMode = scenario.processingMode,
@@ -71,7 +67,7 @@ object UsageStatisticsReportsSettingsService extends LazyLogging {
                 lastDeployedAction = scenario.lastDeployedAction,
                 scenarioId = scenario.processId
               )
-            })
+            )
           )
         }
     }
@@ -101,21 +97,21 @@ object UsageStatisticsReportsSettingsService extends LazyLogging {
       case Some(graph) =>
         graph.nodes
           .map {
-            case data: node.CustomNodeData           => ComponentId(ComponentType.CustomComponent, data.componentId)
-            case data: node.Source                   => ComponentId(ComponentType.Source, data.componentId)
-            case data: node.Sink                     => ComponentId(ComponentType.Sink, data.componentId)
-            case data: node.VariableBuilder          => BuiltInComponentId.RecordVariable
-            case data: node.Variable                 => BuiltInComponentId.Variable
-            case data: node.Enricher                 => ComponentId(ComponentType.Service, data.componentId)
-            case data: node.Processor                => ComponentId(ComponentType.Service, data.componentId)
-            case data: FragmentInput                 => ComponentId(ComponentType.Fragment, "fragment")
-            case data: node.FragmentUsageOutput      => ComponentId(ComponentType.Fragment, "fragment")
-            case data: node.Filter                   => BuiltInComponentId.Filter
-            case data: node.Switch                   => BuiltInComponentId.Choice
-            case data: node.Split                    => BuiltInComponentId.Split
-            case data: node.FragmentInputDefinition  => BuiltInComponentId.FragmentInputDefinition
-            case data: node.FragmentOutputDefinition => BuiltInComponentId.FragmentOutputDefinition
-            case data: node.BranchEndData            => ComponentId(ComponentType.Sink, data.id)
+            case node: node.CustomNodeData        => ComponentId(ComponentType.CustomComponent, node.componentId)
+            case node: node.Source                => ComponentId(ComponentType.Source, node.componentId)
+            case node: node.Sink                  => ComponentId(ComponentType.Sink, node.componentId)
+            case _: node.VariableBuilder          => BuiltInComponentId.RecordVariable
+            case _: node.Variable                 => BuiltInComponentId.Variable
+            case node: node.Enricher              => ComponentId(ComponentType.Service, node.componentId)
+            case node: node.Processor             => ComponentId(ComponentType.Service, node.componentId)
+            case _: FragmentInput                 => ComponentId(ComponentType.Fragment, "fragment")
+            case _: node.FragmentUsageOutput      => ComponentId(ComponentType.Fragment, "fragment")
+            case _: node.Filter                   => BuiltInComponentId.Filter
+            case _: node.Switch                   => BuiltInComponentId.Choice
+            case _: node.Split                    => BuiltInComponentId.Split
+            case _: node.FragmentInputDefinition  => BuiltInComponentId.FragmentInputDefinition
+            case _: node.FragmentOutputDefinition => BuiltInComponentId.FragmentOutputDefinition
+            case node: node.BranchEndData         => ComponentId(ComponentType.Sink, node.id)
           }
           .filterNot(comp => comp.`type` == ComponentType.BuiltIn && (comp.name == "input" || comp.name == "output"))
           .groupBy(identity)
@@ -165,8 +161,6 @@ class UsageStatisticsReportsSettingsService(
       generalStatistics   = ScenarioStatistics.getGeneralStatistics(scenariosInputData, components)
       activity <- new EitherT(fetchActivity(scenariosInputData))
       activityStatistics = ScenarioStatistics.getActivityStatistics(activity)
-//      componentList <- new EitherT(fetchComponentList())
-//      componentStatistics = ScenarioStatistics.getComponentStatistic(componentList, components)
       feStatistics <- EitherT.liftF(fetchFeStatistics())
       designerUptimeStatistics = getDesignerUptimeStatistics
     } yield basicStatistics ++

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/CustomComponentService.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/CustomComponentService.scala
@@ -1,0 +1,15 @@
+package custom.component
+
+import pl.touk.nussknacker.engine.api.{MethodToInvoke, ParamName, Service}
+
+import scala.concurrent.Future
+
+object CustomComponentService extends Service {
+
+  @MethodToInvoke
+  def method(
+      @ParamName("paramStringEditor")
+      param: String
+  ): Future[String] = ???
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatisticsTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatisticsTest.scala
@@ -11,6 +11,7 @@ import pl.touk.nussknacker.engine.api.{MethodToInvoke, ParamName, Service}
 import pl.touk.nussknacker.engine.api.component.Component.AllowedProcessingModes
 import pl.touk.nussknacker.engine.api.component.{
   ComponentGroupName,
+  ComponentId,
   ComponentType,
   DesignerWideComponentId,
   ProcessingMode
@@ -116,7 +117,7 @@ class ScenarioStatisticsTest
       scenarioCategory = "Category1",
       scenarioVersion = VersionId(2),
       createdBy = "user",
-      fragmentsUsedCount = 0,
+      componentsAndFragmentsUsedCount = Map.empty,
       lastDeployedAction = None,
       scenarioId = None
     )
@@ -145,7 +146,7 @@ class ScenarioStatisticsTest
       scenarioCategory = "Category1",
       scenarioVersion = VersionId(2),
       createdBy = "user",
-      fragmentsUsedCount = 0,
+      componentsAndFragmentsUsedCount = Map.empty,
       lastDeployedAction = None,
       scenarioId = None
     )
@@ -173,7 +174,7 @@ class ScenarioStatisticsTest
       scenarioCategory = "Category1",
       scenarioVersion = VersionId(2),
       createdBy = "user",
-      fragmentsUsedCount = 0,
+      componentsAndFragmentsUsedCount = Map.empty,
       lastDeployedAction = None,
       scenarioId = None
     )
@@ -202,7 +203,7 @@ class ScenarioStatisticsTest
       scenarioCategory = "Category1",
       scenarioVersion = VersionId(2),
       createdBy = "user",
-      fragmentsUsedCount = 0,
+      componentsAndFragmentsUsedCount = Map.empty,
       lastDeployedAction = None,
       scenarioId = None
     )
@@ -232,7 +233,7 @@ class ScenarioStatisticsTest
       scenarioCategory = "Category1",
       scenarioVersion = VersionId(2),
       createdBy = "user",
-      fragmentsUsedCount = 0,
+      componentsAndFragmentsUsedCount = Map.empty,
       lastDeployedAction = None,
       scenarioId = None
     )
@@ -269,7 +270,6 @@ class ScenarioStatisticsTest
       mockedFingerprintService,
       () => Future.successful(Right(List.empty)),
       _ => Future.successful(Right(List.empty)),
-      () => Future.successful(Right(List.empty)),
       () => Future.successful(Map.empty[String, Long]),
       List.empty,
       clock
@@ -290,7 +290,6 @@ class ScenarioStatisticsTest
       mockedFingerprintService,
       () => Future.successful(Right(List.empty)),
       _ => Future.successful(Right(List.empty)),
-      () => Future.successful(Right(componentList)),
       () => Future.successful(Map.empty[String, Long]),
       componentWithImplementation,
       clock
@@ -311,7 +310,7 @@ class ScenarioStatisticsTest
       scenarioCategory = "Category1",
       scenarioVersion = VersionId(2),
       createdBy = "user",
-      fragmentsUsedCount = 1,
+      componentsAndFragmentsUsedCount = Map(ComponentId(ComponentType.Fragment, "fragment") -> 1),
       lastDeployedAction = None,
       scenarioId = None
     )
@@ -324,7 +323,7 @@ class ScenarioStatisticsTest
       scenarioCategory = "Category1",
       scenarioVersion = VersionId(2),
       createdBy = "user",
-      fragmentsUsedCount = 0,
+      componentsAndFragmentsUsedCount = Map.empty,
       lastDeployedAction = None,
       scenarioId = None
     )
@@ -337,7 +336,7 @@ class ScenarioStatisticsTest
       scenarioCategory = "Category1",
       scenarioVersion = VersionId(2),
       createdBy = "user",
-      fragmentsUsedCount = 0,
+      componentsAndFragmentsUsedCount = Map.empty,
       lastDeployedAction = None,
       scenarioId = None
     )
@@ -350,7 +349,7 @@ class ScenarioStatisticsTest
       scenarioCategory = "Category1",
       scenarioVersion = VersionId(1),
       createdBy = "user",
-      fragmentsUsedCount = 2,
+      componentsAndFragmentsUsedCount = Map(ComponentId(ComponentType.Fragment, "fragment") -> 2),
       lastDeployedAction = None,
       scenarioId = None
     )
@@ -361,7 +360,6 @@ class ScenarioStatisticsTest
       mockedFingerprintService,
       () => Future.successful(Right(List(nonRunningScenario, runningScenario, fragment, k8sRRScenario))),
       _ => Future.successful(Right(processActivityList)),
-      () => Future.successful(Right(componentList)),
       () => Future.successful(Map.empty[String, Long]),
       componentWithImplementation,
       clock

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatisticsTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatisticsTest.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.ui.statistics
 
+import custom.component.CustomComponentService
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.EitherValues
@@ -321,7 +322,7 @@ class ScenarioStatisticsTest
       UptimeInSecondsAverage -> 0,
       UptimeInSecondsMax     -> 0,
       UptimeInSecondsMin     -> 0,
-      ComponentsCount        -> 2,
+      ComponentsCount        -> 4,
       FragmentsUsedMedian    -> 1,
       FragmentsUsedAverage   -> 1,
       NodesMedian            -> 3,
@@ -465,12 +466,14 @@ class ScenarioStatisticsTest
   private def componentWithImplementation: List[ComponentDefinitionWithImplementation] = List(
     ComponentDefinitionWithImplementation.withEmptyConfig("accountService", TestService),
     ComponentDefinitionWithImplementation.withEmptyConfig("choice", TestService),
+    ComponentDefinitionWithImplementation.withEmptyConfig("customService", CustomComponentService),
+    ComponentDefinitionWithImplementation.withEmptyConfig("anotherCustomService", CustomComponentService),
   )
 
   private def componentUsagesMap: Map[DesignerWideComponentId, Long] = Map(
-    DesignerWideComponentId("service-accountservice") -> 5L,
-    DesignerWideComponentId("someCustomComponent")    -> 1L,
-    DesignerWideComponentId("anotherCustomComponent") -> 1L,
+    DesignerWideComponentId("service-accountservice")       -> 5L,
+    DesignerWideComponentId("service-customservice")        -> 1L,
+    DesignerWideComponentId("service-anothercustomservice") -> 1L,
   )
 
   object TestService extends Service {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatisticsTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatisticsTest.scala
@@ -289,7 +289,7 @@ class ScenarioStatisticsTest
     ).determineQueryParams().value.futureValue.value
 
     params should contain("c_srvcccntsrvc" -> "5")
-    params should contain("c_cstm" -> "1")
+    params should contain("c_cstm" -> "2")
     params.keySet shouldNot contain("c_bltnchc")
   }
 
@@ -339,7 +339,7 @@ class ScenarioStatisticsTest
       UnknownDMCount         -> 0,
       ActiveScenarioCount    -> 2,
       "c_srvcccntsrvc"       -> 5,
-      "c_cstm"               -> 1,
+      "c_cstm"               -> 2,
     ).map { case (k, v) => (k.toString, v.toString) }
     params should contain allElementsOf expectedStats
   }
@@ -469,7 +469,8 @@ class ScenarioStatisticsTest
 
   private def componentUsagesMap: Map[DesignerWideComponentId, Long] = Map(
     DesignerWideComponentId("service-accountservice") -> 5L,
-    DesignerWideComponentId("someCustomComponent")    -> 1L
+    DesignerWideComponentId("someCustomComponent")    -> 1L,
+    DesignerWideComponentId("anotherCustomComponent") -> 1L,
   )
 
   object TestService extends Service {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsServiceTest.scala
@@ -41,6 +41,7 @@ class UsageStatisticsReportsSettingsServiceTest
       fetchActivity = (_: List[ScenarioStatisticsInputData]) => Future.successful(Right(Nil)),
       fetchFeStatistics = () => Future.successful(Map.empty[String, Long]),
       components = List.empty,
+      componentUsage = () => Future.successful(Map.empty),
       designerClock = Clock.systemUTC()
     )
 
@@ -54,9 +55,9 @@ class UsageStatisticsReportsSettingsServiceTest
       fingerprintService = mockedFingerprintService,
       fetchNonArchivedScenariosInputData = () => Future.successful(Right(List.empty)),
       fetchActivity = _ => Future.successful(Right(List.empty)),
-      fetchComponentList = () => Future.successful(Right(List.empty)),
       fetchFeStatistics = () => Future.successful(Map.empty[String, Long]),
       components = List.empty,
+      componentUsage = () => Future.successful(Map.empty),
       designerClock = Clock.systemUTC()
     ).prepareStatisticsUrl().futureValue.value.reduce(_ ++ _)
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsServiceTest.scala
@@ -39,7 +39,6 @@ class UsageStatisticsReportsSettingsServiceTest
       fingerprintService = fingerprintService,
       fetchNonArchivedScenariosInputData = () => Future.successful(Right(Nil)),
       fetchActivity = (_: List[ScenarioStatisticsInputData]) => Future.successful(Right(Nil)),
-      fetchComponentList = () => Future.successful(Right(Nil)),
       fetchFeStatistics = () => Future.successful(Map.empty[String, Long]),
       components = List.empty,
       designerClock = Clock.systemUTC()


### PR DESCRIPTION
## Describe your changes
Remove creating `ComponentListElement` DTOs just to get component usages.
Instead, map of usages per `DesignerWideComponentId` is provided by `ComponentService` and then mapped by id to available components

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
