### PR TITLE
[NU-1559] fix joint js style loading

### DIFF
--- a/designer/client/jest.config.js
+++ b/designer/client/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     },
     moduleFileExtensions: ["js", "json", "jsx", "ts", "tsx", "svg"],
     moduleNameMapper: {
-        "\\.(css|less|scss|sss|styl)$": "<rootDir>/node_modules/jest-css-modules",
+        "\\.(css|less|scss|sss)$": "<rootDir>/node_modules/jest-css-modules",
         "\\.(svg)$": "<rootDir>/__mocks__/svgComponentMock",
         uuid: require.resolve("uuid"),
         "@fontsource/roboto-mono": "<rootDir>/node_modules/jest-css-modules",

--- a/designer/client/src/components/graph/Graph.tsx
+++ b/designer/client/src/components/graph/Graph.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable i18next/no-literal-string */
 import { dia, g, shapes } from "jointjs";
-import styles from "jointjs/dist/joint.css";
+import "jointjs/dist/joint.min.css";
 import { cloneDeep, debounce, isEmpty, isEqual, keys, sortBy, without } from "lodash";
 import React from "react";
 import { filterDragHovered, getLinkNodes, setLinksHovered } from "./utils/dragHelpers";
@@ -39,9 +38,6 @@ import { Theme } from "@mui/material";
 import { getCellsToLayout } from "./GraphPartialsInTS/calcLayout";
 import { PaperContainer } from "./paperContainer";
 import { EventTrackingSelector, EventTrackingType, TrackEventParams } from "../../containers/event-tracking";
-
-// TODO: this is needed here due to our webpack config - needs fixing (NU-1559).
-styles;
 
 function clamp(number: number, max: number) {
     return Math.round(Math.min(max, Math.max(-max, number)));

--- a/designer/client/webpack.config.ts
+++ b/designer/client/webpack.config.ts
@@ -206,7 +206,8 @@ const config: Configuration = {
                 use: ["babel-loader"],
             },
             {
-                test: /\.(css|styl|less)?$/,
+                test: /\.(css|less)?$/,
+                sideEffects: true,
                 use: [
                     "style-loader",
                     {
@@ -224,12 +225,6 @@ const config: Configuration = {
             },
             {
                 test: /\.css?$/,
-                enforce: "pre",
-                exclude: /node_modules/,
-                use: cssPreLoaders,
-            },
-            {
-                test: /\.styl$/,
                 enforce: "pre",
                 exclude: /node_modules/,
                 use: cssPreLoaders,


### PR DESCRIPTION
## Describe your changes
- In jointjs package.json there is a sideEffects flag set to false, which effectively means "this imported module is not used anywhere in the application" for a webpack and `import "jointjs/dist/joint.css";` is not used anywhere from a webpack perspective. We need to set explicitly this flag to true in case of CSS files in the webpack config
 ![image](https://github.com/TouK/nussknacker/assets/9945753/1b99fb31-6b43-4ba6-b162-af61035e8693)

- Remove absolute `styl` from our codebase and config
- Import minified version of jointsjs css 

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
