### PR TITLE
Stop deployment and reschedule actors less gracefully on reload

### DIFF
--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{CustomActionDefinition, ExternalDeploymentId}
 import pl.touk.nussknacker.engine.management.FlinkConfig
 import pl.touk.nussknacker.engine.management.periodic.PeriodicProcessService.PeriodicProcessStatus
-import pl.touk.nussknacker.engine.management.periodic.Utils.{runSafely, stopActorAndWaitUntilItsNameIsFree}
+import pl.touk.nussknacker.engine.management.periodic.Utils.{createActorWithRetry, runSafely}
 import pl.touk.nussknacker.engine.management.periodic.db.{DbInitializer, SlickPeriodicProcessesRepository}
 import pl.touk.nussknacker.engine.management.periodic.flink.FlinkJarManager
 import pl.touk.nussknacker.engine.management.periodic.service.{
@@ -16,7 +16,7 @@ import pl.touk.nussknacker.engine.management.periodic.service.{
   PeriodicProcessListenerFactory,
   ProcessConfigEnricherFactory
 }
-import pl.touk.nussknacker.engine.{BaseModelData, DeploymentManagerDependencies, newdeployment}
+import pl.touk.nussknacker.engine.{BaseModelData, DeploymentManagerDependencies}
 import slick.jdbc
 import slick.jdbc.JdbcProfile
 
@@ -60,21 +60,26 @@ object PeriodicDeploymentManager {
       clock,
       dependencies.actionService
     )
-    val deploymentActor = dependencies.actorSystem.actorOf(
+
+    // These actors have to be created with retries because they can initially fail to create due to taken names,
+    // if the actors (with the same names) created before reload aren't fully stopped (and their names freed) yet
+    val deploymentActor = createActorWithRetry(
+      s"periodic-${periodicBatchConfig.processingType}-deployer",
       DeploymentActor.props(service, periodicBatchConfig.deployInterval),
-      s"periodic-${periodicBatchConfig.processingType}-deployer"
+      dependencies.actorSystem
     )
-    val rescheduleFinishedActor = dependencies.actorSystem.actorOf(
+    val rescheduleFinishedActor = createActorWithRetry(
+      s"periodic-${periodicBatchConfig.processingType}-rescheduler",
       RescheduleFinishedActor.props(service, periodicBatchConfig.rescheduleCheckInterval),
-      s"periodic-${periodicBatchConfig.processingType}-rescheduler"
+      dependencies.actorSystem
     )
 
     val customActionsProvider = customActionsProviderFactory.create(scheduledProcessesRepository, service)
 
     val toClose = () => {
       runSafely(listener.close())
-      runSafely(stopActorAndWaitUntilItsNameIsFree(deploymentActor, dependencies.actorSystem))
-      runSafely(stopActorAndWaitUntilItsNameIsFree(rescheduleFinishedActor, dependencies.actorSystem))
+      runSafely(dependencies.actorSystem.stop(deploymentActor))
+      runSafely(dependencies.actorSystem.stop(rescheduleFinishedActor))
       runSafely(db.close())
     }
     new PeriodicDeploymentManager(

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -78,6 +78,8 @@ object PeriodicDeploymentManager {
 
     val toClose = () => {
       runSafely(listener.close())
+      // deploymentActor and rescheduleFinishedActor just call methods from PeriodicProcessService on interval,
+      // they don't have any internal state, so stopping them non-gracefully is safe
       runSafely(dependencies.actorSystem.stop(deploymentActor))
       runSafely(dependencies.actorSystem.stop(rescheduleFinishedActor))
       runSafely(db.close())

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.{CustomActionDefinition, ExternalDeploymentId}
 import pl.touk.nussknacker.engine.management.FlinkConfig
 import pl.touk.nussknacker.engine.management.periodic.PeriodicProcessService.PeriodicProcessStatus
-import pl.touk.nussknacker.engine.management.periodic.Utils.{gracefulStopActor, runSafely}
+import pl.touk.nussknacker.engine.management.periodic.Utils.{runSafely, stopActorAndWaitUntilItsNameIsFree}
 import pl.touk.nussknacker.engine.management.periodic.db.{DbInitializer, SlickPeriodicProcessesRepository}
 import pl.touk.nussknacker.engine.management.periodic.flink.FlinkJarManager
 import pl.touk.nussknacker.engine.management.periodic.service.{
@@ -73,8 +73,8 @@ object PeriodicDeploymentManager {
 
     val toClose = () => {
       runSafely(listener.close())
-      runSafely(gracefulStopActor(deploymentActor, dependencies.actorSystem))
-      runSafely(gracefulStopActor(rescheduleFinishedActor, dependencies.actorSystem))
+      runSafely(stopActorAndWaitUntilItsNameIsFree(deploymentActor, dependencies.actorSystem))
+      runSafely(stopActorAndWaitUntilItsNameIsFree(rescheduleFinishedActor, dependencies.actorSystem))
       runSafely(db.close())
     }
     new PeriodicDeploymentManager(

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/Utils.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/Utils.scala
@@ -1,16 +1,16 @@
 package pl.touk.nussknacker.engine.management.periodic
 
-import akka.actor.{ActorNotFound, ActorPath, ActorRef, ActorSystem}
+import akka.actor.{ActorRef, ActorSystem, Props}
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 object Utils extends LazyLogging {
 
-  private val ActorResolutionTimeout = 10 seconds
-  private val ActorResolutionPause   = 50 milliseconds
-  private val ActorResolutionRetries = 50
+  private val ActorCreationPause   = 50 milliseconds
+  private val ActorCreationRetries = 50
 
   def runSafely(action: => Unit): Unit = try {
     action
@@ -18,45 +18,23 @@ object Utils extends LazyLogging {
     case t: Throwable => logger.error("Error occurred, but skipping it", t)
   }
 
-  def stopActorAndWaitUntilItsNameIsFree(actorRef: ActorRef, actorSystem: ActorSystem): Unit = {
-    import actorSystem.dispatcher
-    logger.info(s"Stopping $actorRef")
-
-    actorSystem.stop(actorRef)
-
-    val freeNameFuture = for {
-      _ <- waitUntilActorNameIsFree( // this step is necessary because gracefulStop does not guarantee that the supervisor is notified of the name being freed
-        actorRef.path,
-        actorSystem
-      )
-    } yield {}
-
-    Await.result(
-      freeNameFuture,
-      ActorResolutionRetries * (ActorResolutionTimeout + ActorResolutionPause) + (1 second)
-    )
-
-    logger.info(s"Stopped $actorRef and ensured it's name is free")
-  }
-
-  private def waitUntilActorNameIsFree(actorPath: ActorPath, actorSystem: ActorSystem)(implicit e: ExecutionContext) = {
-    retry
-      .Pause(ActorResolutionRetries, ActorResolutionPause)
+  def createActorWithRetry(actorName: String, props: Props, actorSystem: ActorSystem)(
+      implicit ec: ExecutionContext
+  ): ActorRef = {
+    val actorRefFuture = retry
+      .Pause(ActorCreationRetries, ActorCreationPause)
       .apply { () =>
-        val actorResolutionFuture =
-          actorSystem
-            .actorSelection(actorPath)
-            .resolveOne(ActorResolutionTimeout)
-            .map(_ => Left(s"Actor path $actorPath is still taken"))
-
-        actorResolutionFuture.recover { case _: ActorNotFound =>
-          Right(s"Actor path $actorPath is free")
+        Future {
+          Try(actorSystem.actorOf(props, actorName))
         }
       }
       .map {
-        case Left(_)  => throw new IllegalStateException(s"Failed to free actor path $actorPath within allowed retries")
-        case Right(_) => ()
+        case Failure(ex) =>
+          throw new IllegalStateException(s"Failed to create actor '$actorName' within allowed retries: $ex")
+        case Success(a) => a
       }
+
+    Await.result(actorRefFuture, ActorCreationRetries * ActorCreationPause + (1 second))
   }
 
 }

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/Utils.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/Utils.scala
@@ -1,18 +1,14 @@
 package pl.touk.nussknacker.engine.management.periodic
 
 import akka.actor.{ActorNotFound, ActorPath, ActorRef, ActorSystem}
-import akka.pattern.{AskTimeoutException, gracefulStop}
 import com.typesafe.scalalogging.LazyLogging
 
-import java.util.concurrent.TimeoutException
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.{Await, ExecutionContext}
 
 object Utils extends LazyLogging {
 
-  private val GracefulStopTimeout    = 5 seconds
-  private val ActorResolutionTimeout = 5 seconds
+  private val ActorResolutionTimeout = 10 seconds
   private val ActorResolutionPause   = 50 milliseconds
   private val ActorResolutionRetries = 50
 
@@ -22,12 +18,13 @@ object Utils extends LazyLogging {
     case t: Throwable => logger.error("Error occurred, but skipping it", t)
   }
 
-  def gracefulStopActor(actorRef: ActorRef, actorSystem: ActorSystem): Unit = {
+  def stopActorAndWaitUntilItsNameIsFree(actorRef: ActorRef, actorSystem: ActorSystem): Unit = {
     import actorSystem.dispatcher
-    logger.info(s"Gracefully stopping $actorRef")
+    logger.info(s"Stopping $actorRef")
 
-    val gracefulStopFuture = for {
-      _ <- gracefulStop(actorRef, GracefulStopTimeout)
+    actorSystem.stop(actorRef)
+
+    val freeNameFuture = for {
       _ <- waitUntilActorNameIsFree( // this step is necessary because gracefulStop does not guarantee that the supervisor is notified of the name being freed
         actorRef.path,
         actorSystem
@@ -35,11 +32,11 @@ object Utils extends LazyLogging {
     } yield {}
 
     Await.result(
-      gracefulStopFuture,
-      GracefulStopTimeout + ActorResolutionRetries * (ActorResolutionTimeout + ActorResolutionPause) + (1 second)
+      freeNameFuture,
+      ActorResolutionRetries * (ActorResolutionTimeout + ActorResolutionPause) + (1 second)
     )
 
-    logger.info(s"Gracefully stopped $actorRef")
+    logger.info(s"Stopped $actorRef and ensured it's name is free")
   }
 
   private def waitUntilActorNameIsFree(actorPath: ActorPath, actorSystem: ActorSystem)(implicit e: ExecutionContext) = {

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
@@ -20,23 +20,23 @@ class UtilsSpec
 
   "Utils" should {
 
-    "stop actor and free actor path" in {
-      class TestActor extends Actor {
-        override def receive: Receive = { case _ =>
-          ()
-        }
-      }
-      val actorName = "actorName1"
-
-      val actorRef = system.actorOf(Props(new TestActor), actorName)
-
-      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef, system)
-
-      // with normal system.stop(actorRef) or akka.pattern.gracefulStop this throws "actor name is not unique"
-      val actorRef2 = system.actorOf(Props(new TestActor), actorName)
-
-      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef2, system) // stop and free it so it doesn't impact other tests
-    }
+//    "stop actor and free actor path" in {
+//      class TestActor extends Actor {
+//        override def receive: Receive = { case _ =>
+//          ()
+//        }
+//      }
+//      val actorName = "actorName1"
+//
+//      val actorRef = system.actorOf(Props(new TestActor), actorName)
+//
+//      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef, system)
+//
+//      // with normal system.stop(actorRef) or akka.pattern.gracefulStop this throws "actor name is not unique"
+//      val actorRef2 = system.actorOf(Props(new TestActor), actorName)
+//
+//      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef2, system) // stop and free it so it doesn't impact other tests
+//    }
 
     "stop actor and free actor path without waiting for all of it's messages to be processed" in {
       class TestActor extends Actor {

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
@@ -24,7 +24,7 @@ class UtilsSpec extends TestKit(ActorSystem("UtilsSpec")) with AnyWordSpecLike w
 
       val actorRef = system.actorOf(Props(new TestActor), actorName)
 
-      Utils.gracefulStopActor(actorRef, system)
+      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef, system)
 
       // with normal system.stop(actorRef) or akka.pattern.gracefulStop this throws "actor name is not unique"
       system.actorOf(Props(new TestActor), actorName)

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
@@ -2,11 +2,17 @@ package pl.touk.nussknacker.engine.management.periodic
 
 import akka.actor.{Actor, ActorSystem, Props}
 import akka.testkit.TestKit
+import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class UtilsSpec extends TestKit(ActorSystem("UtilsSpec")) with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
+class UtilsSpec
+    extends TestKit(ActorSystem("UtilsSpec"))
+    with AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with LazyLogging {
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -14,19 +20,44 @@ class UtilsSpec extends TestKit(ActorSystem("UtilsSpec")) with AnyWordSpecLike w
 
   "Utils" should {
 
-    "gracefully stop actor and free actor path" in {
+    "stop actor and free actor path" in {
       class TestActor extends Actor {
         override def receive: Receive = { case _ =>
           ()
         }
       }
-      val actorName = "actorName"
+      val actorName = "actorName1"
 
       val actorRef = system.actorOf(Props(new TestActor), actorName)
 
       Utils.stopActorAndWaitUntilItsNameIsFree(actorRef, system)
 
       // with normal system.stop(actorRef) or akka.pattern.gracefulStop this throws "actor name is not unique"
+      system.actorOf(Props(new TestActor), actorName)
+    }
+
+    "stop actor and free actor path without waiting for all of it's messages to be processed" in {
+      class TestActor extends Actor {
+        override def receive: Receive = { case msg =>
+          logger.info(s"Sleeping on the job '$msg' ...")
+          Thread.sleep(1000)
+        }
+      }
+      val actorName =
+        "actorName2" // has to be different from the previous test, because the actor created at the end of that can still live
+
+      val actorRef = system.actorOf(Props(new TestActor), actorName)
+
+      var messageCounter = 0
+      while (messageCounter < 1000) {
+        actorRef ! s"message number $messageCounter"
+        messageCounter += 1
+      }
+
+      Thread.sleep(1000)
+      // with gracefulStop this times out, because the PoisonPill is queued after the many normal messages
+      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef, system)
+
       system.actorOf(Props(new TestActor), actorName)
     }
 

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
@@ -26,14 +26,16 @@ class UtilsSpec
           ()
         }
       }
-      val actorName = "actorName1"
+      val actorName = "actorName"
 
       val actorRef = system.actorOf(Props(new TestActor), actorName)
 
       Utils.stopActorAndWaitUntilItsNameIsFree(actorRef, system)
 
       // with normal system.stop(actorRef) or akka.pattern.gracefulStop this throws "actor name is not unique"
-      system.actorOf(Props(new TestActor), actorName)
+      val actorRef2 = system.actorOf(Props(new TestActor), actorName)
+
+      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef2, system) // stop and free it so it doesn't impact other tests
     }
 
     "stop actor and free actor path without waiting for all of it's messages to be processed" in {
@@ -43,8 +45,7 @@ class UtilsSpec
           Thread.sleep(1000)
         }
       }
-      val actorName =
-        "actorName2" // has to be different from the previous test, because the actor created at the end of that can still live
+      val actorName = "actorName"
 
       val actorRef = system.actorOf(Props(new TestActor), actorName)
 
@@ -58,7 +59,9 @@ class UtilsSpec
       // with gracefulStop this times out, because the PoisonPill is queued after the many normal messages
       Utils.stopActorAndWaitUntilItsNameIsFree(actorRef, system)
 
-      system.actorOf(Props(new TestActor), actorName)
+      val actorRef2 = system.actorOf(Props(new TestActor), actorName)
+
+      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef2, system) // stop and free it so it doesn't impact other tests
     }
 
     "ignore exceptions inside runSafely block" in {

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
@@ -26,7 +26,7 @@ class UtilsSpec
           ()
         }
       }
-      val actorName = "actorName"
+      val actorName = "actorName1"
 
       val actorRef = system.actorOf(Props(new TestActor), actorName)
 
@@ -45,7 +45,7 @@ class UtilsSpec
           Thread.sleep(1000)
         }
       }
-      val actorName = "actorName"
+      val actorName = "actorName2"
 
       val actorRef = system.actorOf(Props(new TestActor), actorName)
 

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/UtilsSpec.scala
@@ -20,23 +20,23 @@ class UtilsSpec
 
   "Utils" should {
 
-//    "stop actor and free actor path" in {
-//      class TestActor extends Actor {
-//        override def receive: Receive = { case _ =>
-//          ()
-//        }
-//      }
-//      val actorName = "actorName1"
-//
-//      val actorRef = system.actorOf(Props(new TestActor), actorName)
-//
-//      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef, system)
-//
-//      // with normal system.stop(actorRef) or akka.pattern.gracefulStop this throws "actor name is not unique"
-//      val actorRef2 = system.actorOf(Props(new TestActor), actorName)
-//
-//      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef2, system) // stop and free it so it doesn't impact other tests
-//    }
+    "stop actor and free actor path" in {
+      class TestActor extends Actor {
+        override def receive: Receive = { case _ =>
+          ()
+        }
+      }
+      val actorName = "actorName"
+
+      val actorRef = system.actorOf(Props(new TestActor), actorName)
+
+      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef, system)
+
+      // with normal system.stop(actorRef) or akka.pattern.gracefulStop this throws "actor name is not unique"
+      val actorRef2 = system.actorOf(Props(new TestActor), actorName)
+
+      Utils.stopActorAndWaitUntilItsNameIsFree(actorRef2, system) // stop and free it so it doesn't impact other tests
+    }
 
     "stop actor and free actor path without waiting for all of it's messages to be processed" in {
       class TestActor extends Actor {
@@ -45,7 +45,7 @@ class UtilsSpec
           Thread.sleep(1000)
         }
       }
-      val actorName = "actorName2"
+      val actorName = "actorName"
 
       val actorRef = system.actorOf(Props(new TestActor), actorName)
 


### PR DESCRIPTION
## Describe your changes
The changes in https://github.com/TouK/nussknacker/pull/5907 proved insufficient, because `gracefulStop` patiently waits for the actor to finish processing ALL it's queued messages, which is a bit too graceful.

After the change, it will only finish it's currently processing message then stop.


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
