### PR TITLE
Fix search nodes panel (do not catch ctrl f)

### DIFF
--- a/designer/client/cypress/e2e/process2.cy.ts
+++ b/designer/client/cypress/e2e/process2.cy.ts
@@ -21,14 +21,8 @@ describe("Process view", () => {
 
     it("should have node search toolbar", () => {
         cy.get("[data-testid=search-panel]").should("be.visible");
-        cy.get("[data-testid=search-panel]")
-            .contains(/^search$/i)
-            .click();
-        cy.get("[title='toggle left panel']").click();
-        cy.get("[data-testid=search-panel]").should("be.not.visible");
-        cy.get("#nk-graph-main").click();
-        cy.realPress(["Meta", "F"]);
-        cy.get("[data-testid=search-panel] input").should("be.visible").should("be.focused");
+        cy.get("[data-testid=search-panel]").contains(/^search$/i);
+        cy.get("[data-testid=search-panel] input").click();
         cy.realType("en");
         cy.get("[data-testid=search-panel]").contains(/sms/i).click();
         cy.getNode("enricher")
@@ -47,9 +41,7 @@ describe("Process view", () => {
         cy.get("[data-testid=window]")
             .contains(/^cancel$/i)
             .click();
-        cy.get("#nk-graph-main").click();
-        cy.realPress(["Meta", "F"]);
-        cy.get("[data-testid=search-panel] input").should("be.visible").should("be.focused");
+        cy.get("[data-testid=search-panel] input").click().clear();
         cy.realType("source");
         cy.wait(750); //wait for animation
         cy.getNode("enricher")

--- a/designer/client/src/components/toolbars/search/SearchPanel.tsx
+++ b/designer/client/src/components/toolbars/search/SearchPanel.tsx
@@ -46,7 +46,7 @@ export function SearchPanel(props: ToolbarPanelProps): ReactElement {
             >
                 <SearchIcon isEmpty={isEmpty(filter)} />
             </SearchInputWithIcon>
-            <SearchResults filterValues={[filter.toLowerCase().trim()].filter(Boolean)} />
+            <SearchResults filterValues={[filter.toLowerCase()].filter(Boolean)} />
         </ToolbarWrapper>
     );
 }

--- a/designer/client/src/components/toolbars/search/SearchPanel.tsx
+++ b/designer/client/src/components/toolbars/search/SearchPanel.tsx
@@ -1,29 +1,21 @@
 import { isEmpty } from "lodash";
 import React, { ReactElement, useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
-import { toggleToolbar } from "../../../actions/nk/toolbars";
 import { useDocumentListeners } from "../../../containers/useDocumentListeners";
-import { getToolbarsConfigId } from "../../../reducers/selectors/toolbars";
-import { useSidePanel } from "../../sidePanels/SidePanel";
 import { SearchIcon } from "../../table/SearchFilter";
 import { Focusable } from "../../themed/InputWithIcon";
 import { ToolbarPanelProps } from "../../toolbarComponents/DefaultToolbarPanel";
 import { ToolbarWrapper } from "../../toolbarComponents/toolbarWrapper/ToolbarWrapper";
 import { SearchResults } from "./SearchResults";
 import { SearchInputWithIcon } from "../../themed/SearchInput";
-import { EventTrackingSelector, getEventTrackingProps, EventTrackingType, useEventTracking } from "../../../containers/event-tracking";
+import { EventTrackingSelector, getEventTrackingProps } from "../../../containers/event-tracking";
 
 export function SearchPanel(props: ToolbarPanelProps): ReactElement {
     const { t } = useTranslation();
-    const dispatch = useDispatch();
-    const toolbarsConfigId = useSelector(getToolbarsConfigId);
-    const { trackEvent } = useEventTracking();
     const [filter, setFilter] = useState<string>("");
     const clearFilter = useCallback(() => setFilter(""), []);
 
     const searchRef = useRef<Focusable>();
-    const sidePanel = useSidePanel();
 
     useDocumentListeners({
         keydown: (e) => {
@@ -36,18 +28,6 @@ export function SearchPanel(props: ToolbarPanelProps): ReactElement {
                     if (target instanceof HTMLElement) {
                         target.blur();
                     }
-                    break;
-                }
-                case "F": {
-                    if (!e.ctrlKey && !e.metaKey) return;
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (!sidePanel.isOpened) {
-                        sidePanel.onToggle();
-                    }
-                    dispatch(toggleToolbar(props.id, toolbarsConfigId, false));
-                    searchRef.current.focus();
-                    trackEvent({ selector: EventTrackingSelector.FocusSearchNodeField, event: EventTrackingType.Keyboard });
                     break;
                 }
             }
@@ -66,7 +46,7 @@ export function SearchPanel(props: ToolbarPanelProps): ReactElement {
             >
                 <SearchIcon isEmpty={isEmpty(filter)} />
             </SearchInputWithIcon>
-            <SearchResults filterValues={filter.toLowerCase().split(/\s/).filter(Boolean)} />
+            <SearchResults filterValues={[filter.toLowerCase().trim()].filter(Boolean)} />
         </ToolbarWrapper>
     );
 }

--- a/designer/client/src/components/toolbars/search/SearchPanel.tsx
+++ b/designer/client/src/components/toolbars/search/SearchPanel.tsx
@@ -1,7 +1,6 @@
 import { isEmpty } from "lodash";
 import React, { ReactElement, useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDocumentListeners } from "../../../containers/useDocumentListeners";
 import { SearchIcon } from "../../table/SearchFilter";
 import { Focusable } from "../../themed/InputWithIcon";
 import { ToolbarPanelProps } from "../../toolbarComponents/DefaultToolbarPanel";
@@ -16,23 +15,6 @@ export function SearchPanel(props: ToolbarPanelProps): ReactElement {
     const clearFilter = useCallback(() => setFilter(""), []);
 
     const searchRef = useRef<Focusable>();
-
-    useDocumentListeners({
-        keydown: (e) => {
-            switch (e.key.toUpperCase()) {
-                case "ESCAPE": {
-                    e.preventDefault();
-                    e.stopImmediatePropagation();
-                    clearFilter();
-                    const target = e.composedPath().shift();
-                    if (target instanceof HTMLElement) {
-                        target.blur();
-                    }
-                    break;
-                }
-            }
-        },
-    });
 
     return (
         <ToolbarWrapper {...props} title={t("panels.search.title", "Search")} onExpand={() => searchRef.current?.focus()}>


### PR DESCRIPTION
## Describe your changes

Search node panel updates:
1. Do not catch ctrl-f event to move focus and cursor to node search. Users use ctrl-f to engage browser search as a last stand solution to search anything within UI.
2. Use exact phrase to search nodes.

Need backport to 1.15 and 1.16.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
