### PR TITLE
[NU-1697] Fix ad hoc submitting empty field error and other small fixes

### DIFF
--- a/designer/client/src/components/comment/StyledComment.tsx
+++ b/designer/client/src/components/comment/StyledComment.tsx
@@ -61,4 +61,7 @@ export const PanelComment = styled("div")(({ theme }) => ({
     marginTop: "1px",
     fontSize: "12px",
     wordBreak: "break-word",
+    a: {
+        color: theme.palette.primary.main,
+    },
 }));

--- a/designer/client/src/components/modals/GenericAction/GenericActionDialog.tsx
+++ b/designer/client/src/components/modals/GenericAction/GenericActionDialog.tsx
@@ -8,7 +8,6 @@ import { LoadingButtonTypes } from "../../../windowManager/LoadingButton";
 import { WindowHeaderIconStyled } from "../../graph/node-modal/nodeDetails/NodeDetailsStyled";
 import { NodeDocs } from "../../graph/node-modal/nodeDetails/SubHeader";
 import { MarkdownForm } from "./MarkdownForm";
-import { isEmpty, omitBy } from "lodash";
 import { ActionValues, GenericActionFormContext } from "./GenericActionFormContext";
 import { Box } from "@mui/material";
 import { useGenericActionValidation } from "./useGenericActionValidation";
@@ -43,12 +42,6 @@ export interface GenericActionData {
     action: GenericAction;
 }
 
-function omitEmpty(value: ActionValues) {
-    return omitBy(value, ({ expression }) => {
-        return isEmpty(expression);
-    });
-}
-
 function GenericActionDialog(props: WindowContentProps<WindowKind, GenericActionData>): ReactElement {
     const { t } = useTranslation();
     const { data, close } = props;
@@ -62,8 +55,7 @@ function GenericActionDialog(props: WindowContentProps<WindowKind, GenericAction
     const { errors, isValid } = useGenericActionValidation(action, value);
 
     const confirm = useCallback(async () => {
-        const values = omitEmpty(value);
-        onConfirmAction(values);
+        onConfirmAction(value);
         close();
     }, [close, onConfirmAction, value]);
 

--- a/designer/client/src/components/toolbars/test/buttons/TestWithFormButton.tsx
+++ b/designer/client/src/components/toolbars/test/buttons/TestWithFormButton.tsx
@@ -34,7 +34,7 @@ function TestWithFormButton({ disabled, name, title, icon, docs, markdownContent
         inform({ text: `Testing with form support only one source - found ${sourcesFound}.` });
     }, [inform, sourcesFound]);
 
-    const Icon = useCallback(() => <UrlIcon src={icon} FallbackComponent={TestWFormIcon} />, [icon]);
+    const Icon = useCallback((props) => <UrlIcon src={icon} FallbackComponent={TestWFormIcon} {...props} />, [icon]);
 
     const action = useTestWithFormAction();
     const oneSourceTest = useCallback(() => {

--- a/designer/client/test/CommentContent-test.tsx
+++ b/designer/client/test/CommentContent-test.tsx
@@ -17,7 +17,7 @@ describe("CommentContent#newContent", () => {
             </NuThemeProvider>,
         );
         expect(container).toContainHTML(
-            '<div><div class="css-10wuv5k"><span class="MuiTypography-root MuiTypography-caption css-1w8legj-MuiTypography-root">This is a <a class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xhj5go-MuiTypography-root-MuiLink-root" href="http://bugs/BUG-123" target="_blank">BUG-123</a></span></div></div>',
+            '<div><div class="css-11j7oje"><span class="MuiTypography-root MuiTypography-caption css-1w8legj-MuiTypography-root">This is a <a class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xhj5go-MuiTypography-root-MuiLink-root" href="http://bugs/BUG-123" target="_blank">BUG-123</a></span></div></div>',
         );
     });
 
@@ -29,7 +29,7 @@ describe("CommentContent#newContent", () => {
             </NuThemeProvider>,
         );
         expect(container).toContainHTML(
-            '<div><div class="css-10wuv5k"><span class="MuiTypography-root MuiTypography-caption css-1w8legj-MuiTypography-root">This is a <a class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xhj5go-MuiTypography-root-MuiLink-root" href="http://bugs/BUG-123" target="_blank">BUG-123</a>, and this is another: <a class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xhj5go-MuiTypography-root-MuiLink-root" href="http://bugs/BUG-124" target="_blank">BUG-124</a></span></div></div>',
+            '<div><div class="css-11j7oje"><span class="MuiTypography-root MuiTypography-caption css-1w8legj-MuiTypography-root">This is a <a class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xhj5go-MuiTypography-root-MuiLink-root" href="http://bugs/BUG-123" target="_blank">BUG-123</a>, and this is another: <a class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xhj5go-MuiTypography-root-MuiLink-root" href="http://bugs/BUG-124" target="_blank">BUG-124</a></span></div></div>',
         );
     });
 


### PR DESCRIPTION
## Describe your changes
3 small fixes
1. Error when submitting empty field in ad hoc form (was caused by omitting empty fields when setting form state causing `Cannot read properties of undefined (reading 'expression')` in editors
2. No ad hoc form header styling caused by not passing className prop (was raising warnings since the component was used in 2 contexts - one requiring passing className) - still not an ideal solution
Before:
![ad-hox-before](https://github.com/TouK/nussknacker/assets/92804917/870f871b-65ba-4bcb-8813-6e679791ef38)
After:
![ad-hoc-icon-fixed](https://github.com/TouK/nussknacker/assets/92804917/0a8f310a-7326-418b-bf3b-d92a8db6f78d)
3. No styling in comment links in comment panel
Before:
![comments-before](https://github.com/TouK/nussknacker/assets/92804917/3d25db8d-89f8-46fd-9196-471243280e05)
After:
![comments-fixed](https://github.com/TouK/nussknacker/assets/92804917/36a84f63-3712-4336-97cd-77cd1287840e)


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
