### PR TITLE
Improvement: Pass implicite nodeId at EagerServiceWithStaticParamers. returnType

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,7 +12,7 @@
 * [#6388](https://github.com/TouK/nussknacker/pull/6388) Fix issue with suggestion expression mode and any value with suggestion in fragmentInput component, now supporting SpEL expressions.
 * [#6269](https://github.com/TouK/nussknacker/pull/6269) SpEL expression validator now works with values that are lists or maps.
   * NOTE: selection (`.?`), projection (`.!`) or operations from the `#COLLECTIONS` helper aren't properly supported in validation expressions, and will cause the result to always be invalid
-* [#6418](https://github.com/TouK/nussknacker/pull/6418) Improvement: Pass implicit nodeId to EagerServiceWithStaticParamers. returnType
+* [#6418](https://github.com/TouK/nussknacker/pull/6418) Improvement: Pass implicit nodeId to `EagerServiceWithStaticParameters.returnType`
 
 1.16.1 (16 July 2024)
 -------------------------

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,7 @@
 * [#6388](https://github.com/TouK/nussknacker/pull/6388) Fix issue with suggestion expression mode and any value with suggestion in fragmentInput component, now supporting SpEL expressions.
 * [#6269](https://github.com/TouK/nussknacker/pull/6269) SpEL expression validator now works with values that are lists or maps.
   * NOTE: selection (`.?`), projection (`.!`) or operations from the `#COLLECTIONS` helper aren't properly supported in validation expressions, and will cause the result to always be invalid
+* [#6418](https://github.com/TouK/nussknacker/pull/6418) Improvement: Pass implicit nodeId to EagerServiceWithStaticParamers. returnType
 
 1.16.1 (16 July 2024)
 -------------------------

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -17,6 +17,8 @@ To see the biggest differences please consult the [changelog](Changelog.md).
         * NOTE: selection (`.?`) or operations from the `#COLLECTIONS` helper cause the map to lose track of its keys/values, reverting its `fields` to an empty Map
     * SpEL list expression are now typed as `TypedObjectWithValue`, with the `underlying` `TypedClass` equal to the `TypedClass` before this change, and with `value` equal to a `java.util.List` of the elements' values.
         * NOTE: selection (`.?`), projection (`.!`) or operations from the `#COLLECTIONS` helper cause the list to lose track of its values, reverting it to a value-less `TypedClass` like before the change
+* [#6418](https://github.com/TouK/nussknacker/pull/6418) Improvement: Pass implicit nodeId to `EagerServiceWithStaticParameters.returnType`
+  * Now method `returnType` from `EagerServiceWithStaticParameters` requires implicit nodeId param
 
 ## In version 1.16.0
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -1803,7 +1803,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
     override def returnType(
         validationContext: ValidationContext,
         parameters: Map[ParameterName, DefinedSingleParameter]
-    ): ValidatedNel[ProcessCompilationError, TypingResult] = {
+    )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, TypingResult] = {
       Valid(
         parameters
           .get(ParameterName("definition"))

--- a/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/service/EagerServiceWithStaticParameters.scala
+++ b/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/service/EagerServiceWithStaticParameters.scala
@@ -56,7 +56,7 @@ trait EagerServiceWithStaticParameters
   def returnType(
       validationContext: ValidationContext,
       parameters: Map[ParameterName, DefinedSingleParameter]
-  ): ValidatedNel[ProcessCompilationError, TypingResult]
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, TypingResult]
 
   override def contextTransformation(context: ValidationContext, dependencies: List[NodeDependencyValue])(
       implicit nodeId: NodeId
@@ -117,7 +117,7 @@ trait EagerServiceWithStaticParametersAndReturnType extends EagerServiceWithStat
   override def returnType(
       validationContext: ValidationContext,
       parameters: Map[ParameterName, DefinedSingleParameter]
-  ): ValidatedNel[ProcessCompilationError, TypingResult] = Valid(returnType)
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, TypingResult] = Valid(returnType)
 
   private class ServiceInvokerImplementation(
       eagerParameters: Map[ParameterName, Any],


### PR DESCRIPTION
At `EagerServiceWithStaticParameters.returnType` we return `ValidatedNel[ProcessCompilationError, TypingResult]`. Most of  the `ProcessCompilationError` implementation requires nodeId, so it seems obvious that we need to pass nodeId on the `returnType`  call.

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
