### PR TITLE
Add type to FE http service Dict api

### DIFF
--- a/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/StringBooleanVariants/useGetAllDicts.ts
+++ b/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/StringBooleanVariants/useGetAllDicts.ts
@@ -13,7 +13,7 @@ export const useGetAllDicts = ({ typ }: Props) => {
     const processingType = useSelector(getProcessingType);
 
     useEffect(() => {
-        httpService.fetchAllProcessDefinitionDataDicts(processingType, typ).then((response) => {
+        httpService.fetchAllProcessDefinitionDataDicts(processingType, typ.refClazzName).then((response) => {
             setProcessDefinitionDicts(response.data.map(({ id, label }) => ({ label, value: id })));
         });
     }, [processingType, typ]);

--- a/designer/client/src/http/HttpService.ts
+++ b/designer/client/src/http/HttpService.ts
@@ -738,11 +738,11 @@ class HttpService {
             );
     }
 
-    fetchAllProcessDefinitionDataDicts(processingType: ProcessingType, { refClazzName }: ReturnedType) {
+    fetchAllProcessDefinitionDataDicts(processingType: ProcessingType, refClazzName: string, type = "TypedClass") {
         return api
             .post<DictOption[]>(`/processDefinitionData/${processingType}/dicts`, {
                 expectedType: {
-                    value: { type: "TypedClass", refClazzName, params: [] },
+                    value: { type: type, refClazzName, params: [] },
                 },
             })
             .catch((error) =>


### PR DESCRIPTION
## Describe your changes

Currently `type` is hardcoded as `TypedClass` string. 
With this change we add a possibility to pass different `type` while fetching Dicts.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
