### PR TITLE
[NU-1679] Manually provided by component's developer canHaveManyInput…

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/CustomStreamTransformer.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/CustomStreamTransformer.scala
@@ -17,12 +17,6 @@ import pl.touk.nussknacker.engine.api.component.{AllProcessingModesComponent, Co
 //from java to scala one and is seems difficult to convert java CustomStreamTransformer, Service etc. into scala ones
 abstract class CustomStreamTransformer extends Component with AllProcessingModesComponent {
 
-  /**
-    * deprecated - use ContextTransformation.join instead
-    */
-  // TODO: remove after full switch to ContextTransformation API
-  def canHaveManyInputs: Boolean = false
-
   // For now it is only supported by Flink streaming runtime
   def canBeEnding: Boolean = false
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/javaapi/context/transformation/JavaDynamicComponent.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/javaapi/context/transformation/JavaDynamicComponent.scala
@@ -129,8 +129,6 @@ class JoinDynamicComponentWrapper[ST](javaDef: JavaJoinDynamicComponent[_ <: Any
 
   override type State = ST
 
-  override def canHaveManyInputs: Boolean = true
-
   override def canBeEnding: Boolean = javaDef.canBeEnding
 
   override def contextTransformation(context: Map[String, ValidationContext], dependencies: List[NodeDependencyValue])(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ProcessTestData.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ProcessTestData.scala
@@ -100,7 +100,7 @@ object ProcessTestData {
       .withCustom(
         existingStreamTransformer,
         Some(Typed[String]),
-        CustomComponentSpecificData(manyInputs = false, canBeEnding = false),
+        CustomComponentSpecificData(canHaveManyInputs = false, canBeEnding = false),
       )
       .withService(
         dictParameterEditorServiceId,
@@ -110,22 +110,22 @@ object ProcessTestData {
       .withCustom(
         otherExistingStreamTransformer,
         Some(Typed[String]),
-        CustomComponentSpecificData(manyInputs = false, canBeEnding = false),
+        CustomComponentSpecificData(canHaveManyInputs = false, canBeEnding = false),
       )
       .withCustom(
         otherExistingStreamTransformer2,
         Some(Typed[String]),
-        CustomComponentSpecificData(manyInputs = false, canBeEnding = false),
+        CustomComponentSpecificData(canHaveManyInputs = false, canBeEnding = false),
       )
       .withCustom(
         optionalEndingStreamTransformer,
         Some(Typed[String]),
-        CustomComponentSpecificData(manyInputs = false, canBeEnding = true),
+        CustomComponentSpecificData(canHaveManyInputs = false, canBeEnding = true),
       )
       .withCustom(
         union,
         Some(Unknown),
-        CustomComponentSpecificData(manyInputs = true, canBeEnding = true),
+        CustomComponentSpecificData(canHaveManyInputs = true, canBeEnding = true),
       )
       .build
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/ComponentGroupsPreparerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/ComponentGroupsPreparerSpec.scala
@@ -94,7 +94,7 @@ class ComponentGroupsPreparerSpec
         .withCustom(
           name = "fooTransformer",
           returnType = Some(Unknown),
-          componentSpecificData = CustomComponentSpecificData(manyInputs = false, canBeEnding = false),
+          componentSpecificData = CustomComponentSpecificData(canHaveManyInputs = false, canBeEnding = false),
           componentGroupName = Some(ComponentGroupName("group1")),
           designerWideComponentId = None
         )
@@ -115,7 +115,7 @@ class ComponentGroupsPreparerSpec
         .withCustom(
           "fooTransformer",
           Some(Unknown),
-          CustomComponentSpecificData(manyInputs = false, canBeEnding = true),
+          CustomComponentSpecificData(canHaveManyInputs = false, canBeEnding = true),
           parameter
         )
         .build

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/ComponentModels.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/ComponentModels.scala
@@ -59,7 +59,6 @@ abstract class DefaultStreamingProcessConfigCreator extends EmptyProcessConfigCr
   }
 
   sealed case class EmptyCustomStreamTransformer(
-      override val canHaveManyInputs: Boolean,
       override val canBeEnding: Boolean
   ) extends CustomStreamTransformer {
     @MethodToInvoke(returnType = classOf[Void]) def invoke(): Unit = {}
@@ -96,8 +95,8 @@ object ComponentMarketingTestConfigCreator extends DefaultStreamingProcessConfig
   override def customStreamTransformers(
       modelDependencies: ProcessObjectDependencies
   ): Map[String, WithCategories[CustomStreamTransformer]] = Map(
-    CustomStreamName         -> all(EmptyCustomStreamTransformer(true, false), Some(CustomStreamName)),
-    OptionalCustomStreamName -> marketing(EmptyCustomStreamTransformer(false, true)),
+    CustomStreamName         -> all(EmptyCustomStreamTransformer(false), Some(CustomStreamName)),
+    OptionalCustomStreamName -> marketing(EmptyCustomStreamTransformer(true)),
   )
 
 }
@@ -131,8 +130,8 @@ object ComponentFraudTestConfigCreator extends DefaultStreamingProcessConfigCrea
   override def customStreamTransformers(
       modelDependencies: ProcessObjectDependencies
   ): Map[String, WithCategories[CustomStreamTransformer]] = Map(
-    CustomStreamName         -> fraud(EmptyCustomStreamTransformer(true, false)),
-    OptionalCustomStreamName -> fraud(EmptyCustomStreamTransformer(false, true)),
+    CustomStreamName         -> fraud(EmptyCustomStreamTransformer(false)),
+    OptionalCustomStreamName -> fraud(EmptyCustomStreamTransformer(true)),
   )
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/ComponentsUsageHelperTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/ComponentsUsageHelperTest.scala
@@ -162,7 +162,7 @@ class ComponentsUsageHelperTest extends AnyFunSuite with Matchers with TableDriv
       .withCustom(
         ProcessTestData.otherExistingStreamTransformer,
         Some(Typed[String]),
-        CustomComponentSpecificData(manyInputs = false, canBeEnding = false),
+        CustomComponentSpecificData(canHaveManyInputs = false, canBeEnding = false),
         componentGroupName = None,
         designerWideComponentId =
           Some(DesignerWideComponentId(ProcessTestData.overriddenOtherExistingStreamTransformer))
@@ -170,7 +170,7 @@ class ComponentsUsageHelperTest extends AnyFunSuite with Matchers with TableDriv
       .withCustom(
         ProcessTestData.otherExistingStreamTransformer2,
         Some(Typed[String]),
-        CustomComponentSpecificData(manyInputs = false, canBeEnding = false),
+        CustomComponentSpecificData(canHaveManyInputs = false, canBeEnding = false),
       )
       .build
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/DefaultComponentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/DefaultComponentServiceSpec.scala
@@ -1,6 +1,5 @@
 package pl.touk.nussknacker.ui.definition.component
 
-import cats.data.NonEmptySet
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.Inside.inside
 import org.scalatest.OptionValues

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -26,6 +26,8 @@
 * [#6437](https://github.com/TouK/nussknacker/pull/6437) Removed deprecated operation to create a scenario:
   POST `/api/processes/{name}/{category}`. POST `/api/processes` should be used instead.
 * [#6415](https://github.com/TouK/nussknacker/pull/6415) Added "Component group" field to fragment properties, which allows selection of the group of components in the Creator Panel in which the fragment will be available
+* [#6462](https://github.com/TouK/nussknacker/pull/6462) Improvement of Component's API: `canHaveManyInputs` property is now 
+  determined automatically, developer doesn't need to provide it by his/her own
 
 1.16.2 (18 July 2024)
 -------------------------

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -12,8 +12,14 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 * [6282](https://github.com/TouK/nussknacker/pull/6184) If you relied on the default value of the `topicsExistenceValidationConfig.enabled`
   setting, you must now be aware that topics will be validated by default (Kafka's `auto.create.topics.enable` setting
   is only considered in case of Sinks). Create proper topics manually if needed.
-* [#6418](https://github.com/TouK/nussknacker/pull/6418) Improvement: Pass implicit nodeId to `EagerServiceWithStaticParameters.returnType`
-  * Now method `returnType` from `EagerServiceWithStaticParameters` requires implicit nodeId param
+* Component's API changes
+  * [#6418](https://github.com/TouK/nussknacker/pull/6418) Improvement: Pass implicit nodeId to `EagerServiceWithStaticParameters.returnType`
+    Now method `returnType` from `EagerServiceWithStaticParameters` requires implicit nodeId param
+  * [#6462](https://github.com/TouK/nussknacker/pull/6462) `CustomStreamTransformer.canHaveManyInputs` field was
+    removed. You don't need to implement any other method in replacement, just remove this method.
+
+### REST API changes
+
 * [#6437](https://github.com/TouK/nussknacker/pull/6437) Removed deprecated operation to create a scenario:
   POST `/api/processes/{name}/{category}`. POST `/api/processes` should be used instead.
 

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionWithMemoTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionWithMemoTransformer.scala
@@ -45,8 +45,6 @@ class UnionWithMemoTransformer(
 
   val KeyField = "key"
 
-  override def canHaveManyInputs: Boolean = true
-
   @MethodToInvoke
   def execute(
       @BranchParamName("key") keyByBranchId: Map[String, LazyParameter[CharSequence]],

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/FullOuterJoinTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/FullOuterJoinTransformer.scala
@@ -53,8 +53,6 @@ class FullOuterJoinTransformer(
 
   import pl.touk.nussknacker.engine.flink.util.transformer.join.FullOuterJoinTransformer._
 
-  override def canHaveManyInputs: Boolean = true
-
   override type State = Nothing
 
   override def nodeDependencies: List[NodeDependency] = List(OutputVariableNameDependency)

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/SingleSideJoinTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/SingleSideJoinTransformer.scala
@@ -41,8 +41,6 @@ class SingleSideJoinTransformer(
 
   import pl.touk.nussknacker.engine.flink.util.transformer.join.SingleSideJoinTransformer._
 
-  override def canHaveManyInputs: Boolean = true
-
   override type State = Nothing
 
   override def nodeDependencies: List[NodeDependency] = List(OutputVariableNameDependency)

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformer.scala
@@ -87,8 +87,6 @@ class UnionTransformer(timestampAssigner: Option[TimestampWatermarkHandler[Times
 
   import UnionTransformer._
 
-  override def canHaveManyInputs: Boolean = true
-
   @MethodToInvoke
   def execute(
       @BranchParamName("Output expression") outputExpressionByBranchId: Map[String, LazyParameter[AnyRef]],

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/EnrichWithAdditionalDataTransformer.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/EnrichWithAdditionalDataTransformer.scala
@@ -61,8 +61,6 @@ object EnrichWithAdditionalDataTransformer extends CustomStreamTransformer with 
         }
       )
 
-  override val canHaveManyInputs: Boolean = true
-
   override type State = Nothing
 
   override def contextTransformation(contexts: Map[String, ValidationContext], dependencies: List[NodeDependencyValue])(

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/JoinTransformerWithEditors.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/JoinTransformerWithEditors.scala
@@ -17,8 +17,6 @@ import javax.annotation.Nullable
 
 object JoinTransformerWithEditors extends CustomStreamTransformer with Serializable {
 
-  override def canHaveManyInputs: Boolean = true
-
   @MethodToInvoke
   def execute(
       @BranchParamName("branchType") branchTypeByBranchId: Map[String, JavaSampleEnum],

--- a/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/Union.scala
+++ b/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/Union.scala
@@ -86,6 +86,4 @@ object Union extends CustomStreamTransformer {
     }
   }
 
-  override def canHaveManyInputs: Boolean = true
-
 }

--- a/engine/lite/request-response/components-utils/src/main/scala/pl/touk/nussknacker/engine/requestresponse/utils/customtransformers/Sorter.scala
+++ b/engine/lite/request-response/components-utils/src/main/scala/pl/touk/nussknacker/engine/requestresponse/utils/customtransformers/Sorter.scala
@@ -51,6 +51,4 @@ object Sorter extends CustomStreamTransformer {
       })
   }
 
-  override def canHaveManyInputs: Boolean = true
-
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/ComponentDefinitionExtractor.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/ComponentDefinitionExtractor.scala
@@ -105,25 +105,26 @@ object ComponentDefinitionExtractor {
     }
 
     (component match {
-      case e: DynamicComponent[_] =>
-        val invoker = new DynamicComponentImplementationInvoker(e)
+      case dynamicComponent: DynamicComponent[_] =>
+        val invoker = new DynamicComponentImplementationInvoker(dynamicComponent)
         Right(
-          withUiDefinitionForNotDisabledComponent(DynamicComponentStaticDefinitionDeterminer.staticReturnType(e)) {
-            (uiDefinition, parametersConfig) =>
-              val componentSpecificData = extractComponentSpecificData(component) {
-                e match {
-                  case _: JoinDynamicComponent[_]        => true
-                  case _: SingleInputDynamicComponent[_] => false
-                }
+          withUiDefinitionForNotDisabledComponent(
+            DynamicComponentStaticDefinitionDeterminer.staticReturnType(dynamicComponent)
+          ) { (uiDefinition, parametersConfig) =>
+            val componentSpecificData = extractComponentSpecificData(component) {
+              dynamicComponent match {
+                case _: JoinDynamicComponent[_]        => true
+                case _: SingleInputDynamicComponent[_] => false
               }
-              DynamicComponentDefinitionWithImplementation(
-                name = componentName,
-                implementationInvoker = invoker,
-                component = e,
-                componentTypeSpecificData = componentSpecificData,
-                uiDefinition = uiDefinition,
-                parametersConfig = parametersConfig
-              )
+            }
+            DynamicComponentDefinitionWithImplementation(
+              name = componentName,
+              implementationInvoker = invoker,
+              component = dynamicComponent,
+              componentTypeSpecificData = componentSpecificData,
+              uiDefinition = uiDefinition,
+              parametersConfig = parametersConfig
+            )
           }
         )
       case _ =>

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/ComponentDefinitionExtractor.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/ComponentDefinitionExtractor.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.definition.component
 import cats.implicits.catsSyntaxSemigroup
 import pl.touk.nussknacker.engine.api.component._
 import pl.touk.nussknacker.engine.api.context.transformation._
+import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.{SinkFactory, SourceFactory}
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
@@ -58,20 +59,21 @@ object ComponentDefinitionExtractor {
       determineDesignerWideId: ComponentId => DesignerWideComponentId,
       additionalConfigsFromProvider: Map[DesignerWideComponentId, ComponentAdditionalConfig]
   ): Option[ComponentDefinitionWithImplementation] = {
-    val (methodDefinitionExtractor: MethodDefinitionExtractor[Component], componentTypeSpecificData) =
+    val (
+      methodDefinitionExtractor: MethodDefinitionExtractor[Component],
+      componentType,
+      customCanBeEnding: Option[Boolean]
+    ) =
       component match {
-        case _: SourceFactory => (MethodDefinitionExtractor.Source, SourceSpecificData)
-        case _: SinkFactory   => (MethodDefinitionExtractor.Sink, SinkSpecificData)
-        case _: Service       => (MethodDefinitionExtractor.Service, ServiceSpecificData)
+        case _: SourceFactory => (MethodDefinitionExtractor.Source, ComponentType.Source, None)
+        case _: SinkFactory   => (MethodDefinitionExtractor.Sink, ComponentType.Sink, None)
+        case _: Service       => (MethodDefinitionExtractor.Service, ComponentType.Service, None)
         case custom: CustomStreamTransformer =>
-          (
-            MethodDefinitionExtractor.CustomStreamTransformer,
-            CustomComponentSpecificData(custom.canHaveManyInputs, custom.canBeEnding)
-          )
+          (MethodDefinitionExtractor.CustomStreamTransformer, ComponentType.CustomComponent, Some(custom.canBeEnding))
         case other => throw new IllegalStateException(s"Not supported Component class: ${other.getClass}")
       }
 
-    val componentId = ComponentId(componentTypeSpecificData.componentType, componentName)
+    val componentId = ComponentId(componentType, componentName)
 
     def additionalConfigFromProvider(overriddenDesignerWideId: Option[DesignerWideComponentId]) = {
       val designerWideId = overriddenDesignerWideId.getOrElse(determineDesignerWideId(componentId))
@@ -89,7 +91,11 @@ object ComponentDefinitionExtractor {
         returnType: Option[TypingResult]
     )(f: (ComponentUiDefinition, Map[ParameterName, ParameterConfig]) => T): Option[T] = {
       val defaultConfig =
-        DefaultComponentConfigDeterminer.forNotBuiltInComponentType(componentTypeSpecificData, returnType.isDefined)
+        DefaultComponentConfigDeterminer.forNotBuiltInComponentType(
+          componentType,
+          returnType.isDefined,
+          customCanBeEnding
+        )
       val configFromAdditional                    = additionalConfigs.getConfig(componentId)
       val combinedConfigWithoutConfigFromProvider = configFromAdditional |+| configFromDefinition |+| defaultConfig
       val designerWideId                          = combinedConfigWithoutConfigFromProvider.componentId
@@ -104,11 +110,17 @@ object ComponentDefinitionExtractor {
         Right(
           withUiDefinitionForNotDisabledComponent(DynamicComponentStaticDefinitionDeterminer.staticReturnType(e)) {
             (uiDefinition, parametersConfig) =>
+              val componentSpecificData = extractComponentSpecificData(component) {
+                e match {
+                  case _: JoinDynamicComponent[_]        => true
+                  case _: SingleInputDynamicComponent[_] => false
+                }
+              }
               DynamicComponentDefinitionWithImplementation(
                 name = componentName,
                 implementationInvoker = invoker,
                 component = e,
-                componentTypeSpecificData = componentTypeSpecificData,
+                componentTypeSpecificData = componentSpecificData,
                 uiDefinition = uiDefinition,
                 parametersConfig = parametersConfig
               )
@@ -136,11 +148,14 @@ object ComponentDefinitionExtractor {
             withUiDefinitionForNotDisabledComponent(returnType) { (uiDefinition, _) =>
               val staticDefinition = ComponentStaticDefinition(methodDef.definedParameters, returnType)
               val invoker          = extractComponentImplementationInvoker(component, methodDef)
+              val componentSpecificData = extractComponentSpecificData(component) {
+                methodDef.definedParameters.exists(_.branchParam)
+              }
               MethodBasedComponentDefinitionWithImplementation(
                 name = componentName,
                 implementationInvoker = invoker,
                 component = component,
-                componentTypeSpecificData = componentTypeSpecificData,
+                componentTypeSpecificData = componentSpecificData,
                 staticDefinition = staticDefinition,
                 uiDefinition = uiDefinition
               )
@@ -149,6 +164,16 @@ object ComponentDefinitionExtractor {
     }).fold(msg => throw new IllegalArgumentException(msg), identity)
 
   }
+
+  private def extractComponentSpecificData(component: Component)(determineCanHaveManyInputsForCustom: => Boolean) =
+    component match {
+      case _: SourceFactory => SourceSpecificData
+      case _: SinkFactory   => SinkSpecificData
+      case _: Service       => ServiceSpecificData
+      case custom: CustomStreamTransformer =>
+        CustomComponentSpecificData(determineCanHaveManyInputsForCustom, custom.canBeEnding)
+      case other => throw new IllegalStateException(s"Not supported Component class: ${other.getClass}")
+    }
 
   private def extractComponentImplementationInvoker(
       component: Component,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/ComponentDefinitionExtractor.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/ComponentDefinitionExtractor.scala
@@ -2,8 +2,8 @@ package pl.touk.nussknacker.engine.definition.component
 
 import cats.implicits.catsSyntaxSemigroup
 import pl.touk.nussknacker.engine.api.component._
+import pl.touk.nussknacker.engine.api.context.JoinContextTransformation
 import pl.touk.nussknacker.engine.api.context.transformation._
-import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.{SinkFactory, SourceFactory}
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
@@ -150,7 +150,7 @@ object ComponentDefinitionExtractor {
               val staticDefinition = ComponentStaticDefinition(methodDef.definedParameters, returnType)
               val invoker          = extractComponentImplementationInvoker(component, methodDef)
               val componentSpecificData = extractComponentSpecificData(component) {
-                methodDef.definedParameters.exists(_.branchParam)
+                methodDef.runtimeClass == classOf[JoinContextTransformation]
               }
               MethodBasedComponentDefinitionWithImplementation(
                 name = componentName,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/ComponentTypeSpecificData.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/ComponentTypeSpecificData.scala
@@ -19,7 +19,7 @@ case object ServiceSpecificData extends ComponentTypeSpecificData {
   override def componentType: ComponentType = ComponentType.Service
 }
 
-final case class CustomComponentSpecificData(manyInputs: Boolean, canBeEnding: Boolean)
+final case class CustomComponentSpecificData(canHaveManyInputs: Boolean, canBeEnding: Boolean)
     extends ComponentTypeSpecificData {
   override def componentType: ComponentType = ComponentType.CustomComponent
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/defaultconfig/DefaultComponentConfigDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/defaultconfig/DefaultComponentConfigDeterminer.scala
@@ -1,34 +1,36 @@
 package pl.touk.nussknacker.engine.definition.component.defaultconfig
 
+import pl.touk.nussknacker.engine.api.component.ComponentType.ComponentType
 import pl.touk.nussknacker.engine.api.component._
 import pl.touk.nussknacker.engine.definition.component._
 
 object DefaultComponentConfigDeterminer {
 
   def forNotBuiltInComponentType(
-      componentTypeSpecificData: ComponentTypeSpecificData,
-      hasReturn: Boolean
+      componentType: ComponentType,
+      hasReturn: Boolean,
+      customCanBeEnding: Option[Boolean]
   ): SingleComponentConfig = {
     // TODO: use convention icon = componentGroup instead of code
-    val configData = componentTypeSpecificData match {
-      case SourceSpecificData =>
+    val configData = componentType match {
+      case ComponentType.Source =>
         ComponentConfigData(DefaultsComponentGroupName.SourcesGroupName, DefaultsComponentIcon.SourceIcon)
-      case SinkSpecificData =>
+      case ComponentType.Sink =>
         ComponentConfigData(DefaultsComponentGroupName.SinksGroupName, DefaultsComponentIcon.SinkIcon)
-      case ServiceSpecificData if hasReturn =>
+      case ComponentType.Service if hasReturn =>
         ComponentConfigData(DefaultsComponentGroupName.EnrichersGroupName, DefaultsComponentIcon.EnricherIcon)
-      case ServiceSpecificData =>
+      case ComponentType.Service =>
         ComponentConfigData(DefaultsComponentGroupName.ServicesGroupName, DefaultsComponentIcon.ServiceIcon)
-      case CustomComponentSpecificData(_, true) =>
+      case ComponentType.CustomComponent if customCanBeEnding.contains(true) =>
         ComponentConfigData(
           DefaultsComponentGroupName.OptionalEndingCustomGroupName,
           DefaultsComponentIcon.CustomComponentIcon
         )
-      case CustomComponentSpecificData(_, _) =>
+      case ComponentType.CustomComponent =>
         ComponentConfigData(DefaultsComponentGroupName.CustomGroupName, DefaultsComponentIcon.CustomComponentIcon)
-      case _ =>
+      case ComponentType.BuiltIn =>
         throw new IllegalStateException(
-          s"InitialComponentConfigDeterminer used with non model component: $componentTypeSpecificData"
+          s"DefaultComponentConfigDeterminer used with built-in component"
         )
     }
     SingleComponentConfig(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testing/ModelDefinitionBuilder.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testing/ModelDefinitionBuilder.scala
@@ -1,6 +1,5 @@
 package pl.touk.nussknacker.engine.testing
 
-import cats.data.NonEmptySet
 import pl.touk.nussknacker.engine.api.SpelExpressionExcludeList
 import pl.touk.nussknacker.engine.api.component.Component.AllowedProcessingModes
 import pl.touk.nussknacker.engine.api.component.{
@@ -164,8 +163,11 @@ final case class ModelDefinitionBuilder(
   ): ModelDefinitionBuilder = {
     val defaultConfig =
       DefaultComponentConfigDeterminer.forNotBuiltInComponentType(
-        componentTypeSpecificData,
-        staticDefinition.returnType.isDefined
+        componentTypeSpecificData.componentType,
+        staticDefinition.returnType.isDefined,
+        Option(componentTypeSpecificData).collect { case CustomComponentSpecificData(_, canBeEnding) =>
+          canBeEnding
+        }
       )
     val configWithOverridenGroupName =
       componentGroupName.map(group => defaultConfig.copy(componentGroup = Some(group))).getOrElse(defaultConfig)

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -45,7 +45,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with OptionValues {
 
-  private val nonEndingOneInputComponent = CustomComponentSpecificData(manyInputs = false, canBeEnding = false)
+  private val nonEndingOneInputComponent = CustomComponentSpecificData(canHaveManyInputs = false, canBeEnding = false)
 
   private val baseDefinitionBuilder = ModelDefinitionBuilder.empty
     .withGlobalVariable("processHelper", ProcessHelper)


### PR DESCRIPTION
… replaced by automatic determining of this property

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
