### PR TITLE
removed environmental variables from the main configuration doc

### DIFF
--- a/docs/configuration/Common.md
+++ b/docs/configuration/Common.md
@@ -1,77 +1,8 @@
 ---
-title: Basics
+title: Common
 sidebar_position: 1
 ---
-# Configuration
-
-## Minimal configuration file
-
-The Docker image and the binary distribution contain minimal working [configuration file](https://github.com/TouK/nussknacker/blob/staging/nussknacker-dist/src/universal/conf/application.conf), which is designed as a base for further customizations using 
-additional configuration files. Check [Conventions section](#conventions) for more details how to amend and override the minimal configuration file. 
-This file is not used by the [Helm chart](https://artifacthub.io/packages/helm/touk/nussknacker), which prepares its own config file. 
-
-The location and name of the configuration files is defined by the `CONFIG_FILE` environment variable. Consult [Basic environment variables](../configuration/Common.md#basic-environment-variables) for information on how this variable is resolved. 
-
-Details of K8s based configuration can be found in  [Nussknacker Helm chart documentation](https://artifacthub.io/packages/helm/touk/nussknacker). 
-## Configuration areas
-
-Nussknacker configuration is divided into several configuration areas, each area addressing a specific aspect of using Nussknacker:
-
-* [Designer](../about/GLOSSARY#nussknacker-designer) configuration (web application ports, security, various UI settings, database),
-* Scenario Types configuration, comprising of:
-  * [Model](./model/ModelConfiguration.md) configuration.
-  * [Scenario Deployment](./ScenarioDeploymentConfiguration.md) configuration,
-  * [Category](./DesignerConfiguration.md/#scenario-type-categories) configuration
-
-[Model](../about/GLOSSARY#model) configuration defines which components and which [Processing Mode](../about/ProcessingModes) will be available for the user. 
-[Scenario Deployment](./ScenarioDeploymentConfiguration.md) configuration defines how scenario using these components will be deployed on the [Engine](../about/engine).
-[Category](./DesignerConfiguration.md/#scenario-type-categories) defines who has access to the given combination of [Model](../about/GLOSSARY#model) and [Scenario Deployment](./ScenarioDeploymentConfiguration.md).
-
-The Scenario Type is a convenient umbrella term that groups all these things. Diagram below presents main relationships between configuration areas.
-
-![Configuration areas](img/configuration_areas.png "configuration areas")
-
-### Configuration file
-
-Let's see how those concepts look in fragment of the configuration file:
-
-<pre>
-{/* Somehow, everything which is in the "pre" block is treated as jsx by Docusaurus*/}
-{/* so, we need to escape "{" */}
-{/* and add leading spaces in a special way. If not jsx parser will remove them */}
-{/* Finally, do not worry - this is a valid jsx comment - you will not see it on Nu page*/}
-
-<b># Designer configuration </b> <br/>
-environment: "local"  <br/> 
-... <br/>
- <br/>
-# Each scenario type is configured here  <br/>
-scenarioTypes {"{"}  <br/>
-{" "} "scenario-type-1": {"{"}<br/>
-{" "}   # Configuration of scenario deployment (Flink used as example here)  <br/>
-{" "}   <b>deploymentConfig:</b> {"{"} <br/>
-{" "}     type: "flinkStreaming" <br/>
-{" "}     restUrl: "http://localhost:8081" <br/> 
-{" "}   } <br/>
-{" "}   # Configuration of model <br/>
-{" "}   <b>modelConfig</b>: {"{"} <br/>
-{" "}     classPath: ["model/defaultModel.jar", "model/flinkExecutor.jar", "components/flink"] <br/>
-{" "}     restartStrategy.default.strategy: disable <br/>
-{" "}     components {"{"} <br/>
-{" "}       ... <br/>
-{" "}     } <br/>
-{" "}   } <br/>
-{" "}   <b>category</b>: "Default" <br/>
-{" "} } <br/>
-} <br/>
-</pre>
-
-It is worth noting that one Nussknacker Designer may be used to work with multiple Scenario Types and allow user:
-
-* To use different set of components depending on the category
-* To deploy scenarios on different [Engines](../about/engines)
-
-See [development configuration](https://github.com/TouK/nussknacker/blob/staging/nussknacker-dist/src/universal/conf/dev-application.conf#L33) (used to test various Nussknacker features) for an example of configuration with more than one Scenario Type.                   
+# Common        
 
 ## Environment variables
 
@@ -143,28 +74,3 @@ Because we use [HOCON](#conventions), you can set (or override) any configuratio
 | OAUTH2_AUDIENCE                                 | string  |                   |
 | OAUTH2_USERNAME_CLAIM                           | string  |                   |
 
-
-## Conventions
-
-* We use HOCON (see the [introduction](https://github.com/lightbend/config#using-hocon-the-json-superset) or 
-  the [full specification](https://github.com/lightbend/config/blob/master/HOCON.md) for details) as our main 
-  configuration format. [Lightbend config library](https://github.com/lightbend/config/tree/master) is used for 
-  parsing configuration files - you can check the [documentation](https://github.com/lightbend/config#standard-behavior)
-  for details on conventions of file names and merging of configuration files.
-* `nussknacker.config.locations` Java system property (`CONFIG_FILE` environment variable for Docker image) defines 
-  location of configuration files (separated by comma). The files are read in order, entries from later files can 
-  override the former (using HOCON fallback mechanism). This mechanism is used to extend or override default 
-  configuration contained in the [minimal configuration file](#minimal-configuration-file)  - see docker demo 
-  for example:
-  * [setting multiple configuration files](https://github.com/TouK/nussknacker-installation-example/blob/master/docker-compose.yml#L29)
-  * [file with configuration override](https://github.com/TouK/nussknacker-installation-example/blob/master/designer/application-customizations.conf)
-* If `config.override_with_env_vars` Java system property is set to true, it is possible to override settings with env 
-  variables. This property is set to true in the official Nussknacker Docker image.
-
-It’s important to remember that model configuration is prepared a bit differently. Please read 
-[model configuration](./model/ModelConfiguration.md) for the details. 
-
-## What is next?
-Most likely you will want to configure enrichers - they are configured under the `modelConfig.components` configuration 
-key - see the [configuration file](#configuration-file). The details of enrichers configuration are in 
-the [Integration chapter](../integration/index.md) of the documentation. 

--- a/docs/configuration/ScenarioDeploymentConfiguration.md
+++ b/docs/configuration/ScenarioDeploymentConfiguration.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 Deployment of a scenario onto the [Engine](../about/engines) is managed by the Designer's extension called [Deployment Manager](../about/GLOSSARY#deployment-manager).
 To enable a given [Deployment Manager](../about/GLOSSARY#deployment-manager) its jar package has to be placed in the Designer's classpath. Nussknacker is distributed with three default [Deployment Managers](../about/GLOSSARY#deployment-manager) (`flinkStreaming`, `lite-k8s`, `lite-embedded`). Their jars are located in the `managers` directory. 
 
-Deployment specific configuration is provided in the `deploymentConfig` section of the configuration file - check [configuration areas](./Common.md#configuration-areas) to understand the structure of the configuration file.
+Deployment specific configuration is provided in the `deploymentConfig` section of the configuration file - check [configuration areas](./index.md#configuration-areas) to understand the structure of the configuration file.
 
 Below is a snippet of scenario deployment configuration.
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2,6 +2,103 @@
 title: Configuration
 ---
 
+# Overview
+
+## Minimal configuration file
+
+The Docker image and the binary distribution contain minimal working [configuration file](https://github.com/TouK/nussknacker/blob/staging/nussknacker-dist/src/universal/conf/application.conf), which is designed as a base for further customizations using 
+additional configuration files. Check [Conventions section](#conventions) for more details how to amend and override the minimal configuration file. 
+This file is not used by the [Helm chart](https://artifacthub.io/packages/helm/touk/nussknacker), which prepares its own config file. 
+
+The location and name of the configuration files is defined by the `CONFIG_FILE` environment variable. Consult [Basic environment variables](../configuration/Common.md#basic-environment-variables) for information on how this variable is resolved. 
+
+Details of K8s based configuration can be found in  [Nussknacker Helm chart documentation](https://artifacthub.io/packages/helm/touk/nussknacker). 
+## Configuration areas
+
+Nussknacker configuration is divided into several configuration areas, each area addressing a specific aspect of using Nussknacker:
+
+* [Designer](../about/GLOSSARY#nussknacker-designer) configuration (web application ports, security, various UI settings, database),
+* Scenario Types configuration, comprising of:
+  * [Model](./model/ModelConfiguration.md) configuration.
+  * [Scenario Deployment](./ScenarioDeploymentConfiguration.md) configuration,
+  * [Category](./DesignerConfiguration.md/#scenario-type-categories) configuration
+
+[Model](../about/GLOSSARY#model) configuration defines which components and which [Processing Mode](../about/ProcessingModes) will be available for the user. 
+[Scenario Deployment](./ScenarioDeploymentConfiguration.md) configuration defines how scenario using these components will be deployed on the [Engine](../about/engine).
+[Category](./DesignerConfiguration.md/#scenario-type-categories) defines who has access to the given combination of [Model](../about/GLOSSARY#model) and [Scenario Deployment](./ScenarioDeploymentConfiguration.md).
+
+The Scenario Type is a convenient umbrella term that groups all these things. Diagram below presents main relationships between configuration areas.
+
+![Configuration areas](img/configuration_areas.png "configuration areas")
+
+### Configuration file
+
+Let's see how those concepts look in fragment of the configuration file:
+
+<pre>
+{/* Somehow, everything which is in the "pre" block is treated as jsx by Docusaurus*/}
+{/* so, we need to escape "{" */}
+{/* and add leading spaces in a special way. If not jsx parser will remove them */}
+{/* Finally, do not worry - this is a valid jsx comment - you will not see it on Nu page*/}
+
+<b># Designer configuration </b> <br/>
+environment: "local"  <br/> 
+... <br/>
+ <br/>
+# Each scenario type is configured here  <br/>
+{" "} <b>scenarioTypes:</b> {"{"}  <br/>
+{" "} "scenario-type-1": {"{"}<br/>
+{" "}   # Configuration of scenario deployment (Flink used as example here)  <br/>
+{" "}   <b>deploymentConfig:</b> {"{"} <br/>
+{" "}     type: "flinkStreaming" <br/>
+{" "}     restUrl: "http://localhost:8081" <br/> 
+{" "}   } <br/>
+{" "}   # Configuration of the model <br/>
+{" "}   <b>modelConfig</b>: {"{"} <br/>
+{" "}     classPath: ["model/defaultModel.jar", "model/flinkExecutor.jar", "components/flink"] <br/>
+{" "}     restartStrategy.default.strategy: disable <br/>
+{" "}     components {"{"} <br/>
+{" "}       ... <br/>
+{" "}     } <br/>
+{" "}   } <br/>
+{" "}   <b>category</b>: "Default" <br/>
+{" "} } <br/>
+} <br/>
+</pre>
+
+It is worth noting that one Nussknacker Designer may be used to work with multiple Scenario Types and allow user:
+
+* To use different set of components depending on the category
+* To deploy scenarios on different [Engines](../about/engines)
+
+See [development configuration](https://github.com/TouK/nussknacker/blob/staging/nussknacker-dist/src/universal/conf/dev-application.conf#L33) (used to test various Nussknacker features) for an example of configuration with more than one Scenario Type.                   
+
+## Conventions
+
+* We use HOCON (see the [introduction](https://github.com/lightbend/config#using-hocon-the-json-superset) or 
+  the [full specification](https://github.com/lightbend/config/blob/master/HOCON.md) for details) as our main 
+  configuration format. [Lightbend config library](https://github.com/lightbend/config/tree/master) is used for 
+  parsing configuration files - you can check the [documentation](https://github.com/lightbend/config#standard-behavior)
+  for details on conventions of file names and merging of configuration files.
+* `nussknacker.config.locations` Java system property (`CONFIG_FILE` environment variable for Docker image) defines 
+  location of configuration files (separated by comma). The files are read in order, entries from later files can 
+  override the former (using HOCON fallback mechanism). This mechanism is used to extend or override default 
+  configuration contained in the [minimal configuration file](#minimal-configuration-file)  - see docker demo 
+  for example:
+  * [setting multiple configuration files](https://github.com/TouK/nussknacker-installation-example/blob/master/docker-compose.yml#L29)
+  * [file with configuration override](https://github.com/TouK/nussknacker-installation-example/blob/master/designer/application-customizations.conf)
+* If `config.override_with_env_vars` Java system property is set to true, it is possible to override settings with env 
+  variables. This property is set to true in the official Nussknacker Docker image.
+
+It’s important to remember that model configuration is prepared a bit differently. Please read 
+[model configuration](./model/ModelConfiguration.md) for the details. 
+
+## What is next?
+Most likely you will want to configure enrichers - they are configured under the `modelConfig.components` configuration 
+key - see the [configuration file](#configuration-file). The details of enrichers configuration are in 
+the [Integration chapter](../integration/index.md) of the documentation. 
+
+
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';
 ```

--- a/docs/configuration/model/ModelConfiguration.md
+++ b/docs/configuration/model/ModelConfiguration.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 # Model configuration
 
 Model definition is part of a scenario type definition. There can be multiple scenario types in one Nussknacker installation, consequently there will also be multiple model definitions in such a case. 
-Check [configuration areas](../Common.md#configuration-areas) to understand where Model configuration should be placed in the Nussknacker configuration. If you deploy to K8s using Nussknacker Helm chart, check [here](../ScenarioDeploymentConfiguration.md#overriding-configuration-passed-to-runtime) how to supply additional model configuration.
+Check [configuration areas](../index.md#configuration-areas) to understand where Model configuration should be placed in the Nussknacker configuration. If you deploy to K8s using Nussknacker Helm chart, check [here](../ScenarioDeploymentConfiguration.md#overriding-configuration-passed-to-runtime) how to supply additional model configuration.
 
 Model defines how to configure [components](../../about/GLOSSARY#component) and certain runtime behavior (e.g. error handling) for a given scenario type. Model configuration is processed not only at the Designer but also passed to the execution engine (e.g. Flink), that’s why it’s parsed and processed a bit differently: 
 

--- a/docs/integration/OpenAPI.md
+++ b/docs/integration/OpenAPI.md
@@ -44,7 +44,7 @@ For arrays, we use `items` to define type of elements.
 ## Configuration
 
 Open API enricher is configured under `components` configuration key. Check
-this [configuration file snippet](../configuration/Common.md#configuration-areas) to understand the
+this [configuration file snippet](../configuration/index.md#configuration-areas) to understand the
 placement of `components` configuration key in the configuration file.
 
 Sample configuration:

--- a/docs/integration/Sql.md
+++ b/docs/integration/Sql.md
@@ -19,7 +19,7 @@ It supports:
 
 ## Configuration
 
-You have to configure a database connection pool you will be using in your `Sql` enricher. It is performed at the root level of the configuration file (the same level as all other configs from Designer configuration area) - see [configuration file](../configuration/Common.md#configuration-file).
+You have to configure a database connection pool you will be using in your `Sql` enricher. It is performed at the root level of the configuration file (the same level as all other configs from Designer configuration area) - see [configuration file](../configuration/index.md#configuration-file).
 
 Sample configuration:
 

--- a/docs/scenarios_authoring/Enrichers.md
+++ b/docs/scenarios_authoring/Enrichers.md
@@ -14,7 +14,7 @@ Usually not all required data are in the data record - some data may reside in a
 Please check [Glossary](../about/GLOSSARY) to understand difference between component and the node (and between configuration of a component and configuration of a node). Understanding the role of [SpEL](../scenarios_authoring/Intro.md#spel) will greatly accelerate your first steps with Nussknacker. 
 
 
-Enricher components need to be added to the Model configuration first; once they are added they will become available in the Designer's components toolbox. Check [configuration areas](../configuration/Common.md#configuration-areas) for the overview of the configuration and [configuration of extra components](../integration/OpenAPI.md) for details of how to configure enricher components.
+Enricher components need to be added to the Model configuration first; once they are added they will become available in the Designer's components toolbox. Check [configuration areas](../configuration/index.md#configuration-areas) for the overview of the configuration and [configuration of extra components](../integration/OpenAPI.md) for details of how to configure enricher components.
 
 
 ## SQL enricher


### PR DESCRIPTION
## Describe your changes

The section on the environment variables was removed from the Configuration overview document, leaving only the overview and concepts in this document. Environment variables are now in a dedicated page (same path), the title of the page is "Common"

## Checklist before merge

<This checklist does not apply>