### PR TITLE
language of parameter's expression is based on editor type

### DIFF
--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/ConfigParameterDefaultValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/ConfigParameterDefaultValueDeterminer.scala
@@ -2,11 +2,9 @@ package pl.touk.nussknacker.engine.definition.component.parameter.defaults
 
 import pl.touk.nussknacker.engine.graph.expression.Expression
 
-object ConfigParameterDefaultValueDeterminer extends ParameterDefaultValueDeterminer {
+object ConfigParameterDefaultValueDeterminer extends ParameterDefaultValueDeterminer with SimpleLanguageDeterminer {
 
-  override def determineParameterDefaultValue(parameters: DefaultValueDeterminerParameters): Option[Expression] = {
-    // TODO: make language configurable as well
-    parameters.parameterConfig.defaultValue.map(Expression.spel)
-  }
+  override def determineParameterDefaultValue(parameters: DefaultValueDeterminerParameters): Option[Expression] =
+    calculateDefaultValue(parameters.determinedEditor, parameters.parameterConfig.defaultValue)
 
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/ConfigParameterDefaultValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/ConfigParameterDefaultValueDeterminer.scala
@@ -2,9 +2,11 @@ package pl.touk.nussknacker.engine.definition.component.parameter.defaults
 
 import pl.touk.nussknacker.engine.graph.expression.Expression
 
-object ConfigParameterDefaultValueDeterminer extends ParameterDefaultValueDeterminer with SimpleLanguageDeterminer {
+object ConfigParameterDefaultValueDeterminer extends ParameterDefaultValueDeterminer {
 
-  override def determineParameterDefaultValue(parameters: DefaultValueDeterminerParameters): Option[Expression] =
-    calculateDefaultValue(parameters.determinedEditor, parameters.parameterConfig.defaultValue)
+  override def determineParameterDefaultValue(parameters: DefaultValueDeterminerParameters): Option[Expression] = {
+    val language = EditorBasedLanguageDeterminer.determineLanguageOf(parameters.determinedEditor)
+    parameters.parameterConfig.defaultValue.map(Expression(language, _))
+  }
 
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorBasedLanguageDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorBasedLanguageDeterminer.scala
@@ -3,21 +3,14 @@ package pl.touk.nussknacker.engine.definition.component.parameter.defaults
 import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.graph.expression.Expression
 
-trait SimpleLanguageDeterminer {
+object EditorBasedLanguageDeterminer {
 
-  def calculateDefaultValue(
-      determinedEditor: Option[ParameterEditor],
-      defaultValue: Option[String]
-  ): Option[Expression] =
-    for {
-      value <- defaultValue
-      language <- determinedEditor
-        .collect {
-          case RawParameterEditor                   => Expression.Language.Spel
-          case simpleEditor: SimpleParameterEditor  => determineLanguageOf(simpleEditor)
-          case DualParameterEditor(simpleEditor, _) => determineLanguageOf(simpleEditor)
-        } orElse Some(Expression.Language.Spel)
-    } yield Expression(language, value)
+  def determineLanguageOf(editor: Option[ParameterEditor]): Expression.Language = editor match {
+    case Some(RawParameterEditor)                   => Expression.Language.Spel
+    case Some(simpleEditor: SimpleParameterEditor)  => determineLanguageOf(simpleEditor)
+    case Some(DualParameterEditor(simpleEditor, _)) => determineLanguageOf(simpleEditor)
+    case None                                       => Expression.Language.Spel
+  }
 
   private def determineLanguageOf(editor: SimpleParameterEditor): Expression.Language =
     editor match {

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/OptionalityBasedDefaultValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/OptionalityBasedDefaultValueDeterminer.scala
@@ -1,39 +1,14 @@
 package pl.touk.nussknacker.engine.definition.component.parameter.defaults
 
-import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.graph.expression.Expression
 
-protected object OptionalityBasedDefaultValueDeterminer extends ParameterDefaultValueDeterminer {
+protected object OptionalityBasedDefaultValueDeterminer
+    extends ParameterDefaultValueDeterminer
+    with SimpleLanguageDeterminer {
 
-  override def determineParameterDefaultValue(parameters: DefaultValueDeterminerParameters): Option[Expression] = {
-    Option(parameters).filter(_.isOptional).map { _ =>
-      val lang = parameters.determinedEditor
-        .map {
-          case RawParameterEditor                   => Expression.Language.Spel
-          case simpleEditor: SimpleParameterEditor  => determineLanguageOf(simpleEditor)
-          case DualParameterEditor(simpleEditor, _) => determineLanguageOf(simpleEditor)
-        }
-        .getOrElse {
-          Expression.Language.Spel
-        }
-
-      Expression(lang, "")
+  override def determineParameterDefaultValue(parameters: DefaultValueDeterminerParameters): Option[Expression] =
+    Option(parameters).filter(_.isOptional).flatMap { _ =>
+      calculateDefaultValue(parameters.determinedEditor, Some(""))
     }
-  }
-
-  private def determineLanguageOf(editor: SimpleParameterEditor) = {
-    editor match {
-      case BoolParameterEditor | StringParameterEditor | DateParameterEditor | TimeParameterEditor |
-          DateTimeParameterEditor | TextareaParameterEditor | JsonParameterEditor | DurationParameterEditor(_) |
-          PeriodParameterEditor(_) | CronParameterEditor | FixedValuesParameterEditor(_) =>
-        Expression.Language.Spel
-      case SqlParameterEditor | SpelTemplateParameterEditor =>
-        Expression.Language.SpelTemplate
-      case DictParameterEditor(_) =>
-        Expression.Language.DictKeyWithLabel
-      case TabularTypedDataEditor =>
-        Expression.Language.TabularDataDefinition
-    }
-  }
 
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/OptionalityBasedDefaultValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/OptionalityBasedDefaultValueDeterminer.scala
@@ -2,13 +2,11 @@ package pl.touk.nussknacker.engine.definition.component.parameter.defaults
 
 import pl.touk.nussknacker.engine.graph.expression.Expression
 
-protected object OptionalityBasedDefaultValueDeterminer
-    extends ParameterDefaultValueDeterminer
-    with SimpleLanguageDeterminer {
+protected object OptionalityBasedDefaultValueDeterminer extends ParameterDefaultValueDeterminer {
 
   override def determineParameterDefaultValue(parameters: DefaultValueDeterminerParameters): Option[Expression] =
-    Option(parameters).filter(_.isOptional).flatMap { _ =>
-      calculateDefaultValue(parameters.determinedEditor, Some(""))
+    Option(parameters).filter(_.isOptional).map { _ =>
+      Expression(EditorBasedLanguageDeterminer.determineLanguageOf(parameters.determinedEditor), "")
     }
 
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/SimpleLanguageDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/SimpleLanguageDeterminer.scala
@@ -1,0 +1,36 @@
+package pl.touk.nussknacker.engine.definition.component.parameter.defaults
+
+import pl.touk.nussknacker.engine.api.definition._
+import pl.touk.nussknacker.engine.graph.expression.Expression
+
+trait SimpleLanguageDeterminer {
+
+  def calculateDefaultValue(
+      determinedEditor: Option[ParameterEditor],
+      defaultValue: Option[String]
+  ): Option[Expression] =
+    for {
+      value <- defaultValue
+      language <- determinedEditor
+        .collect {
+          case RawParameterEditor                   => Expression.Language.Spel
+          case simpleEditor: SimpleParameterEditor  => determineLanguageOf(simpleEditor)
+          case DualParameterEditor(simpleEditor, _) => determineLanguageOf(simpleEditor)
+        } orElse Some(Expression.Language.Spel)
+    } yield Expression(language, value)
+
+  private def determineLanguageOf(editor: SimpleParameterEditor): Expression.Language =
+    editor match {
+      case BoolParameterEditor | StringParameterEditor | DateParameterEditor | TimeParameterEditor |
+          DateTimeParameterEditor | TextareaParameterEditor | JsonParameterEditor | DurationParameterEditor(_) |
+          PeriodParameterEditor(_) | CronParameterEditor | FixedValuesParameterEditor(_) =>
+        Expression.Language.Spel
+      case SqlParameterEditor | SpelTemplateParameterEditor =>
+        Expression.Language.SpelTemplate
+      case DictParameterEditor(_) =>
+        Expression.Language.DictKeyWithLabel
+      case TabularTypedDataEditor =>
+        Expression.Language.TabularDataDefinition
+    }
+
+}

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/TypeRelatedParameterValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/TypeRelatedParameterValueDeterminer.scala
@@ -1,15 +1,9 @@
 package pl.touk.nussknacker.engine.definition.component.parameter.defaults
 
-import pl.touk.nussknacker.engine.api.definition.{
-  DictParameterEditor,
-  DualParameterEditor,
-  ParameterEditor,
-  SpelTemplateParameterEditor,
-  SqlParameterEditor
-}
+import pl.touk.nussknacker.engine.api.definition.ParameterEditor
 import pl.touk.nussknacker.engine.api.typed.typing.SingleTypingResult
 import pl.touk.nussknacker.engine.graph.expression.Expression
-import pl.touk.nussknacker.engine.graph.expression.Expression.Language.DictKeyWithLabel
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language
 
 protected object TypeRelatedParameterValueDeterminer extends ParameterDefaultValueDeterminer {
 
@@ -42,13 +36,10 @@ protected object TypeRelatedParameterValueDeterminer extends ParameterDefaultVal
   }
 
   private def defaultStringExpression(editor: Option[ParameterEditor]): Expression =
-    editor
-      .collect { // TODO: maybe some better way to specify language like Parameter.language
-        case SpelTemplateParameterEditor => Expression.spelTemplate("") // template not need to be wrapped in ''
-        case SqlParameterEditor          => Expression.spelTemplate("")
-        case DictParameterEditor(_)      => Expression(DictKeyWithLabel, "")
-        case DualParameterEditor(DictParameterEditor(_), _) => Expression(DictKeyWithLabel, "")
-      }
-      .getOrElse(Expression.spel("''"))
+    EditorBasedLanguageDeterminer.determineLanguageOf(editor) match {
+      case Language.Spel => Expression.spel("''")
+      case language @ (Language.SpelTemplate | Language.DictKeyWithLabel | Language.TabularDataDefinition) =>
+        Expression(language, "")
+    }
 
 }


### PR DESCRIPTION
## Describe your changes

little change to make `ConfigParameterDefaultValueDeterminer` language aware.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
