### PR TITLE
Extension: Move previousValue and delay components from unbounded to base Flink components

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -45,6 +45,7 @@
     * The editor can be easily switched backed to 'raw' version similarly to the current Kafka Sink
   * [#6545](https://github.com/TouK/nussknacker/pull/6545) Non-physical columns are properly handled in Table Sink now
     * User need to provide only persisted column values now - values for computed columns and virtual columns are not required anymore
+* [#6559](https://github.com/TouK/nussknacker/pull/6559) [#6559](https://github.com/TouK/nussknacker/pull/6559) Extension: Move previousValue and delay components from unbounded to base Flink components
 
 1.16.2 (18 July 2024)
 -------------------------

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/FlinkBaseUnboundedComponentProvider.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/FlinkBaseUnboundedComponentProvider.scala
@@ -49,9 +49,6 @@ object FlinkBaseUnboundedComponentProvider {
 
     val statefulComponents = List(
       ComponentDefinition("union-memo", UnionWithMemoTransformer).withRelativeDocs("DataSourcesAndSinks#unionmemo"),
-      ComponentDefinition("previousValue", PreviousValueTransformer).withRelativeDocs(
-        "DataSourcesAndSinks#previousvalue"
-      ),
       ComponentDefinition("aggregate-sliding", SlidingAggregateTransformerV2).withRelativeDocs(
         "AggregatesInTimeWindows#sliding-window"
       ),
@@ -66,7 +63,6 @@ object FlinkBaseUnboundedComponentProvider {
       ComponentDefinition("full-outer-join", FullOuterJoinTransformer).withRelativeDocs(
         "AggregatesInTimeWindows#full-outer-join"
       ),
-      ComponentDefinition("delay", DelayTransformer).withRelativeDocs("DataSourcesAndSinks#delay")
     )
 
     statefulComponents ++ statelessComponents

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/FlinkBaseUnboundedComponentProvider.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/FlinkBaseUnboundedComponentProvider.scala
@@ -10,12 +10,7 @@ import pl.touk.nussknacker.engine.flink.util.transformer.aggregate.sampleTransfo
   TumblingAggregateTransformer
 }
 import pl.touk.nussknacker.engine.flink.util.transformer.join.{FullOuterJoinTransformer, SingleSideJoinTransformer}
-import pl.touk.nussknacker.engine.flink.util.transformer.{
-  DelayTransformer,
-  PeriodicSourceFactory,
-  PreviousValueTransformer,
-  UnionWithMemoTransformer
-}
+import pl.touk.nussknacker.engine.flink.util.transformer.{PeriodicSourceFactory, UnionWithMemoTransformer}
 import pl.touk.nussknacker.engine.util.config.DocsConfig
 
 class FlinkBaseUnboundedComponentProvider extends ComponentProvider {

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
@@ -9,6 +9,8 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api
 import pl.touk.nussknacker.engine.api._
+import pl.touk.nussknacker.engine.api.component.Component.AllowedProcessingModes
+import pl.touk.nussknacker.engine.api.component.ProcessingMode
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkCustomStreamTransformation}
 import pl.touk.nussknacker.engine.flink.util.keyed.StringKeyOnlyMapper
@@ -20,6 +22,9 @@ import javax.annotation.Nullable
 object DelayTransformer extends DelayTransformer
 
 class DelayTransformer extends CustomStreamTransformer with ExplicitUidInOperatorsSupport with Serializable {
+
+  override def allowedProcessingModes: AllowedProcessingModes =
+    AllowedProcessingModes.SetOf(ProcessingMode.UnboundedStream, ProcessingMode.BoundedStream)
 
   @MethodToInvoke(returnType = classOf[Void])
   def invoke(

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
@@ -9,7 +9,6 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api
 import pl.touk.nussknacker.engine.api._
-import pl.touk.nussknacker.engine.api.component.UnboundedStreamComponent
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkCustomStreamTransformation}
 import pl.touk.nussknacker.engine.flink.util.keyed.StringKeyOnlyMapper
@@ -20,11 +19,7 @@ import javax.annotation.Nullable
 
 object DelayTransformer extends DelayTransformer
 
-class DelayTransformer
-    extends CustomStreamTransformer
-    with UnboundedStreamComponent
-    with ExplicitUidInOperatorsSupport
-    with Serializable {
+class DelayTransformer extends CustomStreamTransformer with ExplicitUidInOperatorsSupport with Serializable {
 
   @MethodToInvoke(returnType = classOf[Void])
   def invoke(

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
@@ -9,8 +9,6 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api
 import pl.touk.nussknacker.engine.api._
-import pl.touk.nussknacker.engine.api.component.Component.AllowedProcessingModes
-import pl.touk.nussknacker.engine.api.component.ProcessingMode
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkCustomStreamTransformation}
 import pl.touk.nussknacker.engine.flink.util.keyed.StringKeyOnlyMapper
@@ -22,9 +20,6 @@ import javax.annotation.Nullable
 object DelayTransformer extends DelayTransformer
 
 class DelayTransformer extends CustomStreamTransformer with ExplicitUidInOperatorsSupport with Serializable {
-
-  override def allowedProcessingModes: AllowedProcessingModes =
-    AllowedProcessingModes.SetOf(ProcessingMode.UnboundedStream, ProcessingMode.BoundedStream)
 
   @MethodToInvoke(returnType = classOf[Void])
   def invoke(

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/FlinkBaseComponentProvider.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/FlinkBaseComponentProvider.scala
@@ -47,7 +47,11 @@ object FlinkBaseComponentProvider {
         .withDesignerWideId("dead-end"),
       ComponentDefinition(name = "decision-table", component = DecisionTable)
         .withRelativeDocs("BasicNodes#decisiontable")
-        .withDesignerWideId("decision-table")
+        .withDesignerWideId("decision-table"),
+      ComponentDefinition("delay", DelayTransformer)
+        .withRelativeDocs("DataSourcesAndSinks#delay"),
+      ComponentDefinition("previousValue", PreviousValueTransformer)
+        .withRelativeDocs("DataSourcesAndSinks#previousvalue"),
     )
   }
 

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
@@ -7,8 +7,6 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api._
-import pl.touk.nussknacker.engine.api.component.Component.AllowedProcessingModes
-import pl.touk.nussknacker.engine.api.component.ProcessingMode
 import pl.touk.nussknacker.engine.api.typed.ReturningType
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process._
@@ -17,9 +15,6 @@ import pl.touk.nussknacker.engine.flink.util.richflink.FlinkKeyOperations
 case object PreviousValueTransformer extends CustomStreamTransformer with ExplicitUidInOperatorsSupport {
 
   type Value = AnyRef
-
-  override def allowedProcessingModes: AllowedProcessingModes =
-    AllowedProcessingModes.SetOf(ProcessingMode.UnboundedStream, ProcessingMode.BoundedStream)
 
   @MethodToInvoke(returnType = classOf[Value])
   def execute(

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
@@ -7,15 +7,12 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api._
-import pl.touk.nussknacker.engine.api.component.UnboundedStreamComponent
+import pl.touk.nussknacker.engine.api.typed.ReturningType
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process._
 import pl.touk.nussknacker.engine.flink.util.richflink.FlinkKeyOperations
 
-case object PreviousValueTransformer
-    extends CustomStreamTransformer
-    with UnboundedStreamComponent
-    with ExplicitUidInOperatorsSupport {
+case object PreviousValueTransformer extends CustomStreamTransformer with ExplicitUidInOperatorsSupport {
 
   type Value = AnyRef
 
@@ -23,7 +20,7 @@ case object PreviousValueTransformer
   def execute(
       @ParamName("groupBy") groupBy: LazyParameter[CharSequence],
       @ParamName("value") value: LazyParameter[Value]
-  ) = FlinkCustomStreamTransformation(
+  ): FlinkCustomStreamTransformation with ReturningType = FlinkCustomStreamTransformation(
     (start: DataStream[Context], ctx: FlinkCustomNodeContext) => {
       val valueTypeInfo = ctx.typeInformationDetection.forType[AnyRef](value.returnType)
       setUidToNodeIdIfNeed(

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
@@ -7,6 +7,8 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api._
+import pl.touk.nussknacker.engine.api.component.Component.AllowedProcessingModes
+import pl.touk.nussknacker.engine.api.component.ProcessingMode
 import pl.touk.nussknacker.engine.api.typed.ReturningType
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process._
@@ -15,6 +17,9 @@ import pl.touk.nussknacker.engine.flink.util.richflink.FlinkKeyOperations
 case object PreviousValueTransformer extends CustomStreamTransformer with ExplicitUidInOperatorsSupport {
 
   type Value = AnyRef
+
+  override def allowedProcessingModes: AllowedProcessingModes =
+    AllowedProcessingModes.SetOf(ProcessingMode.UnboundedStream, ProcessingMode.BoundedStream)
 
   @MethodToInvoke(returnType = classOf[Value])
   def execute(


### PR DESCRIPTION
Delay and previousValue can be used in the same way in bounded as in unbounded types. There's no reason not to use them in bounded.

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
