### PR TITLE
[NU-1766] TypedObjectTypingResult.fields are backed by ListMap for correct RowTypeInfo fields order purpose

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/CommonSupertypeFinder.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/CommonSupertypeFinder.scala
@@ -7,6 +7,9 @@ import pl.touk.nussknacker.engine.api.typed.supertype.CommonSupertypeFinder.{
   looseFinder
 }
 import pl.touk.nussknacker.engine.api.typed.typing._
+import pl.touk.nussknacker.engine.util.Implicits.RichIterable
+
+import scala.collection.immutable.ListMap
 
 /**
   * This class finding common supertype of two types. It basically based on fact that TypingResults are
@@ -74,7 +77,7 @@ class CommonSupertypeFinder private (classResolutionStrategy: SupertypeClassReso
             // We don't return None in case when fields are empty, because we can't be sure the intention of the user
             // e.g. someone can pass json object with missing field declared as optional in schema
             // and want to compare it with literal record that doesn't have this field
-            TypedObjectTypingResult(fields, commonSupertype)
+            Typed.record(fields, commonSupertype)
           }
           .orElse(fallback)
       case (l: TypedObjectTypingResult, r) => singleCommonSupertype(l.objType, r)
@@ -99,9 +102,9 @@ class CommonSupertypeFinder private (classResolutionStrategy: SupertypeClassReso
     }
   }
 
-  private def prepareFields(l: TypedObjectTypingResult, r: TypedObjectTypingResult): Map[String, TypingResult] =
+  private def prepareFields(l: TypedObjectTypingResult, r: TypedObjectTypingResult): Iterable[(String, TypingResult)] =
     (l.fields.toList ++ r.fields.toList)
-      .groupBy(_._1)
+      .orderedGroupBy(_._1)
       .map { case (key, value) => key -> value.map(_._2) }
       .flatMap {
         case (fieldName, singleType :: Nil) =>

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
@@ -8,8 +8,8 @@ import org.apache.commons.lang3.ClassUtils
 import pl.touk.nussknacker.engine.api.typed.supertype.CommonSupertypeFinder
 import pl.touk.nussknacker.engine.api.typed.typing.Typed.fromInstance
 import pl.touk.nussknacker.engine.api.util.{NotNothing, ReflectUtils}
-import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 
+import scala.collection.immutable.ListMap
 import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -54,28 +54,37 @@ object typing {
 
   object TypedObjectTypingResult {
 
-    // TODO: deprecated, will be removed - we should also make the default apply private protected
-    def apply(fields: Map[String, TypingResult]): TypedObjectTypingResult =
-      Typed.record(fields)
-
-    // For backward compatibility, to be removed once downstream projects switch to apply(fields: Map[String, TypingResult])
-    // TODO: remove this after NU-1432 will be done
-    def apply(fields: List[(String, TypingResult)]): TypedObjectTypingResult = Typed.record(fields.toMap)
+    private[typing] def apply(
+        fields: ListMap[String, TypingResult],
+        objType: TypedClass,
+        additionalInfo: Map[String, AdditionalDataValue] = Map.empty
+    ) = new TypedObjectTypingResult(fields, objType, additionalInfo)
 
   }
 
   // TODO: Rename to TypedRecord
-  // TODO: Make the constructor package-protected - inheritance is only use in the InputMeta to override display
-  case class TypedObjectTypingResult(
-      fields: Map[String, TypingResult],
+  // TODO: Make this class final - inheritance is only used in the InputMeta to override display
+  case class TypedObjectTypingResult protected (
+      // Order is important because we base on it in case of Flink's table-api Row serialization, see TypingResultAwareTypeInformationDetection
+      fields: ListMap[String, TypingResult],
       objType: TypedClass,
       additionalInfo: Map[String, AdditionalDataValue] = Map.empty
   ) extends SingleTypingResult {
+
     override def valueOpt: Option[java.util.Map[String, Any]] =
-      fields.map { case (k, v) => v.valueOpt.map((k, _)) }.toList.sequence.map(Map(_: _*).asJava)
+      fields.toList
+        .map { case (k, v) => v.valueOpt.map((k, _)) }
+        .sequence
+        .map(fieldValues => Map(fieldValues: _*).asJava)
 
     override def withoutValue: TypedObjectTypingResult =
-      TypedObjectTypingResult(fields.mapValuesNow(_.withoutValue), objType, additionalInfo)
+      Typed.record(
+        fields.map { case (fieldName, fieldType) =>
+          fieldName -> fieldType.withoutValue
+        },
+        objType,
+        additionalInfo
+      )
 
     override def display: String =
       fields.map { case (name, typ) => s"$name: ${typ.display}" }.toList.sorted.mkString("Record{", ", ", "}")
@@ -334,10 +343,10 @@ object typing {
           TypedNull
         case map: Map[String @unchecked, _] =>
           val fieldTypes = typeMapFields(map)
-          TypedObjectTypingResult(fieldTypes, mapBasedRecordUnderlyingType[Map[_, _]](fieldTypes))
+          Typed.record(fieldTypes, mapBasedRecordUnderlyingType[Map[_, _]](fieldTypes))
         case javaMap: java.util.Map[String @unchecked, _] =>
           val fieldTypes = typeMapFields(javaMap.asScala.toMap)
-          TypedObjectTypingResult(fieldTypes)
+          Typed.record(fieldTypes)
         case list: List[_] =>
           genericTypeClass(classOf[List[_]], List(supertypeOfElementTypes(list)))
         case javaList: java.util.List[_] =>
@@ -405,20 +414,20 @@ object typing {
       }
     }
 
-    def record(fields: Map[String, TypingResult]): TypedObjectTypingResult =
-      TypedObjectTypingResult(fields, mapBasedRecordUnderlyingType[java.util.Map[_, _]](fields))
+    def record(fields: Iterable[(String, TypingResult)]): TypedObjectTypingResult =
+      TypedObjectTypingResult(ListMap(fields.toSeq: _*), mapBasedRecordUnderlyingType[java.util.Map[_, _]](fields))
 
     def record(
-        fields: Map[String, TypingResult],
+        fields: Iterable[(String, TypingResult)],
         objType: TypedClass,
         additionalInfo: Map[String, AdditionalDataValue] = Map.empty
     ): TypedObjectTypingResult =
-      TypedObjectTypingResult(fields, objType, additionalInfo)
+      TypedObjectTypingResult(ListMap(fields.toSeq: _*), objType, additionalInfo)
 
   }
 
-  private[api] def mapBasedRecordUnderlyingType[T: ClassTag](fields: Map[String, TypingResult]): TypedClass = {
-    val valueType = superTypeOfTypes(fields.values)
+  private[api] def mapBasedRecordUnderlyingType[T: ClassTag](fields: Iterable[(String, TypingResult)]): TypedClass = {
+    val valueType = superTypeOfTypes(fields.map(_._2))
     Typed.genericTypeClass[T](List(Typed[String], valueType))
   }
 

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultErrorMessagesSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultErrorMessagesSpec.scala
@@ -9,7 +9,7 @@ import pl.touk.nussknacker.engine.api.typed.typing._
 
 class TypingResultErrorMessagesSpec extends AnyFunSuite with Matchers with OptionValues with Inside {
 
-  private def typeMap(args: (String, TypingResult)*) = Typed.record(args.toMap)
+  private def typeMap(args: (String, TypingResult)*) = Typed.record(args)
 
   private def list(arg: TypingResult) = Typed.genericTypeClass[java.util.List[_]](List(arg))
 

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
@@ -26,7 +26,7 @@ class TypingResultSpec
 
   private val intersectionSuperTypeFinder = CommonSupertypeFinder.Intersection
 
-  private def typeMap(args: (String, TypingResult)*) = Typed.record(args.toMap)
+  private def typeMap(args: (String, TypingResult)*) = Typed.record(args)
 
   private def list(arg: TypingResult) = Typed.genericTypeClass[java.util.List[_]](List(arg))
 

--- a/components/sql/src/main/scala/pl/touk/nussknacker/sql/db/schema/TableDefinition.scala
+++ b/components/sql/src/main/scala/pl/touk/nussknacker/sql/db/schema/TableDefinition.scala
@@ -24,7 +24,7 @@ object TableDefinition {
 }
 
 final case class TableDefinition(columnDefs: List[ColumnDefinition]) {
-  val rowType: TypedObjectTypingResult = Typed.record(columnDefs.map(col => col.name -> col.typing).toMap)
+  val rowType: TypedObjectTypingResult = Typed.record(columnDefs.map(col => col.name -> col.typing))
 
   val resultSetType: TypingResult = Typed.genericTypeClass(classOf[java.util.List[_]], rowType :: Nil)
 }

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -31,11 +31,16 @@ To see the biggest differences please consult the [changelog](Changelog.md).
     * `EmptySource`'s `TypeInformation` implicit parameter was removed
   * [#6545](https://github.com/TouK/nussknacker/pull/6545) `FlinkSink.prepareTestValue` was replaced by `prepareTestValueFunction` -
     a non-parameter method returning a function. Thanks to that, `FlinkSink` is not serialized during test data preparation.
-* [#6436](https://github.com/TouK/nussknacker/pull/6436) Changes to `TypingResult` of SpEL expressions that are maps or lists:
+* `TypingResult` API changes
+  * [#6436](https://github.com/TouK/nussknacker/pull/6436) Changes to `TypingResult` of SpEL expressions that are maps or lists:
     * `TypedObjectTypingResult.valueOpt` now returns a `java.util.Map` instead of `scala.collection.immutable.Map`
-        * NOTE: selection (`.?`) or operations from the `#COLLECTIONS` helper cause the map to lose track of its keys/values, reverting its `fields` to an empty Map
+      * NOTE: selection (`.?`) or operations from the `#COLLECTIONS` helper cause the map to lose track of its keys/values, reverting its `fields` to an empty Map
     * SpEL list expression are now typed as `TypedObjectWithValue`, with the `underlying` `TypedClass` equal to the `TypedClass` before this change, and with `value` equal to a `java.util.List` of the elements' values.
-        * NOTE: selection (`.?`), projection (`.!`) or operations from the `#COLLECTIONS` helper cause the list to lose track of its values, reverting it to a value-less `TypedClass` like before the change
+      * NOTE: selection (`.?`), projection (`.!`) or operations from the `#COLLECTIONS` helper cause the list to lose track of its values, reverting it to a value-less `TypedClass` like before the change
+  * [#6566](https://github.com/TouK/nussknacker/pull/6566) `TypedObjectTypingResult.fields` are backed by `ListMap` for correct `RowTypeInfo`'s fields order purpose.
+    If [#5457](https://github.com/TouK/nussknacker/pull/5457) migrations were applied, it should be a transparent change
+    * Removed deprecated  `TypedObjectTypingResult.apply` methods - should be used `Typed.record` factory method
+    * `Typed.record` factory method takes `Iterable` instead of `Map`
 * [#6503](https://github.com/TouK/nussknacker/pull/6503) `FlinkTestScenarioRunner` cleanups
   * `runWithDataAndTimestampAssigner` method was removed. Instead, `timestampAssigner` was added as an optional parameter into `runWithData`
   * new `runWithDataWithType` was added allowing to test using other types than classes e.g. records

--- a/engine/common/components/src/main/scala/pl/touk/nussknacker/engine/common/components/DecisionTable.scala
+++ b/engine/common/components/src/main/scala/pl/touk/nussknacker/engine/common/components/DecisionTable.scala
@@ -171,7 +171,7 @@ object DecisionTable extends EagerService with SingleInputDynamicComponent[Servi
   }
 
   private def rowDataTypingResult(columnDefinitions: Iterable[Column.Definition]) =
-    TypedObjectTypingResult(
+    Typed.record(
       columnDefinitions.map { columnDef =>
         columnDef.name -> Typed.typedClass(columnDef.aType)
       }.toMap

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/AggregatesSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/AggregatesSpec.scala
@@ -162,13 +162,13 @@ class AggregatesSpec extends AnyFunSuite with TableDrivenPropertyChecks with Mat
 
     val mapAggregator =
       new MapAggregator(namedAggregators.mapValuesNow(_._1).asJava.asInstanceOf[JMap[String, Aggregator]])
-    val input = TypedObjectTypingResult(namedAggregators.mapValuesNow(_._2), objType = Typed.typedClass[JMap[_, _]])
+    val input = Typed.record(namedAggregators.mapValuesNow(_._2), objType = Typed.typedClass[JMap[_, _]])
     val el    = namedAggregators.mapValuesNow(_._3).asJava
-    val stored = TypedObjectTypingResult(
+    val stored = Typed.record(
       namedAggregators.mapValuesNow(_._4),
       objType = Typed.genericTypeClass(classOf[Map[_, _]], List(Typed[String], Unknown))
     )
-    val output = TypedObjectTypingResult(
+    val output = Typed.record(
       namedAggregators.mapValuesNow(_._5),
       objType = Typed.genericTypeClass(classOf[JMap[_, _]], List(Typed[String], Unknown))
     )

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/aggregates.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/aggregates.scala
@@ -363,7 +363,7 @@ object aggregates {
             .toList
             .sequence
             .leftMap(list => s"Invalid fields: ${list.toList.mkString(", ")}")
-          validationRes.map(fields => TypedObjectTypingResult(fields.toMap, objType = objType))
+          validationRes.map(fields => Typed.record(fields, objType = objType))
         case TypedObjectTypingResult(inputFields, _, _) =>
           Invalid(
             s"Fields do not match, aggregateBy: ${inputFields.keys.mkString(", ")}, aggregator: ${scalaFields.keys.mkString(", ")}"

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/source/TableSource.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/source/TableSource.scala
@@ -66,8 +66,6 @@ class TableSource(
           .from(filteringInternalViewName)
       }
       .getOrElse(selectQuery)
-      // We have to keep elements in the same order as in TypingInfo generated based on TypingResults, see TypingResultAwareTypeInformationDetection
-      .select(tableDefinition.sourceRowDataType.toLogicalRowTypeUnsafe.getFieldNames.asScala.toList.sorted.map($): _*)
 
     tableEnv.toDataStream(finalQuery)
   }

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/DataTypesConversions.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/DataTypesConversions.scala
@@ -37,7 +37,7 @@ object DataTypesConversions {
     def toTypingResult: TypedObjectTypingResult = {
       val fieldsTypes = rowType.getFields.asScala.map { field =>
         field.getName -> field.getType.toTypingResult
-      }.toMap
+      }
       Typed.record(fieldsTypes, Typed.typedClass[Row])
     }
 

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
@@ -91,7 +91,7 @@ class TypingResultAwareTypeInformationDetection(customisation: TypingResultAware
 
   def forContext(validationContext: ValidationContext): TypeInformation[Context] = {
     val variables = forType(
-      TypedObjectTypingResult(validationContext.localVariables, Typed.typedClass[Map[String, AnyRef]])
+      Typed.record(validationContext.localVariables, Typed.typedClass[Map[String, AnyRef]])
     )
       .asInstanceOf[TypeInformation[Map[String, Any]]]
     val parentCtx = validationContext.parent.map(forContext)
@@ -119,7 +119,8 @@ class TypingResultAwareTypeInformationDetection(customisation: TypingResultAware
       case a: TypedObjectTypingResult if a.objType.klass == classOf[TypedMap] =>
         TypedMapTypeInformation(a.fields.mapValuesNow(forType))
       case a: TypedObjectTypingResult if a.objType.klass == classOf[Row] =>
-        val (fieldNames, typeInfos) = a.fields.toList.sortBy(_._1).unzip
+        val (fieldNames, typeInfos) = a.fields.unzip
+        // Warning: RowTypeInfo is fields order sensitive
         new RowTypeInfo(typeInfos.map(forType).toArray[TypeInformation[_]], fieldNames.toArray)
       // TODO: better handle specific map implementations - other than HashMap?
       case a: TypedObjectTypingResult if classOf[java.util.Map[String, _]].isAssignableFrom(a.objType.klass) =>

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetectionSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetectionSpec.scala
@@ -43,7 +43,7 @@ class TypingResultAwareTypeInformationDetectionSpec
 
   test("test map serialization") {
     val map = Map("intF" -> 11, "strF" -> "sdfasf", "longF" -> 111L, "fixedLong" -> 12L, "taggedString" -> "1")
-    val typingResult = TypedObjectTypingResult(
+    val typingResult = Typed.record(
       Map(
         "intF"         -> Typed[Int],
         "strF"         -> Typed[String],
@@ -73,7 +73,7 @@ class TypingResultAwareTypeInformationDetectionSpec
   test("map serialization fallbacks to Kryo when available") {
 
     val map          = Map("obj" -> SomeTestClass("name"))
-    val typingResult = TypedObjectTypingResult(Map("obj" -> Typed[SomeTestClass]), Typed.typedClass[Map[String, Any]])
+    val typingResult = Typed.record(Map("obj" -> Typed[SomeTestClass]), Typed.typedClass[Map[String, Any]])
 
     val typeInfo: TypeInformation[Map[String, Any]] = informationDetection.forType(typingResult)
 
@@ -100,7 +100,7 @@ class TypingResultAwareTypeInformationDetectionSpec
       Map(
         "one"            -> Typed[Int],
         "two"            -> Typed[String],
-        "three"          -> TypedObjectTypingResult(Map("key" -> Typed[String]), Typed.typedClass[Map[String, Any]]),
+        "three"          -> Typed.record(Map("key" -> Typed[String]), Typed.typedClass[Map[String, Any]]),
         "arrayOfStrings" -> Typed.fromDetailedType[Array[String]],
         "arrayOfInts"    -> Typed.fromDetailedType[Array[Int]],
       )
@@ -145,13 +145,13 @@ class TypingResultAwareTypeInformationDetectionSpec
 
   test("Test serialization compatibility") {
     val typingResult =
-      TypedObjectTypingResult(Map("intF" -> Typed[Int], "strF" -> Typed[String]), Typed.typedClass[Map[String, Any]])
-    val compatibleTypingResult = TypedObjectTypingResult(
+      Typed.record(Map("intF" -> Typed[Int], "strF" -> Typed[String]), Typed.typedClass[Map[String, Any]])
+    val compatibleTypingResult = Typed.record(
       Map("intF" -> Typed[Int], "strF" -> Typed[String], "longF" -> Typed[Long]),
       Typed.typedClass[Map[String, Any]]
     )
     val incompatibleTypingResult =
-      TypedObjectTypingResult(Map("intF" -> Typed[Int], "strF" -> Typed[Long]), Typed.typedClass[Map[String, Any]])
+      Typed.record(Map("intF" -> Typed[Int], "strF" -> Typed[Long]), Typed.typedClass[Map[String, Any]])
 
     val oldSerializer = informationDetection.forType(typingResult).createSerializer(executionConfigWithoutKryo)
 
@@ -169,7 +169,7 @@ class TypingResultAwareTypeInformationDetectionSpec
   test("serialization compatibility with reconfigured serializer") {
 
     val map          = Map("obj" -> SomeTestClass("name"))
-    val typingResult = TypedObjectTypingResult(Map("obj" -> Typed[SomeTestClass]), Typed.typedClass[Map[String, Any]])
+    val typingResult = Typed.record(Map("obj" -> Typed[SomeTestClass]), Typed.typedClass[Map[String, Any]])
 
     val oldSerializer =
       informationDetection.forType[Map[String, Any]](typingResult).createSerializer(executionConfigWithKryo)
@@ -190,12 +190,12 @@ class TypingResultAwareTypeInformationDetectionSpec
 
   test("serialization compatibility with custom flag config") {
     val typingResult =
-      TypedObjectTypingResult(Map("intF" -> Typed[Int], "strF" -> Typed[String]), Typed.typedClass[CustomTypedObject])
-    val addField = TypedObjectTypingResult(
+      Typed.record(Map("intF" -> Typed[Int], "strF" -> Typed[String]), Typed.typedClass[CustomTypedObject])
+    val addField = Typed.record(
       Map("intF" -> Typed[Int], "strF" -> Typed[String], "longF" -> Typed[Long]),
       Typed.typedClass[CustomTypedObject]
     )
-    val removeField = TypedObjectTypingResult(Map("intF" -> Typed[Int]), Typed.typedClass[CustomTypedObject])
+    val removeField = Typed.record(Map("intF" -> Typed[Int]), Typed.typedClass[CustomTypedObject])
 
     serializeRoundTrip(
       CustomTypedObject(Map[String, AnyRef]("intF" -> (5: java.lang.Integer), "strF" -> "").asJava),

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/global/DocumentationFunctions.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/global/DocumentationFunctions.scala
@@ -88,7 +88,7 @@ object DocumentationFunctions {
         if (x.keys.exists(y.keys.toSet.contains))
           OtherError("Argument maps have common field").invalidNel
         else
-          TypedObjectTypingResult(x ++ y, Typed.typedClass[java.util.HashMap[_, _]], infoX ++ infoY).validNel
+          Typed.record(x ++ y, Typed.typedClass[java.util.HashMap[_, _]], infoX ++ infoY).validNel
       case _ =>
         ArgumentTypeError.invalidNel
     }

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/DynamicParametersSource.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/DynamicParametersSource.scala
@@ -30,7 +30,7 @@ object DynamicParametersSource extends SourceFactory with DynamicParametersMixin
   )(implicit nodeId: NodeId): FinalResults = {
     val paramsTyping = otherParams.map { case (paramName, definedParam) =>
       paramName.value -> definedParam.returnType
-    }.toMap
+    }
     FinalResults.forValidation(validationContext)(
       _.withVariable("input", Typed.record(paramsTyping), paramName = None)
     )

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/KafkaAvroPayloadSourceFactorySpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/KafkaAvroPayloadSourceFactorySpec.scala
@@ -359,7 +359,7 @@ class KafkaAvroPayloadSourceFactorySpec extends KafkaAvroSpecMixin with KafkaAvr
     result.errors shouldBe Nil
     result.outputContext shouldBe ValidationContext(
       Map(
-        VariableConstants.InputVariableName -> TypedObjectTypingResult(
+        VariableConstants.InputVariableName -> Typed.record(
           ListMap(
             "first"  -> AvroStringSettings.stringTypingResult,
             "middle" -> AvroStringSettings.stringTypingResult,

--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -424,7 +424,7 @@ object SampleNodes {
         @ParamName("count") count: Int,
         @OutputVariableName outputVar: String
     )(implicit nodeId: NodeId): ContextTransformation = {
-      val listType                        = Typed.record(definition.asScala.map(_ -> Typed[String]).toMap)
+      val listType                        = Typed.record(definition.asScala.map(_ -> Typed[String]))
       val returnType: typing.TypingResult = Typed.genericTypeClass[java.util.List[_]](List(listType))
 
       EnricherContextTransformation(
@@ -652,7 +652,7 @@ object SampleNodes {
     )(implicit nodeId: NodeId): this.FinalResults = {
       dependencies.collectFirst { case OutputVariableNameValue(name) => name } match {
         case Some(name) =>
-          val result = Typed.record(rest.map { case (k, v) => k.value -> v.returnType }.toMap)
+          val result = Typed.record(rest.map { case (k, v) => k.value -> v.returnType })
           FinalResults.forValidation(context)(_.withVariable(OutputVar.customNode(name), result))
         case None =>
           FinalResults(context, errors = List(CustomNodeError("Output not defined", None)))

--- a/engine/lite/components/request-response-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/RequestResponseTestWithParametersTest.scala
+++ b/engine/lite/components/request-response-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/RequestResponseTestWithParametersTest.scala
@@ -119,11 +119,11 @@ class RequestResponseTestWithParametersTest extends AnyFunSuite with Matchers {
       SimplifiedParam(
         SinkRawValueParamName.value,
         Typed(
-          TypedObjectTypingResult(
+          Typed.record(
             Map("result" -> Typed[String]),
             Typed.genericTypeClass[java.util.Map[_, _]](List(Typed[String], Typed[String]))
           ),
-          TypedObjectTypingResult(
+          Typed.record(
             Map("errorCode" -> Typed[Long]),
             Typed.genericTypeClass[java.util.Map[_, _]](List(Typed[String], Typed[Long]))
           )

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/BuiltInNodeCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/BuiltInNodeCompiler.scala
@@ -129,7 +129,7 @@ class BuiltInNodeCompiler(expressionCompiler: ExpressionCompiler) {
 
     val typedObject = compiledRecord match {
       case Valid(fields) =>
-        Typed.record(fields.map(f => (f.field.name, typedExprToTypingResult(Some(f.typedExpression)))).toMap)
+        Typed.record(fields.map(f => (f.field.name, typedExprToTypingResult(Some(f.typedExpression)))))
       case Invalid(_) => Unknown
     }
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -325,7 +325,7 @@ private[spel] class Typer(
           if (literalKeys.size != keys.size) {
             invalid(MapWithExpressionKeysError)
           } else {
-            valid(Typed.record(literalKeys.zip(typedValues).toMap))
+            valid(Typed.record(literalKeys.zip(typedValues)))
           }
         }
       case e: MethodReference =>

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/variables/MetaVariables.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/variables/MetaVariables.scala
@@ -34,7 +34,7 @@ object MetaVariables {
   }
 
   private def propertiesType(scenarioPropertiesNames: Iterable[String]): TypedObjectTypingResult = {
-    Typed.record(scenarioPropertiesNames.map(_ -> Typed[String]).toMap)
+    Typed.record(scenarioPropertiesNames.map(_ -> Typed[String]))
   }
 
 }

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/validationHelpers.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/validationHelpers.scala
@@ -82,7 +82,7 @@ object validationHelpers {
         .definedBy { context =>
           val newType = Typed.record((1 to numberOfFields).map { i =>
             s"field$i" -> Typed[String]
-          }.toMap)
+          })
           context.withVariable(variableName, newType, paramName = None)
         }
         .implementedBy(null)
@@ -104,7 +104,7 @@ object validationHelpers {
         .definedBy { contexts =>
           val newType = Typed.record(contexts.toSeq.map { case (branchId, _) =>
             branchId -> valueByBranchId(branchId).returnType
-          }.toMap)
+          })
           Valid(ValidationContext(Map(variableName -> newType)))
         }
         .implementedBy(null)
@@ -486,7 +486,7 @@ object validationHelpers {
     )(
         implicit nodeId: NodeId
     ): this.FinalResults = {
-      val result = Typed.record(rest.map { case (k, v) => k.value -> v.returnType }.toMap)
+      val result = Typed.record(rest.map { case (k, v) => k.value -> v.returnType })
       prepareFinalResultWithOptionalVariable(context, Some((name, result)), None)
     }
 

--- a/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/typing/TypingUtils.scala
+++ b/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/typing/TypingUtils.scala
@@ -14,8 +14,7 @@ object TypingUtils {
   }
 
   def typeMapDefinition(definition: Map[String, _]): TypingResult = {
-    // we force use of Map and not some implicit variants (MapLike) to avoid serialization problems...
-    Typed.record(Map(definition.mapValuesNow(typedMapDefinitionFromParameters).toList: _*))
+    Typed.record(definition.mapValuesNow(typedMapDefinitionFromParameters))
   }
 
   private def typedMapDefinitionFromParameters(definition: Any): TypingResult = definition match {

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/collection.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/collection.scala
@@ -298,9 +298,9 @@ object CollectionUtils {
               if commonFieldHasTheSameType(x, y) =>
             listType
               .copy(params =
-                TypedObjectTypingResult(
-                  Map.empty ++ x.view.map { case (key, value) => key -> value.withoutValue } ++ y.view.map {
-                    case (key, value) => key -> value.withoutValue
+                Typed.record(
+                  x.view.map { case (key, value) => key -> value.withoutValue } ++ y.view.map { case (key, value) =>
+                    key -> value.withoutValue
                   },
                   Typed.typedClass[java.util.HashMap[_, _]],
                   infoX ++ infoY
@@ -329,7 +329,7 @@ object CollectionUtils {
         arguments: List[typing.TypingResult]
     ): ValidatedNel[GenericFunctionTypingError, typing.TypingResult] = arguments match {
       case TypedObjectTypingResult(x, _, infoX) :: TypedObjectTypingResult(y, _, infoY) :: Nil =>
-        TypedObjectTypingResult(x ++ y, Typed.typedClass[java.util.HashMap[_, _]], infoX ++ infoY).validNel
+        Typed.record(x ++ y, Typed.typedClass[java.util.HashMap[_, _]], infoX ++ infoY).validNel
       case (typedClass: TypedClass) :: _      => typedClass.validNel
       case _ :: (typedClass: TypedClass) :: _ => typedClass.validNel
       case _                                  => unknownMapType.validNel

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/typed/AvroSchemaTypeDefinitionExtractor.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/typed/AvroSchemaTypeDefinitionExtractor.scala
@@ -29,9 +29,8 @@ class AvroSchemaTypeDefinitionExtractor(recordUnderlyingType: TypedClass) {
       case Schema.Type.RECORD => {
         val fields = schema.getFields.asScala
           .map(field => field.name() -> typeDefinition(field.schema()))
-          .toMap
 
-        TypedObjectTypingResult(fields, recordUnderlyingType)
+        Typed.record(fields, recordUnderlyingType)
       }
       case Schema.Type.ENUM =>
         Typed.typedClass[EnumSymbol]


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
