### PR TITLE
[NU-1769] Determine table boundedness poc

### DIFF
--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/TableTestCases.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/TableTestCases.scala
@@ -15,7 +15,9 @@ object TableTestCases {
           |    someIntComputed AS someInt * 2,
           |    `file.name` STRING NOT NULL METADATA
           |) WITH (
-          |      'connector' = '$connector'
+          |      'connector' = '$connector',
+          |      'path' = 'file:///tmp/whatever',
+          |      'format' = 'csv'
           |);""".stripMargin
 
   }

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/TableDefinition.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/TableDefinition.scala
@@ -1,9 +1,10 @@
 package pl.touk.nussknacker.engine.flink.table
 
+import org.apache.flink.api.connector.source.Boundedness
 import org.apache.flink.table.catalog.ResolvedSchema
 import org.apache.flink.table.types.DataType
 
-final case class TableDefinition(tableName: String, schema: ResolvedSchema) {
+final case class TableDefinition(tableName: String, schema: ResolvedSchema, boundedness: Boundedness) {
 
   lazy val sourceRowDataType: DataType = schema.toSourceRowDataType
 

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/extractor/TablesExtractor.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/extractor/TablesExtractor.scala
@@ -3,11 +3,17 @@ package pl.touk.nussknacker.engine.flink.table.extractor
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.implicits.catsSyntaxValidatedId
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment}
+import org.apache.flink.api.connector.source.Boundedness
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.transformations.WithBoundedness
+import org.apache.flink.table.api.Table
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
 import pl.touk.nussknacker.engine.flink.table.TableDefinition
 import pl.touk.nussknacker.engine.flink.table.extractor.SqlStatementNotExecutedError.statementNotExecutedErrorDescription
 import pl.touk.nussknacker.engine.flink.table.extractor.SqlStatementReader.SqlStatement
 
+import scala.annotation.tailrec
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.{Failure, Success, Try}
 
@@ -31,10 +37,7 @@ object TablesExtractor extends LazyLogging {
   def extractTablesFromFlinkRuntime(
       sqlStatements: List[SqlStatement]
   ): ValidatedNel[SqlStatementNotExecutedError, List[TableDefinition]] = {
-    val settings = EnvironmentSettings
-      .newInstance()
-      .build()
-    val tableEnv = TableEnvironment.create(settings)
+    val tableEnv = StreamTableEnvironment.create(StreamExecutionEnvironment.createLocalEnvironment())
 
     val sqlErrors = sqlStatements.flatMap(s =>
       Try(tableEnv.executeSql(s)) match {
@@ -56,12 +59,33 @@ object TablesExtractor extends LazyLogging {
         .getOrElse(
           throw new IllegalStateException(s"Table extractor could not locate a created table with path: $tablePath")
         )
-    } yield TableDefinition(tableName, table.getResolvedSchema)
+      boundedness = determineBoundedness(tableEnv, table).getOrElse(
+        throw new IllegalStateException(s"Could not determine boundedness of a table: $tablePath")
+      )
+    } yield TableDefinition(tableName, table.getResolvedSchema, boundedness)
 
     NonEmptyList
       .fromList(sqlErrors)
       .map(_.invalid[List[TableDefinition]])
       .getOrElse(tableDefinitions.valid)
+  }
+
+  private def determineBoundedness(env: StreamTableEnvironment, table: Table): Option[Boundedness] = {
+    @tailrec
+    def getSourceTransformation(transformation: Transformation[_]): Option[Boundedness] = {
+      transformation match {
+        case source: WithBoundedness => Some(source.getBoundedness)
+        case _ =>
+          val inputs = transformation.getInputs
+          if (inputs.isEmpty) {
+            None
+          } else {
+            getSourceTransformation(inputs.get(0))
+          }
+      }
+    }
+    val transformation = env.toDataStream(table).getTransformation
+    getSourceTransformation(transformation)
   }
 
 }


### PR DESCRIPTION
## Describe your changes

TODO:
1. Besides boundedness we need to infer it used connector can be used as a source. For example blackhole can only be a sink and others can - _potentially I guess_ (can't find an example) - only be a source. We could infer it like this:
   - Creating a datastream with the table as source throws exception + creating a datastream with table as sink doesn't - we infer that it can be used only as sink
   - Creating a datastream with the table as sink throws exception + creating a datastream with table as source doesn't - we infer that it can be used only as source

We should use this 'source-ableness' and 'sink-ablesness' of a table to validate the table used inside source and sink component.

2. We need to somehow pass the set runtime execution mode to our table source component - it needs to know if its batch mode and report error when an unbounded table is used. Either as `NodeDependency` or as part of `FlinkCustomNodeContext` 

The bad:
Now the Designer will exit with exception if a connector or format that doesn't exist on our classpath is used by any defined table.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
