### PR TITLE
BestEffort*Encoder naming changes:

### DIFF
--- a/common-api/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoderCustomisation.scala
+++ b/common-api/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoderCustomisation.scala
@@ -2,6 +2,6 @@ package pl.touk.nussknacker.engine.util.json
 
 import io.circe.Json
 
-trait ToJsonEncoder {
+trait ToJsonEncoderCustomisation {
   def encoder(delegateEncode: Any => Json): PartialFunction[Any, Json]
 }

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/extractor/HandleResponse.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/extractor/HandleResponse.scala
@@ -2,14 +2,14 @@ package pl.touk.nussknacker.openapi.extractor
 
 import java.util.Collections
 import io.circe.Json
-import pl.touk.nussknacker.engine.json.swagger.extractor.JsonToNuStruct
+import pl.touk.nussknacker.engine.json.swagger.extractor.FromJsonDecoder
 import pl.touk.nussknacker.engine.json.swagger.{SwaggerArray, SwaggerTyped}
 
 object HandleResponse {
 
   def apply(res: Option[Json], responseType: SwaggerTyped): AnyRef = res match {
     case Some(json) =>
-      JsonToNuStruct(json, responseType)
+      FromJsonDecoder.decode(json, responseType)
     case None =>
       responseType match {
         case _: SwaggerArray => Collections.EMPTY_LIST

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/extractor/ServiceRequest.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/extractor/ServiceRequest.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.openapi.extractor
 import io.circe
 import io.circe.Json
 import pl.touk.nussknacker.engine.json.swagger.{SwaggerObject, SwaggerString}
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 import pl.touk.nussknacker.openapi._
 import pl.touk.nussknacker.openapi.extractor.ServiceRequest.SwaggerRequestType
 import sttp.client3._
@@ -52,7 +52,7 @@ private class ServiceRequest(rootUrl: URL, swaggerService: SwaggerService, input
   }
 
   def apply: SwaggerRequestType = {
-    val encoder = BestEffortJsonEncoder(failOnUnknown = false, getClass.getClassLoader)
+    val encoder = ToJsonEncoder(failOnUnknown = false, getClass.getClassLoader)
 
     // FIXME: lepsza obsluga (rozpoznawanie multi headers, itp...)
     val headers: List[Header] = swaggerService.parameters.collect { case paramDef @ HeaderParameter(value, _) =>

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -57,6 +57,11 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 * [#6610](https://github.com/TouK/nussknacker/pull/6610) Add flink node context as parameter to BasicFlinkSink.
   Now one can use `FlinkCustomNodeContext` in order to build sink in `BasicFlinkSink#toFlinkFunction` method.
 * [#6635](https://github.com/TouK/nussknacker/pull/6635) `TypingResultTypeInformation` can't be loaded via SPI mechanism anymore
+* [#6640](https://github.com/TouK/nussknacker/pull/6640) `BestEffort*Encoder` naming changes:
+  * All `BestEffort*Encoder` classes renamed to fit `To<TargetFormat>(SchemaBased)Encoder` naming schema
+  * `JsonToNuStruct` renamed to `FromJsonDecoder` (to fit `From<SourceFormat>Decoder` naming schema)
+  * `ToJsonEncoder` renamed to `ToJsonEncoderCustomisation`
+  * `ToJsonBasedOnSchemaEncoder` renamed to `ToJsonSchemaBasedEncoderCustomisation`
 
 ### REST API changes
 

--- a/docs/developers_guide/Basics.md
+++ b/docs/developers_guide/Basics.md
@@ -46,7 +46,7 @@ If you want to implement own `DeploymentManager`, you should implement this inte
   - [SerializersRegistrar](https://github.com/TouK/nussknacker/blob/staging/engine/flink/extensions-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/serialization/SerializersRegistrar.scala)
   - [FlinkCompatibilityProvider](https://github.com/TouK/nussknacker/blob/staging/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/FlinkCompatibilityProvider.scala)
 - [CustomParameterValidator](https://github.com/TouK/nussknacker/blob/staging/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala)
-- [ToJsonEncoder](https://github.com/TouK/nussknacker/blob/staging/common-api/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoder.scala)
+- [ToJsonEncoderCustomisation](https://github.com/TouK/nussknacker/blob/staging/common-api/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoderCustomisation.scala)
 - [WithExceptionExtractor](https://github.com/TouK/nussknacker/blob/staging/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/exception/WithExceptionExtractor.scala)
 - [ModelConfigLoader](https://github.com/TouK/nussknacker/blob/staging/extensions-api/src/main/scala/pl/touk/nussknacker/engine/modelconfig/ModelConfigLoader.scala)
 - [ProcessMigrations](https://github.com/TouK/nussknacker/blob/staging/extensions-api/src/main/scala/pl/touk/nussknacker/engine/migration/ProcessMigration.scala)

--- a/engine/flink/components/table/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonBasedOnSchemaEncoder
+++ b/engine/flink/components/table/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonBasedOnSchemaEncoder
@@ -1,1 +1,0 @@
-pl.touk.nussknacker.engine.flink.table.utils.RowToJsonBasedOnSchemaEncoder

--- a/engine/flink/components/table/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoder
+++ b/engine/flink/components/table/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoder
@@ -1,1 +1,0 @@
-pl.touk.nussknacker.engine.flink.table.utils.RowToJsonEncoder

--- a/engine/flink/components/table/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoderCustomisation
+++ b/engine/flink/components/table/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoderCustomisation
@@ -1,0 +1,1 @@
+pl.touk.nussknacker.engine.flink.table.utils.RowToJsonEncoderCustomisation

--- a/engine/flink/components/table/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonSchemaBasedEncoderCustomisation
+++ b/engine/flink/components/table/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonSchemaBasedEncoderCustomisation
@@ -1,0 +1,1 @@
+pl.touk.nussknacker.engine.flink.table.utils.RowToJsonSchemaBasedEncoderCustomisation

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/aggregate/TableAggregation.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/aggregate/TableAggregation.scala
@@ -23,7 +23,7 @@ import pl.touk.nussknacker.engine.flink.table.aggregate.TableAggregation.{
   aggregateByInternalColumnName,
   groupByInternalColumnName
 }
-import pl.touk.nussknacker.engine.flink.table.utils.BestEffortTableTypeEncoder
+import pl.touk.nussknacker.engine.flink.table.utils.ToTableTypeEncoder
 
 object TableAggregation {
   private val aggregateByInternalColumnName = "aggregateByInternalColumn"
@@ -80,9 +80,9 @@ class TableAggregation(
 
     override def flatMap(context: Context, out: Collector[Row]): Unit = {
       collectHandlingErrors(context, out) {
-        val evaluatedGroupBy = BestEffortTableTypeEncoder.encode(evaluateGroupBy(context), groupByParam.returnType)
+        val evaluatedGroupBy = ToTableTypeEncoder.encode(evaluateGroupBy(context), groupByParam.returnType)
         val evaluatedAggregateBy =
-          BestEffortTableTypeEncoder.encode(evaluateAggregateByParam(context), aggregateByParam.returnType)
+          ToTableTypeEncoder.encode(evaluateAggregateByParam(context), aggregateByParam.returnType)
 
         val row = Row.withNames()
         row.setField(groupByInternalColumnName, evaluatedGroupBy)
@@ -97,10 +97,10 @@ class TableAggregation(
     Types.ROW_NAMED(
       Array(groupByInternalColumnName, aggregateByInternalColumnName),
       context.typeInformationDetection.forType(
-        BestEffortTableTypeEncoder.alignTypingResult(groupByLazyParam.returnType)
+        ToTableTypeEncoder.alignTypingResult(groupByLazyParam.returnType)
       ),
       context.typeInformationDetection.forType(
-        BestEffortTableTypeEncoder.alignTypingResult(aggregateByLazyParam.returnType)
+        ToTableTypeEncoder.alignTypingResult(aggregateByLazyParam.returnType)
       )
     )
   }
@@ -132,8 +132,8 @@ class TableAggregation(
   private def aggregateResultTypeInfo(context: FlinkCustomNodeContext) = {
     context.typeInformationDetection.forValueWithContext[AnyRef](
       ValidationContext.empty
-        .withVariableUnsafe(KeyVariableName, BestEffortTableTypeEncoder.alignTypingResult(groupByLazyParam.returnType)),
-      BestEffortTableTypeEncoder.alignTypingResult(aggregateByLazyParam.returnType)
+        .withVariableUnsafe(KeyVariableName, ToTableTypeEncoder.alignTypingResult(groupByLazyParam.returnType)),
+      ToTableTypeEncoder.alignTypingResult(aggregateByLazyParam.returnType)
     )
   }
 

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/join/TableJoinComponent.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/join/TableJoinComponent.scala
@@ -21,7 +21,7 @@ import pl.touk.nussknacker.engine.flink.api.process.{
   FlinkCustomNodeContext,
   FlinkLazyParameterFunctionHelper
 }
-import pl.touk.nussknacker.engine.flink.table.utils.{BestEffortTableTypeEncoder, RowConversions}
+import pl.touk.nussknacker.engine.flink.table.utils.{RowConversions, ToTableTypeEncoder}
 import pl.touk.nussknacker.engine.flink.table.utils.RowConversions.{TypeInformationDetectionExtension, rowToContext}
 import pl.touk.nussknacker.engine.flink.util.transformer.join.BranchType
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
@@ -221,7 +221,7 @@ object TableJoinComponent
         row.setField(contextInternalColumnName, RowConversions.contextToRow(context, mainBranchValidationContext))
         row.setField(
           mainKeyInternalColumnName,
-          BestEffortTableTypeEncoder.encode(evaluateKey(context), mainKeyLazyParam.returnType)
+          ToTableTypeEncoder.encode(evaluateKey(context), mainKeyLazyParam.returnType)
         )
         row
       }
@@ -238,7 +238,7 @@ object TableJoinComponent
       Array(contextInternalColumnName, mainKeyInternalColumnName),
       flinkNodeContext.typeInformationDetection.contextRowTypeInfo(mainBranchValidationContext),
       flinkNodeContext.typeInformationDetection.forType(
-        BestEffortTableTypeEncoder.alignTypingResult(mainKeyLazyParam.returnType)
+        ToTableTypeEncoder.alignTypingResult(mainKeyLazyParam.returnType)
       )
     )
   }
@@ -259,11 +259,11 @@ object TableJoinComponent
         val row = Row.withNames()
         row.setField(
           joinedKeyInternalColumnName,
-          BestEffortTableTypeEncoder.encode(evaluateKey(context), joinedKeyLazyParam.returnType)
+          ToTableTypeEncoder.encode(evaluateKey(context), joinedKeyLazyParam.returnType)
         )
         row.setField(
           outputInternalColumnName,
-          BestEffortTableTypeEncoder.encode(evaluateOutput(context), outputLazyParam.returnType)
+          ToTableTypeEncoder.encode(evaluateOutput(context), outputLazyParam.returnType)
         )
         row
       }
@@ -279,10 +279,10 @@ object TableJoinComponent
     Types.ROW_NAMED(
       Array(joinedKeyInternalColumnName, outputInternalColumnName),
       flinkNodeContext.typeInformationDetection.forType(
-        BestEffortTableTypeEncoder.alignTypingResult(joinedKeyLazyParam.returnType)
+        ToTableTypeEncoder.alignTypingResult(joinedKeyLazyParam.returnType)
       ),
       flinkNodeContext.typeInformationDetection.forType(
-        BestEffortTableTypeEncoder.alignTypingResult(outputLazyParam.returnType)
+        ToTableTypeEncoder.alignTypingResult(outputLazyParam.returnType)
       )
     )
   }

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSink.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSink.scala
@@ -16,7 +16,7 @@ import pl.touk.nussknacker.engine.flink.api.exception.{ExceptionHandler, WithExc
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkSink}
 import pl.touk.nussknacker.engine.flink.table.TableDefinition
 import pl.touk.nussknacker.engine.flink.table.extractor.SqlStatementReader.SqlStatement
-import pl.touk.nussknacker.engine.flink.table.utils.BestEffortTableTypeSchemaEncoder
+import pl.touk.nussknacker.engine.flink.table.utils.ToTableTypeSchemaBasedEncoder
 import pl.touk.nussknacker.engine.flink.table.utils.DataTypesExtensions._
 
 class TableSink(
@@ -83,7 +83,7 @@ class EncodeAsTableTypeFunction private (
   override def flatMap(valueWithContext: ValueWithContext[AnyRef], out: Collector[Row]): Unit = {
     exceptionHandler
       .handling(Some(NodeComponentInfo(nodeId, ComponentType.Sink, "table")), valueWithContext.context) {
-        BestEffortTableTypeSchemaEncoder.encodeAsRow(valueWithContext.value, sinkRowType)
+        ToTableTypeSchemaBasedEncoder.encodeAsRow(valueWithContext.value, sinkRowType)
       }
       .foreach(out.collect)
   }
@@ -99,7 +99,7 @@ object EncodeAsTableTypeFunction {
       valueReturnType: TypingResult,
       sinkRowType: RowType
   ): EncodeAsTableTypeFunction = {
-    val alignedType  = BestEffortTableTypeSchemaEncoder.alignTypingResult(valueReturnType, sinkRowType)
+    val alignedType  = ToTableTypeSchemaBasedEncoder.alignTypingResult(valueReturnType, sinkRowType)
     val producedType = flinkNodeContext.typeInformationDetection.forType[Row](alignedType)
     new EncodeAsTableTypeFunction(
       flinkNodeContext.exceptionHandlerPreparer,

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableTypeOutputValidator.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableTypeOutputValidator.scala
@@ -4,14 +4,14 @@ import cats.data.Validated.{Valid, invalidNel}
 import cats.data.ValidatedNel
 import org.apache.flink.table.types.logical.LogicalType
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
-import pl.touk.nussknacker.engine.flink.table.utils.BestEffortTableTypeSchemaEncoder
+import pl.touk.nussknacker.engine.flink.table.utils.ToTableTypeSchemaBasedEncoder
 import pl.touk.nussknacker.engine.flink.table.utils.DataTypesExtensions._
 import pl.touk.nussknacker.engine.util.output.{OutputValidatorError, OutputValidatorExpected, OutputValidatorTypeError}
 
 object TableTypeOutputValidator {
 
   def validate(actualType: TypingResult, expectedType: LogicalType): ValidatedNel[OutputValidatorError, Unit] = {
-    val aligned              = BestEffortTableTypeSchemaEncoder.alignTypingResult(actualType, expectedType)
+    val aligned              = ToTableTypeSchemaBasedEncoder.alignTypingResult(actualType, expectedType)
     val expectedTypingResult = expectedType.toTypingResult
 
     if (aligned.canBeSubclassOf(expectedTypingResult)) {

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/RowConversions.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/RowConversions.scala
@@ -30,7 +30,7 @@ object RowConversions {
     variables.foreach { case (variableName, variableValue) =>
       val encodedValue = validationContext
         .get(variableName)
-        .map(BestEffortTableTypeEncoder.encode(variableValue, _))
+        .map(ToTableTypeEncoder.encode(variableValue, _))
         .getOrElse(variableValue)
       row.setField(variableName, encodedValue)
     }
@@ -56,7 +56,7 @@ object RowConversions {
     def contextRowTypeInfo(validationContext: ValidationContext): TypeInformation[_] = {
       val (fieldNames, typeInfos) =
         validationContext.localVariables
-          .mapValuesNow(BestEffortTableTypeEncoder.alignTypingResult)
+          .mapValuesNow(ToTableTypeEncoder.alignTypingResult)
           .mapValuesNow(typeInformationDetection.forType)
           .unzip
       val variablesRow = new RowTypeInfo(typeInfos.toArray[TypeInformation[_]], fieldNames.toArray)

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/RowToJsonEncoderCustomisation.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/RowToJsonEncoderCustomisation.scala
@@ -3,11 +3,11 @@ package pl.touk.nussknacker.engine.flink.table.utils
 import io.circe.Json
 import org.apache.flink.types.Row
 import org.everit.json.schema.Schema
-import pl.touk.nussknacker.engine.util.json.{EncodeOutput, ToJsonBasedOnSchemaEncoder, ToJsonEncoder}
+import pl.touk.nussknacker.engine.util.json.{EncodeOutput, ToJsonSchemaBasedEncoderCustomisation, ToJsonEncoderCustomisation}
 
 import scala.jdk.CollectionConverters._
 
-class RowToJsonEncoder extends ToJsonEncoder {
+class RowToJsonEncoderCustomisation extends ToJsonEncoderCustomisation {
 
   override def encoder(encode: Any => Json): PartialFunction[Any, Json] = { case row: Row =>
     val fieldNames = row.getFieldNames(true).asScala
@@ -16,7 +16,7 @@ class RowToJsonEncoder extends ToJsonEncoder {
 
 }
 
-class RowToJsonBasedOnSchemaEncoder extends ToJsonBasedOnSchemaEncoder {
+class RowToJsonSchemaBasedEncoderCustomisation extends ToJsonSchemaBasedEncoderCustomisation {
 
   override def encoder(
       encode: ((Any, Schema, Option[String])) => EncodeOutput

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/ToTableTypeEncoder.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/ToTableTypeEncoder.scala
@@ -6,7 +6,7 @@ import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypedObje
 import scala.collection.immutable.ListMap
 import scala.jdk.CollectionConverters._
 
-object BestEffortTableTypeEncoder {
+object ToTableTypeEncoder {
 
   private val javaMapClass = classOf[java.util.Map[_, _]]
 

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/ToTableTypeSchemaBasedEncoder.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/ToTableTypeSchemaBasedEncoder.scala
@@ -11,7 +11,7 @@ import java.util
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
-object BestEffortTableTypeSchemaEncoder {
+object ToTableTypeSchemaBasedEncoder {
 
   private val javaMapClass = classOf[java.util.Map[_, _]]
 

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSerializationSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSerializationSpec.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.api.component.{ComponentType, NodeComponentInf
 import pl.touk.nussknacker.engine.api.exception.{NonTransientException, NuExceptionInfo}
 import pl.touk.nussknacker.engine.api.{CirceUtil, Context, MetaData, StreamMetaData, VariableConstants}
 import pl.touk.nussknacker.engine.kafka.MockProducerCreator
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 import java.time.Instant
 import scala.jdk.CollectionConverters._
@@ -18,7 +18,7 @@ class KafkaExceptionConsumerSerializationSpec extends AnyFunSuite with Matchers 
   private val mockProducer =
     new MockProducer[Array[Byte], Array[Byte]](false, new ByteArraySerializer, new ByteArraySerializer)
 
-  private val encoder = BestEffortJsonEncoder(failOnUnknown = false, getClass.getClassLoader)
+  private val encoder = ToJsonEncoder(failOnUnknown = false, getClass.getClassLoader)
 
   private val metaData = MetaData("test", StreamMetaData())
 

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/TestFromFileSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/flink/TestFromFileSpec.scala
@@ -16,13 +16,13 @@ import pl.touk.nussknacker.engine.flink.test.FlinkTestConfiguration
 import pl.touk.nussknacker.engine.flink.util.sink.SingleValueSinkFactory.SingleValueParamName
 import pl.touk.nussknacker.engine.kafka.KafkaFactory.TopicParamName
 import pl.touk.nussknacker.engine.kafka.source.flink.KafkaSourceFactoryProcessConfigCreator.ResultsHolders
-import pl.touk.nussknacker.engine.kafka.source.{InputMeta, InputMetaToJson}
+import pl.touk.nussknacker.engine.kafka.source.{InputMeta, InputMetaToJsonCustomisation}
 import pl.touk.nussknacker.engine.process.runner.FlinkTestMain
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 import pl.touk.nussknacker.engine.util.ThreadUtils
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 import pl.touk.nussknacker.test.KafkaConfigProperties
 
 import java.util.Collections
@@ -69,8 +69,8 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
       .customNode("transform", "extractedTimestamp", "extractAndTransformTimestamp", "timestampToSet" -> "0L".spel)
       .emptySink("end", "sinkForInputMeta", SingleValueParamName -> "#inputMeta".spel)
 
-    val consumerRecord = new InputMetaToJson()
-      .encoder(BestEffortJsonEncoder.defaultForTests.encode)
+    val consumerRecord = new InputMetaToJsonCustomisation()
+      .encoder(ToJsonEncoder.defaultForTests.encode)
       .apply(inputMeta)
       .mapObject(
         _.add("key", Null)
@@ -99,8 +99,8 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
       headers = Collections.emptyMap(),
       leaderEpoch = 0
     )
-    val consumerRecord = new InputMetaToJson()
-      .encoder(BestEffortJsonEncoder.defaultForTests.encode)
+    val consumerRecord = new InputMetaToJsonCustomisation()
+      .encoder(ToJsonEncoder.defaultForTests.encode)
       .apply(inputMeta)
       .mapObject(
         _.add("key", Null)
@@ -126,8 +126,8 @@ class TestFromFileSpec extends AnyFunSuite with Matchers with LazyLogging {
   private def variable(value: Any) = {
     val json = value match {
       case im: InputMeta[_] =>
-        new InputMetaToJson()
-          .encoder(BestEffortJsonEncoder.defaultForTests.encode)
+        new InputMetaToJsonCustomisation()
+          .encoder(ToJsonEncoder.defaultForTests.encode)
           .apply(im)
       case ln: Long => Json.fromLong(ln)
       case any      => Json.fromString(any.toString)

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/dto/ComplexObject.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/dto/ComplexObject.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.management.sample.dto
 import io.circe.Encoder
 import io.circe.generic.JsonCodec
 import pl.touk.nussknacker.engine.api.DisplayJsonWithEncoder
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 @JsonCodec(encodeOnly = true) case class ComplexObject(foo: java.util.Map[String, Any])
     extends DisplayJsonWithEncoder[ComplexObject]
@@ -11,5 +11,5 @@ import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
 object ComplexObject {
 
   private implicit val mapEncoder: Encoder[java.util.Map[String, Any]] =
-    Encoder.instance[java.util.Map[String, Any]](BestEffortJsonEncoder.defaultForTests.encode)
+    Encoder.instance[java.util.Map[String, Any]](ToJsonEncoder.defaultForTests.encode)
 }

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaJsonPayloadIntegrationSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaJsonPayloadIntegrationSpec.scala
@@ -17,7 +17,7 @@ import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.M
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.MockSchemaRegistryClientFactory
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{ExistingSchemaVersion, SchemaRegistryClientFactory}
 import pl.touk.nussknacker.engine.testing.LocalModelData
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 class KafkaJsonPayloadIntegrationSpec extends AnyFunSuite with KafkaAvroSpecMixin with BeforeAndAfter {
 
@@ -59,7 +59,7 @@ class KafkaJsonPayloadIntegrationSpec extends AnyFunSuite with KafkaAvroSpecMixi
       process,
       topicConfig,
       PaymentV1.exampleData,
-      BestEffortJsonEncoder.defaultForTests.encode(PaymentV1.exampleData)
+      ToJsonEncoder.defaultForTests.encode(PaymentV1.exampleData)
     )
   }
 

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/encode/ToAvroSchemaBasedEncoderSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/encode/ToAvroSchemaBasedEncoderSpec.scala
@@ -16,11 +16,11 @@ import java.time._
 import java.util.UUID
 import scala.collection.immutable.ListSet
 
-class BestEffortAvroEncoderSpec extends AnyFunSpec with Matchers with EitherValuesDetailedMessage {
+class ToAvroSchemaBasedEncoderSpec extends AnyFunSpec with Matchers with EitherValuesDetailedMessage {
 
   import scala.jdk.CollectionConverters._
 
-  final protected val avroEncoder = BestEffortAvroEncoder(ValidationMode.strict)
+  final protected val avroEncoder = ToAvroSchemaBasedEncoder(ValidationMode.strict)
 
   it("should create simple record") {
     val schema = wrapWithRecordSchema("""[
@@ -193,9 +193,9 @@ class BestEffortAvroEncoderSpec extends AnyFunSpec with Matchers with EitherValu
         |  { "name": "foo", "type": "string" }
         |]""".stripMargin)
 
-    BestEffortAvroEncoder(ValidationMode.strict)
+    ToAvroSchemaBasedEncoder(ValidationMode.strict)
       .encodeRecord(Map("foo" -> "bar", "redundant" -> 15).asJava, schema) shouldBe Symbol("invalid")
-    BestEffortAvroEncoder(ValidationMode.lax)
+    ToAvroSchemaBasedEncoder(ValidationMode.lax)
       .encodeRecord(Map("foo" -> "bar", "redundant" -> 15).asJava, schema) shouldBe Symbol("valid")
   }
 

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schema/TestSchema.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schema/TestSchema.scala
@@ -4,7 +4,7 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.schemedkafka.AvroUtils
-import pl.touk.nussknacker.engine.schemedkafka.encode.BestEffortAvroEncoder
+import pl.touk.nussknacker.engine.schemedkafka.encode.ToAvroSchemaBasedEncoder
 
 trait TestSchema {
   lazy val schema: Schema = AvroUtils.parseSchema(stringSchema)
@@ -12,7 +12,7 @@ trait TestSchema {
 }
 
 trait TestSchemaWithRecord extends TestSchema {
-  final protected val avroEncoder                        = BestEffortAvroEncoder(ValidationMode.strict)
+  final protected val avroEncoder                        = ToAvroSchemaBasedEncoder(ValidationMode.strict)
   def encode(data: Map[String, Any]): GenericData.Record = avroEncoder.encodeRecordOrError(data, schema)
   lazy val record: GenericRecord                         = encode(exampleData)
   def exampleData: Map[String, Any]

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/SinkValueEditorWithAvroPayloadIntegrationTest.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/SinkValueEditorWithAvroPayloadIntegrationTest.scala
@@ -9,7 +9,7 @@ import pl.touk.nussknacker.engine.graph.expression
 import pl.touk.nussknacker.engine.kafka.source.InputMeta
 import pl.touk.nussknacker.engine.process.helpers.TestResultsHolder
 import pl.touk.nussknacker.engine.schemedkafka.KafkaAvroIntegrationMockSchemaRegistry.schemaRegistryMockClient
-import pl.touk.nussknacker.engine.schemedkafka.encode.BestEffortAvroEncoder
+import pl.touk.nussknacker.engine.schemedkafka.encode.ToAvroSchemaBasedEncoder
 import pl.touk.nussknacker.engine.schemedkafka.helpers.KafkaAvroSpecMixin
 import pl.touk.nussknacker.engine.schemedkafka.schema.TestSchemaWithRecord
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.MockSchemaRegistryClientFactory
@@ -85,8 +85,8 @@ class SinkValueEditorWithAvroPayloadIntegrationTest extends KafkaAvroSpecMixin w
 
 object SinkValueEditorWithAvroPayloadIntegrationTest {
 
-  private val sinkForInputMetaResultsHolder      = new TestResultsHolder[InputMeta[_]]
-  private val avroEncoder: BestEffortAvroEncoder = BestEffortAvroEncoder(ValidationMode.strict)
+  private val sinkForInputMetaResultsHolder         = new TestResultsHolder[InputMeta[_]]
+  private val avroEncoder: ToAvroSchemaBasedEncoder = ToAvroSchemaBasedEncoder(ValidationMode.strict)
 
   private def encode(a: Any, schema: Schema): AnyRef =
     avroEncoder

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/TestWithTestDataSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/TestWithTestDataSpec.scala
@@ -14,7 +14,7 @@ import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, ScenarioTestJsonRe
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.flink.test.FlinkTestConfiguration
-import pl.touk.nussknacker.engine.kafka.source.{InputMeta, InputMetaToJson}
+import pl.touk.nussknacker.engine.kafka.source.{InputMeta, InputMetaToJsonCustomisation}
 import pl.touk.nussknacker.engine.process.runner.FlinkTestMain
 import pl.touk.nussknacker.engine.schemedkafka.KafkaAvroIntegrationMockSchemaRegistry.schemaRegistryMockClient
 import pl.touk.nussknacker.engine.schemedkafka.KafkaAvroTestProcessConfigCreator
@@ -30,7 +30,7 @@ import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.testmode.TestProcess._
 import pl.touk.nussknacker.engine.util.ThreadUtils
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 import pl.touk.nussknacker.test.KafkaConfigProperties
 import pl.touk.nussknacker.engine.flink.util.sink.SingleValueSinkFactory.SingleValueParamName
 import pl.touk.nussknacker.engine.graph.expression.Expression
@@ -85,8 +85,8 @@ class TestWithTestDataSpec extends AnyFunSuite with Matchers with LazyLogging {
       .customNode("transform", "extractedTimestamp", "extractAndTransformTimestamp", "timestampToSet" -> "0L".spel)
       .emptySink("end", "sinkForInputMeta", SingleValueParamName -> "#inputMeta".spel)
 
-    val consumerRecord = new InputMetaToJson()
-      .encoder(BestEffortJsonEncoder.defaultForTests.encode)
+    val consumerRecord = new InputMetaToJsonCustomisation()
+      .encoder(ToJsonEncoder.defaultForTests.encode)
       .apply(inputMeta)
       .mapObject(
         _.add("key", Null)
@@ -179,8 +179,8 @@ class TestWithTestDataSpec extends AnyFunSuite with Matchers with LazyLogging {
   private def variable(value: Any) = {
     val json = value match {
       case im: InputMeta[_] =>
-        new InputMetaToJson()
-          .encoder(BestEffortJsonEncoder.defaultForTests.encode)
+        new InputMetaToJsonCustomisation()
+          .encoder(ToJsonEncoder.defaultForTests.encode)
           .apply(im)
       case ln: Long => Json.fromLong(ln)
       case any      => Json.fromString(any.toString)

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/FlinkWithKafkaSuite.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/FlinkWithKafkaSuite.scala
@@ -33,7 +33,7 @@ import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerDataFacto
 import pl.touk.nussknacker.engine.process.registrar.FlinkProcessRegistrar
 import pl.touk.nussknacker.engine.process.{ExecutionConfigPreparer, FlinkJobConfig}
 import pl.touk.nussknacker.engine.schemedkafka.AvroUtils
-import pl.touk.nussknacker.engine.schemedkafka.encode.BestEffortAvroEncoder
+import pl.touk.nussknacker.engine.schemedkafka.encode.ToAvroSchemaBasedEncoder
 import pl.touk.nussknacker.engine.schemedkafka.kryo.AvroSerializersRegistrar
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.ConfluentUtils
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.MockSchemaRegistryClient
@@ -137,8 +137,8 @@ abstract class FlinkWithKafkaSuite
       fromAnyRef(false)
     )
 
-  lazy val kafkaConfig: KafkaConfig                = KafkaConfig.parseConfig(config, "config")
-  protected val avroEncoder: BestEffortAvroEncoder = BestEffortAvroEncoder(ValidationMode.strict)
+  lazy val kafkaConfig: KafkaConfig                   = KafkaConfig.parseConfig(config, "config")
+  protected val avroEncoder: ToAvroSchemaBasedEncoder = ToAvroSchemaBasedEncoder(ValidationMode.strict)
 
   protected val givenNotMatchingAvroObj: GenericData.Record = avroEncoder.encodeRecordOrError(
     Map("first" -> "Zenon", "last" -> "Nowak"),

--- a/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalAvroSchemaFunctionalTest.scala
+++ b/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalAvroSchemaFunctionalTest.scala
@@ -1103,16 +1103,16 @@ class LiteKafkaUniversalAvroSchemaFunctionalTest
   test("should catch runtime errors") {
     val testData = Table(
       "config",
-      // Comparing String -> Enum returns true, but in runner BestEffortAvroEncoder tries to encode String (that doesn't meet the requirements) to Enum
+      // Comparing String -> Enum returns true, but in runner ToAvroSchemaBasedEncoder tries to encode String (that doesn't meet the requirements) to Enum
       rConfig(sampleStrFixedV, recordStringSchema, recordEnumSchema, Input),
 
-      // FIXME: Comparing EnumV2 -> Enum returns true, but in runner BestEffortAvroEncoder tries to encode String (that doesn't meet the requirements) to Enum
+      // FIXME: Comparing EnumV2 -> Enum returns true, but in runner ToAvroSchemaBasedEncoder tries to encode String (that doesn't meet the requirements) to Enum
       rConfig(sampleEnumV2, recordEnumSchemaV2, recordEnumSchema, Input),
 
-      // Comparing String -> Fixed returns true, but in runner BestEffortAvroEncoder tries to encode String (that doesn't meet the requirements) to Fixed
+      // Comparing String -> Fixed returns true, but in runner ToAvroSchemaBasedEncoder tries to encode String (that doesn't meet the requirements) to Fixed
       rConfig(sampleString, recordStringSchema, recordFixedSchema, Input),
 
-      // FIXME: Comparing FixedV2 -> Fixed returns true, but in runner BestEffortAvroEncoder tries to encode value FixedV2 to Fixed
+      // FIXME: Comparing FixedV2 -> Fixed returns true, but in runner ToAvroSchemaBasedEncoder tries to encode value FixedV2 to Fixed
       rConfig(sampleFixedV2, recordFixedSchemaV2, recordFixedSchema, Input),
 
       // Situation when we put String -> UUID, where String isn't valid UUID type...

--- a/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalJsonFunctionalTest.scala
+++ b/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalJsonFunctionalTest.scala
@@ -492,7 +492,7 @@ class LiteKafkaUniversalJsonFunctionalTest
           fromFields(List.empty),
           fromFields(List(ObjectFieldName -> fromString("foo")))
         ),
-        // schema evolution on output - it is done by Nussknacker's code - see BestEffortJsonSchemaEncoder
+        // schema evolution on output - it is done by Nussknacker's code - see ToJsonSchemaBasedEncoder
         (
           createObjSchema(required = true, schemaString, schemaNull),
           createObjSchema(required = true, StringSchema.builder().defaultValue("foo").build()),

--- a/engine/lite/components/request-response/src/main/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/jsonschema/sources/JsonSchemaRequestResponseSource.scala
+++ b/engine/lite/components/request-response/src/main/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/jsonschema/sources/JsonSchemaRequestResponseSource.scala
@@ -13,12 +13,12 @@ import pl.touk.nussknacker.engine.api.{CirceUtil, MetaData, NodeId}
 import pl.touk.nussknacker.engine.json.{JsonSchemaBasedParameter, SwaggerBasedJsonSchemaTypeDefinitionExtractor}
 import pl.touk.nussknacker.engine.json.serde.CirceJsonDeserializer
 import pl.touk.nussknacker.engine.json.swagger.SwaggerTyped
-import pl.touk.nussknacker.engine.json.swagger.extractor.JsonToNuStruct
+import pl.touk.nussknacker.engine.json.swagger.extractor.FromJsonDecoder
 import pl.touk.nussknacker.engine.lite.components.requestresponse.jsonschema.sinks.JsonRequestResponseSink.SinkRawValueParamName
 import pl.touk.nussknacker.engine.requestresponse.api.openapi.OpenApiSourceDefinition
 import pl.touk.nussknacker.engine.requestresponse.api.{RequestResponsePostSource, ResponseEncoder}
 import pl.touk.nussknacker.engine.requestresponse.utils.encode.SchemaResponseEncoder
-import pl.touk.nussknacker.engine.util.json.{BestEffortJsonEncoder, JsonSchemaUtils}
+import pl.touk.nussknacker.engine.util.json.{JsonSchemaUtils, ToJsonEncoder}
 import pl.touk.nussknacker.engine.util.json.JsonSchemaImplicits._
 import pl.touk.nussknacker.engine.util.parameters.TestingParametersSupport
 
@@ -91,10 +91,10 @@ class JsonSchemaRequestResponseSource(
         params
           .get(SinkRawValueParamName)
           .map { paramValue =>
-            val json                       = BestEffortJsonEncoder.defaultForTests.encode(paramValue)
+            val json                       = ToJsonEncoder.defaultForTests.encode(paramValue)
             val schema                     = getFirstMatchingSchemaForJson(cs, json)
             val swaggerTyped: SwaggerTyped = SwaggerBasedJsonSchemaTypeDefinitionExtractor.swaggerType(schema)
-            JsonToNuStruct(json, swaggerTyped)
+            FromJsonDecoder.decode(json, swaggerTyped)
           }
           .getOrElse {
             throw new IllegalArgumentException( // Should never happen since CombinedSchema is created using SinkRawValueParamName but still...
@@ -103,9 +103,9 @@ class JsonSchemaRequestResponseSource(
           }
       }
       case _ =>
-        val json = BestEffortJsonEncoder.defaultForTests.encode(TestingParametersSupport.unflattenParameters(params))
+        val json = ToJsonEncoder.defaultForTests.encode(TestingParametersSupport.unflattenParameters(params))
         val swaggerTyped: SwaggerTyped = SwaggerBasedJsonSchemaTypeDefinitionExtractor.swaggerType(inputSchema)
-        JsonToNuStruct(json, swaggerTyped)
+        FromJsonDecoder.decode(json, swaggerTyped)
     }
   }
 

--- a/engine/lite/request-response/components-utils/src/main/scala/pl/touk/nussknacker/engine/requestresponse/utils/encode/SchemaResponseEncoder.scala
+++ b/engine/lite/request-response/components-utils/src/main/scala/pl/touk/nussknacker/engine/requestresponse/utils/encode/SchemaResponseEncoder.scala
@@ -3,12 +3,12 @@ package pl.touk.nussknacker.engine.requestresponse.utils.encode
 import io.circe.Json
 import org.everit.json.schema.Schema
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
-import pl.touk.nussknacker.engine.json.encode.BestEffortJsonSchemaEncoder
+import pl.touk.nussknacker.engine.json.encode.ToJsonSchemaBasedEncoder
 import pl.touk.nussknacker.engine.requestresponse.api.ResponseEncoder
 
 class SchemaResponseEncoder(schema: Schema, validationMode: ValidationMode) extends ResponseEncoder[Any] {
 
-  private val encoder = new BestEffortJsonSchemaEncoder(validationMode)
+  private val encoder = new ToJsonSchemaBasedEncoder(validationMode)
 
   override def toJsonResponse(input: Any, result: List[Any]): Json = {
     result

--- a/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/DefaultResponseEncoder.scala
+++ b/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/DefaultResponseEncoder.scala
@@ -2,12 +2,12 @@ package pl.touk.nussknacker.engine.requestresponse
 
 import io.circe.Json
 import pl.touk.nussknacker.engine.requestresponse.api.ResponseEncoder
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 object DefaultResponseEncoder extends ResponseEncoder[Any] {
 
-  private val bestEffortEncoder = BestEffortJsonEncoder(failOnUnknown = true, getClass.getClassLoader)
+  private val encoder = ToJsonEncoder(failOnUnknown = true, getClass.getClassLoader)
 
-  override def toJsonResponse(input: Any, result: List[Any]): Json = bestEffortEncoder.encode(result)
+  override def toJsonResponse(input: Any, result: List[Any]): Json = encoder.encode(result)
 
 }

--- a/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/openapi/RequestResponseOpenApiGenerator.scala
+++ b/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/openapi/RequestResponseOpenApiGenerator.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.requestresponse.openapi
 
 import io.circe.Json
 import io.circe.syntax._
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 class RequestResponseOpenApiGenerator(oApiVersion: String, oApiInfo: OApiInfo) {
 
@@ -39,7 +39,7 @@ class RequestResponseOpenApiGenerator(oApiVersion: String, oApiInfo: OApiInfo) {
 
 object RequestResponseOpenApiGenerator {
 
-  private val jsonEncoder = BestEffortJsonEncoder(failOnUnknown = true, getClass.getClassLoader)
+  private val jsonEncoder = ToJsonEncoder(failOnUnknown = true, getClass.getClassLoader)
 
   private[requestresponse] def generateScenarioDefinition(
       operationId: String,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testmode/TestInterpreterRunner.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testmode/TestInterpreterRunner.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.testmode
 
 import io.circe.Json
 import pl.touk.nussknacker.engine.api.DisplayJson
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 object TestInterpreterRunner {
 
@@ -12,7 +12,7 @@ object TestInterpreterRunner {
    * and in this case there is loaders conflict
    */
   private[testmode] def testResultsVariableEncoder: Any => io.circe.Json = {
-    lazy val encoder = BestEffortJsonEncoder(failOnUnknown = false, Thread.currentThread().getContextClassLoader)
+    lazy val encoder = ToJsonEncoder(failOnUnknown = false, Thread.currentThread().getContextClassLoader)
     def encode(a: Any): Json = a match {
       case scenarioGraph: DisplayJson =>
         def safeString(a: String): Json = Option(a).map(Json.fromString).getOrElse(Json.Null)

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/encode/ToJsonSchemaBasedEncoder.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/encode/ToJsonSchemaBasedEncoder.scala
@@ -14,15 +14,15 @@ import java.util.ServiceLoader
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-class BestEffortJsonSchemaEncoder(validationMode: ValidationMode) {
+class ToJsonSchemaBasedEncoder(validationMode: ValidationMode) {
 
   import pl.touk.nussknacker.engine.util.json.JsonSchemaImplicits._
 
   private val classLoader = this.getClass.getClassLoader
-  private val jsonEncoder = BestEffortJsonEncoder(failOnUnknown = false, this.getClass.getClassLoader)
+  private val jsonEncoder = ToJsonEncoder(failOnUnknown = false, this.getClass.getClassLoader)
 
   private val optionalEncoders = ServiceLoader
-    .load(classOf[ToJsonBasedOnSchemaEncoder], classLoader)
+    .load(classOf[ToJsonSchemaBasedEncoderCustomisation], classLoader)
     .asScala
     .map(_.encoder(this.encodeBasedOnSchema))
 

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/serde/CirceJsonDeserializer.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/serde/CirceJsonDeserializer.scala
@@ -5,7 +5,7 @@ import org.json.JSONTokener
 import pl.touk.nussknacker.engine.api.typed.CustomNodeValidationException
 import pl.touk.nussknacker.engine.json.SwaggerBasedJsonSchemaTypeDefinitionExtractor
 import pl.touk.nussknacker.engine.json.swagger.SwaggerTyped
-import pl.touk.nussknacker.engine.json.swagger.extractor.JsonToNuStruct
+import pl.touk.nussknacker.engine.json.swagger.extractor.FromJsonDecoder
 import pl.touk.nussknacker.engine.util.json.JsonSchemaUtils
 
 import java.nio.charset.StandardCharsets
@@ -36,7 +36,7 @@ class CirceJsonDeserializer(jsonSchema: Schema) {
       .valueOr(errorMsg => throw CustomNodeValidationException(errorMsg, None))
 
     val circeJson = JsonSchemaUtils.jsonToCirce(validatedJson)
-    val struct    = JsonToNuStruct(circeJson, swaggerTyped)
+    val struct    = FromJsonDecoder.decode(circeJson, swaggerTyped)
     struct
   }
 

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonSchemaBasedEncoderCustomisation.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonSchemaBasedEncoderCustomisation.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.util.json
 
-trait ToJsonBasedOnSchemaEncoder {
+trait ToJsonSchemaBasedEncoderCustomisation {
 
   def encoder(delegateEncode: EncodeInput => EncodeOutput): PartialFunction[EncodeInput, EncodeOutput]
 }

--- a/utils/json-utils/src/test/scala/pl/touk/nussknacker/engine/json/SwaggerBasedJsonSchemaTypeDefinitionExtractorTest.scala
+++ b/utils/json-utils/src/test/scala/pl/touk/nussknacker/engine/json/SwaggerBasedJsonSchemaTypeDefinitionExtractorTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.prop.TableDrivenPropertyChecks
 import pl.touk.nussknacker.engine.api.typed.TypedMap
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult, TypingResult, Unknown}
-import pl.touk.nussknacker.engine.json.swagger.extractor.JsonToNuStruct
+import pl.touk.nussknacker.engine.json.swagger.extractor.FromJsonDecoder
 import pl.touk.nussknacker.engine.json.swagger._
 
 class SwaggerBasedJsonSchemaTypeDefinitionExtractorTest extends AnyFunSuite with TableDrivenPropertyChecks {
@@ -304,7 +304,7 @@ class SwaggerBasedJsonSchemaTypeDefinitionExtractorTest extends AnyFunSuite with
 
     val jsonObject    = Json.obj("time" -> fromString("2022-07-11T18:12:27+02:00"))
     val swaggerObject = new SwaggerObject(elementType = Map("time" -> SwaggerDateTime), AdditionalPropertiesDisabled)
-    val jsonToObjectExtracted = JsonToNuStruct(jsonObject, swaggerObject)
+    val jsonToObjectExtracted = FromJsonDecoder.decode(jsonObject, swaggerObject)
 
     swaggerTypeExtracted.asInstanceOf[TypedObjectTypingResult].fields("time") shouldBe
       Typed.fromInstance(jsonToObjectExtracted.asInstanceOf[TypedMap].get("time"))

--- a/utils/json-utils/src/test/scala/pl/touk/nussknacker/engine/json/encode/ToJsonSchemaBasedEncoderTest.scala
+++ b/utils/json-utils/src/test/scala/pl/touk/nussknacker/engine/json/encode/ToJsonSchemaBasedEncoderTest.scala
@@ -20,7 +20,7 @@ import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, OffsetTime, ZonedDateTime}
 import java.util.Collections
 
-class BestEffortJsonSchemaEncoderTest
+class ToJsonSchemaBasedEncoderTest
     extends AnyFunSuite
     with ValidatedValuesDetailedMessage
     with OptionValues
@@ -30,7 +30,7 @@ class BestEffortJsonSchemaEncoderTest
 
   private val FieldName = "foo"
 
-  private val encoder = new BestEffortJsonSchemaEncoder(ValidationMode.strict)
+  private val encoder = new ToJsonSchemaBasedEncoder(ValidationMode.strict)
 
   private val schemaNumber: NumberSchema        = NumberSchema.builder().build()
   private val schemaIntegerNumber: NumberSchema = NumberSchema.builder().requiresInteger(true).build()

--- a/utils/json-utils/src/test/scala/pl/touk/nussknacker/engine/json/swagger/extractor/FromJsonDecoderTest.scala
+++ b/utils/json-utils/src/test/scala/pl/touk/nussknacker/engine/json/swagger/extractor/FromJsonDecoderTest.scala
@@ -6,12 +6,12 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.typed.TypedMap
 import pl.touk.nussknacker.engine.json.swagger._
-import pl.touk.nussknacker.engine.json.swagger.extractor.JsonToNuStruct.JsonToObjectError
+import pl.touk.nussknacker.engine.json.swagger.extractor.FromJsonDecoder.JsonToObjectError
 
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, OffsetTime, ZoneOffset, ZonedDateTime}
 
-class JsonToNuStructTest extends AnyFunSuite with Matchers {
+class FromJsonDecoderTest extends AnyFunSuite with Matchers {
 
   private val json = Json.obj(
     "field1"       -> fromString("value"),
@@ -46,7 +46,7 @@ class JsonToNuStructTest extends AnyFunSuite with Matchers {
       AdditionalPropertiesDisabled
     )
 
-    val value = JsonToNuStruct(json, definition)
+    val value = FromJsonDecoder.decode(json, definition)
 
     value shouldBe a[TypedMap]
     val fields = value.asInstanceOf[TypedMap]
@@ -73,7 +73,7 @@ class JsonToNuStructTest extends AnyFunSuite with Matchers {
       AdditionalPropertiesDisabled
     )
 
-    val ex = intercept[JsonToObjectError](JsonToNuStruct(json, definition))
+    val ex = intercept[JsonToObjectError](FromJsonDecoder.decode(json, definition))
 
     ex.getMessage shouldBe "JSON returned by service has invalid type at mapField.b. Expected: SwaggerString. Returned json: 2"
     ex.path shouldBe "mapField.b"
@@ -82,17 +82,17 @@ class JsonToNuStructTest extends AnyFunSuite with Matchers {
   test("should skip additionalFields when schema/SwaggerObject does not allow them") {
     val definitionWithoutFields =
       SwaggerObject(elementType = Map("field3" -> SwaggerLong), AdditionalPropertiesDisabled)
-    extractor.JsonToNuStruct(json, definitionWithoutFields) shouldBe TypedMap(Map.empty)
+    extractor.FromJsonDecoder.decode(json, definitionWithoutFields) shouldBe TypedMap(Map.empty)
 
     val definitionWithOneField = SwaggerObject(elementType = Map("field2" -> SwaggerLong), AdditionalPropertiesDisabled)
-    extractor.JsonToNuStruct(json, definitionWithOneField) shouldBe TypedMap(Map("field2" -> 1L))
+    extractor.FromJsonDecoder.decode(json, definitionWithOneField) shouldBe TypedMap(Map("field2" -> 1L))
 
   }
 
   test("should not trim additional fields fields when additionalPropertiesOn") {
     val json       = Json.obj("field1" -> fromString("value"), "field2" -> Json.fromInt(1))
     val definition = SwaggerObject(elementType = Map("field3" -> SwaggerLong))
-    extractor.JsonToNuStruct(json, definition) shouldBe TypedMap(
+    extractor.FromJsonDecoder.decode(json, definition) shouldBe TypedMap(
       Map(
         "field1" -> "value",
         "field2" -> java.math.BigDecimal.valueOf(1)
@@ -102,7 +102,7 @@ class JsonToNuStructTest extends AnyFunSuite with Matchers {
     val jsonIntegers = Json.obj("field1" -> fromInt(2), "field2" -> fromInt(1))
     val definition2 =
       SwaggerObject(elementType = Map("field3" -> SwaggerLong), AdditionalPropertiesEnabled(SwaggerLong))
-    extractor.JsonToNuStruct(jsonIntegers, definition2) shouldBe TypedMap(
+    extractor.FromJsonDecoder.decode(jsonIntegers, definition2) shouldBe TypedMap(
       Map(
         "field1" -> 2L,
         "field2" -> 1L
@@ -115,7 +115,7 @@ class JsonToNuStructTest extends AnyFunSuite with Matchers {
     val definition = SwaggerObject(elementType = Map("field3" -> SwaggerLong), AdditionalPropertiesEnabled(SwaggerLong))
 
     val ex = intercept[JsonToObjectError] {
-      extractor.JsonToNuStruct(json, definition)
+      extractor.FromJsonDecoder.decode(json, definition)
     }
 
     ex.getMessage shouldBe """JSON returned by service has invalid type at field1. Expected: SwaggerLong. Returned json: "value""""
@@ -125,7 +125,7 @@ class JsonToNuStructTest extends AnyFunSuite with Matchers {
     val definition =
       SwaggerObject(elementType = Map("field2" -> SwaggerUnion(List(SwaggerString, SwaggerLong))))
 
-    val value = JsonToNuStruct(json, definition)
+    val value = FromJsonDecoder.decode(json, definition)
 
     value shouldBe a[TypedMap]
     val fields = value.asInstanceOf[TypedMap]
@@ -143,7 +143,7 @@ class JsonToNuStructTest extends AnyFunSuite with Matchers {
     )
 
     def assertPath(json: Json, path: String) =
-      intercept[JsonToObjectError](JsonToNuStruct(json, definition)).path shouldBe path
+      intercept[JsonToObjectError](FromJsonDecoder.decode(json, definition)).path shouldBe path
 
     assertPath(Json.obj("string" -> fromLong(1)), "string")
     assertPath(

--- a/utils/kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoder
+++ b/utils/kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoder
@@ -1,1 +1,0 @@
-pl.touk.nussknacker.engine.kafka.source.InputMetaToJson

--- a/utils/kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoderCustomisation
+++ b/utils/kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoderCustomisation
@@ -1,0 +1,1 @@
+pl.touk.nussknacker.engine.kafka.source.InputMetaToJsonCustomisation

--- a/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/InputMeta.scala
+++ b/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/InputMeta.scala
@@ -4,7 +4,7 @@ import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
 import io.circe.{Encoder, Json}
 import org.apache.kafka.common.record.TimestampType
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedObjectTypingResult, TypingResult}
-import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoderCustomisation
 
 import scala.collection.immutable.ListMap
 
@@ -61,7 +61,7 @@ object InputMeta {
 
 }
 
-class InputMetaToJson extends ToJsonEncoder {
+class InputMetaToJsonCustomisation extends ToJsonEncoderCustomisation {
 
   import pl.touk.nussknacker.engine.api.CirceUtil._
   import pl.touk.nussknacker.engine.api.CirceUtil.codecs._

--- a/utils/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/InputMetaToJsonSpec.scala
+++ b/utils/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/InputMetaToJsonSpec.scala
@@ -8,13 +8,13 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.DisplayJsonWithEncoder
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 import scala.jdk.CollectionConverters._
 
 class InputMetaToJsonSpec extends AnyFunSuite with Matchers with TableDrivenPropertyChecks {
 
-  private val encoder = BestEffortJsonEncoder.defaultForTests
+  private val encoder = ToJsonEncoder.defaultForTests
 
   test("should encode for various keys") {
 

--- a/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaJsonExceptionSerializationSchema.scala
+++ b/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaJsonExceptionSerializationSchema.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.api.{Context, MetaData}
 import pl.touk.nussknacker.engine.api.exception.{NonTransientException, NuExceptionInfo}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.kafka.serialization.KafkaSerializationSchema
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 import java.io.{PrintWriter, StringWriter}
 import java.lang
@@ -47,7 +47,7 @@ class KafkaJsonExceptionSerializationSchema(metaData: MetaData, consumerConfig: 
 
 object KafkaExceptionInfo {
 
-  private val encoder = BestEffortJsonEncoder(failOnUnknown = false, getClass.getClassLoader)
+  private val encoder = ToJsonEncoder(failOnUnknown = false, getClass.getClassLoader)
 
   // TODO: better hostname (e.g. from some Flink config)
   private lazy val hostName = InetAddress.getLocalHost.getHostName

--- a/utils/schemed-kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonBasedOnSchemaEncoder
+++ b/utils/schemed-kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonBasedOnSchemaEncoder
@@ -1,1 +1,0 @@
-pl.touk.nussknacker.engine.schemedkafka.encode.AvroToJsonBasedOnSchemaEncoder

--- a/utils/schemed-kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoder
+++ b/utils/schemed-kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoder
@@ -1,1 +1,0 @@
-pl.touk.nussknacker.engine.schemedkafka.encode.AvroToJsonEncoder

--- a/utils/schemed-kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoderCustomisation
+++ b/utils/schemed-kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonEncoderCustomisation
@@ -1,0 +1,1 @@
+pl.touk.nussknacker.engine.schemedkafka.encode.AvroToJsonEncoderCustomisation

--- a/utils/schemed-kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonSchemaBasedEncoderCustomisation
+++ b/utils/schemed-kafka-components-utils/src/main/resources/META-INF/services/pl.touk.nussknacker.engine.util.json.ToJsonSchemaBasedEncoderCustomisation
@@ -1,0 +1,1 @@
+pl.touk.nussknacker.engine.schemedkafka.encode.AvroToJsonSchemaBasedEncoderCustomisation

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroSchemaOutputValidator.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroSchemaOutputValidator.scala
@@ -41,7 +41,7 @@ class AvroSchemaOutputValidator(validationMode: ValidationMode) extends LazyLogg
   )
 
   /**
-    * see {@link pl.touk.nussknacker.engine.schemedkafka.encode.BestEffortAvroEncoder} for underlying avro types
+    * see {@link pl.touk.nussknacker.engine.schemedkafka.encode.ToAvroSchemaBasedEncoder} for underlying avro types
     */
   def validate(typingResult: TypingResult, schema: Schema): ValidatedNel[OutputValidatorError, Unit] =
     validateTypingResult(typingResult, schema, None)

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroToJsonEncoderCustomisation.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroToJsonEncoderCustomisation.scala
@@ -1,11 +1,11 @@
 package pl.touk.nussknacker.engine.schemedkafka.encode
 
 import io.circe.Json
-import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoderCustomisation
 
 import scala.jdk.CollectionConverters._
 
-class AvroToJsonEncoder extends ToJsonEncoder {
+class AvroToJsonEncoderCustomisation extends ToJsonEncoderCustomisation {
 
   override def encoder(encode: Any => Json): PartialFunction[Any, Json] = {
     case e: org.apache.avro.generic.GenericRecord =>

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroToJsonSchemaBasedEncoderCustomisation.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroToJsonSchemaBasedEncoderCustomisation.scala
@@ -1,10 +1,10 @@
 package pl.touk.nussknacker.engine.schemedkafka.encode
 
 import org.everit.json.schema.Schema
-import pl.touk.nussknacker.engine.util.json.{EncodeInput, EncodeOutput, ToJsonBasedOnSchemaEncoder}
+import pl.touk.nussknacker.engine.util.json.{EncodeInput, EncodeOutput, ToJsonSchemaBasedEncoderCustomisation}
 import scala.jdk.CollectionConverters._
 
-class AvroToJsonBasedOnSchemaEncoder extends ToJsonBasedOnSchemaEncoder {
+class AvroToJsonSchemaBasedEncoderCustomisation extends ToJsonSchemaBasedEncoderCustomisation {
 
   override def encoder(
       delegateEncode: EncodeInput => EncodeOutput

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/ToAvroSchemaBasedEncoder.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/ToAvroSchemaBasedEncoder.scala
@@ -23,7 +23,7 @@ import scala.math.BigDecimal.RoundingMode
 import scala.util.Try
 import scala.collection.compat.immutable.LazyList
 
-class BestEffortAvroEncoder(avroSchemaEvolution: AvroSchemaEvolution, validationMode: ValidationMode) {
+class ToAvroSchemaBasedEncoder(avroSchemaEvolution: AvroSchemaEvolution, validationMode: ValidationMode) {
 
   import scala.jdk.CollectionConverters._
 
@@ -245,10 +245,10 @@ class BestEffortAvroEncoder(avroSchemaEvolution: AvroSchemaEvolution, validation
 
 }
 
-object BestEffortAvroEncoder {
+object ToAvroSchemaBasedEncoder {
 
   final private val DefaultSchemaEvolution = new DefaultAvroSchemaEvolution
 
-  def apply(validationMode: ValidationMode): BestEffortAvroEncoder =
-    new BestEffortAvroEncoder(DefaultSchemaEvolution, validationMode)
+  def apply(validationMode: ValidationMode): ToAvroSchemaBasedEncoder =
+    new ToAvroSchemaBasedEncoder(DefaultSchemaEvolution, validationMode)
 }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -13,7 +13,7 @@ import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.json.JsonSchemaBasedParameter
-import pl.touk.nussknacker.engine.json.encode.{BestEffortJsonSchemaEncoder, JsonSchemaOutputValidator}
+import pl.touk.nussknacker.engine.json.encode.{JsonSchemaOutputValidator, ToJsonSchemaBasedEncoder}
 import pl.touk.nussknacker.engine.kafka.KafkaConfig
 import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransformer.sinkValueParamName
 import pl.touk.nussknacker.engine.schemedkafka.encode._
@@ -99,7 +99,7 @@ class AvroSchemaSupport(kafkaConfig: KafkaConfig) extends ParsedSchemaSupport[Av
   }
 
   override def formValueEncoder(schema: ParsedSchema, validationMode: ValidationMode): Any => AnyRef = {
-    val encoder = BestEffortAvroEncoder(validationMode)
+    val encoder = ToAvroSchemaBasedEncoder(validationMode)
     (value: Any) => encoder.encodeOrError(value, schema.cast().rawSchema())
   }
 
@@ -154,7 +154,7 @@ object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
   }
 
   override def formValueEncoder(schema: ParsedSchema, mode: ValidationMode): Any => AnyRef = { (value: Any) =>
-    new BestEffortJsonSchemaEncoder(mode).encodeOrError(value, schema.cast().rawSchema())
+    new ToJsonSchemaBasedEncoder(mode).encodeOrError(value, schema.cast().rawSchema())
   }
 
   override def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport =

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/RecordFormatterSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/RecordFormatterSupport.scala
@@ -8,7 +8,7 @@ import pl.touk.nussknacker.engine.kafka.KafkaConfig
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.SchemaRegistryClient
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.formatter.{AvroMessageFormatter, AvroMessageReader}
 import pl.touk.nussknacker.engine.util.Implicits._
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 import java.nio.charset.StandardCharsets
 
@@ -31,7 +31,7 @@ trait RecordFormatterSupport {
 
 object JsonPayloadRecordFormatterSupport extends RecordFormatterSupport {
   override def formatMessage(data: Any): Json =
-    BestEffortJsonEncoder(failOnUnknown = false, classLoader = getClass.getClassLoader).encode(data)
+    ToJsonEncoder(failOnUnknown = false, classLoader = getClass.getClassLoader).encode(data)
 
   override def readKeyMessage(
       topic: TopicName.ForSource,

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/typed/AvroSchemaTypeDefinitionExtractor.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/typed/AvroSchemaTypeDefinitionExtractor.scala
@@ -19,7 +19,7 @@ class AvroSchemaTypeDefinitionExtractor(recordUnderlyingType: TypedClass) {
   val dictIdProperty = "nkDictId"
 
   /**
-    * See {@link pl.touk.nussknacker.engine.schemedkafka.encode.BestEffortAvroEncoder} for underlying avro types
+    * See {@link pl.touk.nussknacker.engine.schemedkafka.encode.ToAvroSchemaBasedEncoder} for underlying avro types
     *
     * !When applying changes keep in mind that this Schema.Type pattern matching is duplicated in {@link pl.touk.nussknacker.engine.schemedkafka.AvroDefaultExpressionDeterminer},
     * and is used at {@link  pl.touk.nussknacker.engine.schemedkafka.encode.AvroSchemaOutputValidator}

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroToJsonEncoderCustomisationSpec.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroToJsonEncoderCustomisationSpec.scala
@@ -6,12 +6,12 @@ import org.apache.avro.SchemaBuilder
 import org.apache.avro.generic.GenericRecordBuilder
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
-class AvroToJsonEncoderSpec extends AnyFunSpec with Matchers {
+class AvroToJsonEncoderCustomisationSpec extends AnyFunSpec with Matchers {
 
   val avroToJsonEncoder: PartialFunction[Any, Json] =
-    new AvroToJsonEncoder().encoder(BestEffortJsonEncoder.defaultForTests.encode)
+    new AvroToJsonEncoderCustomisation().encoder(ToJsonEncoder.defaultForTests.encode)
 
   it("should encode generic record") {
     val schema =

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroToJsonSchemaBasedEncoderCustomisationTest.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroToJsonSchemaBasedEncoderCustomisationTest.scala
@@ -11,15 +11,15 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.json.JsonSchemaBuilder
-import pl.touk.nussknacker.engine.json.encode.BestEffortJsonSchemaEncoder
+import pl.touk.nussknacker.engine.json.encode.ToJsonSchemaBasedEncoder
 
-class BestEffortJsonSchemaWithAvroEncoderTest extends AnyFunSuite with Matchers {
+class AvroToJsonSchemaBasedEncoderCustomisationTest extends AnyFunSuite with Matchers {
 
   test("should encode avro generic record") {
     type WithError[T] = ValidatedNel[String, T]
-    val encoder = new BestEffortJsonSchemaEncoder(ValidationMode.strict)
+    val encoder = new ToJsonSchemaBasedEncoder(ValidationMode.strict)
     val avroToJsonEncoder: PartialFunction[(Any, Schema, Option[String]), WithError[Json]] =
-      new AvroToJsonBasedOnSchemaEncoder().encoder(encoder.encodeBasedOnSchema)
+      new AvroToJsonSchemaBasedEncoderCustomisation().encoder(encoder.encodeBasedOnSchema)
 
     val avroSchema =
       SchemaBuilder

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/helpers/KafkaWithSchemaRegistryOperations.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/helpers/KafkaWithSchemaRegistryOperations.scala
@@ -17,7 +17,7 @@ import pl.touk.nussknacker.engine.kafka.{KafkaClient, KafkaRecordUtils, Unspecia
 import pl.touk.nussknacker.engine.schemedkafka.schema.DefaultAvroSchemaEvolution
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.ConfluentUtils
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.serialization.AbstractConfluentKafkaAvroSerializer
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 import java.nio.charset.StandardCharsets
 
@@ -206,5 +206,5 @@ object SimpleKafkaJsonDeserializer extends Deserializer[Any] {
 object SimpleKafkaJsonSerializer extends Serializer[Any] {
 
   override def serialize(topic: String, data: Any): Array[Byte] =
-    BestEffortJsonEncoder.defaultForTests.encode(data).spaces2.getBytes(StandardCharsets.UTF_8)
+    ToJsonEncoder.defaultForTests.encode(data).spaces2.getBytes(StandardCharsets.UTF_8)
 }

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverterSpec.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/confluent/serialization/jsonpayload/JsonPayloadToAvroConverterSpec.scala
@@ -7,8 +7,8 @@ import org.apache.avro.generic.GenericRecord
 import org.scalatest.{Inside, OptionValues}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.schemedkafka.encode.AvroToJsonEncoder
-import pl.touk.nussknacker.engine.util.json.BestEffortJsonEncoder
+import pl.touk.nussknacker.engine.schemedkafka.encode.AvroToJsonEncoderCustomisation
+import pl.touk.nussknacker.engine.util.json.ToJsonEncoder
 
 import java.nio.charset.StandardCharsets
 import java.time.{Instant, LocalDate, LocalTime}
@@ -19,7 +19,7 @@ import scala.util.{Failure, Try}
 class JsonPayloadToAvroConverterSpec extends AnyFunSuite with Matchers with OptionValues with Inside {
 
   val avroToJsonEncoder: PartialFunction[Any, Json] =
-    new AvroToJsonEncoder().encoder(BestEffortJsonEncoder.defaultForTests.encode)
+    new AvroToJsonEncoderCustomisation().encoder(ToJsonEncoder.defaultForTests.encode)
 
   test("date logical type") {
     val schema = prepareSchema("""{ "type": "int", "logicalType": "date" }""", defaultOpt = Some("124"))

--- a/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoderSpec.scala
+++ b/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoderSpec.scala
@@ -11,9 +11,9 @@ import java.util
 import java.util.UUID
 import scala.collection.immutable.{ListMap, ListSet}
 
-class BestEffortJsonEncoderSpec extends AnyFunSpec with Matchers {
+class ToJsonEncoderSpec extends AnyFunSpec with Matchers {
 
-  private val encoder = BestEffortJsonEncoder.defaultForTests
+  private val encoder = ToJsonEncoder.defaultForTests
 
   it("should encode simple elements as a json") {
     encoder.encode(1) shouldEqual fromLong(1)
@@ -81,9 +81,9 @@ class BestEffortJsonEncoderSpec extends AnyFunSpec with Matchers {
   it("should use custom encoders from classloader") {
 
     ClassLoaderWithServices.withCustomServices(
-      List(classOf[ToJsonEncoder] -> classOf[CustomJsonEncoder1], classOf[ToJsonEncoder] -> classOf[CustomJsonEncoder2])
+      List(classOf[ToJsonEncoderCustomisation] -> classOf[CustomJsonEncoderCustomisation1], classOf[ToJsonEncoderCustomisation] -> classOf[CustomJsonEncoderCustomisation2])
     ) { classLoader =>
-      val encoder = BestEffortJsonEncoder(failOnUnknown = true, classLoader)
+      val encoder = ToJsonEncoder(failOnUnknown = true, classLoader)
 
       encoder.encode(
         Map(
@@ -100,7 +100,7 @@ class BestEffortJsonEncoderSpec extends AnyFunSpec with Matchers {
 
 }
 
-class CustomJsonEncoder1 extends ToJsonEncoder {
+class CustomJsonEncoderCustomisation1 extends ToJsonEncoderCustomisation {
 
   override def encoder(encode: Any => Json): PartialFunction[Any, Json] = { case CustomClassToEncode(value) =>
     obj("customEncode" -> encode(value))
@@ -108,7 +108,7 @@ class CustomJsonEncoder1 extends ToJsonEncoder {
 
 }
 
-class CustomJsonEncoder2 extends ToJsonEncoder {
+class CustomJsonEncoderCustomisation2 extends ToJsonEncoderCustomisation {
 
   override def encoder(encode: Any => Json): PartialFunction[Any, Json] = { case _: NestedClassToEncode =>
     fromString("value")


### PR DESCRIPTION
- All `BestEffort*Encoder` classes renamed to fit `To<TargetFormat>(SchemaBased)Encoder` naming schema
- `JsonToNuStruct` renamed to `FromJsonDecoder` (to fit `From<SourceFormat>Decoder` naming schema)
- `ToJsonEncoder` renamed to `ToJsonEncoderCustomisation`
- `ToJsonBasedOnSchemaEncoder` renamed to `ToJsonSchemaBasedEncoderCustomisation`

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
