### PR TITLE
Added docsUrl to PropertiesConfig (#6578)

### DIFF
--- a/designer/client/src/components/graph/node-modal/NodeDetailsContent/selectors.tsx
+++ b/designer/client/src/components/graph/node-modal/NodeDetailsContent/selectors.tsx
@@ -3,7 +3,7 @@ import { getScenario, getScenarioGraph } from "../../../../reducers/selectors/gr
 import { getProcessDefinitionData } from "../../../../reducers/selectors/settings";
 import ProcessUtils from "../../../../common/ProcessUtils";
 import { RootState } from "../../../../reducers";
-import { NodeId, NodeType, NodeValidationError, ScenarioPropertiesConfig, UIParameter } from "../../../../types";
+import { NodeId, NodeType, NodeValidationError, UiScenarioProperties, UIParameter } from "../../../../types";
 import { isEqual } from "lodash";
 
 const createDeepEqualSelector = createSelectorCreator(defaultMemoize, isEqual);
@@ -11,7 +11,7 @@ const createDeepEqualSelector = createSelectorCreator(defaultMemoize, isEqual);
 const getComponentsDefinition = createSelector(getProcessDefinitionData, (s) => s.components);
 export const getScenarioPropertiesConfig = createSelector(
     getProcessDefinitionData,
-    (s) => (s.scenarioPropertiesConfig || {}) as ScenarioPropertiesConfig,
+    (s) => (s.scenarioProperties || {}) as UiScenarioProperties,
 );
 const getNodeResults = createSelector(getScenario, (scenario) => ProcessUtils.getNodeResults(scenario));
 export const getFindAvailableBranchVariables = createSelector(getNodeResults, (nodeResults) =>

--- a/designer/client/src/components/graph/node-modal/nodeDetails/NodeDetailsModalHeader.tsx
+++ b/designer/client/src/components/graph/node-modal/nodeDetails/NodeDetailsModalHeader.tsx
@@ -51,9 +51,14 @@ export const getNodeDetailsModalTitle = (node: NodeType): string => {
 };
 
 export const NodeDetailsModalSubheader = ({ node }: { node: NodeType }): ReactElement => {
-    const { components = {} } = useSelector(getProcessDefinitionData);
+    const { components = {}, scenarioProperties } = useSelector(getProcessDefinitionData);
 
-    const docsUrl = useMemo(() => ProcessUtils.extractComponentDefinition(node, components)?.docsUrl, [components, node]);
+    const docsUrl = useMemo(() => {
+        return NodeUtils.nodeIsProperties(node)
+            ? scenarioProperties?.docsUrl
+            : ProcessUtils.extractComponentDefinition(node, components)?.docsUrl;
+    }, [components, node, scenarioProperties]);
+
     const nodeClass = findNodeClass(node);
 
     return <NodeDocs name={nodeClass} href={docsUrl} />;

--- a/designer/client/src/components/graph/node-modal/properties.tsx
+++ b/designer/client/src/components/graph/node-modal/properties.tsx
@@ -29,7 +29,9 @@ export function Properties({
     showSwitch,
     showValidation,
 }: Props): JSX.Element {
-    const scenarioPropertiesConfig = useSelector(getScenarioPropertiesConfig);
+    const scenarioProperties = useSelector(getScenarioPropertiesConfig);
+    const scenarioPropertiesConfig = scenarioProperties?.propertiesConfig ?? {};
+
     //fixme move this configuration to some better place?
     //we sort by name, to have predictable order of properties (should be replaced by defining order in configuration)
     const scenarioPropertiesSorted = useMemo(

--- a/designer/client/src/types/scenarioGraph.ts
+++ b/designer/client/src/types/scenarioGraph.ts
@@ -37,8 +37,10 @@ export type CustomActionParameter = {
     editor: EditorProps;
 };
 
-export type ScenarioPropertiesConfig = Record<string, ScenarioPropertyConfig>;
-
+export interface UiScenarioProperties {
+    propertiesConfig: { [key: string]: ScenarioPropertyConfig };
+    docsUrl?: string;
+}
 //"ReturnType" is builtin type alias
 export interface ReturnedType {
     display: string;
@@ -60,7 +62,7 @@ export interface ProcessDefinitionData {
     components?: Record<string, ComponentDefinition>;
     classes?: TypingResult[];
     componentGroups?: ComponentGroup[];
-    scenarioPropertiesConfig?: ScenarioPropertiesConfig;
+    scenarioProperties?: UiScenarioProperties;
     edgesForNodes?: EdgesForNode[];
     customActions?: Array<CustomAction>;
 }

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
@@ -21,11 +21,10 @@ package object definition {
 
   // This class contains various views on definitions, used in a different FE contexts
   @JsonCodec(encodeOnly = true) final case class UIDefinitions(
-      // This is dedicated view for the components toolbox panel
       componentGroups: List[UIComponentGroup],
       components: Map[ComponentId, UIComponentDefinition],
       classes: List[TypingResult],
-      scenarioPropertiesConfig: Map[String, UiScenarioPropertyConfig],
+      scenarioProperties: UiScenarioProperties,
       edgesForNodes: List[UINodeEdges],
       customActions: List[UICustomAction]
   )
@@ -117,6 +116,11 @@ package object definition {
   @JsonCodec(encodeOnly = true) final case class UIComponentGroup(
       name: ComponentGroupName,
       components: List[UIComponentNodeTemplate]
+  )
+
+  @JsonCodec final case class UiScenarioProperties(
+      propertiesConfig: Map[String, UiScenarioPropertyConfig],
+      docsUrl: Option[String]
   )
 
   @JsonCodec final case class UiScenarioPropertyConfig(

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
@@ -439,7 +439,8 @@ class AkkaHttpBasedRouteProvider(
                   processingTypeData,
                   prepareAlignedComponentsDefinitionProvider(processingTypeData),
                   new ScenarioPropertiesConfigFinalizer(additionalUIConfigProvider, processingTypeData.name),
-                  fragmentRepository
+                  fragmentRepository,
+                  resolvedConfig.getAs[String]("fragmentPropertiesDocsUrl")
                 )
               )
             }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DefinitionResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DefinitionResourcesSpec.scala
@@ -49,7 +49,8 @@ class DefinitionResourcesSpec
           processingTypeData,
           modelDefinitionEnricher,
           new ScenarioPropertiesConfigFinalizer(TestAdditionalUIConfigProvider, processingTypeData.name),
-          fragmentRepository
+          fragmentRepository,
+          None
         )
       )
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/DefinitionsServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/DefinitionsServiceSpec.scala
@@ -18,6 +18,7 @@ import pl.touk.nussknacker.engine.modelconfig.ComponentsUiConfigParser
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.{ModelData, ProcessingTypeConfig}
+import pl.touk.nussknacker.restmodel.definition.UIDefinitions
 import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.test.config.WithSimplifiedDesignerConfig.TestProcessingType.Streaming
 import pl.touk.nussknacker.test.mock.{MockDeploymentManager, StubFragmentRepository, TestAdditionalUIConfigProvider}
@@ -257,13 +258,13 @@ class DefinitionsServiceSpec extends AnyFunSuite with Matchers with PatientScala
     val typeConfig       = ProcessingTypeConfig.read(ConfigWithScalaVersion.StreamingProcessTypeConfig)
     val model: ModelData = LocalModelData(typeConfig.modelConfig.resolved, List.empty)
 
-    val definitions = prepareDefinitions(model, List.empty)
+    val uiDefinitions = prepareDefinitions(model, List.empty)
 
-    definitions.scenarioPropertiesConfig shouldBe TestAdditionalUIConfigProvider.scenarioPropertyConfigOverride
+    uiDefinitions.scenarioProperties.propertiesConfig shouldBe TestAdditionalUIConfigProvider.scenarioPropertyConfigOverride
       .mapValuesNow(createUIScenarioPropertyConfig)
   }
 
-  private def prepareDefinitions(model: ModelData, fragmentScenarios: List[CanonicalProcess]) = {
+  private def prepareDefinitions(model: ModelData, fragmentScenarios: List[CanonicalProcess]): UIDefinitions = {
     val processingType = Streaming
 
     val alignedComponentsDefinitionProvider = new AlignedComponentsDefinitionProvider(
@@ -280,13 +281,14 @@ class DefinitionsServiceSpec extends AnyFunSuite with Matchers with PatientScala
     new DefinitionsService(
       modelData = model,
       staticDefinitionForDynamicComponents = Map.empty,
-      scenarioPropertiesConfig = Map.empty,
       fragmentPropertiesConfig = Map.empty,
+      scenarioPropertiesConfig = Map.empty,
       deploymentManager = new MockDeploymentManager,
       alignedComponentsDefinitionProvider = alignedComponentsDefinitionProvider,
       scenarioPropertiesConfigFinalizer =
         new ScenarioPropertiesConfigFinalizer(TestAdditionalUIConfigProvider, processingType.stringify),
-      fragmentRepository = new StubFragmentRepository(Map(processingType.stringify -> fragmentScenarios))
+      fragmentRepository = new StubFragmentRepository(Map(processingType.stringify -> fragmentScenarios)),
+      fragmentPropertiesDocsUrl = None
     ).prepareUIDefinitions(processingType.stringify, forFragment = false)(AdminUser("admin", "admin")).futureValue
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
@@ -24,7 +24,7 @@ import pl.touk.nussknacker.engine.graph.node.{FragmentInputDefinition, FragmentO
 import pl.touk.nussknacker.engine.graph.service.ServiceRef
 import pl.touk.nussknacker.engine.management.FlinkStreamingPropertiesConfig
 import pl.touk.nussknacker.engine.spel.SpelExtension._
-import pl.touk.nussknacker.restmodel.definition.UiScenarioPropertyConfig
+import pl.touk.nussknacker.restmodel.definition.{UiScenarioProperties, UiScenarioPropertyConfig}
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.{
   NodeValidationError,
   NodeValidationErrorType,
@@ -254,10 +254,11 @@ class BaseFlowTest
     )
     response.code shouldEqual StatusCode.Ok
 
-    val settingsJson        = response.extractFieldJsonValue("scenarioPropertiesConfig")
+    val settingsJson        = response.extractFieldJsonValue("scenarioProperties")
     val fixedPossibleValues = List(FixedExpressionValue("1", "1"), FixedExpressionValue("2", "2"))
 
-    val settings = Decoder[Map[String, UiScenarioPropertyConfig]].decodeJson(settingsJson).toOption.get
+    val properties       = Decoder[UiScenarioProperties].decodeJson(settingsJson).toOption.get
+    val additionalFields = properties.propertiesConfig
     val streamingDefaultPropertyConfig =
       FlinkStreamingPropertiesConfig.properties.map(p => p._1 -> createUIScenarioPropertyConfig(p._2))
 
@@ -287,7 +288,7 @@ class BaseFlowTest
       )
     ) ++ streamingDefaultPropertyConfig
 
-    settings shouldBe underTest
+    additionalFields shouldBe underTest
   }
 
   test("validate process scenario properties") {

--- a/docs/configuration/model/ModelConfiguration.md
+++ b/docs/configuration/model/ModelConfiguration.md
@@ -179,3 +179,9 @@ scenarioPropertiesConfig {
 }
 ```
 Configuration is similar to [component configuration](#configuration-of-ui-attributes-of-components)
+
+The docs button which is displayed in the scenario properties modal window is by default disabled for properties. One can enable it by adding
+
+``` scenarioPropertiesDocsUrl: "http://custom-configurable-link"```
+
+in the config. 

--- a/nussknacker-dist/src/universal/conf/dev-application.conf
+++ b/nussknacker-dist/src/universal/conf/dev-application.conf
@@ -54,6 +54,8 @@ metricsConfig {
   }
 }
 
+fragmentPropertiesDocsUrl: "https://nussknacker.io/documentation/docs/scenarios_authoring/Fragments/"
+
 scenarioTypes {
   "streaming": {
     deploymentConfig: ${flinkDeploymentConfig}
@@ -62,6 +64,8 @@ scenarioTypes {
       rocksDB: {
         enable: ${?FLINK_ROCKSDB_ENABLE}
       }
+
+      scenarioPropertiesDocsUrl: "https://example.com"
 
       components.openAPI {
         url: ${OPENAPI_SERVICE_URL}"/swagger"


### PR DESCRIPTION
* Added docsUrl to PropertiesConfig on BE, added docsUrl icon display in properties on FE

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
