### PR TITLE
Determine dictionary parameter editor language when no default value is present (#6685)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 1.17.0 (Not released yet)
 -------------------------
+* [#6685](https://github.com/TouK/nussknacker/pull/6685) Fixed an issue with dictionary parameter editor language being set to spel when no default value was present.
 * [#6658](https://github.com/TouK/nussknacker/pull/6658) Bump up circe-yaml lib to 0.15.2
 * [#6398](https://github.com/TouK/nussknacker/pull/6398) Added possibility to define hint texts for scenario properties in config.
 * [#6282](https://github.com/TouK/nussknacker/pull/6184) From now on, the existence of Kafka topics used in Sources and/or 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorPossibleValuesBasedDefaultValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorPossibleValuesBasedDefaultValueDeterminer.scala
@@ -1,10 +1,12 @@
 package pl.touk.nussknacker.engine.definition.component.parameter.defaults
 
 import pl.touk.nussknacker.engine.api.definition.{
+  DictParameterEditor,
   DualParameterEditor,
   FixedValuesParameterEditor,
   TabularTypedDataEditor
 }
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language
 import pl.touk.nussknacker.engine.graph.expression.{Expression, TabularTypedData}
 
 protected object EditorPossibleValuesBasedDefaultValueDeterminer extends ParameterDefaultValueDeterminer {
@@ -19,7 +21,8 @@ protected object EditorPossibleValuesBasedDefaultValueDeterminer extends Paramet
           Some(Expression.spel(firstValue.expression))
         case TabularTypedDataEditor =>
           Some(Expression.tabularDataDefinition(TabularTypedData.empty.stringify))
-        case _ => None
+        case DictParameterEditor(_) => Some(Expression(Language.DictKeyWithLabel, ""))
+        case _                      => None
       }
   }
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorPossibleValuesBasedDefaultValueDeterminerTest.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorPossibleValuesBasedDefaultValueDeterminerTest.scala
@@ -8,6 +8,7 @@ import pl.touk.nussknacker.engine.api.component.ParameterConfig
 import pl.touk.nussknacker.engine.api.typed.typing.Unknown
 import pl.touk.nussknacker.engine.definition.component.parameter.ParameterData
 import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language
 
 class EditorPossibleValuesBasedDefaultValueDeterminerTest extends AnyFunSuite with Matchers {
 
@@ -38,6 +39,12 @@ class EditorPossibleValuesBasedDefaultValueDeterminerTest extends AnyFunSuite wi
     )
 
     determine(fixedValuesEditor) shouldBe Some(Expression.spel("expr1"))
+  }
+
+  test("determine default param value for dictionary parameter editor") {
+    val dictParam = Some(DictParameterEditor("someDictId"))
+
+    determine(dictParam) shouldBe Some(Expression(Language.DictKeyWithLabel, ""))
   }
 
   test("not determine default param value from editors without possible values") {


### PR DESCRIPTION
## Describe your changes

Cherry-pick of changes in https://github.com/TouK/nussknacker/pull/6685

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
