### PR TITLE
Move changelog entry to 1.17 section

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,6 @@
 
 1.18.0 (Not released yet)
 -------------------------
-* [#6685](https://github.com/TouK/nussknacker/pull/6685) Fixed an issue with dictionary parameter editor language being set to spel when no default value was present.
 * Batch processing mode related improvements:
   * [#6692](https://github.com/TouK/nussknacker/pull/6692) Kryo serializers for `UnmodifiableCollection`, `scala.Product` etc. 
     are registered based on class of Serializer instead of instance of Serializer. Thanks to this change, it is possible to use `RAW<>`
@@ -85,6 +84,7 @@
 * [#6614](https://github.com/TouK/nussknacker/pull/6614) Array in SpeL improvements:
   * From now on it is possible to pass an array as a parameter of type List - e.g. `T(java.lang.String).join(',', #array)`.
   * Fix result type of projection (`.!`) - e.g. `#array.![#this]` returns a type array instead of a type List.
+* [#6685](https://github.com/TouK/nussknacker/pull/6685) Fixed an issue with dictionary parameter editor language being set to spel when no default value was present.
 
 1.16.3 (8 August 2024)
 -------------------------


### PR DESCRIPTION
## Describe your changes

This PR moves a changelog entry regarding this change https://github.com/TouK/nussknacker/pull/6685 to 1.17 section as it was merged to `release/1.17` branch after consultation.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
