### PR TITLE
Preserve typing information during expression compilation

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -60,6 +60,7 @@
   * [#6823](https://github.com/TouK/nussknacker/pull/6823) 
     * old process actions and comments migrated to new table in the db
     * Scenario Activity API implementation
+* [#6925](https://github.com/TouK/nussknacker/pull/6925) Fix situation when preset labels were presented as `null` when node didn't pass the validation.
 
 ## 1.17
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ComponentExecutorFactory.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ComponentExecutorFactory.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.compile
 
-import cats.data.ValidatedNel
+import cats.data.IorNel
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.definition.Parameter
@@ -24,7 +24,7 @@ class ComponentExecutorFactory(parameterEvaluator: ParameterEvaluator) extends L
   )(
       implicit nodeId: NodeId,
       metaData: MetaData
-  ): ValidatedNel[ProcessCompilationError, ComponentExecutor] = {
+  ): IorNel[ProcessCompilationError, ComponentExecutor] = {
     NodeValidationExceptionHandler.handleExceptions {
       doCreateComponentExecutor[ComponentExecutor](
         component,
@@ -34,7 +34,7 @@ class ComponentExecutorFactory(parameterEvaluator: ParameterEvaluator) extends L
         componentUseCase,
         nonServicesLazyParamStrategy
       )
-    }
+    }.toIor
   }
 
   private def doCreateComponentExecutor[ComponentExecutor](

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
@@ -281,16 +281,18 @@ class NodeCompiler(
       }
     val validParams =
       expressionCompiler.compileExecutorComponentNodeParameters(validParamDefs.value, ref.parameters, ctx)
-    val validParamsCombinedErrors = validParams.combine(
-      NonEmptyList
-        .fromList(validParamDefs.written)
-        .map(invalid)
-        .getOrElse(valid(List.empty[CompiledParameter]))
-    )
+    val validParamsCombinedErrors = validParams
+      .fold(Invalid(_), Valid(_), (a, _) => Invalid(a))
+      .combine(
+        NonEmptyList
+          .fromList(validParamDefs.written)
+          .map(invalid)
+          .getOrElse(valid(List.empty[CompiledParameter]))
+      )
     val expressionTypingInfo =
       validParams
         .map(_.map(p => p.name.value -> p.typingInfo).toMap)
-        .valueOr(_ => Map.empty[String, ExpressionTypingInfo])
+        .getOrElse(Map.empty[String, ExpressionTypingInfo])
     NodeCompilationResult(expressionTypingInfo, None, newCtx, validParamsCombinedErrors)
   }
 
@@ -558,7 +560,7 @@ class NodeCompiler(
         ctx,
         branchContexts
       )
-      .andThen { compiledParameters =>
+      .flatMap { compiledParameters =>
         factory
           .createComponentExecutor[ComponentExecutor](
             componentDefinition,
@@ -581,7 +583,10 @@ class NodeCompiler(
             (typingInfo, componentExecutor)
           }
       }
-    (compiledObjectWithTypingInfo.map(_._1).valueOr(_ => Map.empty), compiledObjectWithTypingInfo.map(_._2))
+    (
+      compiledObjectWithTypingInfo.map(_._1).getOrElse(Map.empty),
+      compiledObjectWithTypingInfo.map(_._2).fold(Invalid(_), Valid(_), (a, _) => Invalid(a))
+    )
   }
 
   private def contextAfterMethodBasedCreatedComponentExecutor[ComponentExecutor](
@@ -683,7 +688,12 @@ class NodeCompiler(
         )
       }
       val nodeTypingInfo = computedParameters.map(_.map(p => p.name.value -> p.typingInfo).toMap).getOrElse(Map.empty)
-      NodeCompilationResult(nodeTypingInfo, None, outputCtx, serviceRef)
+      NodeCompilationResult(
+        nodeTypingInfo,
+        None,
+        outputCtx,
+        serviceRef.fold(Invalid(_), Valid(_), (a, _) => Invalid(a))
+      )
     }
 
   }


### PR DESCRIPTION
## Describe your changes

Currently, there is a problem with nodes that utilize presets as sometimes labels are not present and are presented as `null`. 
This happens when we want to use a component or fragment with presets, select some values for them and save the scenario. 
If there were any errors during compilation of that node presets will have null labels.

![Zrzut ekranu z 2024-09-20 12-42-53](https://github.com/user-attachments/assets/67ef05a8-c645-41fa-b7bc-8fd512c79565)

This happens because `ProcessDictSubstituor` dynamically adds and removes presets' labels.
```
      if (expr.language == Expression.Language.DictKeyWithLabel && !expr.expression.isBlank) {
        if (isReverse)
          addLabelToDictKeyExpression(process, expr, optionalExpressionTypingInfo, nodeExpressionId)
        else
          removeLabelFromDictKeyExpression(process, expr, nodeExpressionId) // no need to keep label in BE
```

To add labels at that level we need parameters' types which are assigned during compilation. Unfortunately when there is any custom validators error during node compilation we lose typing information.
in `ExperssionCompiler.compileNodeParameters()`
```
    allCompiledParams
      .andThen(allParams => Validations.validateWithCustomValidators(allParams, paramValidatorsMap))
      .combine(redundantMissingValidation.map(_ => List()))
```
allCompiledParams contain the typing info and is of `ValidatedNel` type. When `Validations.validateWithCustomValidators(allParams, paramValidatorsMap)` is `Invalid` we get these errors without previous typing.

To solve this issue I introduced a change which will still pass typing info further even when there are some custom validator errors. Instead of using `Validated` which can represent two states: `Valid` and `Invalid`, I used `Ior` which lets us have 3 states: `Left`, `Right` and `Both`. First two are self-explanatory and `Both` can hold both failure and a success. This way we can preserve the typing info while also preserving errors from custom validation. After testing these changes locally, we preserve the typing info and have correct preset labels even when there were errors during compilation.

![Zrzut ekranu z 2024-09-20 13-52-13](https://github.com/user-attachments/assets/48688759-5089-4738-bd78-a440245a27fc)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
