### PR TITLE
[Fix][NU-1772] Scenario activities migration fix

### DIFF
--- a/designer/server/src/main/scala/db/migration/V1_056__CreateScenarioActivitiesDefinition.scala
+++ b/designer/server/src/main/scala/db/migration/V1_056__CreateScenarioActivitiesDefinition.scala
@@ -76,8 +76,8 @@ object V1_056__CreateScenarioActivitiesDefinition {
       def additionalProperties: Rep[String] = column[String]("additional_properties", NotNull)
 
       def activityTypeIndex = index("activity_type_idx", activityType)
-      def createdAtIndex    = index("created_at_idx", activityType)
-      def scenarioIdIndex   = index("scenario_id_idx", activityType)
+      def createdAtIndex    = index("created_at_idx", createdAt)
+      def scenarioIdIndex   = index("scenario_id_idx", scenarioId)
 
       def tupleWithoutAutoIncId = (
         activityType,

--- a/designer/server/src/main/scala/db/migration/hsql/V1_057__MigrateActionsAndCommentsToScenarioActivities.scala
+++ b/designer/server/src/main/scala/db/migration/hsql/V1_057__MigrateActionsAndCommentsToScenarioActivities.scala
@@ -6,4 +6,11 @@ import slick.jdbc.{HsqldbProfile, JdbcProfile}
 class V1_057__MigrateActionsAndCommentsToScenarioActivities
     extends V1_057__MigrateActionsAndCommentsToScenarioActivitiesDefinition {
   override protected lazy val profile: JdbcProfile = HsqldbProfile
+
+  import profile.api._
+
+  override protected def createGenerateRandomUuidFunction(): DBIOAction[Int, NoStream, Effect.All] = {
+    sqlu"""CREATE FUNCTION generate_random_uuid() RETURNS UUID DETERMINISTIC RETURN UUID();"""
+  }
+
 }

--- a/designer/server/src/main/scala/db/migration/postgres/V1_057__MigrateActionsAndCommentsToScenarioActivities.scala
+++ b/designer/server/src/main/scala/db/migration/postgres/V1_057__MigrateActionsAndCommentsToScenarioActivities.scala
@@ -6,4 +6,11 @@ import slick.jdbc.{JdbcProfile, PostgresProfile}
 class V1_057__MigrateActionsAndCommentsToScenarioActivities
     extends V1_057__MigrateActionsAndCommentsToScenarioActivitiesDefinition {
   override protected lazy val profile: JdbcProfile = PostgresProfile
+
+  import profile.api._
+
+  override protected def createGenerateRandomUuidFunction(): DBIOAction[Int, NoStream, Effect.All] = {
+    sqlu"""CREATE OR REPLACE FUNCTION generate_random_uuid() RETURNS UUID AS 'BEGIN RETURN uuid_in(overlay(overlay(md5(random()::text || '':'' || random()::text) placing ''4'' from 13) placing to_hex(floor(random() * (11 - 8 + 1) + 8)::int)::text from 17)::cstring);END' LANGUAGE plpgsql;"""
+  }
+
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/db/DbTesting.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/db/DbTesting.scala
@@ -85,6 +85,8 @@ trait DbTesting extends BeforeAndAfterEach with BeforeAndAfterAll {
 
   def cleanDB(): Try[Unit] = Using(testDbRef.db.createSession()) { session =>
     session.prepareStatement("""delete from "process_attachments"""").execute()
+    session.prepareStatement("""delete from "process_actions"""").execute()
+    session.prepareStatement("""delete from "process_comments"""").execute()
     session.prepareStatement("""delete from "scenario_activities"""").execute()
     session.prepareStatement("""delete from "process_versions"""").execute()
     session.prepareStatement("""delete from "scenario_labels"""").execute()


### PR DESCRIPTION
## Describe your changes

There was a problem with UUID generation. Query generated by Slick always used the same UUID for all activities, instead of generating new one for each comment.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
