### PR TITLE
Show all dict values on dict parameter editor open

### DIFF
--- a/designer/client/src/components/graph/node-modal/editors/expression/DictParameterEditor/DictParameterEditor.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/DictParameterEditor/DictParameterEditor.tsx
@@ -98,7 +98,8 @@ export const DictParameterEditor: ExtendedEditor<Props> = ({
                     setOpen(false);
                 }}
                 onOpen={async () => {
-                    const fetchedOptions = await fetchProcessDefinitionDataDict(inputValue);
+                    // On open we show all the options
+                    const fetchedOptions = await fetchProcessDefinitionDataDict("");
                     setOptions(fetchedOptions);
                     setOpen(true);
                 }}

--- a/designer/client/src/components/graph/node-modal/editors/expression/DictParameterEditor/DictParameterEditor.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/DictParameterEditor/DictParameterEditor.tsx
@@ -114,8 +114,9 @@ export const DictParameterEditor: ExtendedEditor<Props> = ({
                 inputValue={inputValue}
                 loading={isFetching}
                 renderOption={(props, option) => {
+                    const isSelected = option.key === value?.key;
                     return (
-                        <Box component={"li"} sx={menuOption({}, false, false) as SxProps<Theme>} {...props} aria-selected={false}>
+                        <Box component={"li"} sx={menuOption({}, isSelected, false) as SxProps<Theme>} {...props} aria-selected={false}>
                             {option.label}
                         </Box>
                     );

--- a/designer/client/src/components/graph/node-modal/editors/expression/DictParameterEditor/DictParameterEditor.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/DictParameterEditor/DictParameterEditor.tsx
@@ -116,6 +116,7 @@ export const DictParameterEditor: ExtendedEditor<Props> = ({
                 renderOption={(props, option) => {
                     const isSelected = option.key === value?.key;
                     return (
+                        // aira-selected is set to false as it overrides styles defined in our menuOption
                         <Box component={"li"} sx={menuOption({}, isSelected, false) as SxProps<Theme>} {...props} aria-selected={false}>
                             {option.label}
                         </Box>

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -66,6 +66,7 @@
 * [#6840](https://github.com/TouK/nussknacker/pull/6840) Introduce canCastTo, castTo and castToOrNull extension methods in SpeL.
 * [#6974](https://github.com/TouK/nussknacker/pull/6974) Add SpeL suggestions for cast methods parameter.
 * [#6988](https://github.com/TouK/nussknacker/pull/6988) Remove unused API classes: `MultiMap`, `TimestampedEvictableStateFunction`
+* [#7000](https://github.com/TouK/nussknacker/pull/7000) Show all possible options for dictionary editor on open.
 
 ## 1.17
 


### PR DESCRIPTION
## Describe your changes

Currently, when user wants to change the selected value in dict editor and see possible options he firstly has to manually delete the value:

![output](https://github.com/user-attachments/assets/5e93c3ee-2659-4db6-adab-2013a34cd951)

With this little change on editor open user will be presented with all the options so he does not have to delete the value first.

![output](https://github.com/user-attachments/assets/fa212c3f-56c8-4826-8403-14946941f2b9)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
