### PR TITLE
NU-1827 allow dynamic access via indexer operator on expressions typed to unknown

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -81,6 +81,7 @@
   * [#7058](https://github.com/TouK/nussknacker/pull/7058) Add missing Flink TypeInformation for better serialization
   * [#7097](https://github.com/TouK/nussknacker/pull/7097) Flink base types registration mechanism
 * [#7021](https://github.com/TouK/nussknacker/pull/7021) Definitions service can return definition without UI config
+* [#7010](https://github.com/TouK/nussknacker/pull/7010) Dynamic access allowed via indexer operator (`[]`) on expressions typed as `Unknown`
 
 ## 1.17
 

--- a/docs/scenarios_authoring/Spel.md
+++ b/docs/scenarios_authoring/Spel.md
@@ -238,6 +238,34 @@ If you need to invoke the same method in many places, probably the best solution
 | ------------                                                 | --------  | -------- |
 | `{1, 2, 3, 4}.?[#this > 1].![#this > 2 ? #this * 2 : #this]` | {2, 6, 8} | Double   |
 
+### Dynamic navigation
+
+When we deal with structures which schema is not known to Nussknacker (e.g. data from kafka topics without existing avro/json schema) we will end-up
+with `Unknown` type in designer. For such a type (`Unknown`) we allow dynamic-like access using `[]` operator to access nested fields/elements.
+
+Example `exampleObject` json-like variable
+```
+{
+    "someField": 123,
+    "someNestedObject": {
+        "someFieldInNestedObject": "value"
+    },
+    "someArrayWithObjects": [
+        {
+            "someFieldInObjectInArray": "value" 
+        }
+    ]
+}
+```
+
+can be accessed in e.g. in following ways:
+
+* `#exampleObjects['someField']`
+* `#exampleObjects['someNestedObject']['someFieldInNestedObject']`
+* `#exampleObjects['someArrayWithObjects'][0]['someFieldInObjectInArray']`
+
+Every unknown accessed field/element will produce `Unknown` data type which can be further navigated or [cast](#Casting) to a desired type.
+
 ### Type conversions
 
 It is possible to convert from a type to another type and this can be done by implicit and explicit conversion.
@@ -297,6 +325,7 @@ Available methods:
 - `canCastTo` - checks if a type can be cast to a given class.
 - `castTo` - casts a type to a given class or throws exception if type cannot be cast.
 - `castToOrNull` - casts a type to a given class or return null if type cannot be cast.
+
 
 ## Built-in helpers
 
@@ -389,3 +418,4 @@ On the other hand, formatter created using `#DATE_FORMAT.formatter()` method wil
 - `#DATE_FORMAT.lenientFormatter('yyyy-MM-dd EEEE', 'PL')` - creates lenient version `DateTimeFormatter` using given pattern and locale
 
 For full list of available format options take a look at [DateTimeFormatter api docs](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/format/DateTimeFormatter.html).
+

--- a/engine/flink/management/dev-model/src/test/resources/extractedTypes/devCreator.json
+++ b/engine/flink/management/dev-model/src/test/resources/extractedTypes/devCreator.json
@@ -11889,6 +11889,73 @@
           "params": [],
           "refClazzName": "java.lang.Object",
           "type": "Unknown"
+        },
+        {
+          "display": "Unknown",
+          "params": [],
+          "refClazzName": "java.lang.Object",
+          "type": "Unknown"
+        }
+      ],
+      "refClazzName": "java.util.Map$Entry"
+    },
+    "methods": {
+      "getKey": [
+        {
+          "name": "getKey",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"type": "Unknown"}
+          }
+        }
+      ],
+      "getValue": [
+        {
+          "name": "getValue",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"type": "Unknown"}
+          }
+        }
+      ],
+      "key": [
+        {
+          "name": "key",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"type": "Unknown"}
+          }
+        }
+      ],
+      "toString": [
+        {
+          "name": "toString",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"refClazzName": "java.lang.String"}
+          }
+        }
+      ],
+      "value": [
+        {
+          "name": "value",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"type": "Unknown"}
+          }
+        }
+      ]
+    },
+    "staticMethods": {}
+  },
+  {
+    "clazzName": {
+      "params": [
+        {
+          "display": "Unknown",
+          "params": [],
+          "refClazzName": "java.lang.Object",
+          "type": "Unknown"
         }
       ],
       "refClazzName": "java.util.Set"

--- a/engine/flink/tests/src/test/resources/extractedTypes/defaultModel.json
+++ b/engine/flink/tests/src/test/resources/extractedTypes/defaultModel.json
@@ -12281,6 +12281,73 @@
           "params": [],
           "refClazzName": "java.lang.Object",
           "type": "Unknown"
+        },
+        {
+          "display": "Unknown",
+          "params": [],
+          "refClazzName": "java.lang.Object",
+          "type": "Unknown"
+        }
+      ],
+      "refClazzName": "java.util.Map$Entry"
+    },
+    "methods": {
+      "getKey": [
+        {
+          "name": "getKey",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"type": "Unknown"}
+          }
+        }
+      ],
+      "getValue": [
+        {
+          "name": "getValue",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"type": "Unknown"}
+          }
+        }
+      ],
+      "key": [
+        {
+          "name": "key",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"type": "Unknown"}
+          }
+        }
+      ],
+      "toString": [
+        {
+          "name": "toString",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"refClazzName": "java.lang.String"}
+          }
+        }
+      ],
+      "value": [
+        {
+          "name": "value",
+          "signature": {
+            "noVarArgs": [],
+            "result": {"type": "Unknown"}
+          }
+        }
+      ]
+    },
+    "staticMethods": {}
+  },
+  {
+    "clazzName": {
+      "params": [
+        {
+          "display": "Unknown",
+          "params": [],
+          "refClazzName": "java.lang.Object",
+          "type": "Unknown"
         }
       ],
       "refClazzName": "java.util.Set"

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassExtractionSettings.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/process/ClassExtractionSettings.scala
@@ -271,6 +271,10 @@ object ClassExtractionSettings {
         Set("containsKey", "containsValue", "get", "getOrDefault", "isEmpty", "size", "values", "keySet")
       ),
       MemberNamePredicate(
+        SuperClassPredicate(ExactClassPredicate[util.Map.Entry[_, _]]),
+        Set("getKey", "getValue")
+      ),
+      MemberNamePredicate(
         SuperClassPredicate(ExactClassPredicate[Optional[_]]),
         Set("get", "isEmpty", "isPresent", "orElse")
       ),

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/ClassDefinitionDiscovery.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/ClassDefinitionDiscovery.scala
@@ -32,6 +32,7 @@ class ClassDefinitionDiscovery(classDefinitionExtractor: ClassDefinitionExtracto
   private val mandatoryClasses = (Set(
     classOf[java.util.List[_]],
     classOf[java.util.Map[_, _]],
+    classOf[java.util.Map.Entry[_, _]],
     classOf[java.math.BigDecimal],
     classOf[Number],
     classOf[String],

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/ClassDefinitionSet.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/ClassDefinitionSet.scala
@@ -1,5 +1,7 @@
 package pl.touk.nussknacker.engine.definition.clazz
 
+import com.github.ghik.silencer.silent
+
 object ClassDefinitionSet {
 
   def apply(classDefinitions: Set[ClassDefinition]): ClassDefinitionSet = {
@@ -9,11 +11,44 @@ object ClassDefinitionSet {
 }
 
 case class ClassDefinitionSet(classDefinitionsMap: Map[Class[_], ClassDefinition]) {
-  lazy val unknown = get(classOf[java.lang.Object])
+  lazy val unknown: Option[ClassDefinition] = get(classOf[java.lang.Object])
+
+  private lazy val parameterlessMethodsByDeclaringTypes: Map[DeclaringClassWithMethodName, ParameterlessMethodInfo] = {
+    def getParameterlessMethods(staticMethods: Boolean) = {
+      for {
+        (clazz, classDefinition) <- classDefinitionsMap
+        (methodName, methods)    <- if (staticMethods) classDefinition.staticMethods else classDefinition.methods
+        method                   <- methods
+        if method.signatures.exists(_.parametersToList.isEmpty)
+      } yield DeclaringClassWithMethodName(clazz, methodName) -> ParameterlessMethodInfo(isStatic = staticMethods)
+    }
+    getParameterlessMethods(staticMethods = true) ++ getParameterlessMethods(staticMethods = false)
+  }
 
   def all: Set[ClassDefinition] = classDefinitionsMap.values.toSet
 
-  def get(clazz: Class[_]): Option[ClassDefinition] =
-    classDefinitionsMap.get(clazz)
+  def get(clazz: Class[_]): Option[ClassDefinition] = classDefinitionsMap.get(clazz)
+
+  def isParameterlessMethodAllowed(targetClass: Class[_], methodName: String, staticMethodsOnly: Boolean): Boolean = {
+    extractAllTypesInHierarchy(targetClass).exists(typeToCheck =>
+      parameterlessMethodsByDeclaringTypes
+        .get(DeclaringClassWithMethodName(typeToCheck, methodName))
+        .exists(methodInfo => !staticMethodsOnly || methodInfo.isStatic)
+    )
+  }
+
+  // We do runtime "types-walking" during expression invocation because in ClassDefinitionSet
+  // we have some definitions for interface (e.g. List, Map.Entry) but we don't know exact used
+  // implementation (like ArrayList or Collections.UnmodifiableMap.UnmodifiableEntrySet.UnmodifiableEntry) so we can't precompute it easily
+  @silent("deprecated")
+  private def extractAllTypesInHierarchy(clazz: Class[_]): Stream[Class[_]] = {
+    lazy val superClass          = Option(clazz.getSuperclass).map(_ #:: Stream.empty).getOrElse(Stream.empty)
+    lazy val extractedSuperTypes = (superClass #::: clazz.getInterfaces.toStream).flatMap(extractAllTypesInHierarchy)
+    clazz #:: extractedSuperTypes
+  }
 
 }
+
+private final case class ParameterlessMethodInfo(isStatic: Boolean)
+
+private final case class DeclaringClassWithMethodName(clazz: Class[_], methodName: String)

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -228,7 +228,9 @@ private[spel] class Typer(
         case TypedNull =>
           invalidNodeResult(IllegalIndexingOperation)
         case TypedObjectWithValue(underlying, _) => typeIndexer(e, underlying)
-        case _ =>
+        case Unknown =>
+          validNodeResult(Unknown)
+        case _: TypedClass =>
           val w = validNodeResult(Unknown)
           if (dynamicPropertyAccessAllowed) w else w.tell(List(DynamicPropertyAccessError))
       }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/internal/OptimizedEvaluationContext.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/internal/OptimizedEvaluationContext.scala
@@ -8,6 +8,7 @@ import pl.touk.nussknacker.engine.api.{Context, SpelExpressionExcludeList}
 import pl.touk.nussknacker.engine.definition.clazz.ClassDefinitionSet
 import pl.touk.nussknacker.engine.definition.globalvariables.ExpressionConfigDefinition
 import pl.touk.nussknacker.engine.extension.{ExtensionAwareMethodsDiscovery, ExtensionsAwareMethodInvoker}
+import pl.touk.nussknacker.engine.spel.internal.propertyAccessors.MethodAccessChecker
 import pl.touk.nussknacker.engine.spel.{NuReflectiveMethodExecutor, internal}
 
 import java.lang.reflect.Method
@@ -93,7 +94,10 @@ object EvaluationContextPreparer {
       classDefinitionSet: ClassDefinitionSet
   ): EvaluationContextPreparer = {
     val conversionService = determineConversionService(expressionConfig)
-    val propertyAccessors = internal.propertyAccessors.configured()
+    val propertyAccessors =
+      internal.propertyAccessors.configured(
+        MethodAccessChecker.create(classDefinitionSet, expressionConfig.dynamicPropertyAccessAllowed)
+      )
     new EvaluationContextPreparer(
       classLoader,
       expressionConfig.globalImports,

--- a/scenario-compiler/src/test/java/pl/touk/nussknacker/engine/spel/JavaClassWithStaticParameterlessMethod.java
+++ b/scenario-compiler/src/test/java/pl/touk/nussknacker/engine/spel/JavaClassWithStaticParameterlessMethod.java
@@ -1,0 +1,15 @@
+package pl.touk.nussknacker.engine.spel;
+
+import pl.touk.nussknacker.engine.api.Hidden;
+
+public class JavaClassWithStaticParameterlessMethod {
+
+    public static String someAllowedParameterlessStaticMethod() {
+        return "allowed";
+    }
+
+    @Hidden
+    public static String someHiddenParameterlessStaticMethod() {
+        return "hidden";
+    }
+}

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/TyperSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/TyperSpec.scala
@@ -56,6 +56,14 @@ class TyperSpec extends AnyFunSuite with Matchers with ValidatedValuesDetailedMe
       )
   }
 
+  test("access dynamic field on unknown by indexing operator should return unknown") {
+    typeExpressionForcedType(
+      s"#unknown['foo']",
+      List("unknown" -> Unknown): _*
+    ).validValue.finalResult.typingResult shouldBe
+      Unknown
+  }
+
   test("detect proper List type with value") {
     typeExpression("{1,2}").validValue.finalResult.typingResult shouldBe
       typedListWithElementValues(Typed.typedClass[Int], List(1, 2).asJava)
@@ -186,6 +194,17 @@ class TyperSpec extends AnyFunSuite with Matchers with ValidatedValuesDetailedMe
   ): ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
     val parsed        = parser.parseExpression(expr)
     val validationCtx = ValidationContext(variables.toMap.mapValuesNow(Typed.fromInstance))
+    typer.typeExpression(parsed, validationCtx)
+  }
+
+  private def typeExpressionForcedType(
+      expr: String,
+      variablesTypes: (String, TypingResult)*
+  )(
+      implicit typer: Typer
+  ): ValidatedNel[ExpressionParseError, CollectedTypingResult] = {
+    val parsed        = parser.parseExpression(expr)
+    val validationCtx = ValidationContext(variablesTypes.toMap)
     typer.typeExpression(parsed, validationCtx)
   }
 


### PR DESCRIPTION
## Describe your changes
For now we want:
* enable by default dynamic access using indexer operator for expressions typed to Unknown
* computed type for such an access is always Unknown (or concrete type if property is known)

## Todo
- [x] Disable runtime member access checking in property accessors if dynamicPropertyAccessAllowed=True
- [x] Secure ReflectivePropertyAccessor 
- [ ] Tests for typical use cases (e.g. with untyped json based source or json parsed from util)
- [x] Documentation update
- [ ] Optional: memoization of computed method definition in ClassDefinitionSetChecking trait