### PR TITLE
[NU-7016] Introduce Add button when typing element in user defined list

### DIFF
--- a/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/fields/UserDefinedListInput.tsx
+++ b/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/fields/UserDefinedListInput.tsx
@@ -190,7 +190,7 @@ export const UserDefinedListInput = ({
                         showValidation
                     />
                     <Button variant="contained" onClick={handleAddNewListItem}>
-                        Add
+                        {t("fragment.addListItemButton", "Add")}
                     </Button>
                 </Stack>
                 {userDefinedListOptions?.length > 0 && (

--- a/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/fields/UserDefinedListInput.tsx
+++ b/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/fields/UserDefinedListInput.tsx
@@ -15,7 +15,7 @@ import { GenericValidationRequest } from "../../../../../../../actions/nk/adhocT
 import { debounce } from "lodash";
 import { EditorType } from "../../../../editors/expression/Editor";
 import { useSettings } from "../../SettingsProvider";
-import { Box, FormControl } from "@mui/material";
+import { Box, Button, FormControl, Stack } from "@mui/material";
 
 interface Props {
     onChange: (path: string, value: onChangeType) => void;
@@ -167,27 +167,32 @@ export const UserDefinedListInput = ({
     return (
         <FormControl>
             <SettingLabelStyled>{t("fragment.addListItem", "Add list item:")}</SettingLabelStyled>
-            <Box width={"100%"} flex={1}>
-                <EditableEditor
-                    validationLabelInfo={temporaryValuesTyping && "Typing..."}
-                    expressionObj={{ language: ExpressionLang.SpEL, expression: temporaryListItem }}
-                    onValueChange={(value) => {
-                        setTemporaryListItem(value);
-                        setTemporaryValuesTyping(true);
-                        setTemporaryValueErrors([]);
-                        validateTemporaryListItem(value);
-                    }}
-                    variableTypes={variableTypes}
-                    readOnly={readOnly}
-                    ref={(ref: AceEditor | null) => {
-                        if (ref?.editor) {
-                            ref.editor.commands.addCommand(aceEditorEnterCommand);
-                        }
-                    }}
-                    param={{ editor: { type: EditorType.RAW_PARAMETER_EDITOR } }}
-                    fieldErrors={getValidationErrorsForField(temporaryValueErrors, temporaryItemName)}
-                    showValidation
-                />
+            <Box width={"80%"} flex={1}>
+                <Stack direction="row" paddingY={1} spacing={1} justifyContent={"space-between"} alignItems={"start"}>
+                    <EditableEditor
+                        validationLabelInfo={temporaryValuesTyping && "Typing..."}
+                        expressionObj={{ language: ExpressionLang.SpEL, expression: temporaryListItem }}
+                        onValueChange={(value) => {
+                            setTemporaryListItem(value);
+                            setTemporaryValuesTyping(true);
+                            setTemporaryValueErrors([]);
+                            validateTemporaryListItem(value);
+                        }}
+                        variableTypes={variableTypes}
+                        readOnly={readOnly}
+                        ref={(ref: AceEditor | null) => {
+                            if (ref?.editor) {
+                                ref.editor.commands.addCommand(aceEditorEnterCommand);
+                            }
+                        }}
+                        param={{ editor: { type: EditorType.RAW_PARAMETER_EDITOR } }}
+                        fieldErrors={getValidationErrorsForField(temporaryValueErrors, temporaryItemName)}
+                        showValidation
+                    />
+                    <Button variant="contained" onClick={handleAddNewListItem}>
+                        Add
+                    </Button>
+                </Stack>
                 {userDefinedListOptions?.length > 0 && (
                     <ListItems
                         items={fixedValuesList}


### PR DESCRIPTION
## Describe your changes

In this PR I add the following "Add" button when defining "User defined list" inside fragments input definition: 

![image](https://github.com/user-attachments/assets/9f227992-349f-4684-b8c9-74904a2032b0)


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
