### PR TITLE
[NU-1823] Kafka source without topic schema

### DIFF
--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaUniversalComponentTransformer.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaUniversalComponentTransformer.scala
@@ -73,8 +73,8 @@ abstract class KafkaUniversalComponentTransformer[T, TN <: TopicName: TopicValid
   ): WithError[ParameterCreatorWithNoDependency with ParameterExtractor[String]] = {
     val allTopics = getAllTopics
 
+    // TODO: previously schemaRegistryClient made validation
     val topics: Validated[SchemaRegistryError, List[UnspecializedTopicName]] = Valid(allTopics)
-    // topicSelectionStrategy.getTopics(schemaRegistryClient)
 
     (topics match {
       case Valid(topics) => Writer[List[ProcessCompilationError], List[UnspecializedTopicName]](Nil, topics)

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/BasedOnVersionAvroSchemaDeterminer.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/BasedOnVersionAvroSchemaDeterminer.scala
@@ -6,6 +6,7 @@ import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import org.apache.flink.formats.avro.typeutils.NkSerializableParsedSchema
 import pl.touk.nussknacker.engine.kafka.UnspecializedTopicName
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.OpenAPIJsonSchema
 import pl.touk.nussknacker.engine.schemedkafka.{AvroSchemaDeterminer, RuntimeSchemaData, SchemaDeterminerError}
 
 class BasedOnVersionAvroSchemaDeterminer(
@@ -18,7 +19,7 @@ class BasedOnVersionAvroSchemaDeterminer(
   override def determineSchemaUsedInTyping: Validated[SchemaDeterminerError, RuntimeSchemaData[AvroSchema]] = {
     val version = versionOption match {
       case ExistingSchemaVersion(v) => Some(v)
-      case LatestSchemaVersion      => None
+      case _                        => None
     }
     schemaRegistryClient
       .getFreshSchema(topic, version, isKey = isKey)
@@ -49,10 +50,22 @@ class ParsedSchemaDeterminer(
 ) {
 
   def determineSchemaUsedInTyping: Validated[SchemaDeterminerError, RuntimeSchemaData[ParsedSchema]] = {
-    val version = versionOption match {
-      case ExistingSchemaVersion(v) => Some(v)
-      case LatestSchemaVersion      => None
+    versionOption match {
+      case ExistingSchemaVersion(v) =>
+        val version = Some(v)
+        getTypedSchema(version)
+      case LatestSchemaVersion =>
+        val version = None
+        getTypedSchema(version)
+      case DynamicSchemaVersion(typ) =>
+        getDynamicSchema(typ)
     }
+
+  }
+
+  private def getTypedSchema(
+      version: Option[Int]
+  ): Validated[SchemaDeterminerError, RuntimeSchemaData[ParsedSchema]] = {
     schemaRegistryClient
       .getFreshSchema(topic, version, isKey = isKey)
       .leftMap(err =>
@@ -61,6 +74,45 @@ class ParsedSchemaDeterminer(
       .map(withMetadata =>
         RuntimeSchemaData(new NkSerializableParsedSchema[ParsedSchema](withMetadata.schema), Some(withMetadata.id))
       )
+  }
+
+  private def getDynamicSchema(typ: JsonTypes): Validated[SchemaDeterminerError, RuntimeSchemaData[ParsedSchema]] = {
+    typ match {
+      case JsonTypes.Json =>
+        Valid(
+          RuntimeSchemaData[ParsedSchema](
+            new NkSerializableParsedSchema[ParsedSchema](
+              OpenAPIJsonSchema(
+                """{
+              |  "anyOf": [{
+              |      "type": "object",
+              |      "properties": {
+              |        "_metadata": {
+              |          "oneOf": [
+              |            {"type": "null"},
+              |            {"type": "object"}
+              |          ]
+              |        },
+              |        "_w": {"type": "boolean"},
+              |        "message": {"type": "object"}
+              |      }
+              |    },
+              |    {"type": "object"}]
+              |}""".stripMargin
+              )
+            ),
+            Some(SchemaId.fromInt(JsonTypes.Json.value))
+          )
+        )
+      case JsonTypes.Plain =>
+        Valid(
+          RuntimeSchemaData[ParsedSchema](
+            new NkSerializableParsedSchema[ParsedSchema](OpenAPIJsonSchema("""{"type": "string"}""")),
+            Some(SchemaId.fromInt(JsonTypes.Plain.value))
+          )
+        )
+      case _ => Invalid(new SchemaDeterminerError("Wrong dynamic type", SchemaError.apply("Wrong dynamic type")))
+    }
   }
 
 }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/BasedOnVersionAvroSchemaDeterminer.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/BasedOnVersionAvroSchemaDeterminer.scala
@@ -82,23 +82,9 @@ class ParsedSchemaDeterminer(
         Valid(
           RuntimeSchemaData[ParsedSchema](
             new NkSerializableParsedSchema[ParsedSchema](
+//              Input type in ad hoc or in sink for example is displayed based on this schema, empty makes it Unknown
               OpenAPIJsonSchema(
-                """{
-              |  "anyOf": [{
-              |      "type": "object",
-              |      "properties": {
-              |        "_metadata": {
-              |          "oneOf": [
-              |            {"type": "null"},
-              |            {"type": "object"}
-              |          ]
-              |        },
-              |        "_w": {"type": "boolean"},
-              |        "message": {"type": "object"}
-              |      }
-              |    },
-              |    {"type": "object"}]
-              |}""".stripMargin
+                "{}"
               )
             ),
             Some(SchemaId.fromInt(JsonTypes.Json.value))
@@ -107,7 +93,7 @@ class ParsedSchemaDeterminer(
       case JsonTypes.Plain =>
         Valid(
           RuntimeSchemaData[ParsedSchema](
-            new NkSerializableParsedSchema[ParsedSchema](OpenAPIJsonSchema("""{"type": "string"}""")),
+            new NkSerializableParsedSchema[ParsedSchema](OpenAPIJsonSchema("")),
             Some(SchemaId.fromInt(JsonTypes.Plain.value))
           )
         )

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/SchemaVersionOption.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/SchemaVersionOption.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.engine.schemedkafka.schemaregistry
 
+import enumeratum.values.{IntEnum, IntEnumEntry}
 import pl.touk.nussknacker.engine.util.convert.IntValue
 
 sealed trait SchemaVersionOption
@@ -7,11 +8,15 @@ sealed trait SchemaVersionOption
 object SchemaVersionOption {
 
   val LatestOptionName = "latest"
+  val JsonOptionName   = "Json"
+  val PlainOptionName  = "Plain"
 
   def byName(name: String): SchemaVersionOption = {
     name match {
       case `LatestOptionName` => LatestSchemaVersion
       case IntValue(version)  => ExistingSchemaVersion(version)
+      case `JsonOptionName`   => DynamicSchemaVersion(JsonTypes.Json)
+      case `PlainOptionName`  => DynamicSchemaVersion(JsonTypes.Plain)
       case _                  => throw new IllegalArgumentException(s"Unexpected schema version option: $name")
     }
   }
@@ -21,3 +26,20 @@ object SchemaVersionOption {
 case class ExistingSchemaVersion(version: Int) extends SchemaVersionOption
 
 case object LatestSchemaVersion extends SchemaVersionOption
+
+case class DynamicSchemaVersion(typ: JsonTypes) extends SchemaVersionOption
+
+sealed abstract class JsonTypes(val value: Int) extends IntEnumEntry {
+
+  implicit def apply(): Int = {
+    this.value
+  }
+
+}
+
+object JsonTypes extends IntEnum[JsonTypes] {
+  val values = findValues
+
+  case object Json  extends JsonTypes(1)
+  case object Plain extends JsonTypes(2)
+}

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/SchemaVersionOption.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/SchemaVersionOption.scala
@@ -29,13 +29,7 @@ case object LatestSchemaVersion extends SchemaVersionOption
 
 case class DynamicSchemaVersion(typ: JsonTypes) extends SchemaVersionOption
 
-sealed abstract class JsonTypes(val value: Int) extends IntEnumEntry {
-
-  implicit def apply(): Int = {
-    this.value
-  }
-
-}
+sealed abstract class JsonTypes(val value: Int) extends IntEnumEntry
 
 object JsonTypes extends IntEnum[JsonTypes] {
   val values = findValues

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/formatter/AbstractSchemaBasedRecordFormatter.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/formatter/AbstractSchemaBasedRecordFormatter.scala
@@ -126,22 +126,7 @@ abstract class AbstractSchemaBasedRecordFormatter[K: ClassTag, V: ClassTag] exte
               case Some(IntSchemaId(JsonTypes.Json.value)) =>
                 Option(
                   SchemaWithMetadata(
-                    OpenAPIJsonSchema("""{
-              |  "anyOf": [{
-              |      "type": "object",
-              |      "properties": {
-              |        "_metadata": {
-              |          "oneOf": [
-              |            {"type": "null"},
-              |            {"type": "object"}
-              |          ]
-              |        },
-              |        "_w": {"type": "boolean"},
-              |        "message": {"type": "object"}
-              |      }
-              |    },
-              |    {"type": "object"}]
-              |}""".stripMargin),
+                    OpenAPIJsonSchema("""{"type": "object"}"""),
                     SchemaId.fromInt(JsonTypes.Json.value)
                   ).schema
                 )

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -158,7 +158,7 @@ object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
     val rawSchema = schema.cast().rawSchema()
     (value: Any) => {
       // TODO: For ad-hoc test we create object { "Value" = userInputObject }, so we should go one level deeper
-      // should do it in a better way
+      // should do it in a better way as this crash if both source and sink use topic without schema
 //      if (value.asInstanceOf[Map[String, Map[String, Any]]].head._1.equals("Value")) {
 //        encoder.encodeOrError(value.asInstanceOf[Map[String, Map[String, Any]]].head._2, rawSchema)
 //      } else

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -156,7 +156,14 @@ object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
   override def formValueEncoder(schema: ParsedSchema, mode: ValidationMode): Any => AnyRef = {
     val encoder   = new ToJsonSchemaBasedEncoder(mode)
     val rawSchema = schema.cast().rawSchema()
-    (value: Any) => encoder.encodeOrError(value, rawSchema)
+    (value: Any) => {
+      // TODO: For ad-hoc test we create object { "Value" = userInputObject }, so we should go one level deeper
+      // should do it in a better way
+//      if (value.asInstanceOf[Map[String, Map[String, Any]]].head._1.equals("Value")) {
+//        encoder.encodeOrError(value.asInstanceOf[Map[String, Map[String, Any]]].head._2, rawSchema)
+//      } else
+      encoder.encodeOrError(value, rawSchema)
+    }
   }
 
   override def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport =

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalKafkaDeserializer.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalKafkaDeserializer.scala
@@ -1,15 +1,21 @@
 package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal
 
+import cats.data.Validated
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import org.apache.flink.formats.avro.typeutils.NkSerializableParsedSchema
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.Deserializer
-import pl.touk.nussknacker.engine.kafka.KafkaConfig
+import pl.touk.nussknacker.engine.kafka.{KafkaConfig, UnspecializedTopicName}
 import pl.touk.nussknacker.engine.schemedkafka.RuntimeSchemaData
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.OpenAPIJsonSchema
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.serialization.SchemaRegistryBasedDeserializerFactory
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{
   ChainedSchemaIdFromMessageExtractor,
-  SchemaRegistryClient
+  JsonTypes,
+  SchemaId,
+  SchemaRegistryClient,
+  SchemaTopicError,
+  SchemaWithMetadata
 }
 
 import scala.reflect.ClassTag
@@ -35,8 +41,45 @@ class UniversalKafkaDeserializer[T](
       .withFallbackSchemaId(readerSchemaDataOpt.flatMap(_.schemaIdOpt))
       .getSchemaId(headers, data, isKey)
       .getOrElse(throw MessageWithoutSchemaIdException)
-    val writerSchema = schemaRegistryClient.getSchemaById(writerSchemaId.value).schema
 
+    val schemaWithMetadata =
+      schemaRegistryClient.getFreshSchema(UnspecializedTopicName(topic), None, isKey = false) match {
+        case Validated.Valid(schema) => schema
+        case Validated.Invalid(SchemaTopicError(_)) =>
+          writerSchemaId.value.asInt match {
+            case JsonTypes.Json.value =>
+              SchemaWithMetadata(
+                OpenAPIJsonSchema("""{
+                  |  "anyOf": [{
+                  |      "type": "object",
+                  |      "properties": {
+                  |        "_metadata": {
+                  |          "oneOf": [
+                  |            {"type": "null"},
+                  |            {"type": "object"}
+                  |          ]
+                  |        },
+                  |        "_w": {"type": "boolean"},
+                  |        "message": {"type": "object"}
+                  |      }
+                  |    },
+                  |    {"type": "object"}]
+                  |}""".stripMargin),
+                SchemaId.fromInt(JsonTypes.Json.value)
+              )
+            case JsonTypes.Plain.value =>
+              SchemaWithMetadata(
+                OpenAPIJsonSchema(
+                  """{"type": "string"}"""
+                ),
+                SchemaId.fromInt(JsonTypes.Plain.value)
+              )
+          }
+        case Validated.Invalid(error) =>
+          throw error
+      }
+//    val writerSchema = schemaRegistryClient.getSchemaById(writerSchemaId.value).schema
+    val writerSchema = schemaWithMetadata.schema
     readerSchemaDataOpt
       .map(_.schema.schemaType())
       .foreach(readerSchemaType => {

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalKafkaDeserializer.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalKafkaDeserializer.scala
@@ -49,36 +49,20 @@ class UniversalKafkaDeserializer[T](
           writerSchemaId.value.asInt match {
             case JsonTypes.Json.value =>
               SchemaWithMetadata(
-                OpenAPIJsonSchema("""{
-                  |  "anyOf": [{
-                  |      "type": "object",
-                  |      "properties": {
-                  |        "_metadata": {
-                  |          "oneOf": [
-                  |            {"type": "null"},
-                  |            {"type": "object"}
-                  |          ]
-                  |        },
-                  |        "_w": {"type": "boolean"},
-                  |        "message": {"type": "object"}
-                  |      }
-                  |    },
-                  |    {"type": "object"}]
-                  |}""".stripMargin),
+                // I don't know how these schemas affect deserialization later
+                OpenAPIJsonSchema("""{"type": "object"}"""),
                 SchemaId.fromInt(JsonTypes.Json.value)
               )
             case JsonTypes.Plain.value =>
               SchemaWithMetadata(
-                OpenAPIJsonSchema(
-                  """{"type": "string"}"""
-                ),
+                OpenAPIJsonSchema("""{"type": "string"}"""),
                 SchemaId.fromInt(JsonTypes.Plain.value)
               )
           }
         case Validated.Invalid(error) =>
           throw error
       }
-//    val writerSchema = schemaRegistryClient.getSchemaById(writerSchemaId.value).schema
+
     val writerSchema = schemaWithMetadata.schema
     readerSchemaDataOpt
       .map(_.schema.schemaType())

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
@@ -94,25 +94,11 @@ class UniversalKafkaSourceFactory(
                 (
                   Some(
                     RuntimeSchemaData[ParsedSchema](
-                      new NkSerializableParsedSchema[ParsedSchema](OpenAPIJsonSchema("""{
-                      |  "anyOf": [{
-                      |      "type": "object",
-                      |      "properties": {
-                      |        "_metadata": {
-                      |          "oneOf": [
-                      |            {"type": "null"},
-                      |            {"type": "object"}
-                      |          ]
-                      |        },
-                      |        "_w": {"type": "boolean"},
-                      |        "message": {"type": "object"}
-                      |      }
-                      |    },
-                      |    {}]
-                      |}""".stripMargin)),
+                      new NkSerializableParsedSchema[ParsedSchema](OpenAPIJsonSchema("{}")),
                       Some(SchemaId.fromInt(JsonTypes.Json.value))
                     )
                   ),
+                  // This is the type after it leaves source
                   Unknown
                 )
               )
@@ -125,6 +111,7 @@ class UniversalKafkaSourceFactory(
                       Some(SchemaId.fromInt(JsonTypes.Plain.value))
                     )
                   ),
+                  // This is the type after it leaves source
                   Typed[Array[java.lang.Byte]]
                 )
               )


### PR DESCRIPTION
## Describe your changes
We want to enable user to choose and use topics without schema present on schema registry.



## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
