### PR TITLE
[NU-1772] Fix line breaks in ScenarioActivities db table

### DIFF
--- a/designer/server/src/main/resources/db/migration/hsql/V1_059__FixLineBreaksInActivityAdditionalProperties.sql
+++ b/designer/server/src/main/resources/db/migration/hsql/V1_059__FixLineBreaksInActivityAdditionalProperties.sql
@@ -1,0 +1,3 @@
+UPDATE scenario_activities
+SET additional_properties = REPLACE(additional_properties, CHAR(10), '\n')
+WHERE additional_properties LIKE '%' || CHAR(10) || '%';

--- a/designer/server/src/main/resources/db/migration/hsql/V1_059__FixLineBreaksInActivityAdditionalProperties.sql
+++ b/designer/server/src/main/resources/db/migration/hsql/V1_059__FixLineBreaksInActivityAdditionalProperties.sql
@@ -1,3 +1,3 @@
-UPDATE scenario_activities
-SET additional_properties = REPLACE(additional_properties, CHAR(10), '\n')
-WHERE additional_properties LIKE '%' || CHAR(10) || '%';
+UPDATE "scenario_activities"
+SET "additional_properties" = REPLACE("additional_properties", CHAR(10), '\n')
+WHERE "additional_properties" LIKE '%' || CHAR(10) || '%';

--- a/designer/server/src/main/resources/db/migration/postgres/V1_059__FixLineBreaksInActivityAdditionalProperties.sql
+++ b/designer/server/src/main/resources/db/migration/postgres/V1_059__FixLineBreaksInActivityAdditionalProperties.sql
@@ -1,3 +1,3 @@
-UPDATE scenario_activities
-SET additional_properties = REPLACE(additional_properties, CHR(10), '\n')
-WHERE additional_properties LIKE '%' || CHR(10) || '%';
+UPDATE "scenario_activities"
+SET "additional_properties" = REPLACE("additional_properties", CHR(10), '\n')
+WHERE "additional_properties" LIKE '%' || CHR(10) || '%';

--- a/designer/server/src/main/resources/db/migration/postgres/V1_059__FixLineBreaksInActivityAdditionalProperties.sql
+++ b/designer/server/src/main/resources/db/migration/postgres/V1_059__FixLineBreaksInActivityAdditionalProperties.sql
@@ -1,0 +1,3 @@
+UPDATE scenario_activities
+SET additional_properties = REPLACE(additional_properties, CHR(10), '\n')
+WHERE additional_properties LIKE '%' || CHR(10) || '%';


### PR DESCRIPTION
## Describe your changes

Plaintext activity details from old tables (for example for migration or automatic update) were migrated as part of the JSON in the new table. Newlines were incorrectly migrated as line breaks instead of \n in previous migrations.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
