### PR TITLE
Update Scala 2.13 to 2.13.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 // Warning: Flink doesn't work correctly with 2.12.11
 val scala212 = "2.12.10"
-val scala213 = "2.13.12"
+val scala213 = "2.13.15"
 
 lazy val defaultScalaV = sys.env.get("NUSSKNACKER_SCALA_VERSION") match {
   case None | Some("2.13") => scala213
@@ -27,10 +27,10 @@ lazy val defaultScalaV = sys.env.get("NUSSKNACKER_SCALA_VERSION") match {
 lazy val supportedScalaVersions = List(scala212, scala213)
 
 // Silencer must be compatible with exact scala version - see compatibility matrix: https://search.maven.org/search?q=silencer-plugin
-// Silencer 1.7.x require Scala 2.12.11 (see warning above)
+// Silencer 1.7.x requires Scala 2.12.11+
 // Silencer (and all '@silent' annotations) can be removed after we can upgrade to 2.12.13...
 // https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html
-lazy val silencerV      = "1.7.17"
+lazy val silencerV      = "1.7.19"
 lazy val silencerV_2_12 = "1.6.0"
 
 //TODO: replace configuration by system properties with configuration via environment after removing travis scripts

--- a/build.sbt
+++ b/build.sbt
@@ -363,7 +363,7 @@ def flinkLibScalaDeps(scalaVersion: String, configurations: Option[String] = Non
     ) // we basically need only `org.apache.flink.runtime.types.FlinkScalaKryoInstantiator` from it...
   case (2, 13) =>
     Seq(
-      "pl.touk" %% "flink-scala-2-13" % "1.1.1"
+      "pl.touk" %% "flink-scala-2-13" % "1.1.2"
     ) // our tiny custom module with scala 2.13 `org.apache.flink.runtime.types.FlinkScalaKryoInstantiator` impl
 }.map(m => configurations.map(m % _).getOrElse(m)).map(_ exclude ("com.esotericsoftware", "kryo-shaded"))
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -54,14 +54,20 @@
 * [#6880](https://github.com/TouK/nussknacker/pull/6880) Performance optimization of generating Avro messages with unions
   - shorter message in logs
 * [#6766](https://github.com/TouK/nussknacker/pull/6766) Scenario labels support - you can assign labels to scenarios and use them to filter the scenario list
-* [#6176](https://github.com/TouK/nussknacker/pull/6176) [#6996](https://github.com/TouK/nussknacker/pull/6996) [7012](https://github.com/TouK/nussknacker/pull/7012) [7014](https://github.com/TouK/nussknacker/pull/7014) Update most dependencies to latest versions, most important ones:
+* [#6176](https://github.com/TouK/nussknacker/pull/6176)
+  [#6996](https://github.com/TouK/nussknacker/pull/6996)
+  [#7012](https://github.com/TouK/nussknacker/pull/7012)
+  [#7014](https://github.com/TouK/nussknacker/pull/7014)
+  [#7113](https://github.com/TouK/nussknacker/pull/7113)
+  Update most dependencies to latest versions, most important ones:
   * Flink 1.18.1 -> 1.19.1
   * Jackson 2.15.4 -> 2.17.2
-  * cats 2.10 -> 2.12
+  * Cats 2.10 -> 2.12
   * Avro 1.11.3 -> 1.11.4
   * swagger-parser 2.1.15 -> 2.1.22
   * Tapir -> 1.11.7
   * openapi-circe-yaml -> 0.11.3
+  * Scala 2.13 to 2.13.15
 * Scenario activities mechanism replacing old process actions:
   * [#6822](https://github.com/TouK/nussknacker/pull/6822), [#6929](https://github.com/TouK/nussknacker/pull/6929)
     * Scenario Activity API contract (without BE implementation)

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -91,6 +91,8 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   * [#7097](https://github.com/TouK/nussknacker/pull/7097) Flink base types registration mechanism
     * In case of using types: java.time.LocalDate, java.time.LocalTime, java.time.LocalDateTime with CaseClassTypeInfo mechanism, state probably will be lost
 
+* [#7113](https://github.com/TouK/nussknacker/pull/7113) Scala 2.13 was updated to 2.13.15, you should update your `flink-scala-2.13` to 1.1.2
+
 ### Configuration changes
 * [#6979](https://github.com/TouK/nussknacker/pull/6979) Add `type: "activities-panel"` to the `processToolbarConfig` which replaces removed `{ type: "versions-panel" }` `{ type: "comments-panel" }` and `{ type: "attachments-panel" }`
 

--- a/docs/configuration/model/Flink.md
+++ b/docs/configuration/model/Flink.md
@@ -34,6 +34,7 @@ description: Flink specific model configuration
 Exception handling can be customized using provided `EspExceptionConsumer`. By default, there are two available:
 - `BrieflyLogging`
 - `VerboselyLogging`
+
 More of them can be added with custom extensions. By default, basic error metrics are collected. If for some reason
   it's not desirable, metrics collector can be turned off with `withRateMeter: false` setting. 
 When an exception is raised within a scenario, the handler uses `WithExceptionExtractor` to determine if it should be consumed

--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithFlinkContainers.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithFlinkContainers.scala
@@ -82,8 +82,8 @@ trait WithFlinkContainers extends WithDockerContainers { self: Suite with LazyLo
         case "2.13" =>
           s"""
              |RUN rm $$FLINK_HOME/lib/flink-scala*.jar
-             |RUN wget https://repo1.maven.org/maven2/pl/touk/flink-scala-2-13_2.13/1.1.1/flink-scala-2-13_2.13-1.1.1-assembly.jar -O $$FLINK_HOME/lib/flink-scala-2-13_2.13-1.1.1-assembly.jar
-             |RUN chown flink $$FLINK_HOME/lib/flink-scala-2-13_2.13-1.1.1-assembly.jar
+             |RUN wget https://repo1.maven.org/maven2/pl/touk/flink-scala-2-13_2.13/1.1.2/flink-scala-2-13_2.13-1.1.2-assembly.jar -O $$FLINK_HOME/lib/flink-scala-2-13_2.13-1.1.2-assembly.jar
+             |RUN chown flink $$FLINK_HOME/lib/flink-scala-2-13_2.13-1.1.2-assembly.jar
              |""".stripMargin
         case v => throw new IllegalStateException(s"unsupported scala version: $v")
       }

--- a/examples/dev/nu-scala213.override.yml
+++ b/examples/dev/nu-scala213.override.yml
@@ -3,10 +3,10 @@ x-flink-service-common: &common-flink
     flink-scala213-downloader:
       condition: service_completed_successfully
   volumes:
-    - /tmp/flink-scala-2-13_2.13-1.1.1-assembly.jar:/opt/flink/lib/flink-scala-2-13_2.13-1.1.1-assembly.jar
+    - /tmp/flink-scala-2-13_2.13-1.1.2-assembly.jar:/opt/flink/lib/flink-scala-2-13_2.13-1.1.2-assembly.jar
   entrypoint: [
     "sh", "-c",
-    "rm -f /opt/flink/lib/flink-scala_2.12* && chown flink /opt/flink/lib/flink-scala-2-13_2.13-1.1.1-assembly.jar && /ex-docker-entrypoint.sh \"$@\"", "--"
+    "rm -f /opt/flink/lib/flink-scala_2.12* && chown flink /opt/flink/lib/flink-scala-2-13_2.13-1.1.2-assembly.jar && /ex-docker-entrypoint.sh \"$@\"", "--"
   ]
 
 services:
@@ -23,5 +23,5 @@ services:
       - /tmp:/data
     entrypoint: [
       "sh", "-c",
-      "curl -o /data/flink-scala-2-13_2.13-1.1.1-assembly.jar https://repo1.maven.org/maven2/pl/touk/flink-scala-2-13_2.13/1.1.1/flink-scala-2-13_2.13-1.1.1-assembly.jar"
+      "curl -o /data/flink-scala-2-13_2.13-1.1.2-assembly.jar https://repo1.maven.org/maven2/pl/touk/flink-scala-2-13_2.13/1.1.2/flink-scala-2-13_2.13-1.1.2-assembly.jar"
     ]


### PR DESCRIPTION
## Describe your changes

We build Nu with Scala 2.13.12 and use Tapir built with Scala 2.13.13, which is incompatible - see SIP-51 for details. If we were using sbt 1.10.0+ our build would fail.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
