### PR TITLE
[NU-1848] Restored predefined TypeInfo in TypingResultAwareTypeInform…

### DIFF
--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/typeinformation/FlinkTypeInfoRegistrar.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/typeinformation/FlinkTypeInfoRegistrar.scala
@@ -16,9 +16,10 @@ object FlinkTypeInfoRegistrar {
 
   private val DisableFlinkTypeInfoRegistrationEnvVarName = "NU_DISABLE_FLINK_TYPE_INFO_REGISTRATION"
 
-  private case class RegistrationEntry[T](klass: Class[T], factoryClass: Class[_ <: TypeInfoFactory[T]])
+  // These members are package protected for purpose of TypingResultAwareTypeInformationDetection.FlinkBelow119AdditionalTypeInfo - see comment there
+  private[engine] case class RegistrationEntry[T](klass: Class[T], factoryClass: Class[_ <: TypeInfoFactory[T]])
 
-  private val typeInfoToRegister = List(
+  private[engine] val typeInfoToRegister = List(
     RegistrationEntry(classOf[LocalDate], classOf[LocalDateTypeInfoFactory]),
     RegistrationEntry(classOf[LocalTime], classOf[LocalTimeTypeInfoFactory]),
     RegistrationEntry(classOf[LocalDateTime], classOf[LocalDateTimeTypeInfoFactory]),
@@ -46,7 +47,9 @@ object FlinkTypeInfoRegistrar {
   }
 
   // These methods are mainly for purpose of tests in nussknacker-flink-compatibility project
-  // It should be used in caution as it changes the global state
+  // It should be used with caution as it changes the global state. They will be removed when we stop supporting Flink < 1.19
+  def isFlinkTypeInfoRegistrationEnabled: Boolean = typeInfoRegistrationEnabled.get()
+
   def enableFlinkTypeInfoRegistration(): Unit = {
     typeInfoRegistrationEnabled.set(true)
   }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
@@ -77,7 +77,7 @@ class TypingResultAwareTypeInformationDetection extends TypeInformationDetection
 
   // This extractor is to allow using of predefined type infos in Flink < 1.19. Type info registration was added in 1.19
   // It should be removed when we stop supporting Flink < 1.19
-  private object FlinkBelow119AdditionalTypeInfo {
+  private object FlinkBelow119AdditionalTypeInfo extends Serializable {
 
     def unapply(typingResult: TypingResult): Option[TypeInformation[_]] = {
       if (FlinkTypeInfoRegistrar.isFlinkTypeInfoRegistrationEnabled) {


### PR DESCRIPTION
…ationDetection for Flink below 1.19

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
