### PR TITLE
Fix scenario tests with fragment input validation

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -101,6 +101,7 @@
 * [#7102](https://github.com/TouK/nussknacker/pull/7102) Introduce a new UI to defining aggregations within nodes
 * [#7147](https://github.com/TouK/nussknacker/pull/7147) Fix redundant "ParameterName(...)" wrapper string in exported PDFs in nodes details 
 * [#7178](https://github.com/TouK/nussknacker/pull/7178) Remove autocompletion from markdown editors
+* [#7159](https://github.com/TouK/nussknacker/pull/7159) Fix running scenario tests with provided fragment input validation 
 
 ## 1.17
 

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkTestMainSpec.scala
@@ -6,7 +6,7 @@ import org.apache.flink.runtime.client.JobExecutionException
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.{BeforeAndAfterEach, Inside, OptionValues}
-import pl.touk.nussknacker.engine.api.{CirceUtil, DisplayJsonWithEncoder}
+import pl.touk.nussknacker.engine.api.{CirceUtil, DisplayJsonWithEncoder, FragmentSpecificData, MetaData}
 import pl.touk.nussknacker.engine.api.process.ComponentUseCase
 import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, ScenarioTestJsonRecord}
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
@@ -16,11 +16,21 @@ import pl.touk.nussknacker.engine.flink.test.{
   RecordingExceptionConsumer,
   RecordingExceptionConsumerProvider
 }
-import pl.touk.nussknacker.engine.graph.node.Case
+import pl.touk.nussknacker.engine.graph.node.{Case, FragmentInputDefinition, FragmentOutputDefinition}
 import pl.touk.nussknacker.engine.process.helpers.SampleNodes._
 import pl.touk.nussknacker.engine.testmode.TestProcess._
 import pl.touk.nussknacker.engine.util.ThreadUtils
 import pl.touk.nussknacker.engine.ModelData
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.api.parameter.ParameterValueCompileTimeValidation
+import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
+import pl.touk.nussknacker.engine.compile.FragmentResolver
+import pl.touk.nussknacker.engine.graph.node.FragmentInputDefinition.{FragmentClazzRef, FragmentParameter}
+import pl.touk.nussknacker.engine.process.runner.FlinkTestMainSpec.{
+  fragmentWithValidationName,
+  processWithFragmentParameterValidation
+}
 
 import java.util.{Date, UUID}
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -654,6 +664,23 @@ class FlinkTestMainSpec extends AnyWordSpec with Matchers with Inside with Befor
         variable(List(ComponentUseCase.TestRuntime, ComponentUseCase.TestRuntime))
       )
     }
+
+    "should not throw exception when process fragment has parameter validation defined" in {
+      val scenario = ScenarioBuilder
+        .streaming("scenario1")
+        .source(sourceNodeId, "input")
+        .fragmentOneOut("sub", fragmentWithValidationName, "output", "fragmentResult", "param" -> "'asd'".spel)
+        .emptySink("out", "valueMonitor", "Value" -> "1".spel)
+
+      val resolved = FragmentResolver(List(processWithFragmentParameterValidation)).resolve(scenario)
+
+      val results = runFlinkTest(
+        resolved.valueOr { _ => throw new IllegalArgumentException("Won't happen") },
+        ScenarioTestData(List(ScenarioTestJsonRecord(sourceNodeId, Json.fromString("0|1|2|3|4|5|6")))),
+        useIOMonadInInterpreter
+      )
+      results.exceptions.length shouldBe 0
+    }
   }
 
   private def createTestRecord(
@@ -707,6 +734,34 @@ class FlinkTestMainSpec extends AnyWordSpec with Matchers with Inside with Befor
     }
 
     Json.obj("pretty" -> toJson(value))
+  }
+
+}
+
+object FlinkTestMainSpec {
+  private val fragmentWithValidationName = "fragmentWithValidation"
+
+  private val processWithFragmentParameterValidation: CanonicalProcess = {
+    val fragmentParamName = ParameterName("param")
+    val fragmentParam = FragmentParameter(fragmentParamName, FragmentClazzRef[String]).copy(
+      valueCompileTimeValidation = Some(
+        ParameterValueCompileTimeValidation(
+          validationExpression = Expression.spel("true"),
+          validationFailedMessage = Some("param validation failed")
+        )
+      )
+    )
+
+    CanonicalProcess(
+      MetaData(fragmentWithValidationName, FragmentSpecificData()),
+      List(
+        FlatNode(
+          FragmentInputDefinition("start", List(fragmentParam))
+        ),
+        FlatNode(FragmentOutputDefinition("out1", "output", List.empty))
+      ),
+      List.empty
+    )
   }
 
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilerData.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilerData.scala
@@ -40,7 +40,7 @@ object ProcessCompilerData {
 
     val globalVariablesPreparer = GlobalVariablesPreparer(definitionWithTypes.modelDefinition.expressionConfig)
     val expressionEvaluator =
-      ExpressionEvaluator.optimizedEvaluator(globalVariablesPreparer, listeners)
+      ExpressionEvaluator.unOptimizedEvaluator(globalVariablesPreparer)
 
     val expressionCompiler = ExpressionCompiler.withOptimization(
       userCodeClassLoader,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilerData.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilerData.scala
@@ -39,15 +39,15 @@ object ProcessCompilerData {
       .filter(_.componentType == ComponentType.Service)
 
     val globalVariablesPreparer = GlobalVariablesPreparer(definitionWithTypes.modelDefinition.expressionConfig)
-    val expressionEvaluator =
-      ExpressionEvaluator.unOptimizedEvaluator(globalVariablesPreparer)
 
+    // Here we pass unOptimizedEvaluator for ValidationExpressionParameterValidator
+    // as the optimized once could cause problems with serialization with its listeners during scenario testing
     val expressionCompiler = ExpressionCompiler.withOptimization(
       userCodeClassLoader,
       dictRegistry,
       definitionWithTypes.modelDefinition.expressionConfig,
       definitionWithTypes.classDefinitions,
-      expressionEvaluator
+      ExpressionEvaluator.unOptimizedEvaluator(globalVariablesPreparer)
     )
 
     // for testing environment it's important to take classloader from user jar
@@ -69,8 +69,8 @@ object ProcessCompilerData {
       nodeCompiler,
       customProcessValidator
     )
-
-    val interpreter = Interpreter(listeners, expressionEvaluator, componentUseCase)
+    val expressionEvaluator = ExpressionEvaluator.optimizedEvaluator(globalVariablesPreparer, listeners)
+    val interpreter         = Interpreter(listeners, expressionEvaluator, componentUseCase)
 
     new ProcessCompilerData(
       processCompiler,

--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoder.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoder.scala
@@ -22,7 +22,7 @@ object ToJsonEncoder {
 
 case class ToJsonEncoder(
     failOnUnknown: Boolean,
-    classLoader: ClassLoader,
+    @transient classLoader: ClassLoader,
     highPriority: PartialFunction[Any, Json] = Map()
 ) {
 

--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoder.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoder.scala
@@ -22,7 +22,7 @@ object ToJsonEncoder {
 
 case class ToJsonEncoder(
     failOnUnknown: Boolean,
-    @transient classLoader: ClassLoader,
+    classLoader: ClassLoader,
     highPriority: PartialFunction[Any, Json] = Map()
 ) {
 


### PR DESCRIPTION
## Describe your changes

Currently when we try to test a scenario which uses a fragment which has some validation set on parameter's expression there is an exception during serialization. 

```
12:47:28.764 [nussknacker-designer-akka.actor.default-dispatcher-10] ERROR p.t.n.ui.api.NuDesignerErrorToHttp$ - Unknown error: The implementation of the RichFlatMapFunction is not serializable. The object probably contains or references non serializable fields.
org.apache.flink.api.common.InvalidProgramException: The implementation of the RichFlatMapFunction is not serializable. The object probably contains or references non serializable fields.
        at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:170)
        at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:69)
        at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.clean(StreamExecutionEnvironment.java:2360)
        at org.apache.flink.streaming.api.datastream.DataStream.clean(DataStream.java:202)
        at org.apache.flink.streaming.api.datastream.DataStream.flatMap(DataStream.java:631)
        at pl.touk.nussknacker.engine.process.registrar.FlinkProcessRegistrar.registerInterpretationPart$1(FlinkProcessRegistrar.scala:389)
        at pl.touk.nussknacker.engine.process.registrar.FlinkProcessRegistrar.registerSourcePart$1(FlinkProcessRegistrar.scala:189)
        at pl.touk.nussknacker.engine.process.registrar.FlinkProcessRegistrar.$anonfun$register$5(FlinkProcessRegistrar.scala:174)
        at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
...
```

This happens as deep down there is a classloader passed which cannot be serialized. 
The problem started to occur with introduction of `ValidationExpressionParameterValidator` which holds `ExpressionEvaluator` which was created in an optimized way and thus contains listeners. Especially `ResultsCollectingListener` which has a `variableEncoder` which has the problematic classloader.

In proposed changes at the level of `ProcessCompilerData` I pass `ExpressionEvaluator.unOptimizedEvaluator` which is used only by the validator.
I also left the `ExpressionEvaluator.optimizedEvaluator` intact for the `Interpreter` and `ProcessCompilerData` creation as it's needed there.

I added a test replicating the issue. It passes with the proposed change but would fail in the same way as on the environment without it:

![Zrzut ekranu z 2024-11-18 14-45-40](https://github.com/user-attachments/assets/07e3fcb5-d873-42b3-807d-483d41e6a1f1)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced testing framework for fragments with parameter validation.
	- Introduced a new test case to ensure fragments execute without exceptions when parameter validation is defined.
	- Added a new Activities panel for better scenario activity tracking and introduced scenario labels for improved organization.

- **Bug Fixes**
	- Adjusted expression evaluation strategy in the process compilation preparation phase for improved performance.

- **Documentation**
	- Updated changelog to reflect new version 1.18 and its significant features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->