### PR TITLE
Assign user friendly editor fix

### DIFF
--- a/designer/client/cypress/e2e/process.cy.ts
+++ b/designer/client/cypress/e2e/process.cy.ts
@@ -333,7 +333,7 @@ describe("Process", () => {
         cy.layoutScenario();
 
         cy.contains("button", "ad hoc").should("be.enabled").click();
-        cy.get("[data-testid=window]").should("be.visible").find("input").type("10"); //There should be only one input field
+        cy.get("[data-testid=window]").should("be.visible").find("#ace-editor").type("10");
         cy.get("[data-testid=window]")
             .contains(/^test$/i)
             .should("be.enabled")

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
@@ -4,6 +4,7 @@ import com.carrotsearch.sizeof.RamUsageEstimator
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.definition.{DualParameterEditor, Parameter, StringParameterEditor}
+import pl.touk.nussknacker.engine.api.editor.DualEditorMode
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.api.typed.CanBeSubclassDeterminer
@@ -132,7 +133,7 @@ class ScenarioTestService(
   private def assignUserFriendlyEditor(uiSourceParameter: UISourceParameters): UISourceParameters = {
     val adaptedParameters = uiSourceParameter.parameters.map { uiParameter =>
       uiParameter.editor match {
-        case DualParameterEditor(_ @StringParameterEditor, _)
+        case DualParameterEditor(StringParameterEditor, DualEditorMode.RAW)
             if CanBeSubclassDeterminer.canBeSubclassOf(uiParameter.typ, Typed.apply(classOf[String])).isValid =>
           uiParameter.copy(editor = StringParameterEditor)
         case _ => uiParameter

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
@@ -134,7 +134,7 @@ class ScenarioTestService(
     val adaptedParameters = uiSourceParameter.parameters.map { uiParameter =>
       uiParameter.editor match {
         case DualParameterEditor(StringParameterEditor, DualEditorMode.RAW)
-            if CanBeSubclassDeterminer.canBeSubclassOf(uiParameter.typ, Typed.apply(classOf[String])).isValid =>
+            if uiParameter.typ.canBeSubclassOf(Typed[String]) =>
           uiParameter.copy(editor = StringParameterEditor)
         case _ => uiParameter
       }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
@@ -3,8 +3,7 @@ package pl.touk.nussknacker.ui.process.test
 import com.carrotsearch.sizeof.RamUsageEstimator
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.ProcessVersion
-import pl.touk.nussknacker.engine.api.definition.StringParameterEditor
-import pl.touk.nussknacker.engine.api.definition.Parameter
+import pl.touk.nussknacker.engine.api.definition.{DualParameterEditor, Parameter, StringParameterEditor}
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.test.ScenarioTestData
 import pl.touk.nussknacker.engine.api.typed.CanBeSubclassDeterminer
@@ -17,7 +16,6 @@ import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.TestSourceP
 import pl.touk.nussknacker.ui.api.TestDataSettings
 import pl.touk.nussknacker.ui.definition.DefinitionsService
 import pl.touk.nussknacker.ui.process.deployment.ScenarioTestExecutorService
-import pl.touk.nussknacker.ui.process.label.ScenarioLabel
 import pl.touk.nussknacker.ui.processreport.{NodeCount, ProcessCounter, RawCount}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.ui.uiresolving.UIProcessResolver
@@ -133,10 +131,11 @@ class ScenarioTestService(
 
   private def assignUserFriendlyEditor(uiSourceParameter: UISourceParameters): UISourceParameters = {
     val adaptedParameters = uiSourceParameter.parameters.map { uiParameter =>
-      if (CanBeSubclassDeterminer.canBeSubclassOf(uiParameter.typ, Typed.apply(classOf[String])).isValid) {
-        uiParameter.copy(editor = StringParameterEditor)
-      } else {
-        uiParameter
+      uiParameter.editor match {
+        case DualParameterEditor(_ @StringParameterEditor, _)
+            if CanBeSubclassDeterminer.canBeSubclassOf(uiParameter.typ, Typed.apply(classOf[String])).isValid =>
+          uiParameter.copy(editor = StringParameterEditor)
+        case _ => uiParameter
       }
     }
     uiSourceParameter.copy(parameters = adaptedParameters)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/TestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/TestingApiHttpServiceSpec.scala
@@ -6,10 +6,13 @@ import io.circe.syntax.EncoderOps
 import io.restassured.RestAssured.given
 import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
 import org.scalatest.freespec.AnyFreeSpecLike
+import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
-import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.parameter.{ParameterName, ValueInputWithFixedValuesProvided}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.graph.node.FragmentInputDefinition.{FragmentClazzRef, FragmentParameter}
 import pl.touk.nussknacker.test.base.it.{NuItTest, WithSimplifiedConfigScenarioHelper}
 import pl.touk.nussknacker.test.config.{
   WithBusinessCaseRestAssuredUsersExtensions,
@@ -45,6 +48,36 @@ class TestingApiHttpServiceSpec
       "Raw editor" -> Expression.spel("true"),
       "Value"      -> Expression.spel("#input")
     )
+
+  private val fragmentFixedParameter = FragmentParameter(
+    ParameterName("paramFixedString"),
+    FragmentClazzRef[java.lang.String],
+    initialValue = Some(FixedExpressionValue("'uno'", "uno")),
+    hintText = None,
+    valueEditor = Some(
+      ValueInputWithFixedValuesProvided(
+        fixedValuesList = List(
+          FixedExpressionValue("'uno'", "uno"),
+          FixedExpressionValue("'due'", "due"),
+        ),
+        allowOtherValue = false
+      )
+    ),
+    valueCompileTimeValidation = None
+  )
+
+  private val fragmentRawStringParameter = FragmentParameter(
+    ParameterName("paramRawString"),
+    FragmentClazzRef[java.lang.String],
+    initialValue = None,
+    hintText = None,
+    valueEditor = None,
+    valueCompileTimeValidation = None
+  )
+
+  private def exampleFragment(parameter: FragmentParameter) = ScenarioBuilder
+    .fragmentWithRawParameters("fragment", parameter)
+    .fragmentOutput("fragmentEnd", "output", "out" -> "'hola'".spel)
 
   "The endpoint for capabilities should" - {
     "return valid capabilities for scenario with all capabilities" in {
@@ -172,6 +205,122 @@ class TestingApiHttpServiceSpec
              |""".stripMargin
         )
     }
+    "generate parameters for fragment with fixed list parameter" in {
+      val fragment = exampleFragment(fragmentFixedParameter)
+      given()
+        .applicationState {
+          createSavedScenario(fragment)
+        }
+        .when()
+        .basicAuthAllPermUser()
+        .jsonBody(canonicalGraphStr(fragment))
+        .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${fragment.name}/parameters")
+        .Then()
+        .statusCode(200)
+        .equalsJsonBody(
+          s"""[
+             |    {
+             |        "sourceId": "fragment",
+             |        "parameters": [
+             |            {
+             |                "name": "paramFixedString",
+             |                "typ": {
+             |                    "display": "String",
+             |                    "type": "TypedClass",
+             |                    "refClazzName": "java.lang.String",
+             |                    "params": [
+             |
+             |                    ]
+             |                },
+             |                "editor": {
+             |                    "possibleValues": [
+             |                        {
+             |                            "expression": "",
+             |                            "label": ""
+             |                        },
+             |                        {
+             |                            "expression": "'uno'",
+             |                            "label": "uno"
+             |                        },
+             |                        {
+             |                            "expression": "'due'",
+             |                            "label": "due"
+             |                        }
+             |                    ],
+             |                    "type": "FixedValuesParameterEditor"
+             |                },
+             |                "defaultValue": {
+             |                    "language": "spel",
+             |                    "expression": "'uno'"
+             |                },
+             |                "additionalVariables": {
+             |
+             |                },
+             |                "variablesToHide": [
+             |
+             |                ],
+             |                "branchParam": false,
+             |                "hintText": null,
+             |                "label": "paramFixedString",
+             |                "requiredParam": false
+             |            }
+             |        ]
+             |    }
+             |]
+             |""".stripMargin
+        )
+    }
+    "Generate parameters with simplified (single) editor for fragment with raw string parameter" in {
+      val fragment = exampleFragment(fragmentRawStringParameter)
+      given()
+        .applicationState {
+          createSavedScenario(fragment)
+        }
+        .when()
+        .basicAuthAllPermUser()
+        .jsonBody(canonicalGraphStr(fragment))
+        .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${fragment.name}/parameters")
+        .Then()
+        .statusCode(200)
+        .equalsJsonBody(
+          s"""[
+             |    {
+             |        "sourceId": "fragment",
+             |        "parameters": [
+             |            {
+             |                "name": "paramRawString",
+             |                "typ": {
+             |                    "display": "String",
+             |                    "type": "TypedClass",
+             |                    "refClazzName": "java.lang.String",
+             |                    "params": [
+             |
+             |                    ]
+             |                },
+             |                "editor": {
+             |                    "type": "StringParameterEditor"
+             |                },
+             |                "defaultValue": {
+             |                    "language": "spel",
+             |                    "expression": ""
+             |                },
+             |                "additionalVariables": {
+             |
+             |                },
+             |                "variablesToHide": [
+             |
+             |                ],
+             |                "branchParam": false,
+             |                "hintText": null,
+             |                "label": "paramRawString",
+             |                "requiredParam": false
+             |            }
+             |        ]
+             |    }
+             |]
+             |""".stripMargin
+        )
+    }
     "return error if scenario does not exists" in {
       val notExistingScenarioName = exampleScenario.name.value + "_2"
       given()
@@ -249,4 +398,7 @@ class TestingApiHttpServiceSpec
 
   private val exampleScenarioGraph    = CanonicalProcessConverter.toScenarioGraph(exampleScenario)
   private val exampleScenarioGraphStr = Encoder[ScenarioGraph].apply(exampleScenarioGraph).toString()
+
+  private def canonicalGraphStr(canonical: CanonicalProcess) =
+    Encoder[ScenarioGraph].apply(CanonicalProcessConverter.toScenarioGraph(canonical)).toString()
 }

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -20,10 +20,11 @@
 
 ### 1.18.0 (Not released yet)
 
-* [6944](https://github.com/TouK/nussknacker/pull/6944) Changes around adhoc testing feature
+* [6944](https://github.com/TouK/nussknacker/pull/6944) [7166](https://github.com/TouK/nussknacker/pull/7166) Changes around adhoc testing feature
   * `test-with-form` button was renamed to `adhoc-testing`
   * Improved form validators inside adhoc tests (validation was moved to backend)
   * Moved `testInfo/*` endpoints to `scenarioTesting/` path and rewrite then using Tapir
+  * Fix method `assignUserFriendlyEditor` not to change all String parameter editors to simple `StringParameterEditor` 
 * Batch processing mode related improvements:
   * [#6692](https://github.com/TouK/nussknacker/pull/6692) Kryo serializers for `UnmodifiableCollection`, `scala.Product` etc.
     are registered based on class of Serializer instead of instance of Serializer. Thanks to this change, it is possible to use `RAW<>`

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/build/GraphBuilder.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/build/GraphBuilder.scala
@@ -108,6 +108,17 @@ trait GraphBuilder[R] {
       )
     )
 
+  def fragmentInputWithRawParameters(id: String, params: FragmentParameter*): GraphBuilder[SourceNode] =
+    new SimpleGraphBuilder(
+      SourceNode(
+        FragmentInputDefinition(
+          id = id,
+          parameters = params.toList
+        ),
+        _
+      )
+    )
+
   def fragmentOutput(id: String, outputName: String, params: (String, Expression)*): R =
     creator(EndingNode(FragmentOutputDefinition(id, outputName, params.map(kv => Field(kv._1, kv._2)).toList)))
 

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/build/ScenarioBuilder.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/build/ScenarioBuilder.scala
@@ -7,7 +7,8 @@ import pl.touk.nussknacker.engine.build.GraphBuilder.Creator
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.graph.EspProcess
 import pl.touk.nussknacker.engine.graph.expression.Expression
-import pl.touk.nussknacker.engine.graph.node.SourceNode
+import pl.touk.nussknacker.engine.graph.node.FragmentInputDefinition.FragmentParameter
+import pl.touk.nussknacker.engine.graph.node.{SourceNode, SubsequentNode}
 
 class ProcessMetaDataBuilder private[build] (metaData: MetaData) {
 
@@ -120,16 +121,22 @@ object ScenarioBuilder {
     new ProcessMetaDataBuilder(MetaData(id, RequestResponseMetaData(Some(slug))))
 
   def fragmentWithInputNodeId(id: String, inputNodeId: String, params: (String, Class[_])*): ProcessGraphBuilder = {
-    new ProcessGraphBuilder(
-      GraphBuilder
-        .fragmentInput(inputNodeId, params: _*)
-        .creator
-        .andThen(r => EspProcess(MetaData(id, FragmentSpecificData()), NonEmptyList.of(r)).toCanonicalProcess)
-    )
+    createFragment(id, GraphBuilder.fragmentInput(inputNodeId, params: _*))
+  }
+
+  def fragmentWithRawParameters(id: String, params: FragmentParameter*): ProcessGraphBuilder = {
+    createFragment(id, GraphBuilder.fragmentInputWithRawParameters(id, params: _*))
   }
 
   def fragment(id: String, params: (String, Class[_])*): ProcessGraphBuilder = {
     fragmentWithInputNodeId(id, id, params: _*)
+  }
+
+  private def createFragment(id: String, graphBuilder: GraphBuilder[SourceNode]): ProcessGraphBuilder = {
+    new ProcessGraphBuilder(
+      graphBuilder.creator
+        .andThen(r => EspProcess(MetaData(id, FragmentSpecificData()), NonEmptyList.of(r)).toCanonicalProcess)
+    )
   }
 
 }


### PR DESCRIPTION
## Describe your changes

Method `assignUserFriendlyEditor` was mapping all String type value editors to simple string editor - even fixed lists with possible value of type `String`

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new Activities panel for better organization of scenario activities.
  - Enhanced fragment handling with new methods for creating fragments using raw parameters.
  - Added support for dual parameter editing in UI source parameters.
  - Improved testing capabilities for fragments and their parameters.
  - Enhanced end-to-end tests with more specific assertions and error handling.

- **Bug Fixes**
  - Improved error handling for API endpoints, returning appropriate status codes.

- **Documentation**
  - Updated changelog to reflect new features, enhancements, and bug fixes in version 1.18.

- **Chores**
  - Updated import statements and refactored code for improved organization and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->