### PR TITLE
[NU-1891] remove autocompletion from markdown editors

### DIFF
--- a/designer/client/src/components/graph/node-modal/editors/expression/AceWrapper.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/AceWrapper.tsx
@@ -25,18 +25,18 @@ export interface AceWrapperProps extends Pick<IAceEditorProps, "value" | "onChan
     customAceEditorCompleter?;
     showLineNumbers?: boolean;
     commands?: AceKeyCommand[];
+    enableLiveAutocompletion?: boolean;
 }
 
 export const DEFAULT_OPTIONS: IAceOptions = {
     indentedSoftWrap: false, //removes weird spaces for multiline strings when wrapEnabled=true
-    enableLiveAutocompletion: true,
     enableSnippets: false,
     fontSize: 14,
     highlightActiveLine: false,
     highlightGutterLine: true,
 };
 
-const DEFAULF_EDITOR_PROPS: IEditorProps = {
+const DEFAULT_EDITOR_PROPS: IEditorProps = {
     $blockScrolling: true,
 };
 
@@ -133,7 +133,15 @@ function editorLangToMode(language: ExpressionLang | string, editorMode?: Editor
 }
 
 export default forwardRef(function AceWrapper(
-    { inputProps, customAceEditorCompleter, showLineNumbers, wrapEnabled = true, commands = [], ...props }: AceWrapperProps,
+    {
+        inputProps,
+        customAceEditorCompleter,
+        showLineNumbers,
+        wrapEnabled = true,
+        commands = [],
+        enableLiveAutocompletion = true,
+        ...props
+    }: AceWrapperProps,
     ref: ForwardedRef<ReactAce>,
 ): JSX.Element {
     const { language, readOnly, rows = 1, editorMode } = inputProps;
@@ -183,9 +191,10 @@ export default forwardRef(function AceWrapper(
             className={readOnly ? " read-only" : ""}
             wrapEnabled={!!wrapEnabled}
             showGutter={!!showLineNumbers}
-            editorProps={DEFAULF_EDITOR_PROPS}
+            editorProps={DEFAULT_EDITOR_PROPS}
             setOptions={{
                 ...DEFAULT_OPTIONS,
+                enableLiveAutocompletion,
                 showLineNumbers,
             }}
             enableBasicAutocompletion={customAceEditorCompleter && [customAceEditorCompleter]}

--- a/designer/client/src/components/graph/node-modal/editors/expression/CustomCompleterAceEditor.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/CustomCompleterAceEditor.tsx
@@ -28,10 +28,11 @@ export type CustomCompleterAceEditorProps = {
     showValidation?: boolean;
     isMarked?: boolean;
     className?: string;
+    enableLiveAutocompletion?: boolean;
 };
 
 export function CustomCompleterAceEditor(props: CustomCompleterAceEditorProps): JSX.Element {
-    const { className, isMarked, showValidation, fieldErrors, validationLabelInfo, completer, isLoading } = props;
+    const { className, isMarked, showValidation, fieldErrors, validationLabelInfo, completer, isLoading, enableLiveAutocompletion } = props;
     const { value, onValueChange, ref, ...inputProps } = props.inputProps;
 
     const [editorFocused, setEditorFocused] = useState(false);
@@ -65,6 +66,7 @@ export function CustomCompleterAceEditor(props: CustomCompleterAceEditorProps): 
                             ...inputProps,
                         }}
                         customAceEditorCompleter={completer}
+                        enableLiveAutocompletion={enableLiveAutocompletion}
                     />
                 </Box>
                 <Fade

--- a/designer/client/src/components/graph/node-modal/editors/field/MarkdownFormControl.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/field/MarkdownFormControl.tsx
@@ -15,6 +15,7 @@ export const MarkdownFormControl = ({ value, onChange, className, children, read
         {children}
         <CustomCompleterAceEditor
             {...props}
+            enableLiveAutocompletion={false}
             inputProps={{
                 language: ExpressionLang.MD,
                 className,

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -100,6 +100,7 @@
 * [#7099](https://github.com/TouK/nussknacker/pull/7099) Provide an option to embedded video to the markdown
 * [#7102](https://github.com/TouK/nussknacker/pull/7102) Introduce a new UI to defining aggregations within nodes
 * [#7147](https://github.com/TouK/nussknacker/pull/7147) Fix redundant "ParameterName(...)" wrapper string in exported PDFs in nodes details 
+* [#7178](https://github.com/TouK/nussknacker/pull/7178) Remove autocompletion from markdown editors
 
 ## 1.17
 


### PR DESCRIPTION
## Describe your changes
Before:

https://github.com/user-attachments/assets/d869d7ff-c9cf-41ac-9b18-7fcaa0111d51

After:

https://github.com/user-attachments/assets/908fb757-6acf-4ff6-b64b-3835bb7a5194

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `enableLiveAutocompletion` property for enhanced configurability in the Ace editor components.
	- Added a new Activities panel for improved browsing of scenario activities.
	- Enhanced SpEL with new utility methods and navigation features.
	- Improved user experience with a revamped UI for aggregation definitions and better validation handling.

- **Bug Fixes**
	- Corrected a typo in the editor props constant name.

- **Documentation**
	- Updated changelog to reflect significant updates, enhancements, and breaking changes in version 1.18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->