### PR TITLE
[Nu-1889] provide an unique validation message to the scenario labels

### DIFF
--- a/designer/client/cypress/e2e/labels.cy.ts
+++ b/designer/client/cypress/e2e/labels.cy.ts
@@ -33,6 +33,14 @@ describe("Scenario labels", () => {
 
             cy.get("[data-testid=scenario-label-0]").should("be.visible").contains("tagX");
 
+            cy.get("@labelInput").should("be.visible").click().type("tagX");
+
+            cy.wait("@labelvalidation");
+
+            cy.get("@labelInput").should("be.visible").contains("This label already exists. Please enter a unique value.");
+
+            cy.get("@labelInput").find("input").clear();
+
             cy.get("@labelInput").should("be.visible").click().type("tag2");
 
             cy.wait("@labelvalidation");

--- a/designer/client/src/components/toolbars/scenarioDetails/ScenarioLabels.tsx
+++ b/designer/client/src/components/toolbars/scenarioDetails/ScenarioLabels.tsx
@@ -26,6 +26,8 @@ interface AddLabelProps {
     onClick: () => void;
 }
 
+const labelUniqueValidation = (label: string) => ({ label, messages: ["This label already exists. Please enter a unique value."] });
+
 const AddLabel = ({ onClick }: AddLabelProps) => {
     return (
         <Typography
@@ -125,9 +127,12 @@ export const ScenarioLabels = ({ readOnly }: Props) => {
         setIsEdited(true);
     };
 
-    const isInputInSelectedOptions = (inputValue: string): boolean => {
-        return scenarioLabelOptions.some((option) => inputValue === toLabelValue(option));
-    };
+    const isInputInSelectedOptions = useCallback(
+        (inputValue: string): boolean => {
+            return scenarioLabelOptions.some((option) => inputValue === toLabelValue(option));
+        },
+        [scenarioLabelOptions],
+    );
 
     const inputHelperText = useMemo(() => {
         if (inputErrors.length !== 0) {
@@ -151,9 +156,13 @@ export const ScenarioLabels = ({ readOnly }: Props) => {
                 }
             }
 
+            if (isInputInSelectedOptions(newInput)) {
+                setInputErrors((prevState) => [...prevState, labelUniqueValidation(newInput)]);
+            }
+
             setInputTyping(false);
         }, 500);
-    }, []);
+    }, [isInputInSelectedOptions]);
 
     const validateSelectedOptions = useMemo(() => {
         return debounce(async (labels: LabelOption[]) => {

--- a/designer/client/src/components/toolbars/scenarioDetails/ScenarioLabels.tsx
+++ b/designer/client/src/components/toolbars/scenarioDetails/ScenarioLabels.tsx
@@ -26,7 +26,12 @@ interface AddLabelProps {
     onClick: () => void;
 }
 
-const labelUniqueValidation = (label: string) => ({ label, messages: ["This label already exists. Please enter a unique value."] });
+const labelUniqueValidation = (label: string) => ({
+    label,
+    messages: [
+        i18next.t("panels.scenarioDetails.labels.validation.uniqueValue", "This label already exists. Please enter a unique value."),
+    ],
+});
 
 const AddLabel = ({ onClick }: AddLabelProps) => {
     return (

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -100,6 +100,7 @@
 * [#7099](https://github.com/TouK/nussknacker/pull/7099) Provide an option to embedded video to the markdown
 * [#7102](https://github.com/TouK/nussknacker/pull/7102) Introduce a new UI to defining aggregations within nodes
 * [#7147](https://github.com/TouK/nussknacker/pull/7147) Fix redundant "ParameterName(...)" wrapper string in exported PDFs in nodes details 
+* [#7182](https://github.com/TouK/nussknacker/pull/7182) Provide an unique validation message to the scenario labels
 
 ## 1.17
 


### PR DESCRIPTION
## Describe your changes
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/378b79cd-2959-4db9-91a0-ac75129648f0">

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [x] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced validation for scenario labels, ensuring uniqueness and appropriate error messaging for duplicate or excessively long labels.
	- Introduction of a new Activities panel for better organization of scenario activities.
	- New scenario labels feature to improve scenario management and retrieval.

- **Bug Fixes**
	- Improved error handling and user feedback for label input validation.

- **Documentation**
	- Updated changelog to reflect new features, improvements, and breaking changes in version 1.18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->