### PR TITLE
Fix spel template default expression

### DIFF
--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorPossibleValuesBasedDefaultValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorPossibleValuesBasedDefaultValueDeterminer.scala
@@ -4,6 +4,7 @@ import pl.touk.nussknacker.engine.api.definition.{
   DictParameterEditor,
   DualParameterEditor,
   FixedValuesParameterEditor,
+  SpelTemplateParameterEditor,
   TabularTypedDataEditor
 }
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language
@@ -21,6 +22,8 @@ protected object EditorPossibleValuesBasedDefaultValueDeterminer extends Paramet
           Some(Expression.spel(firstValue.expression))
         case TabularTypedDataEditor =>
           Some(Expression.tabularDataDefinition(TabularTypedData.empty.stringify))
+        case SpelTemplateParameterEditor =>
+          Some(Expression.spelTemplate(""))
         case DictParameterEditor(_) => Some(Expression(Language.DictKeyWithLabel, ""))
         case _                      => None
       }


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a default expression for the `SpelTemplateParameterEditor`, enhancing the user experience by providing a predefined value.
- **Bug Fixes**
	- Ensured existing logic remains intact for other parameter editors, maintaining stability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->