### PR TITLE
change fe dev progressBar chars

### DIFF
--- a/designer/client/progressBar.js
+++ b/designer/client/progressBar.js
@@ -19,7 +19,7 @@ function getElapsed() {
 
 function getBar(percentage) {
     const { barLength, almostDone } = options;
-    const bar = padEnd(repeat("◼︎", Math.ceil(percentage * barLength)), barLength, "□");
+    const bar = padEnd(repeat("◼", Math.ceil(percentage * barLength)), barLength, "_");
     const barColor = percentage > almostDone ? chalk.green : percentage > (almostDone * 2) / 3 ? chalk.yellow : chalk.red;
     return barColor(bar);
 }


### PR DESCRIPTION
just an aesthetic change. the problem was probably only visible in Idea

from this:
<img width="1468" alt="Zrzut ekranu 2024-11-22 o 19 24 09" src="https://github.com/user-attachments/assets/68392c79-4799-4838-97b2-b60ac16a8ca5">

to this:
<img width="1463" alt="Zrzut ekranu 2024-11-22 o 19 23 39" src="https://github.com/user-attachments/assets/b9c6925c-c305-4fe3-a07f-b3313aab0682">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the visual representation of the progress bar with new characters for filled and empty portions.

- **Bug Fixes**
	- Ensured that visual feedback remains consistent with previous functionality despite character changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->