### PR TITLE
Fix: ToJsonEncoder keeps order fields during encoding map

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -20,6 +20,7 @@
 
 ### 1.18.1 (Not released yet)
 
+* [#7207](https://github.com/TouK/nussknacker/pull/7207) Fixed minor clipboard, keyboard and focus related bugs
 * [#7237](https://github.com/TouK/nussknacker/pull/7237) Fix: ToJsonEncoder keeps order fields during encoding map
 
 ### 1.18.0 (22 November 2024)
@@ -113,10 +114,6 @@
 * [#7192](https://github.com/TouK/nussknacker/pull/7192) Fix "Failed to get node validation" when opening node details referencing non-existing component
 * [#7190](https://github.com/TouK/nussknacker/pull/7190) Fix "Failed to get node validation" when opening fragment node details for referencing non-existing fragment 
 * [#7215](https://github.com/TouK/nussknacker/pull/7215) Change typing text to spinner during validation and provide delayed adding on enter until validation finishes in a scenario labels and fragment input
-
-### 1.18.1 (Not released yet)
-
-* [#7207](https://github.com/TouK/nussknacker/pull/7207) Fixed minor clipboard, keyboard and focus related bugs
 
 ## 1.17
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -18,6 +18,10 @@
 * Flink upgrade to 1.19.1. Note: it is possible to use Nussknacker with older versions of Flink, but it requires some extra steps. See [Migration guide](MigrationGuide.md) for details.
 * Performance optimisations of the serialisation of events passing through Flink's `DataStream`s.
 
+### 1.18.1 (Not released yet)
+
+* [#7237](https://github.com/TouK/nussknacker/pull/7237) Fix: ToJsonEncoder keeps order fields during encoding map
+
 ### 1.18.0 (22 November 2024)
 
 * [#6944](https://github.com/TouK/nussknacker/pull/6944) [#7166](https://github.com/TouK/nussknacker/pull/7166) Changes around adhoc testing feature

--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoder.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoder.scala
@@ -10,8 +10,9 @@ import pl.touk.nussknacker.engine.api.DisplayJson
 import pl.touk.nussknacker.engine.util.Implicits._
 
 import java.util.ServiceLoader
-
 import java.util.UUID
+import scala.collection.SeqMap
+import scala.collection.immutable.ListMap
 import scala.jdk.CollectionConverters._
 
 object ToJsonEncoder {
@@ -88,9 +89,13 @@ case class ToJsonEncoder(
   // TODO: make encoder aware of NU Types to encode things like multiset differently. Right now its handled by calling
   //  toString on keys.
   private def encodeMap(map: Map[_, _]) = {
-    val mapWithStringKeys = map.view.map { case (k, v) =>
-      k.toString -> v
-    }.toMap
+    // TODO: Switch to SeqMap after removing support for Scala 2.12
+    val mapWithStringKeys = ListMap.from(
+      map.toList.map { case (k, v) =>
+        k.toString -> v
+      }
+    )
+
     fromFields(mapWithStringKeys.mapValuesNow(encode))
   }
 

--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoder.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoder.scala
@@ -65,15 +65,14 @@ case class ToJsonEncoder(
           case a: OffsetDateTime => Encoder[OffsetDateTime].apply(a)
           case a: UUID           => safeString(a.toString)
           case a: DisplayJson    => a.asJson
-          case a: scala.collection.immutable.ListMap[_, _] => encodeListMap(a)
-          case a: scala.collection.Map[_, _]               => encodeMap(a.toMap)
-          case a: java.util.Map[_, _]                      => encodeMap(a.asScala.toMap)
-          case a: Iterable[_]                              => fromValues(a.map(encode))
-          case a: Enum[_]                                  => safeString(a.toString)
-          case a: java.util.Collection[_]                  => fromValues(a.asScala.map(encode))
-          case a: Array[_]                                 => fromValues(a.map(encode))
-          case _ if !failOnUnknown                         => safeString(any.toString)
-          case a => throw new IllegalArgumentException(s"Invalid type: ${a.getClass}")
+          case a: scala.collection.Map[_, _] => encodeMap(a.toMap)
+          case a: java.util.Map[_, _]        => encodeMap(a.asScala.toMap)
+          case a: Iterable[_]                => fromValues(a.map(encode))
+          case a: Enum[_]                    => safeString(a.toString)
+          case a: java.util.Collection[_]    => fromValues(a.asScala.map(encode))
+          case a: Array[_]                   => fromValues(a.map(encode))
+          case _ if !failOnUnknown           => safeString(any.toString)
+          case a                             => throw new IllegalArgumentException(s"Invalid type: ${a.getClass}")
         }
     )
 
@@ -83,20 +82,12 @@ case class ToJsonEncoder(
       case None            => Null
     }
 
-  private def encodeListMap(value: scala.collection.immutable.ListMap[_, _]): Json = {
-    val mapWithStringKeys = value.view.map { case (k, v) =>
-      k.toString -> encode(v)
-    }
-
-    fromFields(mapWithStringKeys)
-  }
-
   // TODO: make encoder aware of NU Types to encode things like multiset differently. Right now its handled by calling
   //  toString on keys.
   private def encodeMap(map: Map[_, _]) = {
     val mapWithStringKeys = map.view.map { case (k, v) =>
       k.toString -> encode(v)
-    }.toMap
+    }
 
     fromFields(mapWithStringKeys)
   }

--- a/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoderSpec.scala
+++ b/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoderSpec.scala
@@ -9,7 +9,6 @@ import pl.touk.nussknacker.test.ClassLoaderWithServices
 import java.time._
 import java.util
 import java.util.UUID
-import scala.collection.SeqMap
 import scala.collection.immutable.{ListMap, ListSet}
 
 class ToJsonEncoderSpec extends AnyFunSpec with Matchers {
@@ -111,13 +110,11 @@ class ToJsonEncoderSpec extends AnyFunSpec with Matchers {
       "booleanValue"  -> true
     )
 
-    encoder.encode(map) shouldBe Json.obj(
-      "intNumber"     -> fromInt(42),
-      "floatNumber"   -> fromFloatOrNull(42.42f),
-      "someTimestamp" -> fromLong(1496930555793L),
-      "someString"    -> fromString("hello"),
-      "booleanValue"  -> fromBoolean(true),
-    )
+    val expectedJson =
+      """{"intNumber":42,"floatNumber":42.42,"someTimestamp":1496930555793,"someString":"hello","booleanValue":true}"""
+
+    // We compare string because we want to check the order
+    encoder.encode(map).noSpaces shouldBe expectedJson
   }
 
 }

--- a/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoderSpec.scala
+++ b/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/json/ToJsonEncoderSpec.scala
@@ -9,6 +9,7 @@ import pl.touk.nussknacker.test.ClassLoaderWithServices
 import java.time._
 import java.util
 import java.util.UUID
+import scala.collection.SeqMap
 import scala.collection.immutable.{ListMap, ListSet}
 
 class ToJsonEncoderSpec extends AnyFunSpec with Matchers {
@@ -99,6 +100,24 @@ class ToJsonEncoderSpec extends AnyFunSpec with Matchers {
       )
     }
 
+  }
+
+  it("should convert map to json and keep order of keys") {
+    val map = ListMap(
+      "intNumber"     -> 42,
+      "floatNumber"   -> 42.42,
+      "someTimestamp" -> 1496930555793L,
+      "someString"    -> "hello",
+      "booleanValue"  -> true
+    )
+
+    encoder.encode(map) shouldBe Json.obj(
+      "intNumber"     -> fromInt(42),
+      "floatNumber"   -> fromFloatOrNull(42.42f),
+      "someTimestamp" -> fromLong(1496930555793L),
+      "someString"    -> fromString("hello"),
+      "booleanValue"  -> fromBoolean(true),
+    )
   }
 
 }


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON encoding to maintain the order of keys when converting maps.

- **Tests**
	- Added a test case to verify that maps are encoded to JSON while preserving the order of keys.

- **Documentation**
	- Updated changelog to include new features, improvements, and fixes, including the ToJsonEncoder enhancement and other version updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->