### PR TITLE
Use component name instead of id in statistics

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/ScenarioStatistics.scala
@@ -28,6 +28,8 @@ object ScenarioStatistics {
 
   private val nameForFragment = "Fragment"
 
+  private val sameNameForComponentInDifferentGroups = List("kafka", "table")
+
   private def fromNussknackerPackage(component: ComponentDefinitionWithImplementation): Boolean =
     component.component.getClass.getPackageName.startsWith("pl.touk.nussknacker")
 
@@ -166,7 +168,9 @@ object ScenarioStatistics {
           val componentIdOrCustom = components.find(_.designerWideId == designerWideId) match {
             case Some(componentDefinition) =>
               if (fromNussknackerPackage(componentDefinition)) {
-                componentDefinition.id.toString
+                if (sameNameForComponentInDifferentGroups.contains(componentDefinition.name))
+                  componentDefinition.id.toString
+                else componentDefinition.name
               } else nameForCustom
             case None => nameForFragment
           }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/StatisticsApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/StatisticsApiHttpServiceBusinessSpec.scala
@@ -184,7 +184,7 @@ class StatisticsApiHttpServiceBusinessSpec
           (RequestIdStat.name, matchesRegex(uuidRegex)),
           (DesignerUptimeInSeconds.name, matchesRegex("\\d+")),
           //  TODO: Should make a proper test for component mapping
-          ("c_bltnfltr", equalTo("1"))
+          ("c_fltr", equalTo("1"))
         )
     }
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsServiceTest.scala
@@ -140,9 +140,9 @@ class UsageStatisticsReportsSettingsServiceTest
       .map(url => StatisticEncryptionSupport.decodeToString(url.toString))
       .head
 
-    url should include("c_srvcccntsrvc=5")
+    url should include("c_ccntsrvc=5")
     url should include("c_cstm=2")
-    url shouldNot include("c_bltnchc")
+    url shouldNot include("c_chc")
   }
 
   test("should combined statistics for all scenarios") {
@@ -195,7 +195,7 @@ class UsageStatisticsReportsSettingsServiceTest
       LiteEmbeddedDMCount    -> 0,
       UnknownDMCount         -> 0,
       ActiveScenarioCount    -> 2,
-      "c_srvcccntsrvc"       -> 5,
+      "c_ccntsrvc"           -> 5,
       "c_cstm"               -> 2,
     ).map { case (k, v) => (k.toString, v.toString) }
 


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [x] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced component name representation in statistics for better clarity when components share identifiers across different groups.
  
- **Bug Fixes**
	- Updated expected response structure for statistics API endpoints to reflect changes in naming conventions.

- **Tests**
	- Adjusted test cases to align with new expected query parameters and response keys for usage statistics.

- **Style**
	- Minor formatting adjustments made for improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->