### PR TITLE
Fix race conditions failed to instantiate CompiledExpression exception

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -22,7 +22,7 @@
 
 * [#7207](https://github.com/TouK/nussknacker/pull/7207) Fixed minor clipboard, keyboard and focus related bugs
 * [#7237](https://github.com/TouK/nussknacker/pull/7237) Fix: ToJsonEncoder keeps order fields during encoding map
-* [#7240](https://github.com/TouK/nussknacker/pull/7240) Fixed race condition problems when getting value from `ParsedSpelExpression`
+* [#7240](https://github.com/TouK/nussknacker/pull/7240) Fixed race condition problem during SpEL expression evaluation
 
 ### 1.18.0 (22 November 2024)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -22,6 +22,7 @@
 
 * [#7207](https://github.com/TouK/nussknacker/pull/7207) Fixed minor clipboard, keyboard and focus related bugs
 * [#7237](https://github.com/TouK/nussknacker/pull/7237) Fix: ToJsonEncoder keeps order fields during encoding map
+* [#7240](https://github.com/TouK/nussknacker/pull/7240) Fixed race condition problems when getting value from `ParsedSpelExpression`
 
 ### 1.18.0 (22 November 2024)
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
@@ -54,7 +54,7 @@ final case class ParsedSpelExpression(
   @volatile var parsed: Expression = initial
 
   def getValue[T](context: EvaluationContext, desiredResultType: Class[_]): T = {
-    def value(): T = parsed.getValue(context, desiredResultType).asInstanceOf[T]
+    def value(): T = synchronized { parsed.getValue(context, desiredResultType).asInstanceOf[T] }
 
     try {
       value()

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
@@ -58,8 +58,8 @@ final case class ParsedSpelExpression(
   def getValue[T](context: EvaluationContext, desiredResultType: Class[_]): T = {
     def value(): T = {
       // There is a bug in Spring's SpelExpression class: interpretedCount variable is not synchronized with ReflectiveMethodExecutor.didArgumentConversionOccur.
-      // The letter mentioned method check argumentConversionOccurred Boolean which could be false not because conversion not occurred but because method.invoke()
-      // isn't finished yet. Due to this problem we can compile expression which shouldn't be compiled and it generates IllegalStateException errors.
+      // The latter mentioned method check argumentConversionOccurred Boolean which could be false not because conversion not occurred but because method.invoke()
+      // isn't finished yet. Due to this problem an expression that shouldn't be compiled might be compiled. It generates IllegalStateException errors in further evaluations of the expression.
       if (!firstInterpretationFinished.get()) {
         synchronized {
           val valueToReturn = parsed.getValue(context, desiredResultType).asInstanceOf[T]

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
@@ -31,6 +31,7 @@ import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.ExpressionCompil
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser.Flavour
 import pl.touk.nussknacker.engine.spel.internal.EvaluationContextPreparer
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.control.NonFatal
 
 /**
@@ -51,11 +52,22 @@ final case class ParsedSpelExpression(
     parser: () => ValidatedNel[ExpressionParseError, Expression],
     initial: Expression
 ) extends LazyLogging {
-  @volatile var parsed: Expression = initial
+  @volatile var parsed: Expression        = initial
+  private val firstInterpretationFinished = new AtomicBoolean()
 
   def getValue[T](context: EvaluationContext, desiredResultType: Class[_]): T = {
-    def value(): T = synchronized { parsed.getValue(context, desiredResultType).asInstanceOf[T] }
-
+    // This is handled in a safe way as there could be problems with concurrent evaluation due to argument conversions on expression
+    def value(): T = {
+      if (!firstInterpretationFinished.get()) {
+        synchronized {
+          val valueToReturn = parsed.getValue(context, desiredResultType).asInstanceOf[T]
+          firstInterpretationFinished.set(true)
+          valueToReturn
+        }
+      } else {
+        parsed.getValue(context, desiredResultType).asInstanceOf[T]
+      }
+    }
     try {
       value()
     } catch {

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -2055,10 +2055,10 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     parsed.evaluateSync[Any](customCtx) shouldBe 11
     parsed.evaluateSync[Any](customCtx) shouldBe 11
   }
-  /*
-  // This test is commented out as it was indeterministic and ugly, but it was used to verify race condition problems on
+
+  // This test is ignored as it was indeterministic and ugly, but it was used to verify race condition problems on
   // ParsedSpelExpression.getValue. Without the synchronized block inside its method the test would fail the majority of times
-  test(
+  ignore(
     "should not throw 'Failed to instantiate CompiledExpression' when getValue is called on ParsedSpelExpression by multiple threads"
   ) {
     val spelExpression =
@@ -2099,7 +2099,6 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     }
     Await.result(firstFailureOrCompletion, 15.seconds)
   }
-   */
 
 }
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -11,6 +11,7 @@ import org.scalatest.OptionValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.springframework.util.{NumberUtils, StringUtils}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
@@ -67,11 +68,14 @@ import java.nio.charset.{Charset, StandardCharsets}
 import java.time.chrono.{ChronoLocalDate, ChronoLocalDateTime}
 import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId, ZoneOffset}
 import java.util
+import java.util.concurrent.Executors
 import java.util.{Collections, Currency, List => JList, Locale, Map => JMap, Optional, UUID}
 import scala.annotation.varargs
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 import scala.reflect.runtime.universe._
+import scala.util.{Failure, Success}
 
 class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesDetailedMessage with OptionValues {
 
@@ -2051,6 +2055,51 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     parsed.evaluateSync[Any](customCtx) shouldBe 11
     parsed.evaluateSync[Any](customCtx) shouldBe 11
   }
+  /*
+  // This test is commented out as it was indeterministic and ugly, but it was used to verify race condition problems on
+  // ParsedSpelExpression.getValue. Without the synchronized block inside its method the test would fail the majority of times
+  test(
+    "should not throw 'Failed to instantiate CompiledExpression' when getValue is called on ParsedSpelExpression by multiple threads"
+  ) {
+    val spelExpression =
+      parse[LocalDateTime]("T(java.time.LocalDateTime).now().minusDays(14)", ctx).validValue.expression
+        .asInstanceOf[SpelExpression]
+
+    val threadPool                                        = Executors.newFixedThreadPool(1000)
+    implicit val customExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(threadPool)
+
+    // A promise to signal when an exception occurs
+    val failurePromise = Promise[Unit]()
+
+    val tasks = (1 to 10000).map { _ =>
+      Future {
+        try {
+          Thread.sleep(100)
+          // evaluate calls getValue on problematic SpelExpression object
+          spelExpression.evaluate[LocalDateTime](Context("fooId"), Map.empty)
+        } catch {
+          // The real problematic exception is wrapped in SpelExpressionEvaluationException by evaluate method
+          case e: SpelExpressionEvaluationException =>
+            failurePromise.tryFailure(e.cause)
+        }
+      }
+    }
+    val firstFailureOrCompletion = Future.firstCompletedOf(Seq(Future.sequence(tasks), failurePromise.future))
+
+    firstFailureOrCompletion.onComplete {
+      case Success(_) =>
+        println("All tasks completed successfully.")
+        threadPool.shutdown()
+      case Failure(e: IllegalStateException) if e.getMessage == "Failed to instantiate CompiledExpression" =>
+        fail("Exception occurred due to race condition.", e)
+        threadPool.shutdown()
+      case Failure(e) =>
+        fail("Unknown exception occurred", e)
+        threadPool.shutdown()
+    }
+    Await.result(firstFailureOrCompletion, 15.seconds)
+  }
+   */
 
 }
 


### PR DESCRIPTION
## Describe your changes

At our Nussknacker instance we noticed that sometimes there can be problems with evaluating some expressions at runetime and because of that we sometimes lose a few events.

For example we had a problematic expression `"T(java.time.LocalDateTime).now().minusDays(14)"` which caused these exceptions when there was an implicit conversion to `Long` value from `Int`. This is collapsed stacktrace of the exception:

<details>
  <summary>
    Click to expand stacktrace
  </summary>
java.lang.IllegalStateException: Failed to instantiate CompiledExpression
	at org.springframework.expression.spel.standard.SpelCompiler.compile(SpelCompiler.java:113)
	at org.springframework.expression.spel.standard.SpelExpression.compileExpression(SpelExpression.java:526)
	at org.springframework.expression.spel.standard.SpelExpression.checkCompile(SpelExpression.java:491)
	at org.springframework.expression.spel.standard.SpelExpression.getValue(SpelExpression.java:309)
	at pl.touk.nussknacker.engine.spel.ParsedSpelExpression.value$1(SpelExpression.scala:57)
	at pl.touk.nussknacker.engine.spel.ParsedSpelExpression.getValue(SpelExpression.scala:60)
	at pl.touk.nussknacker.engine.spel.SpelExpression.$anonfun$evaluate$1(SpelExpression.scala:110)
	at pl.touk.nussknacker.engine.spel.SpelExpression.logOnException(SpelExpression.scala:115)
	at pl.touk.nussknacker.engine.spel.SpelExpression.evaluate(SpelExpression.scala:105)
	at pl.touk.nussknacker.engine.expression.ExpressionEvaluator.evaluate(ExpressionEvaluator.scala:97)
	at pl.touk.nussknacker.engine.expression.ExpressionEvaluator.evaluateParameter(ExpressionEvaluator.scala:68)
	at pl.touk.nussknacker.engine.expression.ExpressionEvaluator.$anonfun$evaluateParameters$1(ExpressionEvaluator.scala:55)
	at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
	at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
	at scala.collection.immutable.List.foldLeft(List.scala:79)
	at pl.touk.nussknacker.engine.expression.ExpressionEvaluator.evaluateParameters(ExpressionEvaluator.scala:53)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpretNode(Interpreter.scala:73)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpret(Interpreter.scala:41)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpretNext(Interpreter.scala:197)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpretNode(Interpreter.scala:86)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpret(Interpreter.scala:41)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpretNext(Interpreter.scala:197)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpretOptionalNext(Interpreter.scala:188)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpretNode(Interpreter.scala:134)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpret(Interpreter.scala:41)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpretNext(Interpreter.scala:197)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpretNode(Interpreter.scala:74)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpret(Interpreter.scala:41)
	at pl.touk.nussknacker.engine.InterpreterInternal.interpretNext(Interpreter.scala:197)
	at pl.touk.nussknacker.engine.InterpreterInternal.$anonfun$interpretNode$15(Interpreter.scala:127)
	at cats.effect.IOFiber.succeeded(IOFiber.scala:1200)
	at cats.effect.IOFiber.asyncContinueSuccessfulR(IOFiber.scala:1368)
	at cats.effect.IOFiber.run(IOFiber.scala:113)
	at pl.touk.nussknacker.engine.util.SynchronousExecutionContextAndIORuntime$$anon$1.execute(SynchronousExecutionContextAndIORuntime.scala:18)
	at scala.concurrent.impl.ExecutionContextImpl.execute(ExecutionContextImpl.scala:21)
	at cats.effect.IOFiber.scheduleOnForeignEC(IOFiber.scala:1331)
	at cats.effect.IOFiber.scheduleFiber(IOFiber.scala:1315)
	at cats.effect.IOFiber.loop$1(IOFiber.scala:676)
	at cats.effect.IOFiber.stateLoop$1(IOFiber.scala:731)
	at cats.effect.IOFiber.$anonfun$runLoop$1(IOFiber.scala:737)
	at cats.effect.IOFiber.$anonfun$runLoop$1$adapted(IOFiber.scala:627)
	at cats.effect.kernel.Async.$anonfun$fromFuture$5(Async.scala:217)
	at cats.effect.kernel.Async.$anonfun$fromFuture$5$adapted(Async.scala:217)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:484)
	at pl.touk.nussknacker.engine.util.SynchronousExecutionContextAndIORuntime$$anon$1.execute(SynchronousExecutionContextAndIORuntime.scala:18)
	at scala.concurrent.impl.ExecutionContextImpl.execute(ExecutionContextImpl.scala:21)
	at scala.concurrent.impl.Promise$Transformation.submitWithValue(Promise.scala:429)
	at scala.concurrent.impl.Promise$DefaultPromise.submitWithValue(Promise.scala:338)
	at scala.concurrent.impl.Promise$DefaultPromise.tryComplete0(Promise.scala:285)
	at scala.concurrent.impl.Promise$DefaultPromise.linkRootOf(Promise.scala:347)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:478)
	at pl.touk.nussknacker.engine.util.SynchronousExecutionContextAndIORuntime$$anon$1.execute(SynchronousExecutionContextAndIORuntime.scala:18)
	at scala.concurrent.impl.ExecutionContextImpl.execute(ExecutionContextImpl.scala:21)
	at scala.concurrent.impl.Promise$Transformation.submitWithValue(Promise.scala:429)
	at scala.concurrent.impl.Promise$DefaultPromise.submitWithValue(Promise.scala:338)
	at scala.concurrent.impl.Promise$DefaultPromise.tryComplete0(Promise.scala:285)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:504)
	at pl.touk.nussknacker.engine.util.SynchronousExecutionContextAndIORuntime$$anon$1.execute(SynchronousExecutionContextAndIORuntime.scala:18)
	at scala.concurrent.impl.ExecutionContextImpl.execute(ExecutionContextImpl.scala:21)
	at scala.concurrent.impl.Promise$Transformation.submitWithValue(Promise.scala:429)
	at scala.concurrent.impl.Promise$DefaultPromise.submitWithValue(Promise.scala:335)
	at scala.concurrent.impl.Promise$DefaultPromise.tryComplete0(Promise.scala:285)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:504)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.VerifyError: (class: spel/Ex243, method: getValue signature: (Ljava/lang/Object;Lorg/springframework/expression/EvaluationContext;)Ljava/lang/Object;) Expecting to find long on stack
	at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3137)
	at java.base/java.lang.Class.getConstructor0(Class.java:3342)
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2553)
	at org.springframework.util.ReflectionUtils.accessibleConstructor(ReflectionUtils.java:185)
	at org.springframework.expression.spel.standard.SpelCompiler.compile(SpelCompiler.java:110)
	... 65 more
</details>

After analysis it seemed that this expression should not be compiled and instead each time it should be evaluated from the AST (and in the stacktrace we can see that it sometimes behaves differently). After looking at Spel implementation we inferred that it might be caused by some race conditions.

I created a test that creates a lot of Threads trying to evaluate this expression and it fails the majority of the times with the same error and stacktrace proving that this is indeed a problem with race conditions while getting the value. It's not easy to create a test against race conditions so I left it commented out since it's indeterministic and ugly - it was made to verify the root of the problem. 

Putting problematic piece of code into a synchronized block solves this issue. The exception is not thrown and the test passes each time. 

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new Activities panel consolidating scenario activities.
	- Added scenario labels for better organization and retrieval.
	- Enhanced SpEL with navigation through fields in unknown types and new conversion methods.
	- Upgraded Flink to version 1.19.1 with performance optimizations for event serialization.

- **Bug Fixes**
	- Fixed race condition issues during SpEL expression evaluation.
	- Resolved minor clipboard, keyboard, and focus-related bugs.

- **Improvements**
	- Enhanced UI for aggregation definitions and improved validation handling in ad-hoc tests.
	- Performance optimizations for Avro processing and component configuration reloading.

- **Documentation**
	- Changelog updated to reflect new features, improvements, and bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->