### PR TITLE
[NU-1897] flink-executor and lite-runtime modules: Added compile-time dependency to http-utils

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1711,6 +1711,7 @@ lazy val httpUtils = (project in utils("http-utils"))
         "com.softwaremill.sttp.client3" %% "json-common"                      % sttpV,
         "com.softwaremill.sttp.client3" %% "circe"                            % sttpV,
         "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % sttpV,
+        "io.netty"                       % "netty-transport-native-epoll"     % nettyV,
       )
     }
   )
@@ -1728,19 +1729,18 @@ lazy val openapiComponents = (project in component("openapi"))
   .settings(
     name := "nussknacker-openapi",
     libraryDependencies ++= Seq(
-      "io.swagger.core.v3" % "swagger-integration"          % swaggerIntegrationV excludeAll (
+      "io.swagger.core.v3" % "swagger-integration"  % swaggerIntegrationV excludeAll (
         ExclusionRule(organization = "jakarta.activation"),
         ExclusionRule(organization = "jakarta.validation")
       ),
-      "io.netty"           % "netty-transport-native-epoll" % nettyV,
-      "org.apache.flink"   % "flink-streaming-java"         % flinkV     % Provided,
-      "org.scalatest"     %% "scalatest"                    % scalaTestV % "it,test"
+      "org.apache.flink"   % "flink-streaming-java" % flinkV     % Provided,
+      "org.scalatest"     %% "scalatest"            % scalaTestV % "it,test"
     ),
   )
   .dependsOn(
     componentsUtils                % Provided,
     jsonUtils                      % Provided,
-    httpUtils,
+    httpUtils                      % Provided,
     requestResponseComponentsUtils % "it,test",
     flinkComponentsTestkit         % "it,test"
   )

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -15,8 +15,11 @@
 * [#7123](https://github.com/TouK/nussknacker/pull/7123) Fix deployments for scenarios with dict editors after model reload
 * [#7162](https://github.com/TouK/nussknacker/pull/7162) Component API enhancement: ability to access information about
   expression parts used in SpEL template
-* [#7257](https://github.com/TouK/nussknacker/pull/7257) components-api module: Replaced wide dependency to `async-http-client-backend-future`
-  by the narrowest possible dependency to sttp's core
+* async-http-client and Netty dependency cleanups
+  * [#7257](https://github.com/TouK/nussknacker/pull/7257) `components-api` module: Replaced wide dependency to `async-http-client-backend-future`
+    by the narrowest possible dependency to sttp's core
+  * [#7259](https://github.com/TouK/nussknacker/pull/7259) `flink-executor` and `lite-runtime` modules: Added compile-time
+    dependency to `http-utils` (which depends on `async-http-client-backend-future` and indirectly on Netty) 
 
 ## 1.18
 

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -9,8 +9,11 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 * [#7116](https://github.com/TouK/nussknacker/pull/7116) Improve missing Flink Kafka Source / Sink TypeInformation
   * We lost support for old ConsumerRecord constructor supported by Flink 1.14 / 1.15 
   * If you used Kafka source/sink components in your scenarios then state of these scenarios won't be restored
-* [#7257](https://github.com/TouK/nussknacker/pull/7257) `components-api` doesn't depend on `async-http-client-backend-future`.
-  Instead, it depends on sttp's core. If your component rely on this, you should explicitly add dependency to `async-http-client-backend-future`.
+* [#7257](https://github.com/TouK/nussknacker/pull/7257) [#7259](https://github.com/TouK/nussknacker/pull/7259) `components-api` module 
+  doesn't depend on `async-http-client-backend-future`, `http-utils` module is delivered by `flink-executor` and `lite-runtime` modules.
+  If your component had compile-time dependency to `http-utils`, it should be replaced by provided scope
+  If your component relied on the fact that `components-api` depends on `async-http-client-backend-future`, 
+  `async-http-client-backend-future` should be added as a provided dependency
 
 ## In version 1.18.0
 


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated changelog to highlight enhancements in the components-api module and improvements in Flink Kafka handling.
	- Introduced a new endpoint for scenario testing and renamed the 'test adhoc' button to 'adhoc-testing'.
  
- **Bug Fixes**
	- Resolved issues with deployments involving dictionary editors after a model reload.

- **Documentation**
	- Updated migration guide detailing significant changes and compatibility notes for version 1.19.0. 
	- Enhanced changelog with new features, improvements, and dependency updates.

- **Chores**
	- Cleaned up dependencies for improved management and compatibility across projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->