### PR TITLE
Optional requiredParam for UIParameter decoder compatibility

### DIFF
--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/definition/package.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.restmodel
 
 import io.circe.generic.JsonCodec
-import io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
+import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
 import io.circe.{Decoder, Encoder}
 import pl.touk.nussknacker.engine.api.component.{ComponentGroupName, ComponentId}
 import pl.touk.nussknacker.engine.api.definition.ParameterEditor
@@ -35,7 +35,7 @@ package object definition {
       expression: Expression
   )
 
-  @JsonCodec final case class UIParameter(
+  final case class UIParameter(
       name: String,
       typ: TypingResult,
       editor: ParameterEditor,
@@ -53,6 +53,42 @@ package object definition {
       // This attribute is used only by external project
       requiredParam: Boolean,
   )
+
+  object UIParameter {
+
+    implicit val uiParameterEncoder: Encoder[UIParameter] = deriveConfiguredEncoder
+
+    implicit val uiParameterDecoder: Decoder[UIParameter] = {
+      Decoder.instance { c =>
+        for {
+          name                <- c.downField("name").as[String]
+          typ                 <- c.downField("typ").as[TypingResult]
+          editor              <- c.downField("editor").as[ParameterEditor]
+          defaultValue        <- c.downField("defaultValue").as[Expression]
+          additionalVariables <- c.downField("additionalVariables").as[Map[String, TypingResult]]
+          variablesToHide     <- c.downField("variablesToHide").as[Set[String]]
+          branchParam         <- c.downField("branchParam").as[Boolean]
+          hintText            <- c.downField("hintText").as[Option[String]]
+          label               <- c.downField("label").as[String]
+          // requiredParam field was introduced in the 1.18 version and old versions do not provide it
+          // This fallback is needed to migrate the scenario to older versions of NU and can be removed in future releases
+          requiredParam <- c.downField("requiredParam").as[Option[Boolean]].map(_.getOrElse(true))
+        } yield UIParameter(
+          name = name,
+          typ = typ,
+          editor = editor,
+          defaultValue = defaultValue,
+          additionalVariables = additionalVariables,
+          variablesToHide = variablesToHide,
+          branchParam = branchParam,
+          hintText = hintText,
+          label = label,
+          requiredParam = requiredParam
+        )
+      }
+    }
+
+  }
 
   @JsonCodec(encodeOnly = true) final case class UIComponentDefinition(
       // These parameters are mostly used for method based, static components. For dynamic components, it is the last fallback
@@ -133,11 +169,6 @@ package object definition {
       label: Option[String],
       hintText: Option[String]
   )
-
-  object UIParameter {
-    implicit def decoder(implicit typing: Decoder[TypingResult]): Decoder[UIParameter] =
-      deriveConfiguredDecoder[UIParameter]
-  }
 
   object UICustomAction {
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionsService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/definition/DefinitionsService.scala
@@ -170,7 +170,7 @@ object DefinitionsService {
       branchParam = parameter.branchParam,
       hintText = parameter.hintText,
       label = parameter.label,
-      requiredParam = !parameter.isOptional,
+      requiredParam = Some(!parameter.isOptional),
     )
   }
 

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -7002,7 +7002,6 @@ components:
       - additionalVariables
       - branchParam
       - label
-      - requiredParam
       properties:
         name:
           type: string
@@ -7036,7 +7035,9 @@ components:
         label:
           type: string
         requiredParam:
-          type: boolean
+          type:
+          - boolean
+          - 'null'
     UIValueParameterDto:
       title: UIValueParameterDto
       type: object


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON encoding/decoding for the `UIParameter` class, allowing the `requiredParam` field to be optional.
	- Improved handling of parameter optionality in the `DefinitionsService` class.
	- Introduced new API endpoints and updated existing ones in the Nussknacker Designer API, enhancing functionality and usability.

- **Bug Fixes**
	- Ensured backward compatibility for older versions regarding the `requiredParam` field.

- **Documentation**
	- Expanded OpenAPI specification with detailed examples and improved error handling for various endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->