### PR TITLE
Savepoint deserialization fixup - The class is an inner class, but not statically accessible.

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -135,6 +135,7 @@
 ### 1.18.1 (Not released yet)
 
 * [#7207](https://github.com/TouK/nussknacker/pull/7207) Fixed minor clipboard, keyboard and focus related bugs
+* [#7270](https://github.com/TouK/nussknacker/pull/7270) Savepoint deserialization fixup - some taken savepoints (e.g. for scenarios with async enrichers) were not deserializable which led to errors during redeployments on Flink
 
 ## 1.17
 

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.engine.process.typeinformation
 
 import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
-import org.apache.flink.api.common.typeutils.{CompositeTypeSerializerUtil, TypeSerializer, TypeSerializerSnapshot}
 import org.apache.flink.api.java.typeutils.{ListTypeInfo, MapTypeInfo, MultisetTypeInfo, RowTypeInfo}
 import org.apache.flink.types.Row
 import pl.touk.nussknacker.engine.api.context.ValidationContext
@@ -99,20 +98,10 @@ class TypingResultAwareTypeInformationDetection extends TypeInformationDetection
   }
 
   private def createScalaMapTypeInformation(typingResult: TypedObjectTypingResult) =
-    TypedScalaMapTypeInformation(typingResult.fields.mapValuesNow(forType), constructIntermediateCompatibilityResult)
+    TypedScalaMapTypeInformation(typingResult.fields.mapValuesNow(forType))
 
   private def createJavaMapTypeInformation(typingResult: TypedObjectTypingResult) =
-    TypedJavaMapTypeInformation(typingResult.fields.mapValuesNow(forType), constructIntermediateCompatibilityResult)
-
-  protected def constructIntermediateCompatibilityResult(
-      newNestedSerializers: Array[TypeSerializer[_]],
-      oldNestedSerializerSnapshots: Array[TypeSerializerSnapshot[_]]
-  ): CompositeTypeSerializerUtil.IntermediateCompatibilityResult[Nothing] = {
-    CompositeTypeSerializerUtil.constructIntermediateCompatibilityResult(
-      newNestedSerializers.map(_.snapshotConfiguration()),
-      oldNestedSerializerSnapshots
-    )
-  }
+    TypedJavaMapTypeInformation(typingResult.fields.mapValuesNow(forType))
 
   def forValueWithContext[T](
       validationContext: ValidationContext,

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/internal/typedobject/TypedJavaMapBasedTypeInformation.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/internal/typedobject/TypedJavaMapBasedTypeInformation.scala
@@ -3,42 +3,36 @@ package pl.touk.nussknacker.engine.process.typeinformation.internal.typedobject
 import java.{util => jutil}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSnapshot}
-import pl.touk.nussknacker.engine.process.typeinformation.internal.typedobject.TypedObjectBasedTypeInformation.BuildIntermediateSchemaCompatibilityResult
 
 case class TypedJavaMapTypeInformation(
-    informations: Map[String, TypeInformation[_]],
-    buildIntermediateSchemaCompatibilityResultFunction: BuildIntermediateSchemaCompatibilityResult
+    informations: Map[String, TypeInformation[_]]
 ) extends TypedObjectBasedTypeInformation[jutil.Map[String, AnyRef]](informations) {
 
   override def createSerializer(
       serializers: Array[(String, TypeSerializer[_])]
   ): TypeSerializer[jutil.Map[String, AnyRef]] =
-    TypedJavaMapSerializer(serializers, buildIntermediateSchemaCompatibilityResultFunction)
+    TypedJavaMapSerializer(serializers)
 
 }
 
 @SerialVersionUID(1L)
 case class TypedJavaMapSerializer(
-    override val serializers: Array[(String, TypeSerializer[_])],
-    override val buildIntermediateSchemaCompatibilityResultFunction: BuildIntermediateSchemaCompatibilityResult
+    override val serializers: Array[(String, TypeSerializer[_])]
 ) extends TypedObjectBasedTypeSerializer[jutil.Map[String, AnyRef]](serializers)
     with BaseJavaMapBasedSerializer[AnyRef, jutil.Map[String, AnyRef]] {
 
   override def duplicate(serializers: Array[(String, TypeSerializer[_])]): TypeSerializer[jutil.Map[String, AnyRef]] =
-    TypedJavaMapSerializer(serializers, buildIntermediateSchemaCompatibilityResultFunction)
+    TypedJavaMapSerializer(serializers)
 
   override def createInstance(): jutil.Map[String, AnyRef] = new jutil.HashMap()
 
   override def snapshotConfiguration(
       snapshots: Array[(String, TypeSerializerSnapshot[_])]
-  ): TypeSerializerSnapshot[jutil.Map[String, AnyRef]] = new TypedJavaMapSerializerSnapshot(snapshots) {
-    override val buildIntermediateSchemaCompatibilityResult: BuildIntermediateSchemaCompatibilityResult =
-      buildIntermediateSchemaCompatibilityResultFunction
-  }
+  ): TypeSerializerSnapshot[jutil.Map[String, AnyRef]] = new TypedJavaMapSerializerSnapshot(snapshots)
 
 }
 
-abstract class TypedJavaMapSerializerSnapshot extends TypedObjectBasedSerializerSnapshot[jutil.Map[String, AnyRef]] {
+final class TypedJavaMapSerializerSnapshot extends TypedObjectBasedSerializerSnapshot[jutil.Map[String, AnyRef]] {
 
   def this(serializers: Array[(String, TypeSerializerSnapshot[_])]) = {
     this()
@@ -48,6 +42,6 @@ abstract class TypedJavaMapSerializerSnapshot extends TypedObjectBasedSerializer
   override protected def restoreSerializer(
       restored: Array[(String, TypeSerializer[_])]
   ): TypeSerializer[jutil.Map[String, AnyRef]] =
-    TypedJavaMapSerializer(restored, buildIntermediateSchemaCompatibilityResult)
+    TypedJavaMapSerializer(restored)
 
 }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/internal/typedobject/TypedScalaMapBasedTypeInformation.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/internal/typedobject/TypedScalaMapBasedTypeInformation.scala
@@ -3,24 +3,21 @@ package pl.touk.nussknacker.engine.process.typeinformation.internal.typedobject
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSnapshot}
-import pl.touk.nussknacker.engine.process.typeinformation.internal.typedobject.TypedObjectBasedTypeInformation.BuildIntermediateSchemaCompatibilityResult
 
 case class TypedScalaMapTypeInformation(
-    informations: Map[String, TypeInformation[_]],
-    buildIntermediateSchemaCompatibilityResultFunction: BuildIntermediateSchemaCompatibilityResult
+    informations: Map[String, TypeInformation[_]]
 ) extends TypedObjectBasedTypeInformation[Map[String, _ <: AnyRef]](informations) {
 
   override def createSerializer(
       serializers: Array[(String, TypeSerializer[_])]
   ): TypeSerializer[Map[String, _ <: AnyRef]] =
-    TypedScalaMapSerializer(serializers, buildIntermediateSchemaCompatibilityResultFunction)
+    TypedScalaMapSerializer(serializers)
 
 }
 
 @SerialVersionUID(1L)
 case class TypedScalaMapSerializer(
-    override val serializers: Array[(String, TypeSerializer[_])],
-    override val buildIntermediateSchemaCompatibilityResultFunction: BuildIntermediateSchemaCompatibilityResult
+    override val serializers: Array[(String, TypeSerializer[_])]
 ) extends TypedObjectBasedTypeSerializer[Map[String, _ <: AnyRef]](serializers)
     with LazyLogging {
 
@@ -36,20 +33,17 @@ case class TypedScalaMapSerializer(
   override def get(value: Map[String, _ <: AnyRef], k: String): AnyRef = value.getOrElse(k, null)
 
   override def duplicate(serializers: Array[(String, TypeSerializer[_])]): TypeSerializer[Map[String, _ <: AnyRef]] =
-    TypedScalaMapSerializer(serializers, buildIntermediateSchemaCompatibilityResultFunction)
+    TypedScalaMapSerializer(serializers)
 
   override def createInstance(): Map[String, _ <: AnyRef] = Map.empty
 
   override def snapshotConfiguration(
       snapshots: Array[(String, TypeSerializerSnapshot[_])]
-  ): TypeSerializerSnapshot[Map[String, _ <: AnyRef]] = new TypedScalaMapSerializerSnapshot(snapshots) {
-    override val buildIntermediateSchemaCompatibilityResult: BuildIntermediateSchemaCompatibilityResult =
-      buildIntermediateSchemaCompatibilityResultFunction
-  }
+  ): TypeSerializerSnapshot[Map[String, _ <: AnyRef]] = new TypedScalaMapSerializerSnapshot(snapshots)
 
 }
 
-abstract class TypedScalaMapSerializerSnapshot extends TypedObjectBasedSerializerSnapshot[Map[String, _ <: AnyRef]] {
+final class TypedScalaMapSerializerSnapshot extends TypedObjectBasedSerializerSnapshot[Map[String, _ <: AnyRef]] {
 
   def this(serializers: Array[(String, TypeSerializerSnapshot[_])]) = {
     this()
@@ -59,6 +53,6 @@ abstract class TypedScalaMapSerializerSnapshot extends TypedObjectBasedSerialize
   override protected def restoreSerializer(
       restored: Array[(String, TypeSerializer[_])]
   ): TypeSerializer[Map[String, _ <: AnyRef]] =
-    TypedScalaMapSerializer(restored, buildIntermediateSchemaCompatibilityResult)
+    TypedScalaMapSerializer(restored)
 
 }

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetectionSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetectionSpec.scala
@@ -264,20 +264,17 @@ class TypingResultAwareTypeInformationDetectionSpec
   }
 
   private def assertNested(serializer: TypeSerializer[_], nested: (String, TypeSerializer[_] => Assertion)*): Unit = {
-    inside(serializer.asInstanceOf[TypeSerializer[Map[String, _ <: AnyRef]]]) {
-      case TypedScalaMapSerializer(array, _) =>
-        array.zipAll(nested.toList, null, null).foreach {
-          case ((name, serializer), (expectedName, expectedSerializer)) =>
-            name shouldBe expectedName
-            expectedSerializer(serializer)
-        }
+    inside(serializer.asInstanceOf[TypeSerializer[Map[String, _ <: AnyRef]]]) { case TypedScalaMapSerializer(array) =>
+      array.zipAll(nested.toList, null, null).foreach { case ((name, serializer), (expectedName, expectedSerializer)) =>
+        name shouldBe expectedName
+        expectedSerializer(serializer)
+      }
     }
   }
 
   private def assertMapSerializers(serializer: TypeSerializer[_], nested: (String, TypeSerializer[_])*) = {
-    inside(serializer.asInstanceOf[TypeSerializer[Map[String, _ <: AnyRef]]]) {
-      case TypedScalaMapSerializer(array, _) =>
-        array.toList shouldBe nested.toList
+    inside(serializer.asInstanceOf[TypeSerializer[Map[String, _ <: AnyRef]]]) { case TypedScalaMapSerializer(array) =>
+      array.toList shouldBe nested.toList
     }
   }
 


### PR DESCRIPTION


## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Streamlined handling of type information for Java and Scala maps, improving performance and simplifying the implementation.
	- Enhanced Component API to access information about expression parts used in SpEL templates.
	- Kafka sources and sinks can now operate with schemaless topics.
	- Lifted `TypingResult` information for dictionaries.
	- Improved handling of missing Flink Kafka Source/Sink `TypeInformation`.
	- Fixed deployment issues related to scenarios with dictionary editors after model reload.

- **Bug Fixes**
	- Addressed issues with savepoint deserialization, particularly for scenarios involving asynchronous enrichers.

- **Tests**
	- Simplified test methods to improve readability while maintaining thorough validation of serialization processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->