### PR TITLE
providerType config and idle source

### DIFF
--- a/docs/configuration/model/ModelConfiguration.md
+++ b/docs/configuration/model/ModelConfiguration.md
@@ -54,12 +54,12 @@ Below you can see typical component configuration, each section describes config
 ```
   components {
     sqlHsql {
-      providerType: sql
+      providerType: databaseEnricher
       jdbcUrl: jdbc:hsql...//
       admin/pass
     }
     sqlOracle {
-      providerType: sql
+      providerType: databaseEnricher
       jdbcUrl: jdbc:oracle...//
       admin/pass
     }

--- a/docs/scenarios_authoring/AggregatesInTimeWindows.md
+++ b/docs/scenarios_authoring/AggregatesInTimeWindows.md
@@ -14,6 +14,9 @@ Nussknacker implements 3 types of time windows - tumbling, sliding and session w
 
 Regardless of the window type used, events are grouped into windows based on the event time. Therefore, it is important to understand where Nussknacker takes information about event time from, can event time info be accessed from SpEL and so on - you can find more info [here](../scenarios_authoring/DataSourcesAndSinks.md#notion-of-time--flink-engine-only).
 
+Finally, understanding watermarks and problems caused by idle sources will clarify why in certain situations aggregate events or results of joins are not generated. A good description of the problem can be found [here](https://medium.com/@ipolyzos_/understanding-watermarks-in-apache-flink-c8793a50fbb8).
+
+
 
 ## Common behavior
 


### PR DESCRIPTION
An error in our configuration guide (provideType configuration) + a warning on problems caused by idle sources. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and structure of Model Configuration documentation, including updates on `providerType` for `sqlHsql` and `sqlOracle`.
	- Expanded guidance on classPath configuration and UI attributes customization.
	- Added new sections on component links, group mapping, and scenario properties.
	- Updated `AggregatesInTimeWindows.md` to include information on watermarks and idle sources in stream processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->