### PR TITLE
[Fix] Improve periodic data fetching

### DIFF
--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
@@ -5,6 +5,7 @@ import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName, V
 import pl.touk.nussknacker.engine.deployment.CustomActionDefinition
 import pl.touk.nussknacker.engine.newdeployment
 
+import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 
@@ -93,7 +94,8 @@ trait DeploymentManager extends AutoCloseable {
 trait ManagerSpecificScenarioActivitiesStoredByManager { self: DeploymentManager =>
 
   def managerSpecificScenarioActivities(
-      processIdWithName: ProcessIdWithName
+      processIdWithName: ProcessIdWithName,
+      after: Option[Instant],
   ): Future[List[ScenarioActivity]]
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/scenarioactivity/FetchScenarioActivityService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/scenarioactivity/FetchScenarioActivityService.scala
@@ -45,9 +45,7 @@ class FetchScenarioActivityService(
       deploymentManager <- deploymentManagerDispatcher.deploymentManager(processIdWithName)
       deploymentManagerSpecificActivities <- deploymentManager match {
         case Some(manager: ManagerSpecificScenarioActivitiesStoredByManager) =>
-          manager
-            .managerSpecificScenarioActivities(processIdWithName)
-            .map(_.filter { activity => after.forall(after => activity.date > after) })
+          manager.managerSpecificScenarioActivities(processIdWithName, after)
         case Some(_) | None =>
           Future.successful(List.empty)
       }

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
@@ -18,6 +18,7 @@ import pl.touk.nussknacker.engine.newdeployment.DeploymentId
 import pl.touk.nussknacker.engine.testing.StubbingCommands
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 
+import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -138,7 +139,8 @@ object MockableDeploymentManagerProvider {
     override def deploymentSynchronisationSupport: DeploymentSynchronisationSupport = NoDeploymentSynchronisationSupport
 
     override def managerSpecificScenarioActivities(
-        processIdWithName: ProcessIdWithName
+        processIdWithName: ProcessIdWithName,
+        after: Option[Instant],
     ): Future[List[ScenarioActivity]] =
       Future.successful(MockableDeploymentManager.managerSpecificScenarioActivities.get())
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentActor.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentActor.scala
@@ -8,6 +8,7 @@ import pl.touk.nussknacker.engine.management.periodic.DeploymentActor.{
   DeploymentCompleted,
   WaitingForDeployment
 }
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithCanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeployment
 
 import scala.concurrent.Future
@@ -21,8 +22,8 @@ object DeploymentActor {
   }
 
   private[periodic] def props(
-      findToBeDeployed: => Future[Seq[PeriodicProcessDeployment[CanonicalProcess]]],
-      deploy: PeriodicProcessDeployment[CanonicalProcess] => Future[Unit],
+      findToBeDeployed: => Future[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]],
+      deploy: PeriodicProcessDeployment[WithCanonicalProcess] => Future[Unit],
       interval: FiniteDuration
   ) = {
     Props(new DeploymentActor(findToBeDeployed, deploy, interval))
@@ -30,14 +31,14 @@ object DeploymentActor {
 
   private[periodic] case object CheckToBeDeployed
 
-  private case class WaitingForDeployment(ids: List[PeriodicProcessDeployment[CanonicalProcess]])
+  private case class WaitingForDeployment(ids: List[PeriodicProcessDeployment[WithCanonicalProcess]])
 
   private case object DeploymentCompleted
 }
 
 class DeploymentActor(
-    findToBeDeployed: => Future[Seq[PeriodicProcessDeployment[CanonicalProcess]]],
-    deploy: PeriodicProcessDeployment[CanonicalProcess] => Future[Unit],
+    findToBeDeployed: => Future[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]],
+    deploy: PeriodicProcessDeployment[WithCanonicalProcess] => Future[Unit],
     interval: FiniteDuration
 ) extends Actor
     with Timers
@@ -73,7 +74,7 @@ class DeploymentActor(
       }
   }
 
-  private def receiveOngoingDeployment(runDetails: PeriodicProcessDeployment[CanonicalProcess]): Receive = {
+  private def receiveOngoingDeployment(runDetails: PeriodicProcessDeployment[WithCanonicalProcess]): Receive = {
     case CheckToBeDeployed =>
       logger.debug(s"Still waiting for ${runDetails.display} to be deployed")
     case DeploymentCompleted =>

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/JarManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/JarManager.scala
@@ -12,10 +12,10 @@ private[periodic] trait JarManager {
   def prepareDeploymentWithJar(
       processVersion: ProcessVersion,
       canonicalProcess: CanonicalProcess
-  ): Future[DeploymentWithJarData[CanonicalProcess]]
+  ): Future[DeploymentWithJarData.WithCanonicalProcess]
 
   def deployWithJar(
-      deploymentWithJarData: DeploymentWithJarData[CanonicalProcess],
+      deploymentWithJarData: DeploymentWithJarData.WithCanonicalProcess,
       deploymentData: DeploymentData,
   ): Future[Option[ExternalDeploymentId]]
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -25,7 +25,7 @@ import pl.touk.nussknacker.engine.{BaseModelData, DeploymentManagerDependencies}
 import slick.jdbc
 import slick.jdbc.JdbcProfile
 
-import java.time.Clock
+import java.time.{Clock, Instant}
 import scala.concurrent.{ExecutionContext, Future}
 
 object PeriodicDeploymentManager {
@@ -250,9 +250,10 @@ class PeriodicDeploymentManager private[periodic] (
   //    - we may need to refactor PeriodicDeploymentManager data source first
 
   override def managerSpecificScenarioActivities(
-      processIdWithName: ProcessIdWithName
+      processIdWithName: ProcessIdWithName,
+      after: Option[Instant],
   ): Future[List[ScenarioActivity]] =
-    service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName)
+    service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, after)
 
   private def actionInstantBatch(command: DMPerformSingleExecutionCommand): Future[SingleExecutionResult] = {
     val processName           = command.processVersion.processName

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
@@ -24,11 +24,14 @@ import pl.touk.nussknacker.engine.management.periodic.PeriodicProcessService.{
 }
 import pl.touk.nussknacker.engine.management.periodic.PeriodicStateStatus.{ScheduledStatus, WaitingForScheduleStatus}
 import pl.touk.nussknacker.engine.management.periodic.db.PeriodicProcessesRepository
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.{
+  WithCanonicalProcess,
+  WithoutCanonicalProcess
+}
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeploymentStatus.PeriodicProcessDeploymentStatus
 import pl.touk.nussknacker.engine.management.periodic.model._
 import pl.touk.nussknacker.engine.management.periodic.service._
 import pl.touk.nussknacker.engine.management.periodic.util.DeterministicUUIDFromLong
-import pl.touk.nussknacker.engine.management.periodic.util.DeterministicUUIDFromLong.longUUID
 import pl.touk.nussknacker.engine.util.AdditionalComponentConfigsForRuntimeExtractor
 
 import java.time.chrono.ChronoLocalDateTime
@@ -68,9 +71,12 @@ class PeriodicProcessService(
   private implicit val localDateTimeOrdering: Ordering[LocalDateTime] = Ordering.by(identity[ChronoLocalDateTime[_]])
 
   def getScenarioActivitiesSpecificToPeriodicProcess(
-      processIdWithName: ProcessIdWithName
+      processIdWithName: ProcessIdWithName,
+      after: Option[Instant],
   ): Future[List[ScenarioActivity]] = for {
-    schedulesState <- scheduledProcessesRepository.getSchedulesState(processIdWithName.name).run
+    schedulesState <- scheduledProcessesRepository
+      .getSchedulesState(processIdWithName.name, after.map(localDateTimeAtSystemDefaultZone))
+      .run
     groupedByProcess        = schedulesState.groupedByPeriodicProcess
     deployments             = groupedByProcess.flatMap(_.deployments)
     deploymentsWithStatuses = deployments.flatMap(d => scheduledExecutionStatusAndDateFinished(d).map((d, _)))
@@ -158,7 +164,7 @@ class PeriodicProcessService(
   private def initialSchedule(
       scheduleMap: ScheduleProperty,
       scheduleDates: List[(ScheduleName, Option[LocalDateTime])],
-      deploymentWithJarData: DeploymentWithJarData[CanonicalProcess],
+      deploymentWithJarData: DeploymentWithJarData.WithCanonicalProcess,
       processActionId: ProcessActionId
   ): Future[Unit] = {
     scheduledProcessesRepository
@@ -180,7 +186,7 @@ class PeriodicProcessService(
       .map(_ => ())
   }
 
-  def findToBeDeployed: Future[Seq[PeriodicProcessDeployment[CanonicalProcess]]] = {
+  def findToBeDeployed: Future[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]] = {
     for {
       toBeDeployed <- scheduledProcessesRepository.findToBeDeployed.run.flatMap { toDeployList =>
         Future.sequence(toDeployList.map(checkIfNotRunning)).map(_.flatten)
@@ -194,8 +200,8 @@ class PeriodicProcessService(
   // Currently we don't allow simultaneous runs of one scenario - only sequential, so if other schedule kicks in, it'll have to wait
   // TODO: we show allow to deploy scenarios with different scheduleName to be deployed simultaneous
   private def checkIfNotRunning(
-      toDeploy: PeriodicProcessDeployment[CanonicalProcess]
-  ): Future[Option[PeriodicProcessDeployment[CanonicalProcess]]] = {
+      toDeploy: PeriodicProcessDeployment[WithCanonicalProcess]
+  ): Future[Option[PeriodicProcessDeployment[WithCanonicalProcess]]] = {
     delegateDeploymentManager
       .getProcessStates(toDeploy.periodicProcess.processVersion.processName)(DataFreshnessPolicy.Fresh)
       .map(
@@ -394,7 +400,7 @@ class PeriodicProcessService(
       _ <- activeSchedules.groupedByPeriodicProcess.map(p => deactivateAction(p.process)).sequence.runWithCallbacks
     } yield runningDeploymentsForSchedules.map(deployment => DeploymentId(deployment.toString))
 
-  private def deactivateAction(process: PeriodicProcess[_]): RepositoryAction[Callback] = {
+  private def deactivateAction(process: PeriodicProcess[WithoutCanonicalProcess]): RepositoryAction[Callback] = {
     logger.info(s"Deactivate periodic process id: ${process.id.value}")
     for {
       _ <- scheduledProcessesRepository.markInactive(process.id)
@@ -413,7 +419,7 @@ class PeriodicProcessService(
         .map(_ => ())
     }
 
-  def deploy(deployment: PeriodicProcessDeployment[CanonicalProcess]): Future[Unit] = {
+  def deploy(deployment: PeriodicProcessDeployment[WithCanonicalProcess]): Future[Unit] = {
     // TODO: set status before deployment?
     val id = deployment.id
     val deploymentData = DeploymentData(
@@ -545,7 +551,7 @@ class PeriodicProcessService(
   }
 
   private def scheduledExecutionStatusAndDateFinished(
-      entity: PeriodicProcessDeployment[Unit],
+      entity: PeriodicProcessDeployment[WithoutCanonicalProcess],
   ): Option[FinishedScheduledExecutionMetadata] = {
     for {
       status <- entity.state.status match {
@@ -576,6 +582,10 @@ class PeriodicProcessService(
   // LocalDateTime's in the context of PeriodicProcess are created using clock with system default timezone
   private def instantAtSystemDefaultZone(localDateTime: LocalDateTime): Instant = {
     localDateTime.atZone(ZoneId.systemDefault).toInstant
+  }
+
+  private def localDateTimeAtSystemDefaultZone(instant: Instant): LocalDateTime = {
+    instant.atZone(ZoneId.systemDefault).toLocalDateTime
   }
 
 }

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
@@ -581,11 +581,11 @@ class PeriodicProcessService(
 
   // LocalDateTime's in the context of PeriodicProcess are created using clock with system default timezone
   private def instantAtSystemDefaultZone(localDateTime: LocalDateTime): Instant = {
-    localDateTime.atZone(ZoneId.systemDefault).toInstant
+    localDateTime.atZone(clock.getZone).toInstant
   }
 
   private def localDateTimeAtSystemDefaultZone(instant: Instant): LocalDateTime = {
-    instant.atZone(ZoneId.systemDefault).toLocalDateTime
+    instant.atZone(clock.getZone).toLocalDateTime
   }
 
 }

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -18,7 +18,7 @@ import slick.dbio.{DBIOAction, Effect, NoStream}
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.{JdbcBackend, JdbcProfile}
 
-import java.time.{Clock, Instant, LocalDateTime, ZonedDateTime}
+import java.time.{Clock, LocalDateTime}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -7,24 +7,27 @@ import io.circe.parser.decode
 import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionId
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic._
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.{
+  WithCanonicalProcess,
+  WithoutCanonicalProcess
+}
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeploymentStatus.PeriodicProcessDeploymentStatus
 import pl.touk.nussknacker.engine.management.periodic.model._
 import slick.dbio.{DBIOAction, Effect, NoStream}
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.{JdbcBackend, JdbcProfile}
 
-import java.time.{Clock, Instant, LocalDateTime, ZoneId}
+import java.time.{Clock, Instant, LocalDateTime, ZonedDateTime}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 
 object PeriodicProcessesRepository {
 
   def createPeriodicProcessDeployment(
-      processEntity: PeriodicProcessEntity,
+      processEntity: PeriodicProcessEntityWithJson,
       processDeploymentEntity: PeriodicProcessDeploymentEntity
-  ): PeriodicProcessDeployment[CanonicalProcess] = {
+  ): PeriodicProcessDeployment[WithCanonicalProcess] = {
     val process = createPeriodicProcessWithJson(processEntity)
     PeriodicProcessDeployment(
       processDeploymentEntity.id,
@@ -48,18 +51,18 @@ object PeriodicProcessesRepository {
     )
   }
 
-  def createPeriodicProcessWithJson(processEntity: PeriodicProcessEntity): PeriodicProcess[CanonicalProcess] = {
+  def createPeriodicProcessWithJson(
+      processEntity: PeriodicProcessEntityWithJson
+  ): PeriodicProcess[WithCanonicalProcess] = {
     val processVersion   = createProcessVersion(processEntity)
     val scheduleProperty = prepareScheduleProperty(processEntity)
     PeriodicProcess(
       processEntity.id,
-      model.DeploymentWithJarData(
+      model.DeploymentWithJarData.WithCanonicalProcess(
         processVersion = processVersion,
         inputConfigDuringExecutionJson = processEntity.inputConfigDuringExecutionJson,
         jarFileName = processEntity.jarFileName,
-        process = processEntity.processJson.getOrElse(
-          throw new IllegalArgumentException("Missing required scenario json in processEntity")
-        )
+        process = processEntity.processJson,
       ),
       scheduleProperty,
       processEntity.active,
@@ -68,16 +71,16 @@ object PeriodicProcessesRepository {
     )
   }
 
-  def createPeriodicProcessWithoutJson(processEntity: PeriodicProcessEntity): PeriodicProcess[Unit] = {
+  def createPeriodicProcessWithoutJson(
+      processEntity: PeriodicProcessEntity
+  ): PeriodicProcess[WithoutCanonicalProcess] = {
     val processVersion   = createProcessVersion(processEntity)
     val scheduleProperty = prepareScheduleProperty(processEntity)
     PeriodicProcess(
       processEntity.id,
-      model.DeploymentWithJarData(
+      model.DeploymentWithJarData.WithoutCanonicalProcess(
         processVersion = processVersion,
-        inputConfigDuringExecutionJson = processEntity.inputConfigDuringExecutionJson,
         jarFileName = processEntity.jarFileName,
-        process = ()
       ),
       scheduleProperty,
       processEntity.active,
@@ -113,14 +116,15 @@ trait PeriodicProcessesRepository {
   def markInactive(processId: PeriodicProcessId): Action[Unit]
 
   def getSchedulesState(
-      scenarioName: ProcessName
+      scenarioName: ProcessName,
+      after: Option[LocalDateTime],
   ): Action[SchedulesState]
 
   def create(
-      deploymentWithJarData: DeploymentWithJarData[CanonicalProcess],
+      deploymentWithJarData: DeploymentWithJarData.WithCanonicalProcess,
       scheduleProperty: ScheduleProperty,
       processActionId: ProcessActionId
-  ): Action[PeriodicProcess[CanonicalProcess]]
+  ): Action[PeriodicProcess[WithCanonicalProcess]]
 
   def getLatestDeploymentsForActiveSchedules(
       processName: ProcessName,
@@ -133,17 +137,17 @@ trait PeriodicProcessesRepository {
       deploymentsPerScheduleMaxCount: Int
   ): Action[SchedulesState]
 
-  def findToBeDeployed: Action[Seq[PeriodicProcessDeployment[CanonicalProcess]]]
+  def findToBeDeployed: Action[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]]
 
-  def findToBeRetried: Action[Seq[PeriodicProcessDeployment[CanonicalProcess]]]
+  def findToBeRetried: Action[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]]
 
   def findActiveSchedulesForProcessesHavingDeploymentWithMatchingStatus(
       expectedDeploymentStatuses: Set[PeriodicProcessDeploymentStatus]
   ): Action[SchedulesState]
 
-  def findProcessData(id: PeriodicProcessDeploymentId): Action[PeriodicProcessDeployment[CanonicalProcess]]
+  def findProcessData(id: PeriodicProcessDeploymentId): Action[PeriodicProcessDeployment[WithCanonicalProcess]]
 
-  def findProcessData(processName: ProcessName): Action[Seq[PeriodicProcess[CanonicalProcess]]]
+  def findProcessData(processName: ProcessName): Action[Seq[PeriodicProcess[WithCanonicalProcess]]]
 
   def markDeployed(id: PeriodicProcessDeploymentId): Action[Unit]
 
@@ -163,7 +167,7 @@ trait PeriodicProcessesRepository {
       scheduleName: ScheduleName,
       runAt: LocalDateTime,
       deployMaxRetries: Int
-  ): Action[PeriodicProcessDeployment[CanonicalProcess]]
+  ): Action[PeriodicProcessDeployment[WithCanonicalProcess]]
 
 }
 
@@ -188,27 +192,29 @@ class SlickPeriodicProcessesRepository(
   override def run[T](action: DBIOAction[T, NoStream, Effect.All]): Future[T] = db.run(action.transactionally)
 
   override def getSchedulesState(
-      scenarioName: ProcessName
+      scenarioName: ProcessName,
+      afterOpt: Option[LocalDateTime],
   ): Action[SchedulesState] = {
     PeriodicProcessesWithoutJson
       .filter(_.processName === scenarioName)
       .join(PeriodicProcessDeployments)
       .on(_.id === _.periodicProcessId)
+      .filterOpt(afterOpt)((entities, after) => entities._2.completedAt > after)
       .result
       .map(toSchedulesState)
   }
 
   override def create(
-      deploymentWithJarData: DeploymentWithJarData[CanonicalProcess],
+      deploymentWithJarData: DeploymentWithJarData.WithCanonicalProcess,
       scheduleProperty: ScheduleProperty,
       processActionId: ProcessActionId
-  ): Action[PeriodicProcess[CanonicalProcess]] = {
-    val processEntity = PeriodicProcessEntity(
+  ): Action[PeriodicProcess[WithCanonicalProcess]] = {
+    val processEntity = PeriodicProcessEntityWithJson(
       id = PeriodicProcessId(-1),
       processName = deploymentWithJarData.processVersion.processName,
       processVersionId = deploymentWithJarData.processVersion.versionId,
       processingType = processingType,
-      processJson = Some(deploymentWithJarData.process),
+      processJson = deploymentWithJarData.process,
       inputConfigDuringExecutionJson = deploymentWithJarData.inputConfigDuringExecutionJson,
       jarFileName = deploymentWithJarData.jarFileName,
       scheduleProperty = scheduleProperty.asJson.noSpaces,
@@ -222,7 +228,7 @@ class SlickPeriodicProcessesRepository(
 
   private def now(): LocalDateTime = LocalDateTime.now(clock)
 
-  override def findToBeDeployed: Action[Seq[PeriodicProcessDeployment[CanonicalProcess]]] =
+  override def findToBeDeployed: Action[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]] =
     activePeriodicProcessWithDeploymentQuery
       .filter { case (_, d) =>
         d.runAt <= now() &&
@@ -231,7 +237,7 @@ class SlickPeriodicProcessesRepository(
       .result
       .map(_.map((PeriodicProcessesRepository.createPeriodicProcessDeployment _).tupled))
 
-  override def findToBeRetried: Action[Seq[PeriodicProcessDeployment[CanonicalProcess]]] =
+  override def findToBeRetried: Action[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]] =
     activePeriodicProcessWithDeploymentQuery
       .filter { case (_, d) =>
         d.nextRetryAt <= now() &&
@@ -240,7 +246,9 @@ class SlickPeriodicProcessesRepository(
       .result
       .map(_.map((PeriodicProcessesRepository.createPeriodicProcessDeployment _).tupled))
 
-  override def findProcessData(id: PeriodicProcessDeploymentId): Action[PeriodicProcessDeployment[CanonicalProcess]] = {
+  override def findProcessData(
+      id: PeriodicProcessDeploymentId
+  ): Action[PeriodicProcessDeployment[WithCanonicalProcess]] = {
     (PeriodicProcessesWithJson join PeriodicProcessDeployments on (_.id === _.periodicProcessId))
       .filter { case (_, deployment) => deployment.id === id }
       .result
@@ -248,7 +256,7 @@ class SlickPeriodicProcessesRepository(
       .map((PeriodicProcessesRepository.createPeriodicProcessDeployment _).tupled)
   }
 
-  override def findProcessData(processName: ProcessName): Action[Seq[PeriodicProcess[CanonicalProcess]]] = {
+  override def findProcessData(processName: ProcessName): Action[Seq[PeriodicProcess[WithCanonicalProcess]]] = {
     PeriodicProcessesWithJson
       .filter(p => p.active === true && p.processName === processName)
       .result
@@ -331,7 +339,7 @@ class SlickPeriodicProcessesRepository(
   }
 
   private def getLatestDeploymentsForEachSchedule(
-      periodicProcessesQuery: Query[PeriodicProcessesTable, PeriodicProcessEntity, Seq],
+      periodicProcessesQuery: Query[PeriodicProcessWithoutJson, PeriodicProcessEntityWithoutJson, Seq],
       deploymentsPerScheduleMaxCount: Int
   ): Action[SchedulesState] = {
     val filteredPeriodicProcessQuery = periodicProcessesQuery.filter(p => p.processingType === processingType)
@@ -345,7 +353,7 @@ class SlickPeriodicProcessesRepository(
   }
 
   private def getLatestDeploymentsForEachSchedulePostgres(
-      periodicProcessesQuery: Query[PeriodicProcessesTable, PeriodicProcessEntity, Seq],
+      periodicProcessesQuery: Query[PeriodicProcessWithoutJson, PeriodicProcessEntityWithoutJson, Seq],
       deploymentsPerScheduleMaxCount: Int
   ): Action[Seq[(PeriodicProcessEntity, PeriodicProcessDeploymentEntity)]] = {
     // To effectively limit deployments to given count for each schedule in one query, we use window functions in slick
@@ -379,7 +387,7 @@ class SlickPeriodicProcessesRepository(
   // If we decided to support more databases, we should consider some optimization like extracting periodic_schedule table
   // with foreign key to periodic_process and with schedule_name column - it would reduce number of queries
   private def getLatestDeploymentsForEachScheduleJdbcGeneric(
-      periodicProcessesQuery: Query[PeriodicProcessesTable, PeriodicProcessEntity, Seq],
+      periodicProcessesQuery: Query[PeriodicProcessWithoutJson, PeriodicProcessEntityWithoutJson, Seq],
       deploymentsPerScheduleMaxCount: Int
   ): Action[Seq[(PeriodicProcessEntity, PeriodicProcessDeploymentEntity)]] = {
     // It is debug instead of warn to not bloast logs when e.g. for some reasons is used hsql under the hood
@@ -421,7 +429,7 @@ class SlickPeriodicProcessesRepository(
       scheduleName: ScheduleName,
       runAt: LocalDateTime,
       deployMaxRetries: Int
-  ): Action[PeriodicProcessDeployment[CanonicalProcess]] = {
+  ): Action[PeriodicProcessDeployment[WithCanonicalProcess]] = {
     val deploymentEntity = PeriodicProcessDeploymentEntity(
       id = PeriodicProcessDeploymentId(-1),
       periodicProcessId = id,

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/flink/FlinkJarManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/flink/FlinkJarManager.scala
@@ -51,10 +51,10 @@ private[periodic] class FlinkJarManager(
   override def prepareDeploymentWithJar(
       processVersion: ProcessVersion,
       canonicalProcess: CanonicalProcess
-  ): Future[DeploymentWithJarData[CanonicalProcess]] = {
+  ): Future[DeploymentWithJarData.WithCanonicalProcess] = {
     logger.info(s"Prepare deployment for scenario: $processVersion")
     copyJarToLocalDir(processVersion).map { jarFileName =>
-      DeploymentWithJarData(
+      DeploymentWithJarData.WithCanonicalProcess(
         processVersion = processVersion,
         process = canonicalProcess,
         inputConfigDuringExecutionJson = inputConfigDuringExecution.serialized,
@@ -74,7 +74,7 @@ private[periodic] class FlinkJarManager(
   }
 
   override def deployWithJar(
-      deploymentWithJarData: DeploymentWithJarData[CanonicalProcess],
+      deploymentWithJarData: DeploymentWithJarData.WithCanonicalProcess,
       deploymentData: DeploymentData
   ): Future[Option[ExternalDeploymentId]] = {
     val processVersion = deploymentWithJarData.processVersion

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/DeploymentWithJarData.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/DeploymentWithJarData.scala
@@ -1,10 +1,25 @@
 package pl.touk.nussknacker.engine.management.periodic.model
 
 import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 
-case class DeploymentWithJarData[ProcessRep](
-    processVersion: ProcessVersion,
-    process: ProcessRep,
-    inputConfigDuringExecutionJson: String,
-    jarFileName: String
-)
+sealed trait DeploymentWithJarData {
+  def processVersion: ProcessVersion
+  def jarFileName: String
+}
+
+object DeploymentWithJarData {
+
+  final case class WithCanonicalProcess(
+      processVersion: ProcessVersion,
+      jarFileName: String,
+      process: CanonicalProcess,
+      inputConfigDuringExecutionJson: String,
+  ) extends DeploymentWithJarData
+
+  final case class WithoutCanonicalProcess(
+      processVersion: ProcessVersion,
+      jarFileName: String
+  ) extends DeploymentWithJarData
+
+}

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcess.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcess.scala
@@ -9,9 +9,9 @@ import java.time.LocalDateTime
 
 case class PeriodicProcessId(value: Long) extends MappedTo[Long]
 
-case class PeriodicProcess[ProcessRep](
+case class PeriodicProcess[DeploymentData <: DeploymentWithJarData](
     id: PeriodicProcessId,
-    deploymentData: DeploymentWithJarData[ProcessRep],
+    deploymentData: DeploymentData,
     scheduleProperty: ScheduleProperty,
     active: Boolean,
     createdAt: LocalDateTime,

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcessDeployment.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/PeriodicProcessDeployment.scala
@@ -7,9 +7,9 @@ import slick.lifted.MappedTo
 import java.time.{Clock, LocalDateTime}
 
 // TODO: We should separate schedules concept from deployments - fully switch to ScheduleData and ScheduleDeploymentData
-case class PeriodicProcessDeployment[ProcessRep](
+case class PeriodicProcessDeployment[DeploymentData <: DeploymentWithJarData](
     id: PeriodicProcessDeploymentId,
-    periodicProcess: PeriodicProcess[ProcessRep],
+    periodicProcess: PeriodicProcess[DeploymentData],
     createdAt: LocalDateTime,
     runAt: LocalDateTime,
     scheduleName: ScheduleName,

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/SchedulesState.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/model/SchedulesState.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.management.periodic.model
 
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.management.periodic.db.{PeriodicProcessDeploymentEntity, PeriodicProcessesRepository}
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithoutCanonicalProcess
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 
 import java.time.LocalDateTime
@@ -35,7 +36,10 @@ case class SchedulesState(schedules: Map[ScheduleId, ScheduleData]) {
 // For most operations it will contain only one latest deployment but for purpose of statuses of historical deployments
 // it has list instead of one element.
 // This structure should contain SingleScheduleProperty as well. See note above
-case class ScheduleData(process: PeriodicProcess[Unit], latestDeployments: List[ScheduleDeploymentData])
+case class ScheduleData(
+    process: PeriodicProcess[WithoutCanonicalProcess],
+    latestDeployments: List[ScheduleDeploymentData]
+)
 
 // To identify schedule we need scheduleName - None for SingleScheduleProperty and Some(key) for MultipleScheduleProperty keys
 // Also we need PeriodicProcessId to distinguish between active schedules and some inactive from the past for the same PeriodicProcessId
@@ -53,9 +57,9 @@ case class ScheduleDeploymentData(
 ) {
 
   def toFullDeploymentData(
-      process: PeriodicProcess[Unit],
+      process: PeriodicProcess[WithoutCanonicalProcess],
       scheduleName: ScheduleName
-  ): PeriodicProcessDeployment[Unit] =
+  ): PeriodicProcessDeployment[WithoutCanonicalProcess] =
     PeriodicProcessDeployment(id, process, createdAt, runAt, scheduleName, retriesLeft, nextRetryAt, state)
 
   def display = s"deploymentId=$id"
@@ -80,10 +84,11 @@ object ScheduleDeploymentData {
 
 // These below are temporary structures, see notice next to SchedulesState
 case class PeriodicProcessScheduleData(
-    process: PeriodicProcess[Unit],
-    deployments: List[PeriodicProcessDeployment[Unit]]
+    process: PeriodicProcess[WithoutCanonicalProcess],
+    deployments: List[PeriodicProcessDeployment[WithoutCanonicalProcess]]
 ) {
-  def existsDeployment(predicate: PeriodicProcessDeployment[Unit] => Boolean): Boolean = deployments.exists(predicate)
+  def existsDeployment(predicate: PeriodicProcessDeployment[WithoutCanonicalProcess] => Boolean): Boolean =
+    deployments.exists(predicate)
 
   def display: String = {
     val deploymentsForSchedules = deployments.map(_.display)

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/service/AdditionalDeploymentDataProvider.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/service/AdditionalDeploymentDataProvider.scala
@@ -1,19 +1,22 @@
 package pl.touk.nussknacker.engine.management.periodic.service
 
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithCanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeployment
 
 import java.time.format.DateTimeFormatter
 
 trait AdditionalDeploymentDataProvider {
 
-  def prepareAdditionalData(runDetails: PeriodicProcessDeployment[CanonicalProcess]): Map[String, String]
+  def prepareAdditionalData(runDetails: PeriodicProcessDeployment[WithCanonicalProcess]): Map[String, String]
 
 }
 
 object DefaultAdditionalDeploymentDataProvider extends AdditionalDeploymentDataProvider {
 
-  override def prepareAdditionalData(runDetails: PeriodicProcessDeployment[CanonicalProcess]): Map[String, String] = {
+  override def prepareAdditionalData(
+      runDetails: PeriodicProcessDeployment[WithCanonicalProcess]
+  ): Map[String, String] = {
     Map(
       "deploymentId" -> runDetails.id.value.toString,
       "runAt"        -> runDetails.runAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/service/PeriodicProcessListener.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/service/PeriodicProcessListener.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import pl.touk.nussknacker.engine.api.deployment.StatusDetails
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.ExternalDeploymentId
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithCanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeployment
 
 /*
@@ -21,28 +22,30 @@ trait PeriodicProcessListenerFactory {
 }
 
 sealed trait PeriodicProcessEvent {
-  val deployment: PeriodicProcessDeployment[CanonicalProcess]
+  val deployment: PeriodicProcessDeployment[WithCanonicalProcess]
 }
 
 case class DeployedEvent(
-    deployment: PeriodicProcessDeployment[CanonicalProcess],
+    deployment: PeriodicProcessDeployment[WithCanonicalProcess],
     externalDeploymentId: Option[ExternalDeploymentId]
 ) extends PeriodicProcessEvent
 
-case class FinishedEvent(deployment: PeriodicProcessDeployment[CanonicalProcess], processState: Option[StatusDetails])
-    extends PeriodicProcessEvent
+case class FinishedEvent(
+    deployment: PeriodicProcessDeployment[WithCanonicalProcess],
+    processState: Option[StatusDetails]
+) extends PeriodicProcessEvent
 
 case class FailedOnDeployEvent(
-    deployment: PeriodicProcessDeployment[CanonicalProcess],
+    deployment: PeriodicProcessDeployment[WithCanonicalProcess],
     processState: Option[StatusDetails]
 ) extends PeriodicProcessEvent
 
 case class FailedOnRunEvent(
-    deployment: PeriodicProcessDeployment[CanonicalProcess],
+    deployment: PeriodicProcessDeployment[WithCanonicalProcess],
     processState: Option[StatusDetails]
 ) extends PeriodicProcessEvent
 
-case class ScheduledEvent(deployment: PeriodicProcessDeployment[CanonicalProcess], firstSchedule: Boolean)
+case class ScheduledEvent(deployment: PeriodicProcessDeployment[WithCanonicalProcess], firstSchedule: Boolean)
     extends PeriodicProcessEvent
 
 object EmptyListener extends EmptyListener

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/service/ProcessConfigEnricher.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/service/ProcessConfigEnricher.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.management.periodic.service
 
 import com.typesafe.config.{Config, ConfigFactory}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithCanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeployment
 import pl.touk.nussknacker.engine.management.periodic.service.ProcessConfigEnricher.{
   DeployData,
@@ -46,7 +47,7 @@ object ProcessConfigEnricher {
   case class DeployData(
       canonicalProcess: CanonicalProcess,
       inputConfigDuringExecutionJson: String,
-      deployment: PeriodicProcessDeployment[CanonicalProcess]
+      deployment: PeriodicProcessDeployment[WithCanonicalProcess]
   ) extends ProcessConfigEnricherInputData
 
   case class EnrichedProcessConfig(inputConfigDuringExecutionJson: String)

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentActorTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentActorTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.DeploymentActor.CheckToBeDeployed
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithCanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeployment
 
 import scala.concurrent.Future
@@ -33,11 +34,11 @@ class DeploymentActorTest extends AnyFunSuite with TestKitBase with Matchers wit
   }
 
   private def shouldFindToBeDeployedScenarios(
-      result: Future[Seq[PeriodicProcessDeployment[CanonicalProcess]]]
+      result: Future[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]]
   ): Unit = {
     val probe   = TestProbe()
     var counter = 0
-    def findToBeDeployed: Future[Seq[PeriodicProcessDeployment[CanonicalProcess]]] = {
+    def findToBeDeployed: Future[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]] = {
       counter += 1
       probe.ref ! s"invoked $counter"
       result
@@ -54,14 +55,14 @@ class DeploymentActorTest extends AnyFunSuite with TestKitBase with Matchers wit
   }
 
   test("should deploy found scenario") {
-    val probe                                                          = TestProbe()
-    val waitingDeployment                                              = PeriodicProcessDeploymentGen()
-    var toBeDeployed: Seq[PeriodicProcessDeployment[CanonicalProcess]] = Seq(waitingDeployment)
-    var actor: ActorRef                                                = null
-    def findToBeDeployed: Future[Seq[PeriodicProcessDeployment[CanonicalProcess]]] = {
+    val probe                                                              = TestProbe()
+    val waitingDeployment                                                  = PeriodicProcessDeploymentGen()
+    var toBeDeployed: Seq[PeriodicProcessDeployment[WithCanonicalProcess]] = Seq(waitingDeployment)
+    var actor: ActorRef                                                    = null
+    def findToBeDeployed: Future[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]] = {
       Future.successful(toBeDeployed)
     }
-    def deploy(deployment: PeriodicProcessDeployment[CanonicalProcess]): Future[Unit] = {
+    def deploy(deployment: PeriodicProcessDeployment[WithCanonicalProcess]): Future[Unit] = {
       probe.ref ! deployment
       // Simulate periodic check for waiting scenarios while deploying a scenario.
       actor ! CheckToBeDeployed

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/JarManagerStub.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/JarManagerStub.scala
@@ -9,15 +9,15 @@ import scala.concurrent.Future
 
 class JarManagerStub extends JarManager {
 
-  var deployWithJarFuture: Future[Option[ExternalDeploymentId]]                  = Future.successful(None)
-  var lastDeploymentWithJarData: Option[DeploymentWithJarData[CanonicalProcess]] = None
+  var deployWithJarFuture: Future[Option[ExternalDeploymentId]]                     = Future.successful(None)
+  var lastDeploymentWithJarData: Option[DeploymentWithJarData.WithCanonicalProcess] = None
 
   override def prepareDeploymentWithJar(
       processVersion: ProcessVersion,
       canonicalProcess: CanonicalProcess
-  ): Future[DeploymentWithJarData[CanonicalProcess]] = {
+  ): Future[DeploymentWithJarData.WithCanonicalProcess] = {
     Future.successful(
-      model.DeploymentWithJarData(
+      model.DeploymentWithJarData.WithCanonicalProcess(
         processVersion = processVersion,
         process = canonicalProcess,
         inputConfigDuringExecutionJson = "",
@@ -27,7 +27,7 @@ class JarManagerStub extends JarManager {
   }
 
   override def deployWithJar(
-      deploymentWithJarData: DeploymentWithJarData[CanonicalProcess],
+      deploymentWithJarData: DeploymentWithJarData.WithCanonicalProcess,
       deploymentData: DeploymentData,
   ): Future[Option[ExternalDeploymentId]] = {
     lastDeploymentWithJarData = Some(deploymentWithJarData)

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/JarManagerTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/JarManagerTest.scala
@@ -63,7 +63,7 @@ class JarManagerTest extends AnyFunSuite with Matchers with ScalaFutures with Pa
     val modelJarProvider = new FlinkModelJarProvider(currentModelUrls)
     val jarManager       = createJarManager(jarsDir, modelJarProvider)
 
-    def verifyAndDeleteJar(result: Future[DeploymentWithJarData[CanonicalProcess]]): Unit = {
+    def verifyAndDeleteJar(result: Future[DeploymentWithJarData.WithCanonicalProcess]): Unit = {
       val copiedJarFile = jarsDir.resolve(result.futureValue.jarFileName)
       Files.exists(copiedJarFile) shouldBe true
       Files.readAllBytes(copiedJarFile) shouldBe modelJarFileContent

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessDeploymentGen.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessDeploymentGen.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.management.periodic
 
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithCanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.model.{
   PeriodicProcessDeployment,
   PeriodicProcessDeploymentId,
@@ -15,7 +16,7 @@ object PeriodicProcessDeploymentGen {
 
   val now: LocalDateTime = LocalDateTime.now()
 
-  def apply(): PeriodicProcessDeployment[CanonicalProcess] = {
+  def apply(): PeriodicProcessDeployment[WithCanonicalProcess] = {
     PeriodicProcessDeployment(
       id = PeriodicProcessDeploymentId(42),
       periodicProcess = PeriodicProcessGen(),

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessGen.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessGen.scala
@@ -4,16 +4,17 @@ import pl.touk.nussknacker.engine.api.ProcessVersion
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.CronSchedulePropertyExtractor.CronPropertyDefaultName
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithCanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.model.{DeploymentWithJarData, PeriodicProcess, PeriodicProcessId}
 
 import java.time.LocalDateTime
 
 object PeriodicProcessGen {
 
-  def apply(): PeriodicProcess[CanonicalProcess] = {
+  def apply(): PeriodicProcess[WithCanonicalProcess] = {
     PeriodicProcess(
       id = PeriodicProcessId(42),
-      deploymentData = DeploymentWithJarData(
+      deploymentData = DeploymentWithJarData.WithCanonicalProcess(
         processVersion = ProcessVersion.empty,
         process = buildCanonicalProcess(),
         inputConfigDuringExecutionJson = "{}",

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
@@ -70,11 +70,11 @@ class PeriodicProcessServiceIntegrationTest
 
   private val sampleProcess = CanonicalProcess(MetaData(processName.value, StreamMetaData()), Nil)
 
-  private val startTime = Instant.parse("2021-04-06T11:18:00Z")
+  private val startTime = Instant.parse("2021-04-06T13:18:00Z")
 
   // we truncate to millis, as HSQL stores with that precision...
   private def fixedClock(instant: Instant) =
-    Clock.tick(Clock.fixed(instant, ZoneId.systemDefault()), java.time.Duration.ofMillis(1))
+    Clock.tick(Clock.fixed(instant, ZoneOffset.UTC), java.time.Duration.ofMillis(1))
 
   private def localTime(instant: Instant) = LocalDateTime.now(fixedClock(instant))
 
@@ -550,7 +550,7 @@ class PeriodicProcessServiceIntegrationTest
     inactiveStates.latestDeploymentForSchedule(schedule2).state.status shouldBe PeriodicProcessDeploymentStatus.Finished
 
     val activities = service
-      .getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, Some(startTime.plusMillis(4000)))
+      .getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, Some(startTime))
       .futureValue
     val firstActivity  = activities.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     val secondActivity = activities(1).asInstanceOf[ScenarioActivity.PerformedScheduledExecution]

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
@@ -70,11 +70,11 @@ class PeriodicProcessServiceIntegrationTest
 
   private val sampleProcess = CanonicalProcess(MetaData(processName.value, StreamMetaData()), Nil)
 
-  private val startTime = Instant.parse("2021-04-06T13:18:00Z")
+  private val startTime = Instant.parse("2021-04-06T11:18:00Z")
 
   // we truncate to millis, as HSQL stores with that precision...
   private def fixedClock(instant: Instant) =
-    Clock.tick(Clock.fixed(instant, ZoneOffset.UTC), java.time.Duration.ofMillis(1))
+    Clock.tick(Clock.fixed(instant, ZoneId.systemDefault()), java.time.Duration.ofMillis(1))
 
   private def localTime(instant: Instant) = LocalDateTime.now(fixedClock(instant))
 
@@ -253,7 +253,7 @@ class PeriodicProcessServiceIntegrationTest
     //       and state of deployment
     inactiveStates.firstScheduleData.latestDeployments.head.state.status shouldBe PeriodicProcessDeploymentStatus.Scheduled
 
-    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
     val firstActivity = activities.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     activities shouldBe List(
       ScenarioActivity.PerformedScheduledExecution(
@@ -302,7 +302,7 @@ class PeriodicProcessServiceIntegrationTest
     service.deploy(toBeRetried).futureValue
     service.findToBeDeployed.futureValue.toList shouldBe Nil
 
-    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
     val firstActivity = activities.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     activities shouldBe List(
       ScenarioActivity.PerformedScheduledExecution(
@@ -383,7 +383,7 @@ class PeriodicProcessServiceIntegrationTest
     service.deactivate(processName).futureValue
     service.getLatestDeploymentsForActiveSchedules(processName).futureValue shouldBe empty
 
-    val activities = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
     activities shouldBe empty
   }
 
@@ -430,7 +430,7 @@ class PeriodicProcessServiceIntegrationTest
     toDeployAfterFinish.head.scheduleName.value.value shouldBe secondSchedule
 
     val firstActivity = eventually {
-      val result = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+      val result = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
       result should not be empty
       result.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     }
@@ -549,7 +549,9 @@ class PeriodicProcessServiceIntegrationTest
     inactiveStates.latestDeploymentForSchedule(schedule1).state.status shouldBe PeriodicProcessDeploymentStatus.Finished
     inactiveStates.latestDeploymentForSchedule(schedule2).state.status shouldBe PeriodicProcessDeploymentStatus.Finished
 
-    val activities     = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities = service
+      .getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, Some(startTime.plusMillis(4000)))
+      .futureValue
     val firstActivity  = activities.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     val secondActivity = activities(1).asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     activities shouldBe List(
@@ -648,7 +650,7 @@ class PeriodicProcessServiceIntegrationTest
     val stateAfterHandleFinished = service.getLatestDeploymentsForActiveSchedules(processName).futureValue
     stateAfterHandleFinished.latestDeploymentForSingleSchedule.state.status shouldBe PeriodicProcessDeploymentStatus.Scheduled
 
-    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
     val firstActivity = activities.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     activities shouldBe List(
       ScenarioActivity.PerformedScheduledExecution(

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceTest.scala
@@ -16,6 +16,7 @@ import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.PeriodicProcessService.PeriodicProcessStatus
 import pl.touk.nussknacker.engine.management.periodic.db.PeriodicProcessesRepository.createPeriodicProcessDeployment
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithCanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeploymentStatus.PeriodicProcessDeploymentStatus
 import pl.touk.nussknacker.engine.management.periodic.model.{PeriodicProcessDeployment, PeriodicProcessDeploymentStatus}
 import pl.touk.nussknacker.engine.management.periodic.service.ProcessConfigEnricher.EnrichedProcessConfig
@@ -85,7 +86,7 @@ class PeriodicProcessServiceTest
       additionalDeploymentDataProvider = new AdditionalDeploymentDataProvider {
 
         override def prepareAdditionalData(
-            runDetails: PeriodicProcessDeployment[CanonicalProcess]
+            runDetails: PeriodicProcessDeployment[WithCanonicalProcess]
         ): Map[String, String] =
           additionalData + ("runId" -> runDetails.id.value.toString)
 

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/db/InMemPeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/db/InMemPeriodicProcessesRepository.scala
@@ -12,11 +12,12 @@ import pl.touk.nussknacker.engine.management.periodic.db.InMemPeriodicProcessesR
   ProcessIdSequence
 }
 import pl.touk.nussknacker.engine.management.periodic.db.PeriodicProcessesRepository.createPeriodicProcessDeployment
+import pl.touk.nussknacker.engine.management.periodic.model.DeploymentWithJarData.WithCanonicalProcess
 import pl.touk.nussknacker.engine.management.periodic.model.PeriodicProcessDeploymentStatus.PeriodicProcessDeploymentStatus
 import pl.touk.nussknacker.engine.management.periodic.model._
 
 import java.time.chrono.ChronoLocalDateTime
-import java.time.{LocalDateTime, ZoneId}
+import java.time.{Instant, LocalDateTime, ZoneId}
 import java.util.concurrent.atomic.AtomicLong
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -30,7 +31,7 @@ object InMemPeriodicProcessesRepository {
 
 class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicProcessesRepository {
 
-  var processEntities: mutable.ListBuffer[PeriodicProcessEntity]              = ListBuffer.empty
+  var processEntities: mutable.ListBuffer[PeriodicProcessEntityWithJson]      = ListBuffer.empty
   var deploymentEntities: mutable.ListBuffer[PeriodicProcessDeploymentEntity] = ListBuffer.empty
 
   private implicit val localDateOrdering: Ordering[LocalDateTime] = Ordering.by(identity[ChronoLocalDateTime[_]])
@@ -68,17 +69,15 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
       processActionId: Option[ProcessActionId] = None
   ): PeriodicProcessId = {
     val id = PeriodicProcessId(ProcessIdSequence.incrementAndGet())
-    val entity = PeriodicProcessEntity(
+    val entity = PeriodicProcessEntityWithJson(
       id = id,
       processName = processName,
       processVersionId = VersionId.initialVersionId,
       processingType = processingType,
-      processJson = Some(
-        ScenarioBuilder
-          .streaming(processName.value)
-          .source("start", "source")
-          .emptySink("end", "KafkaSink")
-      ),
+      processJson = ScenarioBuilder
+        .streaming(processName.value)
+        .source("start", "source")
+        .emptySink("end", "KafkaSink"),
       inputConfigDuringExecutionJson = "{}",
       jarFileName = "",
       scheduleProperty = scheduleProperty.asJson.noSpaces,
@@ -116,7 +115,8 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
   }
 
   override def getSchedulesState(
-      scenarioName: ProcessName
+      scenarioName: ProcessName,
+      after: Option[LocalDateTime],
   ): Action[SchedulesState] = {
     val filteredProcesses = processEntities.filter { pe =>
       pe.processName == scenarioName && deploymentEntities.exists(d => d.periodicProcessId == pe.id)
@@ -132,17 +132,17 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
       }
 
   override def create(
-      deploymentWithJarData: DeploymentWithJarData[CanonicalProcess],
+      deploymentWithJarData: DeploymentWithJarData.WithCanonicalProcess,
       scheduleProperty: ScheduleProperty,
       processActionId: ProcessActionId,
-  ): PeriodicProcess[CanonicalProcess] = {
+  ): PeriodicProcess[WithCanonicalProcess] = {
     val id = PeriodicProcessId(Random.nextLong())
-    val periodicProcess = PeriodicProcessEntity(
+    val periodicProcess = PeriodicProcessEntityWithJson(
       id = id,
       processName = deploymentWithJarData.processVersion.processName,
       processVersionId = deploymentWithJarData.processVersion.versionId,
       processingType = processingType,
-      processJson = Some(deploymentWithJarData.process),
+      processJson = deploymentWithJarData.process,
       inputConfigDuringExecutionJson = deploymentWithJarData.inputConfigDuringExecutionJson,
       jarFileName = deploymentWithJarData.jarFileName,
       scheduleProperty = scheduleProperty.asJson.noSpaces,
@@ -203,28 +203,28 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
         }
     } yield deploymentGroupedByScheduleName).toMap)
 
-  override def findToBeDeployed: Seq[PeriodicProcessDeployment[CanonicalProcess]] = {
+  override def findToBeDeployed: Seq[PeriodicProcessDeployment[WithCanonicalProcess]] = {
     val scheduled = findActive(PeriodicProcessDeploymentStatus.Scheduled)
     readyToRun(scheduled)
   }
 
-  override def findToBeRetried: Action[Seq[PeriodicProcessDeployment[CanonicalProcess]]] = {
+  override def findToBeRetried: Action[Seq[PeriodicProcessDeployment[WithCanonicalProcess]]] = {
     val toBeRetried = findActive(PeriodicProcessDeploymentStatus.FailedOnDeploy).filter(_.retriesLeft > 0)
     readyToRun(toBeRetried)
   }
 
-  override def findProcessData(id: PeriodicProcessDeploymentId): PeriodicProcessDeployment[CanonicalProcess] =
+  override def findProcessData(id: PeriodicProcessDeploymentId): PeriodicProcessDeployment[WithCanonicalProcess] =
     (for {
       d <- deploymentEntities if d.id == id
       p <- processEntities if p.id == d.periodicProcessId
     } yield createPeriodicProcessDeployment(p, d)).head
 
-  override def findProcessData(processName: ProcessName): Seq[PeriodicProcess[CanonicalProcess]] =
+  override def findProcessData(processName: ProcessName): Seq[PeriodicProcess[WithCanonicalProcess]] =
     processEntities(processName)
       .filter(_.active)
       .map(PeriodicProcessesRepository.createPeriodicProcessWithJson)
 
-  private def processEntities(processName: ProcessName): Seq[PeriodicProcessEntity] =
+  private def processEntities(processName: ProcessName): Seq[PeriodicProcessEntityWithJson] =
     processEntities
       .filter(process => process.processName == processName && process.processingType == processingType)
       .toSeq
@@ -267,7 +267,7 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
       scheduleName: ScheduleName,
       runAt: LocalDateTime,
       deployMaxRetries: Int
-  ): PeriodicProcessDeployment[CanonicalProcess] = {
+  ): PeriodicProcessDeployment[WithCanonicalProcess] = {
     val deploymentEntity = PeriodicProcessDeploymentEntity(
       id = PeriodicProcessDeploymentId(Random.nextLong()),
       periodicProcessId = id,
@@ -294,22 +294,24 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
       }
   }
 
-  private def findActive(status: PeriodicProcessDeploymentStatus): Seq[PeriodicProcessDeployment[CanonicalProcess]] =
+  private def findActive(
+      status: PeriodicProcessDeploymentStatus
+  ): Seq[PeriodicProcessDeployment[WithCanonicalProcess]] =
     findActive(
       Seq(status)
     )
 
   private def findActive(
       statusList: Seq[PeriodicProcessDeploymentStatus]
-  ): Seq[PeriodicProcessDeployment[CanonicalProcess]] =
+  ): Seq[PeriodicProcessDeployment[WithCanonicalProcess]] =
     (for {
       p <- processEntities if p.active && p.processingType == processingType
       d <- deploymentEntities if d.periodicProcessId == p.id && statusList.contains(d.status)
     } yield createPeriodicProcessDeployment(p, d)).toSeq
 
   private def readyToRun(
-      deployments: Seq[PeriodicProcessDeployment[CanonicalProcess]]
-  ): Seq[PeriodicProcessDeployment[CanonicalProcess]] = {
+      deployments: Seq[PeriodicProcessDeployment[WithCanonicalProcess]]
+  ): Seq[PeriodicProcessDeployment[WithCanonicalProcess]] = {
     val now = LocalDateTime.now()
     deployments.filter(d => d.runAt.isBefore(now) || d.runAt.isEqual(now))
   }

--- a/utils/test-utils/src/main/resources/logback-test.xml
+++ b/utils/test-utils/src/main/resources/logback-test.xml
@@ -19,9 +19,9 @@
 
     <!-- let's keep here INFO - if it will produce too many logs, we should rather think if our INFO logs are too much verbose... -->
     <logger name="pl.touk.nussknacker" level="${NUSSKNACKER_LOG_LEVEL:-INFO}"/>
-    <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG"/>
-    <logger name="slick.jdbc.JdbcBackend.parameter" level="DEBUG"/>
-    <logger name="slick.jdbc.StatementInvoker.result" level="DEBUG"/>
+    <logger name="slick.jdbc.JdbcBackend.statement" level="${SLICK_SQL_LOG_LEVEL:-INFO}"/>
+    <logger name="slick.jdbc.JdbcBackend.parameter" level="${SLICK_SQL_LOG_LEVEL:-INFO}"/>
+    <logger name="slick.jdbc.StatementInvoker.result" level="${SLICK_SQL_LOG_LEVEL:-INFO}"/>
     <logger name="DockerTest" level="DEBUG"/>
     <!-- To not show "The module flink-runtime-web could not be found in the class path" stack trace, even when debug enabled -->
     <logger name="org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint" level="INFO"/>

--- a/utils/test-utils/src/main/resources/logback-test.xml
+++ b/utils/test-utils/src/main/resources/logback-test.xml
@@ -19,9 +19,9 @@
 
     <!-- let's keep here INFO - if it will produce too many logs, we should rather think if our INFO logs are too much verbose... -->
     <logger name="pl.touk.nussknacker" level="${NUSSKNACKER_LOG_LEVEL:-INFO}"/>
-    <logger name="slick.jdbc.JdbcBackend.statement" level="${SLICK_SQL_LOG_LEVEL:-INFO}"/>
-    <logger name="slick.jdbc.JdbcBackend.parameter" level="${SLICK_SQL_LOG_LEVEL:-INFO}"/>
-    <logger name="slick.jdbc.StatementInvoker.result" level="${SLICK_SQL_LOG_LEVEL:-INFO}"/>
+    <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG"/>
+    <logger name="slick.jdbc.JdbcBackend.parameter" level="DEBUG"/>
+    <logger name="slick.jdbc.StatementInvoker.result" level="DEBUG"/>
     <logger name="DockerTest" level="DEBUG"/>
     <!-- To not show "The module flink-runtime-web could not be found in the class path" stack trace, even when debug enabled -->
     <logger name="org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint" level="INFO"/>


### PR DESCRIPTION
## Describe your changes

- Nussknacker was fetching too much data for periodic process deployments - it was fetching unused `inputConfigDuringExecutionJson` from the db even when full JSON was not fetched.
- added time limit argument to the query, that fetches periodic deployments for notifications

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
