### PR TITLE
[Fix] Fix notifications to not trigger state update for fragments, fetch less periodic deployments for notifications

### DIFF
--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
@@ -5,6 +5,7 @@ import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName, V
 import pl.touk.nussknacker.engine.deployment.CustomActionDefinition
 import pl.touk.nussknacker.engine.newdeployment
 
+import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 
@@ -93,7 +94,8 @@ trait DeploymentManager extends AutoCloseable {
 trait ManagerSpecificScenarioActivitiesStoredByManager { self: DeploymentManager =>
 
   def managerSpecificScenarioActivities(
-      processIdWithName: ProcessIdWithName
+      processIdWithName: ProcessIdWithName,
+      after: Option[Instant],
   ): Future[List[ScenarioActivity]]
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/notifications/Notification.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/notifications/Notification.scala
@@ -3,9 +3,15 @@ package pl.touk.nussknacker.ui.notifications
 import derevo.circe.{decoder, encoder}
 import derevo.derive
 import io.circe.{Decoder, Encoder}
-import pl.touk.nussknacker.engine.api.deployment.{ProcessActionState, ScenarioActionName}
+import pl.touk.nussknacker.engine.api.deployment.{
+  DeploymentRelatedActivity,
+  ProcessActionState,
+  ScenarioActionName,
+  ScenarioActivity
+}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.ui.notifications.DataToRefresh.DataToRefresh
+import pl.touk.nussknacker.ui.util.ScenarioActivityUtils.ScenarioActivityOps
 import sttp.tapir.Schema
 import sttp.tapir.derevo.schema
 
@@ -69,17 +75,20 @@ object Notification {
   }
 
   def scenarioStateUpdateNotification(
-      id: String,
-      activityName: String,
+      activity: ScenarioActivity,
       name: ProcessName
   ): Notification = {
-    // We don't want to display this notification, because it causes the activities toolbar to refresh
+    val toRefresh = activity match {
+      case _: DeploymentRelatedActivity => List(DataToRefresh.activity, DataToRefresh.state)
+      case _                            => List(DataToRefresh.activity)
+    }
     Notification(
-      id = id,
+      id = s"${activity.scenarioActivityId.value.toString}_${activity.lastModifiedAt.toEpochMilli}",
       scenarioName = Some(name),
-      message = activityName,
+      message = activity.activityType.entryName,
+      // We don't want to display this notification, because it causes the activities toolbar to refresh
       `type` = None,
-      toRefresh = List(DataToRefresh.activity, DataToRefresh.state)
+      toRefresh = toRefresh
     )
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/notifications/NotificationService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/notifications/NotificationService.scala
@@ -6,7 +6,6 @@ import pl.touk.nussknacker.ui.notifications.NotificationService.NotificationsSco
 import pl.touk.nussknacker.ui.process.repository.{DBIOActionRunner, ScenarioActionRepository}
 import pl.touk.nussknacker.ui.process.scenarioactivity.FetchScenarioActivityService
 import pl.touk.nussknacker.ui.security.api.LoggedUser
-import pl.touk.nussknacker.ui.util.ScenarioActivityUtils.ScenarioActivityOps
 
 import java.time.{Clock, Instant}
 import scala.concurrent.duration.FiniteDuration
@@ -103,11 +102,7 @@ class NotificationServiceImpl(
         case Left(_)           => List.empty
       }
       notificationsForScenarioActivities = allActivities.map { activity =>
-        Notification.scenarioStateUpdateNotification(
-          s"${activity.scenarioActivityId.value.toString}_${activity.lastModifiedAt.toEpochMilli}",
-          activity.activityType.entryName,
-          processName
-        )
+        Notification.scenarioStateUpdateNotification(activity, processName)
       }
     } yield notificationsForScenarioActivities
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/scenarioactivity/FetchScenarioActivityService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/scenarioactivity/FetchScenarioActivityService.scala
@@ -45,9 +45,7 @@ class FetchScenarioActivityService(
       deploymentManager <- deploymentManagerDispatcher.deploymentManager(processIdWithName)
       deploymentManagerSpecificActivities <- deploymentManager match {
         case Some(manager: ManagerSpecificScenarioActivitiesStoredByManager) =>
-          manager
-            .managerSpecificScenarioActivities(processIdWithName)
-            .map(_.filter { activity => after.forall(after => activity.date > after) })
+          manager.managerSpecificScenarioActivities(processIdWithName, after)
         case Some(_) | None =>
           Future.successful(List.empty)
       }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/notifications/NotificationServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/notifications/NotificationServiceTest.scala
@@ -200,7 +200,7 @@ class NotificationServiceTest
         Some(processName),
         "SCENARIO_CREATED",
         None,
-        List(DataToRefresh.activity, DataToRefresh.state)
+        List(DataToRefresh.activity)
       ),
       Notification(
         notifications(2).id,

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
@@ -18,6 +18,7 @@ import pl.touk.nussknacker.engine.newdeployment.DeploymentId
 import pl.touk.nussknacker.engine.testing.StubbingCommands
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 
+import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -138,7 +139,8 @@ object MockableDeploymentManagerProvider {
     override def deploymentSynchronisationSupport: DeploymentSynchronisationSupport = NoDeploymentSynchronisationSupport
 
     override def managerSpecificScenarioActivities(
-        processIdWithName: ProcessIdWithName
+        processIdWithName: ProcessIdWithName,
+        after: Option[Instant],
     ): Future[List[ScenarioActivity]] =
       Future.successful(MockableDeploymentManager.managerSpecificScenarioActivities.get())
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -25,7 +25,7 @@ import pl.touk.nussknacker.engine.{BaseModelData, DeploymentManagerDependencies}
 import slick.jdbc
 import slick.jdbc.JdbcProfile
 
-import java.time.Clock
+import java.time.{Clock, Instant}
 import scala.concurrent.{ExecutionContext, Future}
 
 object PeriodicDeploymentManager {
@@ -250,9 +250,10 @@ class PeriodicDeploymentManager private[periodic] (
   //    - we may need to refactor PeriodicDeploymentManager data source first
 
   override def managerSpecificScenarioActivities(
-      processIdWithName: ProcessIdWithName
+      processIdWithName: ProcessIdWithName,
+      after: Option[Instant],
   ): Future[List[ScenarioActivity]] =
-    service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName)
+    service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, after)
 
   private def actionInstantBatch(command: DMPerformSingleExecutionCommand): Future[SingleExecutionResult] = {
     val processName           = command.processVersion.processName

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
@@ -253,7 +253,7 @@ class PeriodicProcessServiceIntegrationTest
     //       and state of deployment
     inactiveStates.firstScheduleData.latestDeployments.head.state.status shouldBe PeriodicProcessDeploymentStatus.Scheduled
 
-    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
     val firstActivity = activities.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     activities shouldBe List(
       ScenarioActivity.PerformedScheduledExecution(
@@ -302,7 +302,7 @@ class PeriodicProcessServiceIntegrationTest
     service.deploy(toBeRetried).futureValue
     service.findToBeDeployed.futureValue.toList shouldBe Nil
 
-    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
     val firstActivity = activities.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     activities shouldBe List(
       ScenarioActivity.PerformedScheduledExecution(
@@ -383,7 +383,7 @@ class PeriodicProcessServiceIntegrationTest
     service.deactivate(processName).futureValue
     service.getLatestDeploymentsForActiveSchedules(processName).futureValue shouldBe empty
 
-    val activities = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
     activities shouldBe empty
   }
 
@@ -430,7 +430,7 @@ class PeriodicProcessServiceIntegrationTest
     toDeployAfterFinish.head.scheduleName.value.value shouldBe secondSchedule
 
     val firstActivity = eventually {
-      val result = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+      val result = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
       result should not be empty
       result.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     }
@@ -549,7 +549,7 @@ class PeriodicProcessServiceIntegrationTest
     inactiveStates.latestDeploymentForSchedule(schedule1).state.status shouldBe PeriodicProcessDeploymentStatus.Finished
     inactiveStates.latestDeploymentForSchedule(schedule2).state.status shouldBe PeriodicProcessDeploymentStatus.Finished
 
-    val activities     = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities     = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
     val firstActivity  = activities.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     val secondActivity = activities(1).asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     activities shouldBe List(
@@ -648,7 +648,7 @@ class PeriodicProcessServiceIntegrationTest
     val stateAfterHandleFinished = service.getLatestDeploymentsForActiveSchedules(processName).futureValue
     stateAfterHandleFinished.latestDeploymentForSingleSchedule.state.status shouldBe PeriodicProcessDeploymentStatus.Scheduled
 
-    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName).futureValue
+    val activities    = service.getScenarioActivitiesSpecificToPeriodicProcess(processIdWithName, None).futureValue
     val firstActivity = activities.head.asInstanceOf[ScenarioActivity.PerformedScheduledExecution]
     activities shouldBe List(
       ScenarioActivity.PerformedScheduledExecution(

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/db/InMemPeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/db/InMemPeriodicProcessesRepository.scala
@@ -116,7 +116,8 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
   }
 
   override def getSchedulesState(
-      scenarioName: ProcessName
+      scenarioName: ProcessName,
+      after: Option[LocalDateTime],
   ): Action[SchedulesState] = {
     val filteredProcesses = processEntities.filter { pe =>
       pe.processName == scenarioName && deploymentEntities.exists(d => d.periodicProcessId == pe.id)


### PR DESCRIPTION
## Describe your changes

- Notifications not related to deployments or cancels should not trigger scenario state refresh on FE
- limited number of periodic deployments fetched from DB (filtering by date) for notifications

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
