### PR TITLE
Allow "run now" only for currently deployed version, which must be presented on UI

### DIFF
--- a/designer/client/cypress/e2e/connectionError.cy.ts
+++ b/designer/client/cypress/e2e/connectionError.cy.ts
@@ -82,12 +82,12 @@ describe("Connection error", () => {
 
         const statusIntervalTick = 10000;
         const visibleStatusToastMessageBeforeConnectionError = () => {
-            cy.intercept("/api/processes/*/status", { statusCode: 502 });
+            cy.intercept("/api/processes/*/status?currentlyPresentedVersionId=*", { statusCode: 502 });
 
             // Check if the status toast message is not visible after the backend connection issue. We need to speed up interval to not wait 12s for a request
             cy.contains(/Cannot fetch status/).should("be.visible");
 
-            cy.intercept("/api/processes/*/status", (req) => {
+            cy.intercept("/api/processes/*/status?currentlyPresentedVersionId=*", (req) => {
                 req.continue();
             });
         };

--- a/designer/client/src/actions/nk/process.ts
+++ b/designer/client/src/actions/nk/process.ts
@@ -26,9 +26,9 @@ export function fetchProcessToDisplay(processName: ProcessName, versionId?: Proc
     };
 }
 
-export function loadProcessState(processName: ProcessName): ThunkAction {
+export function loadProcessState(processName: ProcessName, processVersionId: number): ThunkAction {
     return (dispatch) =>
-        HttpService.fetchProcessState(processName).then(({ data }) =>
+        HttpService.fetchProcessState(processName, processVersionId).then(({ data }) =>
             dispatch({
                 type: "PROCESS_STATE_LOADED",
                 processState: data,

--- a/designer/client/src/components/modals/AddAttachmentDialog.tsx
+++ b/designer/client/src/components/modals/AddAttachmentDialog.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 import { Typography } from "@mui/material";
 import httpService from "../../http/HttpService";
 import { useDispatch, useSelector } from "react-redux";
-import { getProcessName, getProcessVersionId } from "../../reducers/selectors/graph";
+import { getProcessVersionId, getProcessName } from "../../reducers/selectors/graph";
 import { AddAttachment, Attachment } from "../processAttach/AddAttachment";
 import { AttachmentEl } from "../processAttach/AttachmentEl";
 import { getScenarioActivities } from "../../actions/nk/scenarioActivities";

--- a/designer/client/src/components/modals/CustomActionDialog.tsx
+++ b/designer/client/src/components/modals/CustomActionDialog.tsx
@@ -19,6 +19,7 @@ import { nodeValue } from "../graph/node-modal/NodeDetailsContent/NodeTableStyle
 import { getValidationErrorsForField } from "../graph/node-modal/editors/Validators";
 import { getFeatureSettings } from "../../reducers/selectors/settings";
 import CommentInput from "../comment/CommentInput";
+import { getProcessVersionId } from "../../reducers/selectors/graph";
 
 interface CustomActionFormProps extends ChangeableValue<UnknownRecord> {
     action: CustomAction;
@@ -95,6 +96,7 @@ function CustomActionForm(props: CustomActionFormProps): JSX.Element {
 
 export function CustomActionDialog(props: WindowContentProps<WindowKind, CustomAction>): JSX.Element {
     const processName = useSelector(getProcessName);
+    const processVersionId = useSelector(getProcessVersionId);
     const dispatch = useDispatch();
     const action = props.data.meta;
     const [validationError, setValidationError] = useState("");
@@ -111,7 +113,7 @@ export function CustomActionDialog(props: WindowContentProps<WindowKind, CustomA
     const confirmAction = useCallback(async () => {
         await HttpService.customAction(processName, action.name, value, comment).then((response) => {
             if (response.isSuccess) {
-                dispatch(loadProcessState(processName));
+                dispatch(loadProcessState(processName, processVersionId));
                 props.close();
             } else {
                 setValidationError(response.msg);

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/CancelDeployButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/CancelDeployButton.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { loadProcessState } from "../../../../actions/nk";
 import Icon from "../../../../assets/img/toolbarButtons/stop.svg";
 import HttpService from "../../../../http/HttpService";
-import { getProcessName, isCancelPossible } from "../../../../reducers/selectors/graph";
+import { getProcessName, getProcessVersionId, isCancelPossible } from "../../../../reducers/selectors/graph";
 import { getCapabilities } from "../../../../reducers/selectors/other";
 import { WindowKind, useWindows } from "../../../../windowManager";
 import { ToggleProcessActionModalData } from "../../../modals/DeployProcessDialog";
@@ -18,11 +18,12 @@ export default function CancelDeployButton(props: ToolbarButtonProps) {
     const { disabled, type } = props;
     const cancelPossible = useSelector(isCancelPossible);
     const processName = useSelector(getProcessName);
+    const processVersionId = useSelector(getProcessVersionId);
     const capabilities = useSelector(getCapabilities);
     const available = !disabled && cancelPossible && capabilities.deploy;
 
     const { open } = useWindows();
-    const action = (p, c) => HttpService.cancel(p, c).finally(() => dispatch(loadProcessState(processName)));
+    const action = (p, c) => HttpService.cancel(p, c).finally(() => dispatch(loadProcessState(processName, processVersionId)));
     const message = t("panels.actions.deploy-canel.dialog", "Cancel scenario {{name}}", { name: processName });
 
     return (

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/DeployButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/DeployButton.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { disableToolTipsHighlight, enableToolTipsHighlight, loadProcessState } from "../../../../actions/nk";
 import Icon from "../../../../assets/img/toolbarButtons/deploy.svg";
 import HttpService from "../../../../http/HttpService";
-import { getProcessName, hasError, isDeployPossible, isSaveDisabled } from "../../../../reducers/selectors/graph";
+import { getProcessName, getProcessVersionId, hasError, isDeployPossible, isSaveDisabled } from "../../../../reducers/selectors/graph";
 import { getCapabilities } from "../../../../reducers/selectors/other";
 import { useWindows } from "../../../../windowManager";
 import { WindowKind } from "../../../../windowManager";
@@ -19,6 +19,7 @@ export default function DeployButton(props: ToolbarButtonProps) {
     const saveDisabled = useSelector(isSaveDisabled);
     const hasErrors = useSelector(hasError);
     const processName = useSelector(getProcessName);
+    const processVersionId = useSelector(getProcessVersionId);
     const capabilities = useSelector(getCapabilities);
     const { disabled, type } = props;
 
@@ -38,7 +39,7 @@ export default function DeployButton(props: ToolbarButtonProps) {
     const { open } = useWindows();
 
     const message = t("panels.actions.deploy.dialog", "Deploy scenario {{name}}", { name: processName });
-    const action = (p, c) => HttpService.deploy(p, c).finally(() => dispatch(loadProcessState(processName)));
+    const action = (p, c) => HttpService.deploy(p, c).finally(() => dispatch(loadProcessState(processName, processVersionId)));
 
     return (
         <ToolbarButton

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/PerformSingleExecutionButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/PerformSingleExecutionButton.tsx
@@ -4,7 +4,12 @@ import { useDispatch, useSelector } from "react-redux";
 import { loadProcessState } from "../../../../actions/nk";
 import Icon from "../../../../assets/img/toolbarButtons/perform-single-execution.svg";
 import HttpService from "../../../../http/HttpService";
-import { getProcessName, isPerformSingleExecutionPossible, isPerformSingleExecutionVisible } from "../../../../reducers/selectors/graph";
+import {
+    getProcessName,
+    getProcessVersionId,
+    isPerformSingleExecutionPossible,
+    isPerformSingleExecutionVisible,
+} from "../../../../reducers/selectors/graph";
 import { getCapabilities } from "../../../../reducers/selectors/other";
 import { useWindows, WindowKind } from "../../../../windowManager";
 import { ToggleProcessActionModalData } from "../../../modals/DeployProcessDialog";
@@ -24,11 +29,13 @@ export default function PerformSingleExecutionButton(props: ToolbarButtonProps) 
     const isVisible = useSelector(isPerformSingleExecutionVisible);
     const isPossible = useSelector(isPerformSingleExecutionPossible);
     const processName = useSelector(getProcessName);
+    const processVersionId = useSelector(getProcessVersionId);
     const capabilities = useSelector(getCapabilities);
     const available = !disabled && isPossible && capabilities.deploy;
 
     const { open } = useWindows();
-    const action = (p, c) => HttpService.performSingleExecution(p, c).finally(() => dispatch(loadProcessState(processName)));
+    const action = (p, c) =>
+        HttpService.performSingleExecution(p, c).finally(() => dispatch(loadProcessState(processName, processVersionId)));
     const message = t("panels.actions.perform-single-execution.dialog", "Perform single execution", { name: processName });
 
     const defaultTooltip = t("panels.actions.perform-single-execution.tooltip", "run now");

--- a/designer/client/src/containers/Notifications.tsx
+++ b/designer/client/src/containers/Notifications.tsx
@@ -11,7 +11,7 @@ import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import DangerousOutlinedIcon from "@mui/icons-material/DangerousOutlined";
 import { markBackendNotificationRead, updateBackendNotifications } from "../actions/nk/notifications";
 import { loadProcessState } from "../actions/nk";
-import { getProcessName } from "../reducers/selectors/graph";
+import { getProcessName, getProcessVersionId } from "../reducers/selectors/graph";
 import { useChangeConnectionError } from "./connectionErrorProvider";
 import i18next from "i18next";
 import { ThunkAction } from "../actions/reduxTypes";
@@ -44,7 +44,7 @@ const prepareNotification =
     };
 
 const handleRefresh =
-    ({ scenarioName, toRefresh }: BackendNotification, currentScenarioName: string): ThunkAction =>
+    ({ scenarioName, toRefresh }: BackendNotification, currentScenarioName: string, processVersionId: number): ThunkAction =>
     (dispatch) => {
         if (!scenarioName || scenarioName !== currentScenarioName) {
             return;
@@ -54,13 +54,13 @@ const handleRefresh =
                 case "activity":
                     return dispatch(getScenarioActivities(scenarioName));
                 case "state":
-                    return dispatch(loadProcessState(scenarioName));
+                    return dispatch(loadProcessState(scenarioName, processVersionId));
             }
         });
     };
 
 const prepareNotifications =
-    (notifications: BackendNotification[], scenarioName: string): ThunkAction =>
+    (notifications: BackendNotification[], scenarioName: string, processVersionId: number): ThunkAction =>
     (dispatch, getState) => {
         const state = getState();
         const { processedNotificationIds } = getBackendNotifications(state);
@@ -74,7 +74,7 @@ const prepareNotifications =
 
         notifications.filter(onlyUnreadPredicate).forEach((notification) => {
             dispatch(prepareNotification(notification));
-            dispatch(handleRefresh(notification, scenarioName));
+            dispatch(handleRefresh(notification, scenarioName, processVersionId));
         });
     };
 
@@ -86,13 +86,14 @@ export function Notifications(): JSX.Element {
     useEffect(() => HttpService.setNotificationActions(bindActionCreators(NotificationActions, dispatch)));
 
     const currentScenarioName = useSelector(getProcessName);
+    const processVersionId = useSelector(getProcessVersionId);
 
     const refresh = useCallback(() => {
         HttpService.loadBackendNotifications(currentScenarioName)
             .then((notifications) => {
                 handleChangeConnectionError(null);
                 dispatch(updateBackendNotifications(notifications.map(({ id }) => id)));
-                dispatch(prepareNotifications(notifications, currentScenarioName));
+                dispatch(prepareNotifications(notifications, currentScenarioName, processVersionId));
             })
             .catch((error) => {
                 const isNetworkAccess = navigator.onLine;

--- a/designer/client/src/containers/Visualization.tsx
+++ b/designer/client/src/containers/Visualization.tsx
@@ -20,7 +20,7 @@ import { useRouteLeavingGuard } from "../components/RouteLeavingGuard";
 import SpinnerWrapper from "../components/spinner/SpinnerWrapper";
 import Toolbars from "../components/toolbars/Toolbars";
 import { RootState } from "../reducers";
-import { getGraph, getScenario, getScenarioGraph } from "../reducers/selectors/graph";
+import { getGraph, getProcessVersionId, getScenario, getScenarioGraph } from "../reducers/selectors/graph";
 import { getCapabilities } from "../reducers/selectors/other";
 import { getProcessDefinitionData } from "../reducers/selectors/settings";
 import { useWindows } from "../windowManager";
@@ -51,9 +51,10 @@ function useUnmountCleanup() {
 function useProcessState(refreshTime = 10000) {
     const dispatch = useDispatch();
     const scenario = useSelector(getScenario);
+    const versionId = useSelector(getProcessVersionId);
     const { isFragment, isArchived, name } = scenario || {};
 
-    const fetch = useCallback(() => dispatch(loadProcessState(name)), [dispatch, name]);
+    const fetch = useCallback(() => dispatch(loadProcessState(name, versionId)), [dispatch, name, versionId]);
     const disabled = !name || isFragment || isArchived;
 
     useInterval(fetch, {

--- a/designer/client/src/http/HttpService.ts
+++ b/designer/client/src/http/HttpService.ts
@@ -315,8 +315,8 @@ class HttpService {
         return promise;
     }
 
-    fetchProcessState(processName: ProcessName) {
-        const promise = api.get(`/processes/${encodeURIComponent(processName)}/status`);
+    fetchProcessState(processName: ProcessName, processVersionId: number) {
+        const promise = api.get(`/processes/${encodeURIComponent(processName)}/status?currentlyPresentedVersionId=${processVersionId}`);
         promise.catch((error) => this.#addError(i18next.t("notification.error.cannotFetchStatus", "Cannot fetch status"), error));
         return promise;
     }

--- a/designer/client/src/reducers/selectors/graph.ts
+++ b/designer/client/src/reducers/selectors/graph.ts
@@ -61,8 +61,8 @@ export const isPerformSingleExecutionVisible = createSelector([getProcessState],
     ProcessStateUtils.canSeePerformSingleExecution(state),
 );
 export const isPerformSingleExecutionPossible = createSelector(
-    [isSaveDisabled, hasError, getProcessState, isFragment],
-    (saveDisabled, error, state, fragment) => !fragment && saveDisabled && !error && ProcessStateUtils.canPerformSingleExecution(state),
+    [hasError, getProcessState, isFragment],
+    (error, state, fragment) => !fragment && !error && ProcessStateUtils.canPerformSingleExecution(state),
 );
 export const isMigrationPossible = createSelector(
     [isSaveDisabled, hasError, getProcessState, isFragment],

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/DeploymentManager.scala
@@ -17,10 +17,16 @@ trait DeploymentManagerInconsistentStateHandlerMixIn {
       lastStateAction: Option[ProcessAction],
       latestVersionId: VersionId,
       deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState] = {
     val engineStateResolvedWithLastAction = flattenStatus(lastStateAction, statusDetails)
     Future.successful(
-      processStateDefinitionManager.processState(engineStateResolvedWithLastAction, latestVersionId, deployedVersionId)
+      processStateDefinitionManager.processState(
+        engineStateResolvedWithLastAction,
+        latestVersionId,
+        deployedVersionId,
+        currentlyPresentedVersionId
+      )
     )
   }
 
@@ -46,6 +52,7 @@ trait DeploymentManager extends AutoCloseable {
       lastStateAction: Option[ProcessAction],
       latestVersionId: VersionId,
       deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   )(
       implicit freshnessPolicy: DataFreshnessPolicy
   ): Future[WithDataFreshnessStatus[ProcessState]] = {
@@ -56,7 +63,8 @@ trait DeploymentManager extends AutoCloseable {
         statusDetailsWithFreshness.value,
         lastStateAction,
         latestVersionId,
-        deployedVersionId
+        deployedVersionId,
+        currentlyPresentedVersionId,
       ).map(state => statusDetailsWithFreshness.map(_ => state))
     } yield stateWithFreshness
   }
@@ -79,6 +87,7 @@ trait DeploymentManager extends AutoCloseable {
       lastStateAction: Option[ProcessAction],
       latestVersionId: VersionId,
       deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState]
 
   def processStateDefinitionManager: ProcessStateDefinitionManager

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessStateDefinitionManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/ProcessStateDefinitionManager.scala
@@ -59,9 +59,10 @@ trait ProcessStateDefinitionManager {
   def processState(
       statusDetails: StatusDetails,
       latestVersionId: VersionId,
-      deployedVersionId: Option[VersionId]
+      deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   ): ProcessState = {
-    val status = ProcessStatus(statusDetails.status, latestVersionId, deployedVersionId)
+    val status = ProcessStatus(statusDetails.status, latestVersionId, deployedVersionId, currentlyPresentedVersionId)
     ProcessState(
       statusDetails.externalDeploymentId,
       statusDetails.status,
@@ -92,7 +93,8 @@ object ProcessStateDefinitionManager {
   final case class ProcessStatus(
       stateStatus: StateStatus,
       latestVersionId: VersionId,
-      deployedVersionId: Option[VersionId]
+      deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   )
 
   /**

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/cache/CachingProcessStateDeploymentManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/cache/CachingProcessStateDeploymentManager.scala
@@ -29,8 +29,16 @@ class CachingProcessStateDeploymentManager(
       lastStateAction: Option[ProcessAction],
       latestVersionId: VersionId,
       deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState] =
-    delegate.resolve(idWithName, statusDetails, lastStateAction, latestVersionId, deployedVersionId)
+    delegate.resolve(
+      idWithName,
+      statusDetails,
+      lastStateAction,
+      latestVersionId,
+      deployedVersionId,
+      currentlyPresentedVersionId
+    )
 
   override def getProcessStates(
       name: ProcessName

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleProcessStateDefinitionManager.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/api/deployment/simple/SimpleProcessStateDefinitionManager.scala
@@ -39,6 +39,6 @@ object SimpleProcessStateDefinitionManager extends ProcessStateDefinitionManager
     SimpleStateStatus.definitions
 
   def errorFailedToGet(versionId: VersionId): ProcessState =
-    processState(StatusDetails(FailedToGet, None), versionId, None)
+    processState(StatusDetails(FailedToGet, None), versionId, None, None)
 
 }

--- a/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
+++ b/designer/deployment-manager-api/src/main/scala/pl/touk/nussknacker/engine/testing/DeploymentManagerStub.scala
@@ -28,6 +28,7 @@ class DeploymentManagerStub extends BaseDeploymentManager with StubbingCommands 
       lastStateAction: Option[ProcessAction],
       latestVersionId: VersionId,
       deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState] = {
     val lastStateActionStatus = lastStateAction match {
       case Some(action) if action.actionName == ScenarioActionName.Deploy =>
@@ -41,7 +42,8 @@ class DeploymentManagerStub extends BaseDeploymentManager with StubbingCommands 
       processStateDefinitionManager.processState(
         StatusDetails(lastStateActionStatus, None),
         latestVersionId,
-        deployedVersionId
+        deployedVersionId,
+        currentlyPresentedVersionId,
       )
     )
   }

--- a/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/SimpleProcessStateSpec.scala
+++ b/designer/deployment-manager-api/src/test/scala/pl/touk/nussknacker/engine/api/deployment/SimpleProcessStateSpec.scala
@@ -15,7 +15,8 @@ class SimpleProcessStateSpec extends AnyFunSpec with Matchers with Inside {
     SimpleProcessStateDefinitionManager.processState(
       StatusDetails(stateStatus, None, Some(ExternalDeploymentId("12"))),
       VersionId(1),
-      None
+      None,
+      None,
     )
 
   it("scenario state should be during deploy") {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessStateProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessStateProvider.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.ui.process
 
 import cats.Traverse
 import pl.touk.nussknacker.engine.api.deployment.{DataFreshnessPolicy, ProcessState}
-import pl.touk.nussknacker.engine.api.process.ProcessIdWithName
+import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, VersionId}
 import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
 import pl.touk.nussknacker.ui.process.repository.ScenarioWithDetailsEntity
 import pl.touk.nussknacker.ui.security.api.LoggedUser
@@ -22,7 +22,8 @@ trait ProcessStateProvider {
   )(implicit user: LoggedUser, freshnessPolicy: DataFreshnessPolicy): Future[ProcessState]
 
   def getProcessState(
-      processIdWithName: ProcessIdWithName
+      processIdWithName: ProcessIdWithName,
+      currentlyPresentedVersionId: Option[VersionId],
   )(implicit user: LoggedUser, freshnessPolicy: DataFreshnessPolicy): Future[ProcessState]
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/InvalidDeploymentManagerStub.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/InvalidDeploymentManagerStub.scala
@@ -31,8 +31,16 @@ object InvalidDeploymentManagerStub extends DeploymentManager {
       lastStateAction: Option[ProcessAction],
       latestVersionId: VersionId,
       deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState] = {
-    Future.successful(processStateDefinitionManager.processState(stubbedStatus, latestVersionId, deployedVersionId))
+    Future.successful(
+      processStateDefinitionManager.processState(
+        stubbedStatus,
+        latestVersionId,
+        deployedVersionId,
+        currentlyPresentedVersionId
+      )
+    )
   }
 
   override def processStateDefinitionManager: ProcessStateDefinitionManager = SimpleProcessStateDefinitionManager

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/activities/DbScenarioActivityRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/activities/DbScenarioActivityRepository.scala
@@ -437,11 +437,13 @@ class DbScenarioActivityRepository private (override protected val dbRef: DbRef,
   private def doEditComment(comment: String)(
       entity: ScenarioActivityEntityData
   )(implicit user: LoggedUser): ScenarioActivityEntityData = {
+    val now = clock.instant()
     entity.copy(
       comment = Some(comment),
       lastModifiedByUserName = Some(user.username),
+      lastModifiedAt = Some(Timestamp.from(now)),
       additionalProperties = entity.additionalProperties.withProperty(
-        key = s"comment_replaced_by_${user.username}_at_${clock.instant()}",
+        key = s"comment_replaced_by_${user.username}_at_$now",
         value = entity.comment.getOrElse(""),
       )
     )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/StubProcessStateProvider.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/StubProcessStateProvider.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.test.mock
 
 import cats.Traverse
 import pl.touk.nussknacker.engine.api.deployment._
-import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName}
+import pl.touk.nussknacker.engine.api.process.{ProcessIdWithName, ProcessName, VersionId}
 import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
 import pl.touk.nussknacker.ui.process.ProcessStateProvider
 import pl.touk.nussknacker.ui.process.repository.ScenarioWithDetailsEntity
@@ -19,7 +19,8 @@ class StubProcessStateProvider(states: Map[ProcessName, ProcessState]) extends P
     Future.successful(states(processDetails.name))
 
   override def getProcessState(
-      processIdWithName: ProcessIdWithName
+      processIdWithName: ProcessIdWithName,
+      currentlyPresentedVersionId: Option[VersionId],
   )(implicit user: LoggedUser, freshnessPolicy: DataFreshnessPolicy): Future[ProcessState] =
     Future.successful(states(processIdWithName.name))
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/notifications/NotificationServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/notifications/NotificationServiceTest.scala
@@ -278,7 +278,8 @@ class NotificationServiceTest
     SimpleProcessStateDefinitionManager.processState(
       StatusDetails(SimpleStateStatus.NotDeployed, None),
       VersionId(1),
-      None
+      None,
+      Some(VersionId(1)),
     )
 
   private def createServices(deploymentManager: DeploymentManager) = {
@@ -287,7 +288,8 @@ class NotificationServiceTest
         any[ProcessIdWithName],
         any[Option[ProcessAction]],
         any[VersionId],
-        any[Option[VersionId]]
+        any[Option[VersionId]],
+        any[Option[VersionId]],
       )(any[DataFreshnessPolicy])
     )
       .thenReturn(Future.successful(WithDataFreshnessStatus.fresh(notDeployed)))

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentServiceSpec.scala
@@ -94,6 +94,8 @@ class DeploymentServiceSpec
 
   private val deploymentService = createDeploymentService(None)
 
+  private val initialVersionId = ProcessVersion.empty.versionId
+
   deploymentManager = new MockDeploymentManager(
     SimpleStateStatus.Running,
     DefaultProcessingTypeDeployedScenariosProvider(testDbRef, "streaming"),
@@ -170,7 +172,7 @@ class DeploymentServiceSpec
 
     eventually {
       val status = deploymentServiceWithCommentSettings
-        .getProcessState(processIdWithName)
+        .getProcessState(processIdWithName, Some(initialVersionId))
         .futureValue
         .status
 
@@ -201,7 +203,7 @@ class DeploymentServiceSpec
 
     eventually {
       deploymentServiceWithCommentSettings
-        .getProcessState(processIdWithName)
+        .getProcessState(processIdWithName, Some(initialVersionId))
         .futureValue
         .status shouldBe SimpleStateStatus.Running
     }
@@ -221,7 +223,7 @@ class DeploymentServiceSpec
 
       eventually {
         val status = deploymentServiceWithCommentSettings
-          .getProcessState(processIdWithName)
+          .getProcessState(processIdWithName, Some(initialVersionId))
           .futureValue
           .status
 
@@ -252,14 +254,14 @@ class DeploymentServiceSpec
         )
         .futureValue
       deploymentService
-        .getProcessState(processIdWithName)
+        .getProcessState(processIdWithName, Some(initialVersionId))
         .futureValue
         .status shouldBe SimpleStateStatus.DuringDeploy
     }
 
     eventually {
       deploymentService
-        .getProcessState(processIdWithName)
+        .getProcessState(processIdWithName, Some(initialVersionId))
         .futureValue
         .status shouldBe SimpleStateStatus.Running
     }
@@ -273,7 +275,7 @@ class DeploymentServiceSpec
       deploymentService.processCommand(CancelScenarioCommand(CommonCommandData(processId, None, user)))
       eventually {
         deploymentService
-          .getProcessState(processId)
+          .getProcessState(processId, Some(initialVersionId))
           .futureValue
           .status shouldBe SimpleStateStatus.DuringCancel
       }
@@ -301,7 +303,7 @@ class DeploymentServiceSpec
     val (processId, deployActionId) = prepareDeployedProcess(processName).dbioActionValues
 
     checkIsFollowingDeploy(
-      deploymentService.getProcessState(processId).futureValue,
+      deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue,
       expected = true
     )
     fetchingProcessRepository
@@ -314,11 +316,11 @@ class DeploymentServiceSpec
       // we simulate what happens when retrieveStatus is called multiple times to check only one comment is added
       (1 to 5).foreach { _ =>
         checkIsFollowingDeploy(
-          deploymentService.getProcessState(processId).futureValue,
+          deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue,
           expected = false
         )
       }
-      val finishedStatus = deploymentService.getProcessState(processId).futureValue
+      val finishedStatus = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
       finishedStatus.status shouldBe SimpleStateStatus.Finished
       finishedStatus.allowedActions shouldBe List(
         ScenarioActionName.Deploy,
@@ -338,13 +340,13 @@ class DeploymentServiceSpec
 
     deploymentManager.withEmptyProcessState(processName) {
       val stateAfterJobRetention =
-        deploymentService.getProcessState(processId).futureValue
+        deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
       stateAfterJobRetention.status shouldBe SimpleStateStatus.Finished
     }
 
     archiveProcess(processId).dbioActionValues
     deploymentService
-      .getProcessState(processId)
+      .getProcessState(processId, Some(initialVersionId))
       .futureValue
       .status shouldBe SimpleStateStatus.Finished
   }
@@ -359,7 +361,10 @@ class DeploymentServiceSpec
         .dbioActionValues
         .flatMap(_.lastStateAction)
         .map(_.actionName) shouldBe expectedAction
-      deploymentService.getProcessState(processIdWithName).futureValue.status shouldBe expectedStatus
+      deploymentService
+        .getProcessState(processIdWithName, Some(initialVersionId))
+        .futureValue
+        .status shouldBe expectedStatus
     }
 
     deploymentManager.withEmptyProcessState(processName) {
@@ -439,7 +444,10 @@ class DeploymentServiceSpec
       listener.events shouldBe Symbol("empty")
       // during short period of time, status will be during deploy - because parallelism validation are done in the same critical section as deployment
       eventually {
-        deploymentService.getProcessState(processIdWithName).futureValue.status shouldBe SimpleStateStatus.NotDeployed
+        deploymentService
+          .getProcessState(processIdWithName, Some(initialVersionId))
+          .futureValue
+          .status shouldBe SimpleStateStatus.NotDeployed
       }
     }
   }
@@ -450,7 +458,7 @@ class DeploymentServiceSpec
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Canceled) {
       deploymentService
-        .getProcessState(processId)
+        .getProcessState(processId, Some(initialVersionId))
         .futureValue
         .status shouldBe SimpleStateStatus.Canceled
     }
@@ -468,7 +476,7 @@ class DeploymentServiceSpec
 
     deploymentManager.withEmptyProcessState(processName) {
       deploymentService
-        .getProcessState(processId)
+        .getProcessState(processId, Some(initialVersionId))
         .futureValue
         .status shouldBe SimpleStateStatus.Canceled
     }
@@ -493,7 +501,7 @@ class DeploymentServiceSpec
 
     deploymentManager.withEmptyProcessState(processName) {
       deploymentService
-        .getProcessState(processId)
+        .getProcessState(processId, Some(initialVersionId))
         .futureValue
         .status shouldBe SimpleStateStatus.Canceled
     }
@@ -511,7 +519,7 @@ class DeploymentServiceSpec
     val (processId, _)           = prepareCanceledProcess(processName).dbioActionValues
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Running) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
 
       val expectedStatus = ProblemStateStatus.shouldNotBeRunning(true)
       state.status shouldBe expectedStatus
@@ -526,7 +534,7 @@ class DeploymentServiceSpec
     val processId                = prepareProcess(processName).dbioActionValues
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Running) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
       state.status shouldBe SimpleStateStatus.NotDeployed
     }
   }
@@ -536,7 +544,7 @@ class DeploymentServiceSpec
     val (processId, _)           = prepareCanceledProcess(processName).dbioActionValues
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.DuringCancel) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
 
       state.status shouldBe SimpleStateStatus.DuringCancel
     }
@@ -550,7 +558,7 @@ class DeploymentServiceSpec
       StatusDetails(SimpleStateStatus.Restarting, None, Some(ExternalDeploymentId("12")), Some(ProcessVersion.empty))
 
     deploymentManager.withProcessStates(processName, List(state)) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
 
       state.status shouldBe SimpleStateStatus.Restarting
       state.allowedActions shouldBe List(ScenarioActionName.Cancel)
@@ -563,7 +571,7 @@ class DeploymentServiceSpec
     val (processId, _)           = prepareDeployedProcess(processName).dbioActionValues
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Canceled) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
 
       val expectedStatus = ProblemStateStatus.shouldBeRunning(VersionId(1L), "admin")
       state.status shouldBe expectedStatus
@@ -578,7 +586,7 @@ class DeploymentServiceSpec
     val (processId, _)           = prepareDeployedProcess(processName).dbioActionValues
 
     deploymentManager.withEmptyProcessState(processName) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
 
       val expectedStatus = ProblemStateStatus.shouldBeRunning(VersionId(1L), "admin")
       state.status shouldBe expectedStatus
@@ -603,7 +611,7 @@ class DeploymentServiceSpec
     )
 
     deploymentManager.withProcessStateVersion(processName, SimpleStateStatus.Running, version) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
 
       val expectedStatus = ProblemStateStatus.mismatchDeployedVersion(VersionId(2L), VersionId(1L), "admin")
       state.status shouldBe expectedStatus
@@ -629,7 +637,7 @@ class DeploymentServiceSpec
 
     // FIXME: doesnt check recover from failed verifications ???
     deploymentManager.withProcessStateVersion(processName, ProblemStateStatus.Failed, version) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
 
       state.status shouldBe ProblemStateStatus.Failed
       state.allowedActions shouldBe List(ScenarioActionName.Deploy, ScenarioActionName.Cancel)
@@ -641,7 +649,7 @@ class DeploymentServiceSpec
     val (processId, _)           = prepareDeployedProcess(processName).dbioActionValues
 
     deploymentManager.withProcessStateVersion(processName, SimpleStateStatus.Running, Option.empty) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
 
       val expectedStatus = ProblemStateStatus.missingDeployedVersion(VersionId(1L), "admin")
       state.status shouldBe expectedStatus
@@ -657,7 +665,7 @@ class DeploymentServiceSpec
 
     // FIXME: doesnt check recover from failed future of findJobStatus ???
     deploymentManager.withProcessStateVersion(processName, ProblemStateStatus.FailedToGet, Option.empty) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
 
       val expectedStatus = ProblemStateStatus.FailedToGet
       state.status shouldBe expectedStatus
@@ -678,7 +686,7 @@ class DeploymentServiceSpec
 
     deploymentManager.withEmptyProcessState(processName) {
       deploymentService
-        .getProcessState(ProcessIdWithName(processId.id, processName))
+        .getProcessState(ProcessIdWithName(processId.id, processName), Some(initialVersionId))
         .futureValue
         .status shouldBe SimpleStateStatus.NotDeployed
     }
@@ -700,7 +708,7 @@ class DeploymentServiceSpec
 
     deploymentManager.withEmptyProcessState(processName) {
       deploymentService
-        .getProcessState(processId)
+        .getProcessState(processId, Some(initialVersionId))
         .futureValue
         .status shouldBe SimpleStateStatus.NotDeployed
     }
@@ -722,7 +730,7 @@ class DeploymentServiceSpec
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Running) {
       deploymentService
-        .getProcessState(ProcessIdWithName(processId.id, processName))
+        .getProcessState(ProcessIdWithName(processId.id, processName), Some(initialVersionId))
         .futureValue
         .status shouldBe SimpleStateStatus.NotDeployed
     }
@@ -737,7 +745,7 @@ class DeploymentServiceSpec
     val processName: ProcessName = generateProcessName
     val (processId, _)           = prepareArchivedProcess(processName, None).dbioActionValues
 
-    val state = deploymentService.getProcessState(processId).futureValue
+    val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
     state.status shouldBe SimpleStateStatus.NotDeployed
   }
 
@@ -748,7 +756,7 @@ class DeploymentServiceSpec
     val (processId, _)           = prepareArchivedProcess(processName, None).dbioActionValues
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Running) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
       state.status shouldBe SimpleStateStatus.NotDeployed
     }
   }
@@ -757,7 +765,7 @@ class DeploymentServiceSpec
     val processName: ProcessName = generateProcessName
     val (processId, _)           = prepareArchivedProcess(processName, Some(Cancel)).dbioActionValues
 
-    val state = deploymentService.getProcessState(processId).futureValue
+    val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
     state.status shouldBe SimpleStateStatus.Canceled
   }
 
@@ -766,7 +774,7 @@ class DeploymentServiceSpec
     val (processId, _)           = prepareArchivedProcess(processName, Some(Cancel)).dbioActionValues
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Running) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
       state.status shouldBe SimpleStateStatus.Canceled
     }
   }
@@ -775,7 +783,7 @@ class DeploymentServiceSpec
     val processName: ProcessName = generateProcessName
     val (processId, _)           = preparedUnArchivedProcess(processName, None).dbioActionValues
 
-    val state = deploymentService.getProcessState(processId).futureValue
+    val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
     state.status shouldBe SimpleStateStatus.NotDeployed
   }
 
@@ -786,7 +794,7 @@ class DeploymentServiceSpec
       .addInProgressAction(processId.id, ScenarioActionName.Deploy, Some(VersionId(1)), None)
       .dbioActionValues
 
-    val state = deploymentService.getProcessState(processId).futureValue
+    val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
     state.status shouldBe SimpleStateStatus.DuringDeploy
   }
 
@@ -832,7 +840,7 @@ class DeploymentServiceSpec
     val (processId, _)           = prepareArchivedProcess(processName, None).dbioActionValues
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Running) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
       state.status shouldBe SimpleStateStatus.NotDeployed
     }
   }
@@ -841,7 +849,7 @@ class DeploymentServiceSpec
     val processName: ProcessName = generateProcessName
     val (processId, _)           = prepareArchivedProcess(processName, Some(Deploy)).dbioActionValues
 
-    val state = deploymentService.getProcessState(processId).futureValue
+    val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
     state.status shouldBe ProblemStateStatus.ArchivedShouldBeCanceled
   }
 
@@ -850,7 +858,7 @@ class DeploymentServiceSpec
     val (processId, _)           = prepareArchivedProcess(processName, Some(Cancel)).dbioActionValues
 
     deploymentManager.withEmptyProcessState(processName) {
-      val state = deploymentService.getProcessState(processId).futureValue
+      val state = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
       state.status shouldBe SimpleStateStatus.Canceled
     }
   }
@@ -860,7 +868,7 @@ class DeploymentServiceSpec
     val (processId, _)           = preparedUnArchivedProcess(processName, Some(Cancel)).dbioActionValues
 
     deploymentManager.withProcessStateStatus(processName, SimpleStateStatus.Running) {
-      val state          = deploymentService.getProcessState(processId).futureValue
+      val state          = deploymentService.getProcessState(processId, Some(initialVersionId)).futureValue
       val expectedStatus = ProblemStateStatus.shouldNotBeRunning(true)
       state.status shouldBe expectedStatus
       state.icon shouldBe ProblemStateStatus.icon
@@ -875,7 +883,10 @@ class DeploymentServiceSpec
 
     deploymentManager.withEmptyProcessState(processName) {
       val initialStatus = SimpleStateStatus.NotDeployed
-      deploymentService.getProcessState(processIdWithName).futureValue.status shouldBe initialStatus
+      deploymentService
+        .getProcessState(processIdWithName, Some(initialVersionId))
+        .futureValue
+        .status shouldBe initialStatus
       deploymentManager.withWaitForDeployFinish(processName) {
         deploymentService
           .processCommand(
@@ -887,12 +898,15 @@ class DeploymentServiceSpec
           )
           .futureValue
         deploymentService
-          .getProcessState(processIdWithName)
+          .getProcessState(processIdWithName, Some(initialVersionId))
           .futureValue
           .status shouldBe SimpleStateStatus.DuringDeploy
 
         deploymentService.invalidateInProgressActions()
-        deploymentService.getProcessState(processIdWithName).futureValue.status shouldBe initialStatus
+        deploymentService
+          .getProcessState(processIdWithName, Some(initialVersionId))
+          .futureValue
+          .status shouldBe initialStatus
       }
     }
   }
@@ -907,7 +921,7 @@ class DeploymentServiceSpec
     val durationLongerThanTimeout = timeout.plus(patienceConfig.timeout)
     deploymentManager.withDelayBeforeStateReturn(durationLongerThanTimeout) {
       val status = serviceWithTimeout
-        .getProcessState(processId)
+        .getProcessState(processId, Some(initialVersionId))
         .futureValueEnsuringInnerException(durationLongerThanTimeout)
         .status
       status shouldBe ProblemStateStatus.FailedToGet
@@ -919,7 +933,7 @@ class DeploymentServiceSpec
     val id                       = prepareFragment(processName).dbioActionValues
 
     assertThrowsWithParent[FragmentStateException] {
-      deploymentService.getProcessState(id).futureValue
+      deploymentService.getProcessState(id, Some(initialVersionId)).futureValue
     }
   }
 

--- a/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
+++ b/engine/development/deploymentManager/src/main/scala/pl/touk/nussknacker/development/manager/MockableDeploymentManagerProvider.scala
@@ -66,9 +66,15 @@ object MockableDeploymentManagerProvider {
         lastStateAction: Option[ProcessAction],
         latestVersionId: VersionId,
         deployedVersionId: Option[VersionId],
+        currentlyPresentedVersionId: Option[VersionId],
     ): Future[ProcessState] = {
       Future.successful(
-        processStateDefinitionManager.processState(statusDetails.head, latestVersionId, deployedVersionId)
+        processStateDefinitionManager.processState(
+          statusDetails.head,
+          latestVersionId,
+          deployedVersionId,
+          currentlyPresentedVersionId
+        )
       )
     }
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -204,6 +204,7 @@ class PeriodicDeploymentManager private[periodic] (
       lastStateAction: Option[ProcessAction],
       latestVersionId: VersionId,
       deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState] = {
     val statusDetails = statusDetailsList.head
     // TODO: add "real" presentation of deployments in GUI
@@ -213,7 +214,8 @@ class PeriodicDeploymentManager private[periodic] (
           statusDetails.status.asInstanceOf[PeriodicProcessStatus].mergedStatusDetails.status
         ),
         latestVersionId,
-        deployedVersionId
+        deployedVersionId,
+        currentlyPresentedVersionId,
       )
     Future.successful(mergedStatus.copy(tooltip = processStateDefinitionManager.statusTooltip(statusDetails.status)))
   }

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicStateStatus.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicStateStatus.scala
@@ -37,9 +37,14 @@ object PeriodicStateStatus {
 
   val statusActionsPF: PartialFunction[ProcessStatus, List[ScenarioActionName]] = {
     case ProcessStatus(SimpleStateStatus.Running, _, _, _) =>
-      List(ScenarioActionName.Cancel) // periodic processes cannot be redeployed from GUI
-    case ProcessStatus(_: ScheduledStatus, _, deployedVersionId, currentlyPresentedVersionId)
-        if currentlyPresentedVersionId == deployedVersionId =>
+      // periodic processes cannot be redeployed from GUI
+      List(ScenarioActionName.Cancel)
+    case ProcessStatus(_: ScheduledStatus, _, deployedVersionId, Some(currentlyPresentedVersionId))
+        if deployedVersionId.contains(currentlyPresentedVersionId) =>
+      List(ScenarioActionName.Cancel, ScenarioActionName.Deploy, ScenarioActionName.PerformSingleExecution)
+    case ProcessStatus(_: ScheduledStatus, _, _, None) =>
+      // At the moment of deployment or validation, we may not have the information about the currently displayed version
+      // In that case we assume, that it was validated before the deployment was initiated.
       List(ScenarioActionName.Cancel, ScenarioActionName.Deploy, ScenarioActionName.PerformSingleExecution)
     case ProcessStatus(_: ScheduledStatus, _, _, _) =>
       List(ScenarioActionName.Cancel, ScenarioActionName.Deploy)

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicStateStatus.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicStateStatus.scala
@@ -5,6 +5,7 @@ import pl.touk.nussknacker.engine.api.deployment.StateStatus.StatusName
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus.ProblemStateStatus
 import pl.touk.nussknacker.engine.api.deployment.{ScenarioActionName, StateDefinitionDetails, StateStatus}
+import pl.touk.nussknacker.engine.api.process.VersionId
 
 import java.net.URI
 import java.time.LocalDateTime
@@ -35,16 +36,16 @@ object PeriodicStateStatus {
   val WaitingForScheduleStatus: StateStatus = StateStatus("WAITING_FOR_SCHEDULE")
 
   val statusActionsPF: PartialFunction[ProcessStatus, List[ScenarioActionName]] = {
-    case ProcessStatus(SimpleStateStatus.Running, _, _) =>
+    case ProcessStatus(SimpleStateStatus.Running, _, _, _) =>
       List(ScenarioActionName.Cancel) // periodic processes cannot be redeployed from GUI
-    case ProcessStatus(_: ScheduledStatus, latestVersionId, deployedVersionId)
-        if deployedVersionId.contains(latestVersionId) =>
+    case ProcessStatus(_: ScheduledStatus, _, deployedVersionId, currentlyPresentedVersionId)
+        if currentlyPresentedVersionId == deployedVersionId =>
       List(ScenarioActionName.Cancel, ScenarioActionName.Deploy, ScenarioActionName.PerformSingleExecution)
-    case ProcessStatus(_: ScheduledStatus, _, _) =>
+    case ProcessStatus(_: ScheduledStatus, _, _, _) =>
       List(ScenarioActionName.Cancel, ScenarioActionName.Deploy)
-    case ProcessStatus(WaitingForScheduleStatus, _, _) =>
+    case ProcessStatus(WaitingForScheduleStatus, _, _, _) =>
       List(ScenarioActionName.Cancel) // or maybe should it be empty??
-    case ProcessStatus(_: ProblemStateStatus, _, _) =>
+    case ProcessStatus(_: ProblemStateStatus, _, _, _) =>
       List(ScenarioActionName.Cancel) // redeploy is not allowed
   }
 
@@ -73,18 +74,18 @@ object PeriodicStateStatus {
 
   def customActionTooltips(processStatus: ProcessStatus): Map[ScenarioActionName, String] = {
     processStatus match {
-      case ProcessStatus(_: ScheduledStatus, latestVersionId, deployedVersionId)
-          if deployedVersionId.contains(latestVersionId) =>
+      case ProcessStatus(_: ScheduledStatus, _, deployedVersionId, currentlyPresentedVersionId)
+          if currentlyPresentedVersionId == deployedVersionId =>
         Map.empty
-      case ProcessStatus(_: ScheduledStatus, latestVersionId, deployedVersionIdOpt) =>
-        val deployedVersionStr = deployedVersionIdOpt match {
-          case Some(deployedVersionId) => s" (version ${deployedVersionId.value} is deployed)"
-          case None                    => ""
+      case ProcessStatus(_: ScheduledStatus, _, deployedVersionIdOpt, currentlyPresentedVersionId) =>
+        def print(versionIdOpt: Option[VersionId]) = versionIdOpt match {
+          case Some(versionId) => s"${versionId.value}"
+          case None            => "[unknown]"
         }
         Map(
-          ScenarioActionName.PerformSingleExecution -> s"There is new version ${latestVersionId.value} available$deployedVersionStr"
+          ScenarioActionName.PerformSingleExecution -> s"Version ${print(deployedVersionIdOpt)} is deployed, but different version ${print(currentlyPresentedVersionId)} is displayed"
         )
-      case ProcessStatus(other, _, _) =>
+      case ProcessStatus(other, _, _, _) =>
         Map(ScenarioActionName.PerformSingleExecution -> s"Disabled for ${other.name} status.")
     }
   }

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/DeploymentManagerStub.scala
@@ -33,12 +33,14 @@ class DeploymentManagerStub extends BaseDeploymentManager with StubbingCommands 
       lastStateAction: Option[ProcessAction],
       latestVersionId: VersionId,
       deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState] =
     Future.successful(
       processStateDefinitionManager.processState(
         statusDetails.headOption.getOrElse(StatusDetails(SimpleStateStatus.NotDeployed, None)),
         latestVersionId,
-        deployedVersionId
+        deployedVersionId,
+        currentlyPresentedVersionId,
       )
     )
 

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessStateDefinitionManagerTest.scala
@@ -74,20 +74,24 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
       ProcessStatus(
         stateStatus = ScheduledStatus(nextRunAt = LocalDateTime.now()),
         latestVersionId = VersionId(5),
-        deployedVersionId = Some(VersionId(5))
+        deployedVersionId = Some(VersionId(5)),
+        currentlyPresentedVersionId = Some(VersionId(5)),
       )
     ) shouldEqual Map.empty
   }
 
-  test("display custom tooltip for perform single execution when older version is deployed") {
+  test(
+    "display custom tooltip for perform single execution when deployed version is different than currently displayed"
+  ) {
     PeriodicStateStatus.customActionTooltips(
       ProcessStatus(
         stateStatus = ScheduledStatus(nextRunAt = LocalDateTime.now()),
         latestVersionId = VersionId(5),
-        deployedVersionId = Some(VersionId(4))
+        deployedVersionId = Some(VersionId(4)),
+        currentlyPresentedVersionId = Some(VersionId(5)),
       )
     ) shouldEqual Map(
-      ScenarioActionName.PerformSingleExecution -> "There is new version 5 available (version 4 is deployed)"
+      ScenarioActionName.PerformSingleExecution -> "Version 4 is deployed, but different version 5 is displayed"
     )
   }
 
@@ -96,7 +100,8 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
       ProcessStatus(
         stateStatus = SimpleStateStatus.Canceled,
         latestVersionId = VersionId(5),
-        deployedVersionId = Some(VersionId(4))
+        deployedVersionId = Some(VersionId(4)),
+        currentlyPresentedVersionId = Some(VersionId(5)),
       )
     ) shouldEqual Map(
       ScenarioActionName.PerformSingleExecution -> "Disabled for CANCELED status."

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
@@ -45,6 +45,7 @@ abstract class FlinkDeploymentManager(
       lastStateAction: Option[ProcessAction],
       latestVersionId: VersionId,
       deployedVersionId: Option[VersionId],
+      currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState] = {
     for {
       actionAfterPostprocessOpt <- postprocess(idWithName, statusDetails)
@@ -55,7 +56,8 @@ abstract class FlinkDeploymentManager(
     } yield processStateDefinitionManager.processState(
       engineStateResolvedWithLastAction,
       latestVersionId,
-      deployedVersionId
+      deployedVersionId,
+      currentlyPresentedVersionId,
     )
   }
 

--- a/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkProcessStateSpec.scala
+++ b/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkProcessStateSpec.scala
@@ -16,6 +16,7 @@ class FlinkProcessStateSpec extends AnyFunSpec with Matchers with Inside {
       StatusDetails(stateStatus, None, Some(ExternalDeploymentId("12")), Some(ProcessVersion.empty)),
       VersionId(1),
       None,
+      None,
     )
 
   it("scenario state should be during deploy") {

--- a/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedProcessStateDefinitionManager.scala
+++ b/engine/lite/embeddedDeploymentManager/src/main/scala/pl/touk/nussknacker/engine/embedded/EmbeddedProcessStateDefinitionManager.scala
@@ -11,7 +11,7 @@ import pl.touk.nussknacker.engine.api.deployment.{OverridingProcessStateDefiniti
 object EmbeddedProcessStateDefinitionManager
     extends OverridingProcessStateDefinitionManager(
       delegate = SimpleProcessStateDefinitionManager,
-      statusActionsPF = { case ProcessStatus(SimpleStateStatus.Restarting, _, _) =>
+      statusActionsPF = { case ProcessStatus(SimpleStateStatus.Restarting, _, _, _) =>
         List(ScenarioActionName.Cancel)
       }
     )


### PR DESCRIPTION
## Describe your changes

Change of business requirements:
- "run now" should be possible in the context of currently deployed version, even if it is not a latest version

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
