### PR TITLE
Handle scenario names with spaces when performing migration tests

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/RemoteEnvironment.scala
@@ -21,19 +21,12 @@ import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetailsForMigra
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationErrors
 import pl.touk.nussknacker.ui.NuDesignerError.XError
 import pl.touk.nussknacker.ui.api.description.MigrationApiEndpoints.Dtos.ApiVersion
-import pl.touk.nussknacker.ui.migrations.{
-  MigrateScenarioData,
-  MigrateScenarioDataV1,
-  MigrateScenarioDataV2,
-  MigrationApiAdapterService
-}
+import pl.touk.nussknacker.ui.migrations.{MigrateScenarioData, MigrateScenarioDataV2, MigrationApiAdapterService}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import pl.touk.nussknacker.ui.util.ScenarioGraphComparator.Difference
 import pl.touk.nussknacker.ui.util.{ApiAdapterServiceError, OutOfRangeAdapterRequestError, ScenarioGraphComparator}
 import pl.touk.nussknacker.ui.{FatalError, NuDesignerError}
 
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import scala.collection.parallel.ExecutionContextTaskSupport
 import scala.collection.parallel.immutable.ParVector
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -156,7 +149,7 @@ class HttpRemoteEnvironment(
     )
   }
 
-  override def close(): Unit = Await.ready(http.shutdownAllConnectionPools(), closeTimeout)
+  override def close(): Unit = Await.ready(closeAsync(), closeTimeout)
 
   def closeAsync(): Future[Unit] = http.shutdownAllConnectionPools()
 }
@@ -355,7 +348,7 @@ trait StandardRemoteEnvironment extends FailFastCirceSupport with RemoteEnvironm
       HttpMethods.GET,
       "processesDetails" :: Nil,
       Query(
-        ("names", names.map(ns => URLEncoder.encode(ns.value, StandardCharsets.UTF_8)).mkString(",")),
+        ("names", names.map(_.value).mkString(",")),
         ("isArchived", "false"),
         ("skipNodeResults", "true"),
       )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/StandardRemoteEnvironmentSpec.scala
@@ -56,7 +56,7 @@ class StandardRemoteEnvironmentSpec
           request: MessageEntity,
           header: Seq[HttpHeader]
       ): Future[HttpResponse] = {
-        if (path.toString().startsWith(s"$baseUri/processes/a") && method == HttpMethods.GET) {
+        if (path == baseUri.withPath(baseUri.path + "/processes/a%20b%20c") && method == HttpMethods.GET) {
           Marshal(
             ScenarioWithDetailsConversions.fromEntityWithScenarioGraph(
               wrapGraphWithScenarioDetailsEntity(name, scenarioGraph),
@@ -68,7 +68,7 @@ class StandardRemoteEnvironmentSpec
               HttpResponse(StatusCodes.OK, entity = entity)
             }
         } else {
-          throw new AssertionError(s"Not expected $path")
+          throw new AssertionError(s"Not expected ${method.value} $path")
         }
       }
     }
@@ -91,7 +91,7 @@ class StandardRemoteEnvironmentSpec
           request: MessageEntity,
           headers: Seq[HttpHeader]
       ): Future[HttpResponse] = {
-        if (path.toString().startsWith(s"$baseUri/processes/%C5%82%C3%B3d%C5%BA") && method == HttpMethods.GET) {
+        if (path == baseUri.withPath(baseUri.path + "/processes/%C5%82%C3%B3d%C5%BA") && method == HttpMethods.GET) {
           Marshal(
             ScenarioWithDetailsConversions.fromEntityWithScenarioGraph(
               wrapGraphWithScenarioDetailsEntity(name, scenarioGraph),
@@ -338,7 +338,7 @@ class StandardRemoteEnvironmentSpec
       object GetProcessesDetails {
         def unapply(arg: (Uri, HttpMethod)): Option[Set[ProcessName]] = {
           val uri = arg._1
-          if (uri.toString().startsWith(s"$baseUri/processesDetails") && uri
+          if (uri.withQuery(Uri.Query.Empty) == baseUri.withPath(baseUri.path + "/processesDetails") && uri
               .query()
               .get("isArchived")
               .contains("false") && arg._2 == HttpMethods.GET) {

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -26,6 +26,7 @@
     * Improved scenario state management to include information about current and deployed versions and allow more customization
 * [#7184](https://github.com/TouK/nussknacker/pull/7184) Improve Nu Designer API notifications endpoint, to include events related to currently displayed scenario
 * [#7323](https://github.com/TouK/nussknacker/pull/7323) Improve Periodic DeploymentManager db queries
+* [#7332](https://github.com/TouK/nussknacker/pull/7332) Handle scenario names with spaces when performing migration tests, they were ignored
 
 ## 1.18
 


### PR DESCRIPTION
## Describe your changes

Enables migration tests for scenarios with spaces in their names, they were ignored.

This was caused by double encoding of query string with scenario names: first a space character was manually encoded as `+`, and then `Uri.Query` percent-encoded it as `%2B`. For example, we were trying to fetch scenario "test+scenario" instead of "test scenario".

Plus some improvements in related test class.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
