### PR TITLE
Integer dictionary support in fragment inputs

### DIFF
--- a/designer/client/src/components/graph/node-modal/fragment-input-definition/item/types.ts
+++ b/designer/client/src/components/graph/node-modal/fragment-input-definition/item/types.ts
@@ -86,6 +86,7 @@ export function isPermittedTypeVariant(item: FragmentInputParameter): item is Pe
         resolveRefClazzName(item.typ.refClazzName) === "String",
         resolveRefClazzName(item.typ.refClazzName) === "Boolean",
         resolveRefClazzName(item.typ.refClazzName) === "Long",
+        resolveRefClazzName(item.typ.refClazzName) === "Integer",
     ].includes(true);
 }
 

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -187,19 +187,20 @@ object PrettyValidationErrors {
         )
       case UnsupportedFixedValuesType(paramName, typ, _) =>
         node(
-          message = s"Fixed values list can only be be provided for type String or Boolean, found: $typ",
+          message = s"Fixed values list can only be be provided for type String, Integer, Long or Boolean, found: $typ",
           description = "Please check component definition",
           paramName = Some(qualifiedParamFieldName(paramName = paramName, subFieldName = Some(TypFieldName)))
         )
       case UnsupportedDictParameterEditorType(paramName, typ, _) =>
         node(
-          s"Dictionary parameter editor can only be used for parameters of type String, Long or Boolean, found: $typ",
-          "Please check component definition",
+          message =
+            s"Dictionary parameter editor can only be used for parameters of type String, Integer, Long or Boolean, found: $typ",
+          description = "Please check component definition",
           paramName = Some(qualifiedParamFieldName(paramName = paramName, subFieldName = Some(TypFieldName)))
         )
       case EmptyFixedListForRequiredField(paramName, _) =>
         node(
-          s"Non-empty fixed list of values have to be declared for required parameter",
+          message = s"Non-empty fixed list of values have to be declared for required parameter",
           description = "Please add a value to the list of possible values",
           paramName = Some(qualifiedParamFieldName(paramName = paramName, subFieldName = Some(InputModeFieldName)))
         )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DictApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DictApiHttpServiceSpec.scala
@@ -31,8 +31,14 @@ class DictApiHttpServiceSpec
         .post(s"$nuDesignerHttpAddress/api/processDefinitionData/${Streaming.stringify}/dicts")
         .Then()
         .statusCode(200)
-        .equalsJsonBody("[]")
-
+        .equalsJsonBody(
+          s"""[
+             |  {
+             |    "id" : "integer_dict",
+             |    "label" : "integer_dict"
+             |  }
+             |]""".stripMargin
+        )
     }
 
     "return proper list for expected type String" in {
@@ -84,6 +90,10 @@ class DictApiHttpServiceSpec
         .equalsJsonBody(
           s"""[
              |  {
+             |    "id": "integer_dict",
+             |    "label": "integer_dict"
+             |  },
+             |  {
              |    "id" : "long_dict",
              |    "label" : "long_dict"
              |  }
@@ -91,7 +101,7 @@ class DictApiHttpServiceSpec
         )
     }
 
-    "return proper list for expected type BigDecimal" in {
+    "return proper list for expected type BigInteger" in {
       given()
         .when()
         .basicAuthAllPermUser()
@@ -107,6 +117,11 @@ class DictApiHttpServiceSpec
         .statusCode(200)
         .equalsJsonBody(
           s"""[
+             |
+             |  {
+             |    "id": "integer_dict",
+             |    "label": "integer_dict"
+             |  },
              |  {
              |    "id" : "long_dict",
              |    "label" : "long_dict"

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -29,6 +29,7 @@
 * [#7332](https://github.com/TouK/nussknacker/pull/7332) Handle scenario names with spaces when performing migration tests, they were ignored
 * [#7346](https://github.com/TouK/nussknacker/pull/7346) OpenAPI enricher: ability to configure common secret for any security scheme
 * [#7307](https://github.com/TouK/nussknacker/pull/7307) Added StddevPop, StddevSamp, VarPop and VarSamp aggregators
+* [#7341](https://github.com/TouK/nussknacker/pull/7341) Added possibility to choose presets and define lists for Integer typed parameter inputs in fragments.
 
 ## 1.18
 

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/DevProcessConfigCreator.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/DevProcessConfigCreator.scala
@@ -242,6 +242,7 @@ class DevProcessConfigCreator extends ProcessConfigCreator {
         BusinessConfigDictionary.id -> BusinessConfigDictionary.definition,
         BooleanDictionary.id -> BooleanDictionary.definition, // not available through global variables, but still available through DictParameterEditor
         LongDictionary.id -> LongDictionary.definition, // not available through global variables, but still available through DictParameterEditor
+        IntegerDictionary.id -> IntegerDictionary.definition // not available through global variables, but still available through DictParameterEditor
       )
     )
   }

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/dict/IntegerDictionary.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/dict/IntegerDictionary.scala
@@ -1,0 +1,23 @@
+package pl.touk.nussknacker.engine.management.sample.dict
+
+import pl.touk.nussknacker.engine.api.dict.embedded.EmbeddedDictDefinition
+import pl.touk.nussknacker.engine.api.dict.{DictDefinition, DictInstance, ReturningKeyWithoutTransformation}
+import pl.touk.nussknacker.engine.api.typed.typing
+import pl.touk.nussknacker.engine.api.typed.typing.Typed
+
+object IntegerDictionary {
+  val id: String = "integer_dict"
+
+  val definition: DictDefinition = new EmbeddedDictDefinition with ReturningKeyWithoutTransformation {
+    override def valueType(dictId: String): typing.SingleTypingResult = Typed.typedClass[java.lang.Integer]
+
+    override def labelByKey: Map[String, String] = Map(
+      "-2147483648" -> "large (negative) number",
+      "42"          -> "small number",
+      "2147483647"  -> "big number"
+    )
+
+  }
+
+  val instance: DictInstance = DictInstance(id, definition)
+}

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/FragmentParameterValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/FragmentParameterValidator.scala
@@ -38,12 +38,14 @@ import scala.util.Try
 object FragmentParameterValidator {
 
   val permittedTypesForEditors: List[FragmentClazzRef] = List(
-    FragmentClazzRef[java.lang.Boolean],
     FragmentClazzRef[String],
+    FragmentClazzRef[java.lang.Boolean],
+    FragmentClazzRef[java.lang.Integer],
     FragmentClazzRef[java.lang.Long],
     FragmentClazzRef("String"),
     FragmentClazzRef("Boolean"),
-    FragmentClazzRef("Long")
+    FragmentClazzRef("Integer"),
+    FragmentClazzRef("Long"),
   )
 
 }


### PR DESCRIPTION
## Describe your changes
Added possibility to choose presets and define lists for Integer typed parameter inputs in fragments
## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
