### PR TITLE
Reduce response payload size for scenarios tab

### DIFF
--- a/designer/client/src/components/graph/node-modal/fragment-input-definition/item/types.ts
+++ b/designer/client/src/components/graph/node-modal/fragment-input-definition/item/types.ts
@@ -1,3 +1,4 @@
+import { isNil } from "lodash";
 import { Expression, ReturnedType } from "../../../../../types";
 import { resolveRefClazzName } from "./utils";
 
@@ -78,7 +79,7 @@ export function isAnyValueWithSuggestionsParameter(item: PermittedTypeParameterV
 }
 
 export function isAnyValueParameter(item: PermittedTypeParameterVariant): item is AnyValueParameterVariant {
-    return item.valueEditor === null;
+    return isNil(item.valueEditor);
 }
 
 const permittedTypesMapping = {

--- a/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/fields/InputModeSelect.tsx
+++ b/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/fields/InputModeSelect.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { isNil } from "lodash";
 import { Option } from "../../../FieldsSelect";
 import { TypeSelect } from "../../../TypeSelect";
 import { useTranslation } from "react-i18next";
@@ -23,12 +24,11 @@ export default function InputModeSelect(props: Props) {
     const { t } = useTranslation();
     const { temporaryUserDefinedList } = useSettings();
 
-    const value =
-        item.valueEditor === null
-            ? InputMode.AnyValue
-            : item.valueEditor.allowOtherValue
-            ? InputMode.AnyValueWithSuggestions
-            : InputMode.FixedList;
+    const value = isNil(item.valueEditor)
+        ? InputMode.AnyValue
+        : item.valueEditor.allowOtherValue
+        ? InputMode.AnyValueWithSuggestions
+        : InputMode.FixedList;
     return (
         <>
             <FormControl>

--- a/designer/client/src/reducers/scenarioState.ts
+++ b/designer/client/src/reducers/scenarioState.ts
@@ -4,7 +4,9 @@ import { ProcessStateType } from "../components/Process/types";
 export const reducer: Reducer<ProcessStateType> = (state = null, action: Action): ProcessStateType => {
     switch (action.type) {
         case "DISPLAY_PROCESS":
-            return action.scenario.state;
+            // Since scenario endpoint doesn't return null attributes the state will be undefined for fragments.
+            // Redux does not allow to return undefined values so in that case we return null explicitly.
+            return action.scenario.state ?? null;
         case "PROCESS_STATE_LOADED":
             return action.processState;
         default:

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/scenariodetails/ScenarioWithDetails.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/scenariodetails/ScenarioWithDetails.scala
@@ -77,12 +77,18 @@ object ScenarioWithDetails {
 
   import io.circe.generic.semiauto._
 
+  // TODO: We remove null values from json to make response payload lighter.
+  // The target solution would be to introduce pagination to the /api/processes endpoint.
   implicit val encoder: Encoder[ScenarioWithDetails] =
-    deriveEncoder[ScenarioWithDetails]
-      .contramap[ScenarioWithDetails](_.copy(processId = None))
+    deepDropNulls(
+      deriveEncoder[ScenarioWithDetails]
+        .contramap[ScenarioWithDetails](_.copy(processId = None))
+    )
 
   implicit val decoder: Decoder[ScenarioWithDetails] =
     deriveDecoder[ScenarioWithDetails]
+
+  private def deepDropNulls[A](encoder: Encoder[A]): Encoder[A] = encoder.mapJson(_.deepDropNullValues)
 
 }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppApiHttpService.scala
@@ -182,7 +182,7 @@ class AppApiHttpService(
     processService
       .getLatestProcessesWithDetails(
         ScenarioQuery.unarchivedProcesses,
-        GetScenarioWithDetailsOptions.withsScenarioGraph.withValidation
+        GetScenarioWithDetailsOptions.withScenarioGraph.withValidation
       )
       .map { processes =>
         processes

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -17,6 +17,7 @@ import pl.touk.nussknacker.ui.process.ProcessService.{
   CreateScenarioCommand,
   FetchScenarioGraph,
   GetScenarioWithDetailsOptions,
+  SkipAdditionalFields,
   UpdateScenarioCommand
 }
 import pl.touk.nussknacker.ui.process.ScenarioWithDetailsConversions._
@@ -81,7 +82,7 @@ class ProcessesResources(
             complete {
               processService.getLatestProcessesWithDetails(
                 query,
-                GetScenarioWithDetailsOptions.detailsOnly.withFetchState
+                GetScenarioWithDetailsOptions.withoutAdditionalFields.withFetchState
               )
             }
           }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessesResources.scala
@@ -233,12 +233,12 @@ class ProcessesResources(
                 thisVersion <- processService.getProcessWithDetails(
                   processId,
                   thisVersion,
-                  GetScenarioWithDetailsOptions.withsScenarioGraph
+                  GetScenarioWithDetailsOptions.withScenarioGraph
                 )
                 otherVersion <- processService.getProcessWithDetails(
                   processId,
                   otherVersion,
-                  GetScenarioWithDetailsOptions.withsScenarioGraph
+                  GetScenarioWithDetailsOptions.withScenarioGraph
                 )
               } yield ScenarioGraphComparator.compare(thisVersion.scenarioGraphUnsafe, otherVersion.scenarioGraphUnsafe)
             }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResources.scala
@@ -51,7 +51,7 @@ class RemoteEnvironmentResources(
             for {
               processes <- processService.getLatestProcessesWithDetails(
                 ScenarioQuery.unarchived,
-                GetScenarioWithDetailsOptions.withsScenarioGraph
+                GetScenarioWithDetailsOptions.withScenarioGraph
               )
               comparison <- compareProcesses(processes)
             } yield NuDesignerErrorToHttp.toResponseEither(comparison)
@@ -137,7 +137,7 @@ class RemoteEnvironmentResources(
       .getProcessWithDetails(
         processIdWithName,
         version,
-        GetScenarioWithDetailsOptions.withsScenarioGraph
+        GetScenarioWithDetailsOptions.withScenarioGraph
       )
       .flatMap(fun)
       .map(NuDesignerErrorToHttp.toResponseEither[T])

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
@@ -73,7 +73,7 @@ object ProcessService {
     val detailsOnly: GetScenarioWithDetailsOptions =
       new GetScenarioWithDetailsOptions(SkipScenarioGraph, fetchState = false)
 
-    val withsScenarioGraph: GetScenarioWithDetailsOptions =
+    val withScenarioGraph: GetScenarioWithDetailsOptions =
       new GetScenarioWithDetailsOptions(FetchScenarioGraph(), fetchState = false)
 
     val withoutAdditionalFields: GetScenarioWithDetailsOptions =

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ScenarioWithDetailsConversions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ScenarioWithDetailsConversions.scala
@@ -1,9 +1,11 @@
 package pl.touk.nussknacker.ui.process
 
+import pl.touk.nussknacker.engine.api.deployment.ProcessAction
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.process.ProcessId
 import pl.touk.nussknacker.restmodel.scenariodetails.{ScenarioParameters, ScenarioWithDetails}
 import pl.touk.nussknacker.restmodel.validation.ScenarioGraphWithValidationResult
+import pl.touk.nussknacker.ui.process.ProcessService.SkipAdditionalFields
 import pl.touk.nussknacker.ui.process.repository.ScenarioWithDetailsEntity
 
 object ScenarioWithDetailsConversions {
@@ -52,6 +54,25 @@ object ScenarioWithDetailsConversions {
       history = details.history,
       modelVersion = details.modelVersion,
       state = None
+    )
+  }
+
+  def skipAdditionalFields(details: ScenarioWithDetails, skipOptions: SkipAdditionalFields): ScenarioWithDetails = {
+    def skipProcessActionOptionalFields(processAction: Option[ProcessAction]) = processAction.map(
+      _.copy(
+        failureMessage = None,
+        commentId = None,
+        comment = None,
+        buildInfo = Map.empty
+      )
+    )
+    def getProcessAction(processAction: Option[ProcessAction]) =
+      if (skipOptions.skipProcessActionOptionalFields) skipProcessActionOptionalFields(processAction) else processAction
+
+    details.copy(
+      lastDeployedAction = getProcessAction(details.lastDeployedAction),
+      lastStateAction = getProcessAction(details.lastStateAction),
+      lastAction = getProcessAction(details.lastAction)
     )
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/statistics/UsageStatisticsReportsSettingsService.scala
@@ -48,7 +48,7 @@ object UsageStatisticsReportsSettingsService extends LazyLogging {
       processService
         .getLatestProcessesWithDetails(
           ScenarioQuery.unarchived,
-          GetScenarioWithDetailsOptions.withsScenarioGraph.withFetchState
+          GetScenarioWithDetailsOptions.withScenarioGraph.withFetchState
         )(user)
         .map { scenariosDetails =>
           Right(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -130,7 +130,7 @@ class ProcessesResourcesSpec
   }
 
   test("/api/processes should return lighter details without ProcessAction's additional fields") {
-    createDeployedWithCustomActionScenario(processName, category = Category1)
+    createDeployedScenario(processName, category = Category1)
     Get(s"/api/processes") ~> withReaderUser() ~> applicationRoute ~> check {
       status shouldEqual StatusCodes.OK
       val loadedProcess = responseAs[List[ScenarioWithDetails]]

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -129,6 +129,30 @@ class ProcessesResourcesSpec
     }
   }
 
+  test("/api/processes should return lighter details without ProcessAction's additional fields") {
+    createDeployedWithCustomActionScenario(processName, category = Category1)
+    Get(s"/api/processes") ~> withReaderUser() ~> applicationRoute ~> check {
+      status shouldEqual StatusCodes.OK
+      val loadedProcess = responseAs[List[ScenarioWithDetails]]
+
+      loadedProcess.head.lastAction should matchPattern {
+        case Some(
+              ProcessAction(_, _, _, _, _, _, _, _, None, None, None, buildInfo)
+            ) if buildInfo.isEmpty =>
+      }
+      loadedProcess.head.lastStateAction should matchPattern {
+        case Some(
+              ProcessAction(_, _, _, _, _, _, _, _, None, None, None, buildInfo)
+            ) if buildInfo.isEmpty =>
+      }
+      loadedProcess.head.lastDeployedAction should matchPattern {
+        case Some(
+              ProcessAction(_, _, _, _, _, _, _, _, None, None, None, buildInfo)
+            ) if buildInfo.isEmpty =>
+      }
+    }
+  }
+
   test("return single process") {
     createDeployedExampleScenario(processName, category = Category1)
     MockableDeploymentManager.configureScenarioStatuses(

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -42,6 +42,7 @@
 * [#7386](https://github.com/TouK/nussknacker/pull/7386) Improve Periodic DeploymentManager db queries, continuation of [#7323](https://github.com/TouK/nussknacker/pull/7323)
 * [#7360](https://github.com/TouK/nussknacker/pull/7360) Added Median aggregator
 * [#7388](https://github.com/TouK/nussknacker/pull/7388) Ability to configure a required permission for component links
+* [#7354](https://github.com/TouK/nussknacker/pull/7354) Reduce response payload size when fetching scenarios for scenarios tab by removing unused fields and `null` attributes.
 
 ## 1.18
 


### PR DESCRIPTION
## Describe your changes

Currently when we enter scenarios tab we fetch a lot of data regarding them. Some of the data isn't used at that level. It only bloats the response payload slowing down loading the tab.

In our Nussknacker instance we have a lot of scenarios so response payloads for that tab can reach around 7.6 MB. The biggest unused attribute that is sent along with the scenarios' details is `buildInfo`. We can remove it along with a few others not needed fields and we can also omit null attributes in the response JSON. By doing so we can decrease the response payload up to 25%. Which can help us a bit with long load times of scenarios tab.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
