### PR TITLE
[Nu-7231] Do not allow inline maps with non string keys to be defined in FragmentInputDefinition

### DIFF
--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/fragment/FragmentParameterTypingParser.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/fragment/FragmentParameterTypingParser.scala
@@ -28,10 +28,12 @@ class FragmentParameterTypingParser(classLoader: ClassLoader, classDefinitions: 
     val setPattern  = "Set\\[(.+)\\]".r
 
     Try(className match {
-      case mapPattern(x, y) =>
+      case mapPattern(x, y) if x == "String" =>
         val resolvedFirstTypeParam  = resolveInnerClass(x)
         val resolvedSecondTypeParam = resolveInnerClass(y)
         Typed.genericTypeClass[java.util.Map[_, _]](List(resolvedFirstTypeParam, resolvedSecondTypeParam))
+      case mapPattern(_, _) =>
+        throw new IllegalArgumentException("Obtained map with non string key")
       case listPattern(x) =>
         val resolvedTypeParam = resolveInnerClass(x)
         Typed.genericTypeClass[java.util.List[_]](List(resolvedTypeParam))

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
@@ -1160,6 +1160,35 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
     }
   }
 
+  test("should not allow creation of inline map with non string keys in FragmentInputDefinition") {
+    val nodeId: String = "in"
+    val paramName      = "param1"
+
+    inside(
+      validate(
+        FragmentInputDefinition(
+          nodeId,
+          List(
+            FragmentParameter(
+              ParameterName(paramName),
+              FragmentClazzRef("Map[Long, Double]"),
+              required = false,
+              initialValue = None,
+              hintText = None,
+              valueEditor = None,
+              valueCompileTimeValidation = None
+            )
+          ),
+        ),
+        ValidationContext.empty,
+        Map.empty,
+        outgoingEdges = List(OutgoingEdge("any", Some(FragmentOutput("out1"))))
+      )
+    ) { case ValidationPerformed(errors, None, None) =>
+      errors shouldBe List(FragmentParamClassLoadError(ParameterName("param1"), "Map[Long, Double]", "in"))
+    }
+  }
+
   test(
     "should not allow usage of generic type in FragmentInputDefinition parameter when occurring type is not on classpath"
   ) {


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
