### PR TITLE
[NU-1940] Add seconds to sample generator period editor and remove white arrows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -477,27 +477,6 @@ def filterDevConfigArtifacts(files: Seq[(File, String)]) = {
   files.filterNot { case (file, _) => devConfigFiles.contains(file.getName) }
 }
 
-ThisBuild / Test / testListeners += new TestReportListener {
-
-  override def testEvent(event: TestEvent): Unit = {
-    event.result.foreach {
-      case TestResult.Failed => {
-        import java.lang.management.ManagementFactory
-
-        println("Test failed! Generating thread dump...")
-        val threadDump = ManagementFactory.getThreadMXBean.dumpAllThreads(true, true)
-        threadDump.foreach { thread =>
-          println(thread.toString)
-        }
-      }
-    }
-  }
-
-  override def startGroup(name: String): Unit                   = ()
-  override def endGroup(name: String, t: Throwable): Unit       = ()
-  override def endGroup(name: String, result: TestResult): Unit = ()
-}
-
 lazy val distribution: Project = sbt
   .Project("dist", file("nussknacker-dist"))
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -477,6 +477,27 @@ def filterDevConfigArtifacts(files: Seq[(File, String)]) = {
   files.filterNot { case (file, _) => devConfigFiles.contains(file.getName) }
 }
 
+ThisBuild / Test / testListeners += new TestReportListener {
+
+  override def testEvent(event: TestEvent): Unit = {
+    event.result.foreach {
+      case TestResult.Failed => {
+        import java.lang.management.ManagementFactory
+
+        println("Test failed! Generating thread dump...")
+        val threadDump = ManagementFactory.getThreadMXBean.dumpAllThreads(true, true)
+        threadDump.foreach { thread =>
+          println(thread.toString)
+        }
+      }
+    }
+  }
+
+  override def startGroup(name: String): Unit                   = ()
+  override def endGroup(name: String, t: Throwable): Unit       = ()
+  override def endGroup(name: String, result: TestResult): Unit = ()
+}
+
 lazy val distribution: Project = sbt
   .Project("dist", file("nussknacker-dist"))
   .settings(commonSettings)

--- a/designer/client/src/components/graph/node-modal/editors/expression/Duration/TimeRangeComponent.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/Duration/TimeRangeComponent.tsx
@@ -65,7 +65,7 @@ export default function TimeRangeComponent(props: Props) {
             <input
                 readOnly={readOnly}
                 value={value[component.fieldName] || ""}
-                onChange={(event) => onChange(component.fieldName, parseInt(event.target.value))}
+                onChange={(event) => onChange(component.fieldName, event.target.value)}
                 className={cx([
                     nodeInput,
                     "time-range-input",
@@ -73,7 +73,6 @@ export default function TimeRangeComponent(props: Props) {
                     isMarked && "marked",
                     readOnly && "read-only",
                 ])}
-                type={"number"}
             />
             <span className={"time-range-component-label"}>{component.label}</span>
         </div>

--- a/designer/client/src/components/graph/node-modal/editors/expression/Duration/TimeRangeEditor.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/Duration/TimeRangeEditor.tsx
@@ -24,11 +24,15 @@ export default function TimeRangeEditor(props: Props): JSX.Element {
     const [value, setValue] = useState(() => decode(expression));
 
     const onComponentChange = useCallback(
-        (fieldName: string, fieldValue: number) => {
-            setValue({
-                ...value,
-                [fieldName]: isNaN(fieldValue) ? null : fieldValue,
-            });
+        (fieldName: string, fieldValue: string) => {
+            // treating empty string as null to allow deleting single digit
+            const parsedValue = fieldValue === "" ? null : parseInt(fieldValue);
+            if (parsedValue === null || !isNaN(parsedValue)) {
+                setValue({
+                    ...value,
+                    [fieldName]: parsedValue,
+                });
+            }
         },
         [value],
     );

--- a/designer/client/test/Editors/DurationEditor-test.tsx
+++ b/designer/client/test/Editors/DurationEditor-test.tsx
@@ -29,7 +29,6 @@ describe(DurationEditor.name, () => {
             </NuThemeProvider>,
         );
 
-        expect(screen.getByRole("spinbutton")).toHaveClass(nodeInputWithError);
         expect(screen.getByText("validation error")).toBeInTheDocument();
     });
 });

--- a/designer/client/test/Editors/PeriodEditor-test.tsx
+++ b/designer/client/test/Editors/PeriodEditor-test.tsx
@@ -29,7 +29,6 @@ describe(PeriodEditor.name, () => {
             </NuThemeProvider>,
         );
 
-        expect(screen.getByRole("spinbutton")).toHaveClass(nodeInputWithError);
         expect(screen.getByText("validation error")).toBeInTheDocument();
     });
 });

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -32,8 +32,10 @@
 * [#7341](https://github.com/TouK/nussknacker/pull/7341) Added possibility to choose presets and define lists for Integer typed parameter inputs in fragments.
 * [#7356](https://github.com/TouK/nussknacker/pull/7356) Integers converted to BigDecimals have scale 18,
   this fixes issue with unexpected low scale when performing division on BigDecimals which were created in such conversion.
-* [#7368](https://github.com/TouK/nussknacker/pull/7368) Component rename: `periodic` to `sample-generator`
 * [#7379](https://github.com/TouK/nussknacker/pull/7379) Removed CustomAction mechanism.
+* Changes to `periodic` component (renamed to `sample-generator`):
+    * [#7368](https://github.com/TouK/nussknacker/pull/7368) Component rename: `periodic` to `sample-generator`
+    * [#7373](https://github.com/TouK/nussknacker/pull/7373) Improvements to `period` editor
 
 ## 1.18
 

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/SampleGeneratorSourceFactory.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/SampleGeneratorSourceFactory.scala
@@ -8,6 +8,7 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.component.UnboundedStreamComponent
+import pl.touk.nussknacker.engine.api.editor.{DualEditor, DualEditorMode, SimpleEditor, SimpleEditorType}
 import pl.touk.nussknacker.engine.api.process.{BasicContextInitializer, Source, SourceFactory}
 import pl.touk.nussknacker.engine.api.typed.typing.Unknown
 import pl.touk.nussknacker.engine.api.typed.{ReturningType, typing}
@@ -24,6 +25,7 @@ import pl.touk.nussknacker.engine.flink.api.typeinformation.TypeInformationDetec
 import pl.touk.nussknacker.engine.util.TimestampUtils.supportedTypeToMillis
 
 import java.time.Duration
+import java.time.temporal.ChronoUnit
 import java.{util => jul}
 import javax.annotation.Nullable
 import javax.validation.constraints.Min
@@ -50,7 +52,15 @@ class SampleGeneratorSourceFactory(timestampAssigner: TimestampWatermarkHandler[
   @silent("deprecated")
   @MethodToInvoke
   def create(
-      @ParamName("period") period: Duration,
+      @ParamName("period")
+      @DualEditor(
+        simpleEditor = new SimpleEditor(
+          `type` = SimpleEditorType.DURATION_EDITOR,
+          timeRangeComponents = Array(ChronoUnit.DAYS, ChronoUnit.HOURS, ChronoUnit.MINUTES, ChronoUnit.SECONDS)
+        ),
+        defaultMode = DualEditorMode.SIMPLE
+      )
+      period: Duration,
       // TODO: @DefaultValue(1) instead of nullable
       @ParamName("count") @Nullable @Min(1) nullableCount: Integer,
       @ParamName("value") value: LazyParameter[AnyRef]


### PR DESCRIPTION
## Describe your changes

Changelog entry for this PR is in https://github.com/TouK/nussknacker/pull/7376

2 changes:
- add seconds field to period editor for sample generator (BE config)
- get rid of white arrows caused by input type=number. added some logic in https://github.com/TouK/nussknacker/pull/7373/files#diff-8773d281000063ecd74bda2c023f3a835e0bd99504543a657f32cab1932a60f3R27-R35 to not allow non-numbers - same as input type=number.

Before
![sample-gen-before](https://github.com/user-attachments/assets/97f3a9a5-0ee2-4398-ba4a-ec98d299a81b)

After
![sample-gen-after](https://github.com/user-attachments/assets/5172059f-7923-4def-a7d7-ad02755ff1db)




## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
