### PR TITLE
Periodic scenario status query improvement

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentService.scala
@@ -447,11 +447,14 @@ class DeploymentService(
           .map {
             case process if process.isFragment => DBIO.successful(process)
             case process =>
-              val prefetchedStatusDetails = for {
-                prefetchedStatusDetailsForProcessingTypes <- prefetchedStates.get(process.processingType)
-                prefetchedStatusDetails                   <- prefetchedStatusDetailsForProcessingTypes.get(process.name)
-              } yield prefetchedStatusDetails
-              prefetchedStatusDetails match {
+              val prefetchedState = for {
+                prefetchedStatesForProcessingType <- prefetchedStates.get(process.processingType)
+                // State is prefetched for all scenarios for the given processing type.
+                // If there is no information available for a specific scenario name,
+                // then it means that DM is not aware of this scenario, and we should default to List.empty[StatusDetails].
+                prefetchedState = prefetchedStatesForProcessingType.getOrElse(process.name, List.empty)
+              } yield prefetchedState
+              prefetchedState match {
                 case Some(prefetchedStatusDetails) =>
                   getProcessStateUsingPrefetchedStatus(
                     process.toEntity,
@@ -466,7 +469,6 @@ class DeploymentService(
                     None,
                   ).map(state => process.copy(state = Some(state)))
               }
-
           }
           .sequence[DB, ScenarioWithDetails]
       } yield processesWithState

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -36,6 +36,7 @@
 * Changes to `periodic` component (renamed to `sample-generator`):
     * [#7368](https://github.com/TouK/nussknacker/pull/7368) Component rename: `periodic` to `sample-generator`
     * [#7373](https://github.com/TouK/nussknacker/pull/7373) Improvements to `period` editor
+* [#7386](https://github.com/TouK/nussknacker/pull/7386) Improve Periodic DeploymentManager db queries, continuation of [#7323](https://github.com/TouK/nussknacker/pull/7323)
 
 ## 1.18
 

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -211,7 +211,7 @@ class PeriodicDeploymentManager private[periodic] (
       currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState] = {
     val statusDetails = statusDetailsList match {
-      case ::(head, _) =>
+      case head :: _ =>
         head
       case Nil =>
         val status = PeriodicProcessStatus(List.empty, List.empty)

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicDeploymentManager.scala
@@ -210,7 +210,13 @@ class PeriodicDeploymentManager private[periodic] (
       deployedVersionId: Option[VersionId],
       currentlyPresentedVersionId: Option[VersionId],
   ): Future[ProcessState] = {
-    val statusDetails = statusDetailsList.head
+    val statusDetails = statusDetailsList match {
+      case ::(head, _) =>
+        head
+      case Nil =>
+        val status = PeriodicProcessStatus(List.empty, List.empty)
+        status.mergedStatusDetails.copy(status = status)
+    }
     // TODO: add "real" presentation of deployments in GUI
     val mergedStatus = processStateDefinitionManager
       .processState(

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessService.scala
@@ -507,9 +507,7 @@ class PeriodicProcessService(
               allStatusDetailsInDelegate <- supported.getAllProcessesStates()
               allStatusDetailsInPeriodic <- mergeStatusWithDeployments(allStatusDetailsInDelegate.value)
               result = allStatusDetailsInPeriodic.map { case (name, status) => (name, List(status)) }
-            } yield
-              if (allStatusDetailsInDelegate.cached) WithDataFreshnessStatus.cached(result)
-              else WithDataFreshnessStatus.fresh(result)
+            } yield allStatusDetailsInDelegate.map(_ => result)
           }
 
         }


### PR DESCRIPTION
## Describe your changes

This PR fixes few problems, that caused the previous performance improvement (https://github.com/TouK/nussknacker/pull/7323) to not be fully effective:
- Periodic DM did not return information about scenarios that were not present on underlying Flink DM
- that caused the DeploymentService to fetch them separately, one-by-one, thus not taking advantage of fetching all at once

Tested on a real-world example, with ~350 periodic scenarios, with query every 10 seconds for 6 minutes:
- before: App profiling showed 35 seconds spent in repository methods, fetching scenarios one-by-one
- after: 0.2 second spent in repository, fetching all scenarios at once

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
