### PR TITLE
Handle all finished periodic scenarios waiting for reschedule instead of one

### DIFF
--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -325,7 +325,7 @@ class SlickPeriodicProcessesRepository(
     getLatestDeploymentsForEachSchedule(
       processesHavingDeploymentsWithMatchingStatus,
       deploymentsPerScheduleMaxCount = 1
-    ).map(_.values.headOption.getOrElse(SchedulesState(Map.empty)))
+    ).map(schedulesForProcessNames => SchedulesState(schedulesForProcessNames.values.map(_.schedules).reduce(_ ++ _)))
   }
 
   override def getLatestDeploymentsForActiveSchedules(

--- a/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
+++ b/engine/flink/management/periodic/src/main/scala/pl/touk/nussknacker/engine/management/periodic/db/PeriodicProcessesRepository.scala
@@ -325,7 +325,11 @@ class SlickPeriodicProcessesRepository(
     getLatestDeploymentsForEachSchedule(
       processesHavingDeploymentsWithMatchingStatus,
       deploymentsPerScheduleMaxCount = 1
-    ).map(schedulesForProcessNames => SchedulesState(schedulesForProcessNames.values.map(_.schedules).reduce(_ ++ _)))
+    ).map(schedulesForProcessNames =>
+      SchedulesState(
+        schedulesForProcessNames.values.map(_.schedules).foldLeft(Map.empty[ScheduleId, ScheduleData])(_ ++ _)
+      )
+    )
   }
 
   override def getLatestDeploymentsForActiveSchedules(

--- a/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
+++ b/engine/flink/management/periodic/src/test/scala/pl/touk/nussknacker/engine/management/periodic/PeriodicProcessServiceIntegrationTest.scala
@@ -235,6 +235,7 @@ class PeriodicProcessServiceIntegrationTest
     )
     service.handleFinished.futureValue
 
+    // here we check that scenarios that not fired are still on the "toDeploy" list and finished are not on the list
     val toDeployAfterFinish = service.findToBeDeployed.futureValue
     toDeployAfterFinish.map(_.periodicProcess.processVersion.processName) should contain only every30MinutesProcessName
     service.deactivate(processName).futureValue
@@ -268,6 +269,58 @@ class PeriodicProcessServiceIntegrationTest
         nextRetryAt = None
       ),
     )
+  }
+
+  it should "handleFinished for all finished periodic scenarios waiting for reschedule" in withFixture() { f =>
+    val timeToTriggerCheck = startTime.plus(2, ChronoUnit.HOURS)
+    var currentTime        = startTime
+    def service            = f.periodicProcessService(currentTime)
+
+    service
+      .schedule(
+        cronEveryHour,
+        ProcessVersion.empty.copy(processName = ProcessName("first")),
+        sampleProcess,
+        randomProcessActionId
+      )
+      .futureValue
+    service
+      .schedule(
+        cronEveryHour,
+        ProcessVersion.empty.copy(processName = ProcessName("second")),
+        sampleProcess,
+        randomProcessActionId
+      )
+      .futureValue
+
+    currentTime = timeToTriggerCheck
+
+    // deploy all
+    service.findToBeDeployed.futureValue
+      .foreach(pp => service.deploy(pp).futureValue)
+
+    val stateAfterDeploy = service.getLatestDeploymentsForActiveSchedules(1).futureValue
+    stateAfterDeploy should have size 2
+
+    // finish all
+    stateAfterDeploy.values.foreach(schedulesState => {
+      val deployment = schedulesState.firstScheduleData.latestDeployments.head
+      f.delegateDeploymentManagerStub.setStateStatus(
+        processName,
+        SimpleStateStatus.Finished,
+        Some(deployment.id)
+      )
+    })
+    service.handleFinished.futureValue
+
+    // check all are rescheduled for next run
+    val stateAfterFinish = service.getLatestDeploymentsForActiveSchedules(1).futureValue
+    stateAfterFinish.values.foreach(schedulesState => {
+      val deployment = schedulesState.firstScheduleData.latestDeployments.head
+      deployment.state should matchPattern {
+        case PeriodicProcessDeploymentState(_, _, PeriodicProcessDeploymentStatus.Scheduled) =>
+      }
+    })
   }
 
   it should "redeploy scenarios that failed on deploy" in withFixture(deploymentRetryConfig =


### PR DESCRIPTION
## Describe your changes

Problem occurs when multiple periodic scenarios waiting for reschedule.

For periodic scenarios "handleFinished" processed only one scenario. When this scenario fails to be rescheduled (and stays in "deployed" state) in the next iteration "handleFinished" fetches the same list of periodic scenarios to reschedule. And those scenarios have no chance to be rescheduled.

Here I change "reschedule only first of waiting scenarios" to "reschedule all of waiting scenarios".


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
