### PR TITLE
[NU-1946] Method get on array types returns array's component type instead of Unknown

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -42,6 +42,7 @@
 * [#7386](https://github.com/TouK/nussknacker/pull/7386) Improve Periodic DeploymentManager db queries, continuation of [#7323](https://github.com/TouK/nussknacker/pull/7323)
 * [#7360](https://github.com/TouK/nussknacker/pull/7360) Added Median aggregator
 * [#7388](https://github.com/TouK/nussknacker/pull/7388) Ability to configure a required permission for component links
+* [#7403](https://github.com/TouK/nussknacker/pull/7403) Method get on array types returns array's component type instead of Unknown
 
 ## 1.18
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/extension/ExtensionMethods.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/extension/ExtensionMethods.scala
@@ -77,17 +77,17 @@ object ExtensionMethods {
 abstract class ExtensionMethod[R: ClassTag] {
   val argsSize: Int
   def invoke(target: Any, args: Object*): R
-  def returnType: Class[R] = classTag[R].runtimeClass.asInstanceOf[Class[R]]
+  def returnType: Class[_] = classTag[R].runtimeClass
 }
 
 object ExtensionMethod {
 
-  def NoArg[R: ClassTag](method: Any => R): ExtensionMethod[R] = new ExtensionMethod {
+  def NoArg[R: ClassTag](method: Any => R): ExtensionMethod[R] = new ExtensionMethod[R] {
     override val argsSize: Int                         = 0
     override def invoke(target: Any, args: Object*): R = method(target)
   }
 
-  def SingleArg[T, R: ClassTag](method: (Any, T) => R): ExtensionMethod[R] = new ExtensionMethod {
+  def SingleArg[T, R: ClassTag](method: (Any, T) => R): ExtensionMethod[R] = new ExtensionMethod[R] {
     override val argsSize: Int                         = 1
     override def invoke(target: Any, args: Object*): R = method(target, args.head.asInstanceOf[T])
   }

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -1504,11 +1504,13 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
 
   test("should allow using list methods on array projection") {
     evaluate[Any]("'a,b'.split(',').![#this].isEmpty()") shouldBe false
+    evaluate[String]("'a,b'.split(',').![#this].get(0)") shouldBe "a"
   }
 
   test("should allow using list methods on array") {
     evaluate[Any]("#array.isEmpty()") shouldBe false
     evaluate[Any]("#intArray.isEmpty()") shouldBe false
+    evaluate[String]("#array.get(0)") shouldBe "a"
   }
 
   test("should allow using list methods on nested arrays") {


### PR DESCRIPTION
## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
