### PR TITLE
Map int32 integer format in OpenAPI schema to the `Integer` type

### DIFF
--- a/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/parser/SwaggerParserTest.scala
+++ b/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/parser/SwaggerParserTest.scala
@@ -21,7 +21,7 @@ class SwaggerParserTest extends AnyFunSuite with BaseOpenAPITest with Matchers {
     openApi.name.value shouldBe "getCollectionDataUsingGET"
 
     openApi.parameters shouldBe List(
-      UriParameter("accountNo", SwaggerLong),
+      UriParameter("accountNo", SwaggerInteger),
       QueryParameter("pretty", SwaggerBool),
       HeaderParameter("System-Name", SwaggerString),
       HeaderParameter("System-User-Name", SwaggerString),

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -47,6 +47,7 @@
 * [#7354](https://github.com/TouK/nussknacker/pull/7354) Reduce response payload size when fetching scenarios for scenarios tab by removing unused fields and `null` attributes.
 * [#7404](https://github.com/TouK/nussknacker/pull/7404) Fix spel evaluation error when using conversion extensions methods or array.get extension method
 * [#7420](https://github.com/TouK/nussknacker/pull/7420) Add toInteger and toIntegerOrNull conversions. Also add canBeInteger extension
+* [#7438](https://github.com/TouK/nussknacker/pull/7438) Map int32 integer format in OpenAPI schema to the `Integer` type
 
 ## 1.18
 

--- a/docs/integration/OpenAPI.md
+++ b/docs/integration/OpenAPI.md
@@ -29,6 +29,8 @@ Table below describes data types that OpenAPI integration handles:
 | string       |                | String              |
 | string       | date-time      | LocalDateTime       |
 | integer      |                | Long                |
+| integer      | int32          | Integer             |
+| integer      | int64          | Long                |
 | number       |                | BigDecimal          |
 | number       | double         | Double              |
 | number       | float          | Double              |

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/swagger/SwaggerTyped.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/swagger/SwaggerTyped.scala
@@ -131,6 +131,8 @@ object SwaggerTyped {
             case (Some("string"), Some("date"))      => SwaggerDate
             case (Some("string"), Some("time"))      => SwaggerTime
             case (Some("string"), _)                 => SwaggerString
+            case (Some("integer"), Some("int32"))    => SwaggerInteger
+            case (Some("integer"), Some("int64"))    => SwaggerLong
             case (Some("integer"), _) =>
               inferredIntType(
                 schema.getMinimum,

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/swagger/decode/FromJsonSchemaBasedDecoder.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/swagger/decode/FromJsonSchemaBasedDecoder.scala
@@ -71,7 +71,6 @@ object FromJsonSchemaBasedDecoder {
         case SwaggerInteger =>
           extract[JsonNumber](_.asNumber, n => int2Integer(n.toDouble.toInt))
         case SwaggerLong =>
-          // FIXME: to ok?
           extract[JsonNumber](_.asNumber, n => long2Long(n.toDouble.toLong))
         case SwaggerBigInteger =>
           extract[JsonNumber](_.asNumber, _.toBigInt.map(_.bigInteger).orNull)

--- a/utils/json-utils/src/test/scala/pl/touk/nussknacker/engine/json/swagger/SwaggerTypedTest.scala
+++ b/utils/json-utils/src/test/scala/pl/touk/nussknacker/engine/json/swagger/SwaggerTypedTest.scala
@@ -1,0 +1,23 @@
+package pl.touk.nussknacker.engine.json.swagger
+
+import io.swagger.v3.oas.models.media.{IntegerSchema, ObjectSchema, Schema}
+import org.scalatest.funsuite.AnyFunSuite
+import pl.touk.nussknacker.engine.api.typed.typing.Typed
+import pl.touk.nussknacker.test.ProcessUtils.convertToAnyShouldWrapper
+
+class SwaggerTypedTest extends AnyFunSuite {
+
+  test("should map int32 and int64 integer formats") {
+    val schema = new ObjectSchema()
+      .addProperty("int32", new IntegerSchema().format("int32"))
+      .addProperty("int64", new IntegerSchema().format("int64"))
+      .addProperty("integer", new IntegerSchema().format(null))
+
+    val result = SwaggerTyped(schema, Map.empty).typingResult
+
+    result shouldBe Typed.record(
+      Map("int32" -> Typed[Integer], "int64" -> Typed[java.lang.Long], "integer" -> Typed[java.lang.Long])
+    )
+  }
+
+}


### PR DESCRIPTION
## Describe your changes

Use better type for `int32` integers

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [x] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
