### PR TITLE
Fix fragment nodes errors in scenario's tips

### DIFF
--- a/designer/client/src/components/graph/NodeUtils.ts
+++ b/designer/client/src/components/graph/NodeUtils.ts
@@ -213,6 +213,25 @@ class NodeUtils {
             }
         }
     };
+
+    // We can recognize that a node is part of a referenced fragment by making sure that:
+    // 1. The nodeId is not present in the scenarioGraph
+    // 2. There is a fragment node in the scenarioGraph whose name is part of the nodeId
+    isFragmentNodeReference = (nodeId: NodeId, scenarioGraph: ScenarioGraph): boolean => {
+        const isNodePresentInScenarioGraph = !!this.getNodeById(nodeId, scenarioGraph);
+        return !isNodePresentInScenarioGraph && scenarioGraph.nodes.some((n) => nodeId.startsWith(n.id));
+    };
+
+    getDetailsFromFragmentNode = (nodeId: NodeId, scenarioGraph: ScenarioGraph): { fragmentId: string; fragmentNodeId: string } | null => {
+        if (this.isFragmentNodeReference(nodeId, scenarioGraph)) {
+            const fragment = scenarioGraph.nodes.find((n) => nodeId.startsWith(n.id));
+            return {
+                fragmentId: fragment.ref.id,
+                fragmentNodeId: nodeId.replace(`${fragment.id}-`, ""),
+            };
+        }
+        return null;
+    };
 }
 
 //TODO this pattern is not necessary, just export every public function as in actions.js

--- a/designer/client/src/components/tips/error/NodeErrorsLinkSection.tsx
+++ b/designer/client/src/components/tips/error/NodeErrorsLinkSection.tsx
@@ -5,6 +5,9 @@ import { NodeId, NodeType } from "../../../types";
 import { ErrorHeader } from "./ErrorHeader";
 import { NodeErrorLink } from "./NodeErrorLink";
 import { Scenario } from "../../Process/types";
+import { NavLink } from "react-router-dom";
+import { ErrorLinkStyle } from "./styled";
+import { visualizationUrl } from "../../../common/VisualizationUrl";
 
 interface NodeErrorsLinkSectionProps {
     nodeIds: NodeId[];
@@ -22,6 +25,23 @@ export default function NodeErrorsLinkSection(props: NodeErrorsLinkSectionProps)
             <div>
                 <ErrorHeader message={message} />
                 {nodeIds.map((nodeId, index) => {
+                    const isFragmentNodeReference = NodeUtils.isFragmentNodeReference(nodeId, scenario.scenarioGraph);
+                    if (isFragmentNodeReference) {
+                        const { fragmentId, fragmentNodeId } = NodeUtils.getDetailsFromFragmentNode(nodeId, scenario.scenarioGraph);
+                        return (
+                            <React.Fragment key={nodeId}>
+                                <ErrorLinkStyle
+                                    variant={"body2"}
+                                    component={NavLink}
+                                    target={"_blank"}
+                                    to={visualizationUrl(fragmentId, fragmentNodeId)}
+                                >
+                                    {nodeId}
+                                </ErrorLinkStyle>
+                                {index < nodeIds.length - 1 ? separator : null}
+                            </React.Fragment>
+                        );
+                    }
                     const details = NodeUtils.getNodeById(nodeId, scenario.scenarioGraph);
                     return (
                         <React.Fragment key={nodeId}>

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -48,6 +48,9 @@
 * [#7404](https://github.com/TouK/nussknacker/pull/7404) Fix spel evaluation error when using conversion extensions methods or array.get extension method
 * [#7420](https://github.com/TouK/nussknacker/pull/7420) Add toInteger and toIntegerOrNull conversions. Also add canBeInteger extension
 * [#7438](https://github.com/TouK/nussknacker/pull/7438) Map int32 integer format in OpenAPI schema to the `Integer` type
+* [#7446](https://github.com/TouK/nussknacker/pull/7446) Small changes regarding node errors in fragments used in scenarios:
+  * Fragment error node tips in scenarios are now clickable and open problematic node edit window in a new tab.
+  * Fragment nodes are now highlighted when they contain nodes with errors.
 
 ## 1.18
 


### PR DESCRIPTION
## Describe your changes

Currently when we have a scenario which uses a fragment which has errors we get information about it in the `Tips` section. Unfortunately they are not clickable unlike other node errors. Furthermore the node representing the fragment is not highligted and does not indictate that there is something wrong with it.

![output](https://github.com/user-attachments/assets/4cdf8487-8add-4a9d-afc0-a8346bf7db40)

With these changes error tips regarding fragment nodes are now clickable and open in a new tab problematic fragment node so the user can fix the error. Also, the fragment node will be highlighted now to indicate a problem with it.

![output2](https://github.com/user-attachments/assets/ba3af142-408c-4078-94b2-8f53a6e0108e)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
