### PR TITLE
[NU-1974] Initialize model classloaders only once

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/factory/NussknackerAppFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/factory/NussknackerAppFactory.scala
@@ -7,6 +7,7 @@ import cats.effect.{IO, Resource}
 import com.typesafe.scalalogging.LazyLogging
 import io.dropwizard.metrics5.MetricRegistry
 import io.dropwizard.metrics5.jmx.JmxReporter
+import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
 import pl.touk.nussknacker.engine.util.{JavaClassVersionChecker, SLF4JBridgeHandlerRegistrar}
 import pl.touk.nussknacker.engine.{ConfigWithUnresolvedVersion, ProcessingTypeConfig}
@@ -126,7 +127,7 @@ class NussknackerAppFactory(
   ): ModelClassLoaderProvider = {
     val defaultWorkingDirOpt = None
     ModelClassLoaderProvider(
-      processingTypeConfigs.mapValues(c => ModelClassLoaderDependencies(c.classPath, defaultWorkingDirOpt))
+      processingTypeConfigs.mapValuesNow(c => ModelClassLoaderDependencies(c.classPath, defaultWorkingDirOpt))
     )
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ModelClassLoaderProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ModelClassLoaderProvider.scala
@@ -1,0 +1,68 @@
+package pl.touk.nussknacker.ui.process.processingtype
+
+import pl.touk.nussknacker.engine.util.loader.ModelClassLoader
+
+import java.nio.file.Path
+
+final case class ModelClassLoaderDependencies(classpath: List[String], workingDirectoryOpt: Option[Path]) {
+
+  def show(): String = {
+    val workingDirectoryReadable = workingDirectoryOpt match {
+      case Some(value) => value.toString
+      case None        => "None (default)"
+    }
+    s"classpath: ${classpath.mkString(", ")}, workingDirectoryOpt: $workingDirectoryReadable"
+  }
+
+}
+
+class ModelClassLoaderProvider private (
+    processingTypeClassLoaders: Map[String, (ModelClassLoader, ModelClassLoaderDependencies)]
+) {
+
+  def forProcessingTypeUnsafe(processingTypeName: String): ModelClassLoader = {
+    processingTypeClassLoaders
+      .getOrElse(
+        processingTypeName,
+        throw new IllegalArgumentException(
+          s"Unknown ProcessingType: $processingTypeName, known ProcessingTypes are: ${processingTypeName.mkString(", ")}"
+        )
+      )
+      ._1
+  }
+
+  def validateReloadConsistency(
+      dependenciesFromReload: Map[String, ModelClassLoaderDependencies]
+  ): Unit = {
+    if (dependenciesFromReload.keySet != processingTypeClassLoaders.keySet) {
+      throw new IllegalStateException(
+        s"""Processing types cannot be added, removed, or renamed during processing type reload.
+           |Reloaded processing types: [${dependenciesFromReload.keySet.toList.sorted.mkString(", ")}]
+           |Current processing types: [${processingTypeClassLoaders.keySet.toList.sorted.mkString(", ")}]
+           |If you need to modify this, please restart the application with desired config.""".stripMargin
+      )
+    }
+    dependenciesFromReload.foreach { case (processingType, reloadedConfig) =>
+      val currentConfig = processingTypeClassLoaders.mapValues(_._2)(processingType)
+      if (reloadedConfig != currentConfig) {
+        throw new IllegalStateException(
+          s"Error during processing types reload. Model ClassLoader dependencies such as classpath cannot be modified during reload. " +
+            s"For processing type [$processingType], reloaded ClassLoader dependencies: [${reloadedConfig.show()}] " +
+            s"do not match current dependencies: [${currentConfig.show()}]"
+        )
+      }
+    }
+  }
+
+}
+
+object ModelClassLoaderProvider {
+
+  def apply(processingTypeConfig: Map[String, ModelClassLoaderDependencies]): ModelClassLoaderProvider = {
+    val processingTypesClassloaders = processingTypeConfig.map { case (name, deps) =>
+      name -> (ModelClassLoader(deps.classpath, deps.workingDirectoryOpt) -> deps)
+    }
+    new ModelClassLoaderProvider(processingTypesClassloaders)
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ModelClassLoaderProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ModelClassLoaderProvider.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.ui.process.processingtype
 
+import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.util.loader.ModelClassLoader
 
 import java.nio.file.Path
@@ -43,7 +44,7 @@ class ModelClassLoaderProvider private (
       )
     }
     dependenciesFromReload.foreach { case (processingType, reloadedConfig) =>
-      val currentConfig = processingTypeClassLoaders.mapValues(_._2)(processingType)
+      val currentConfig = processingTypeClassLoaders.mapValuesNow(_._2)(processingType)
       if (reloadedConfig != currentConfig) {
         throw new IllegalStateException(
           s"Error during processing types reload. Model ClassLoader dependencies such as classpath cannot be modified during reload. " +

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/LocalProcessingTypeDataLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/LocalProcessingTypeDataLoader.scala
@@ -7,7 +7,11 @@ import pl.touk.nussknacker.engine.api.process.ProcessingType
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.ui.process.processingtype.loader.ProcessingTypeDataLoader.toValueWithRestriction
 import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataState
-import pl.touk.nussknacker.ui.process.processingtype.{CombinedProcessingTypeData, ProcessingTypeData}
+import pl.touk.nussknacker.ui.process.processingtype.{
+  CombinedProcessingTypeData,
+  ModelClassLoaderProvider,
+  ProcessingTypeData
+}
 
 class LocalProcessingTypeDataLoader(
     modelData: Map[ProcessingType, (String, ModelData)],
@@ -16,7 +20,8 @@ class LocalProcessingTypeDataLoader(
 
   override def loadProcessingTypeData(
       getModelDependencies: ProcessingType => ModelDependencies,
-      getDeploymentManagerDependencies: ProcessingType => DeploymentManagerDependencies
+      getDeploymentManagerDependencies: ProcessingType => DeploymentManagerDependencies,
+      modelClassLoaderProvider: ModelClassLoaderProvider
   ): IO[ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData]] = IO {
     val processingTypes = modelData.map { case (processingType, (category, model)) =>
       val deploymentManagerDependencies = getDeploymentManagerDependencies(processingType)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/ProcessingTypeDataLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/ProcessingTypeDataLoader.scala
@@ -6,6 +6,7 @@ import pl.touk.nussknacker.engine.{DeploymentManagerDependencies, ModelDependenc
 import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataState
 import pl.touk.nussknacker.ui.process.processingtype.{
   CombinedProcessingTypeData,
+  ModelClassLoaderProvider,
   ProcessingTypeData,
   ValueWithRestriction
 }
@@ -15,6 +16,7 @@ trait ProcessingTypeDataLoader {
   def loadProcessingTypeData(
       getModelDependencies: ProcessingType => ModelDependencies,
       getDeploymentManagerDependencies: ProcessingType => DeploymentManagerDependencies,
+      modelClassLoaderProvider: ModelClassLoaderProvider
   ): IO[ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData]]
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
@@ -65,7 +65,7 @@ import pl.touk.nussknacker.ui.process.newdeployment.synchronize.{
   DeploymentsStatusesSynchronizer
 }
 import pl.touk.nussknacker.ui.process.newdeployment.{DeploymentRepository, DeploymentService}
-import pl.touk.nussknacker.ui.process.processingtype.ProcessingTypeData
+import pl.touk.nussknacker.ui.process.processingtype.{ModelClassLoaderProvider, ProcessingTypeData}
 import pl.touk.nussknacker.ui.process.processingtype.loader.ProcessingTypeDataLoader
 import pl.touk.nussknacker.ui.process.processingtype.provider.ReloadableProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.process.repository._
@@ -108,7 +108,8 @@ class AkkaHttpBasedRouteProvider(
     sttpBackend: SttpBackend[Future, Any],
     processingTypeDataLoader: ProcessingTypeDataLoader,
     feStatisticsRepository: FEStatisticsRepository[Future],
-    designerClock: Clock
+    designerClock: Clock,
+    modelClassLoaderProvider: ModelClassLoaderProvider
 )(
     implicit system: ActorSystem,
     materializer: Materializer,
@@ -139,7 +140,8 @@ class AkkaHttpBasedRouteProvider(
         dbioRunner,
         sttpBackend,
         featureTogglesConfig,
-        globalNotificationRepository
+        globalNotificationRepository,
+        modelClassLoaderProvider
       )
 
       deploymentsStatusesSynchronizer = new DeploymentsStatusesSynchronizer(
@@ -704,7 +706,8 @@ class AkkaHttpBasedRouteProvider(
       dbioActionRunner: DBIOActionRunner,
       sttpBackend: SttpBackend[Future, Any],
       featureTogglesConfig: FeatureTogglesConfig,
-      globalNotificationRepository: InMemoryTimeseriesRepository[Notification]
+      globalNotificationRepository: InMemoryTimeseriesRepository[Notification],
+      modelClassLoaderProvider: ModelClassLoaderProvider
   ): Resource[IO, ReloadableProcessingTypeDataProvider] = {
     Resource
       .make(
@@ -723,6 +726,7 @@ class AkkaHttpBasedRouteProvider(
               sttpBackend,
               _
             ),
+            modelClassLoaderProvider
           )
           val loadAndNotifyIO = laodProcessingTypeDataIO
             .map { state =>

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/NuResourcesTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/NuResourcesTest.scala
@@ -24,6 +24,7 @@ import pl.touk.nussknacker.engine.api.process.VersionId.initialVersionId
 import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.definition.test.{ModelDataTestInfoProvider, TestInfoProvider}
+import pl.touk.nussknacker.engine.util.loader.ModelClassLoader
 import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
@@ -127,7 +128,8 @@ trait NuResourcesTest
   protected val deploymentManagerProvider: DeploymentManagerProvider =
     new MockManagerProvider(deploymentManager)
 
-  private val modelData = ModelData(processingTypeConfig, modelDependencies)
+  private val modelData =
+    ModelData(processingTypeConfig, modelDependencies, ModelClassLoader.apply(processingTypeConfig.classPath, None))
 
   protected val testProcessingTypeDataProvider: ProcessingTypeDataProvider[ProcessingTypeData, _] =
     mapProcessingTypeDataProvider(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
@@ -7,11 +7,6 @@ import cats.data.ValidatedNel
 import com.google.common.collect.LinkedHashMultimap
 import com.typesafe.config.Config
 import pl.touk.nussknacker.engine._
-import pl.touk.nussknacker.engine.api.definition.{
-  NotBlankParameterValidator,
-  NotNullParameterValidator,
-  StringParameterEditor
-}
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.ProcessName
@@ -19,6 +14,7 @@ import pl.touk.nussknacker.engine.api.{ProcessVersion, StreamMetaData}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment._
 import pl.touk.nussknacker.engine.management.{FlinkDeploymentManager, FlinkStreamingDeploymentManagerProvider}
+import pl.touk.nussknacker.engine.util.loader.ModelClassLoader
 import pl.touk.nussknacker.test.config.ConfigWithScalaVersion
 import pl.touk.nussknacker.test.utils.domain.TestFactory
 import shapeless.syntax.typeable.typeableOps
@@ -47,7 +43,8 @@ class MockDeploymentManager(
 ) extends FlinkDeploymentManager(
       ModelData(
         ProcessingTypeConfig.read(ConfigWithScalaVersion.StreamingProcessTypeConfig),
-        TestFactory.modelDependencies
+        TestFactory.modelDependencies,
+        ModelClassLoader(ProcessingTypeConfig.read(ConfigWithScalaVersion.StreamingProcessTypeConfig).classPath, None)
       ),
       DeploymentManagerDependencies(
         deployedScenariosProvider,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/config/ConfigurationTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/config/ConfigurationTest.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.ui.config
 import cats.effect.unsafe.implicits.global
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.util.loader.ModelClassLoader
 import pl.touk.nussknacker.engine.{ModelData, ProcessingTypeConfig}
 import pl.touk.nussknacker.test.config.ConfigWithScalaVersion
 import pl.touk.nussknacker.test.utils.domain.TestFactory
@@ -17,10 +18,14 @@ class ConfigurationTest extends AnyFunSuite with Matchers {
   // warning: can't be val - uses ConfigFactory.load which breaks "should preserve config overrides" test
   private def globalConfig = ConfigWithScalaVersion.TestsConfig
 
-  private def modelData: ModelData = ModelData(
-    ProcessingTypeConfig.read(ConfigWithScalaVersion.StreamingProcessTypeConfig),
-    TestFactory.modelDependencies
-  )
+  private def modelData: ModelData = {
+    val config = ProcessingTypeConfig.read(ConfigWithScalaVersion.StreamingProcessTypeConfig)
+    ModelData(
+      config,
+      TestFactory.modelDependencies,
+      ModelClassLoader(config.classPath, None)
+    )
+  }
 
   private lazy val modelDataConfig = modelData.modelConfig
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeDataProviderSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeDataProviderSpec.scala
@@ -57,7 +57,8 @@ class ProcessingTypeDataProviderSpec extends AnyFunSuite with Matchers {
     loader
       .loadProcessingTypeData(
         _ => modelDependencies,
-        _ => TestFactory.deploymentManagerDependencies
+        _ => TestFactory.deploymentManagerDependencies,
+        ModelClassLoaderProvider(allProcessingTypes.map(_ -> ModelClassLoaderDependencies(List.empty, None)).toMap)
       )
       .unsafeRunSync()
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ScenarioParametersServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ScenarioParametersServiceTest.scala
@@ -14,6 +14,7 @@ import pl.touk.nussknacker.engine.api.component.{ComponentProvider, DesignerWide
 import pl.touk.nussknacker.engine.api.process.ProcessingType
 import pl.touk.nussknacker.engine.definition.component.Components.ComponentDefinitionExtractionMode
 import pl.touk.nussknacker.engine.deployment.EngineSetupName
+import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioParameters
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage
@@ -297,7 +298,7 @@ class ScenarioParametersServiceTest
             ),
           _ => TestFactory.deploymentManagerDependencies,
           ModelClassLoaderProvider(
-            designerConfig.processingTypeConfigs.configByProcessingType.mapValues(conf =>
+            designerConfig.processingTypeConfigs.configByProcessingType.mapValuesNow(conf =>
               ModelClassLoaderDependencies(conf.classPath, None)
             )
           )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ScenarioParametersServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ScenarioParametersServiceTest.scala
@@ -296,6 +296,11 @@ class ScenarioParametersServiceTest
               ComponentDefinitionExtractionMode.FinalDefinition
             ),
           _ => TestFactory.deploymentManagerDependencies,
+          ModelClassLoaderProvider(
+            designerConfig.processingTypeConfigs.configByProcessingType.mapValues(conf =>
+              ModelClassLoaderDependencies(conf.classPath, None)
+            )
+          )
         )
         .unsafeRunSync()
     val parametersService = processingTypeData.getCombined().parametersService

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerProviderHelper.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerProviderHelper.scala
@@ -12,6 +12,7 @@ import pl.touk.nussknacker.engine.api.deployment.{
 }
 import pl.touk.nussknacker.engine.definition.component.Components.ComponentDefinitionExtractionMode
 import pl.touk.nussknacker.engine.management.FlinkStreamingDeploymentManagerProvider
+import pl.touk.nussknacker.engine.util.loader.ModelClassLoader
 import pl.touk.nussknacker.engine.{
   ConfigWithUnresolvedVersion,
   DeploymentManagerDependencies,
@@ -26,7 +27,8 @@ object FlinkStreamingDeploymentManagerProviderHelper {
   def createDeploymentManager(
       processingTypeConfig: ConfigWithUnresolvedVersion,
   ): DeploymentManager = {
-    val typeConfig = ProcessingTypeConfig.read(processingTypeConfig)
+    val typeConfig       = ProcessingTypeConfig.read(processingTypeConfig)
+    val modelClassLoader = ModelClassLoader(typeConfig.classPath, None)
     val modelData = ModelData(
       processingTypeConfig = typeConfig,
       ModelDependencies(
@@ -34,8 +36,9 @@ object FlinkStreamingDeploymentManagerProviderHelper {
         determineDesignerWideId = id => DesignerWideComponentId(id.toString),
         workingDirectoryOpt = None,
         _ => true,
-        ComponentDefinitionExtractionMode.FinalDefinition
-      )
+        ComponentDefinitionExtractionMode.FinalDefinition,
+      ),
+      modelClassLoader
     )
     val actorSystem = ActorSystem("FlinkStreamingDeploymentManagerProviderHelper")
     val backend     = AsyncHttpClientFutureBackend.usingConfig(new DefaultAsyncHttpClientConfig.Builder().build())

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkStreamingDeploymentManagerSpec.scala
@@ -18,6 +18,7 @@ import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId}
 import pl.touk.nussknacker.engine.definition.component.Components.ComponentDefinitionExtractionMode
 import pl.touk.nussknacker.engine.deployment.DeploymentData
+import pl.touk.nussknacker.engine.util.loader.ModelClassLoader
 
 import java.net.URI
 import java.nio.file.{Files, Paths}
@@ -271,7 +272,8 @@ class FlinkStreamingDeploymentManagerSpec extends AnyFunSuite with Matchers with
         workingDirectoryOpt = None,
         _ => true,
         ComponentDefinitionExtractionMode.FinalDefinition
-      )
+      ),
+      ModelClassLoader(processingTypeConfig.classPath, None)
     )
     val definition = modelData.modelDefinition
     definition.components.components.map(_.id) should contain(ComponentId(ComponentType.Service, "accountService"))

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/ModelData.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/ModelData.scala
@@ -40,8 +40,11 @@ object ModelData extends LazyLogging {
         Map[DesignerWideComponentId, ComponentAdditionalConfig]
     ) => ModelDefinition
 
-  def apply(processingTypeConfig: ProcessingTypeConfig, dependencies: ModelDependencies): ModelData = {
-    val modelClassLoader = ModelClassLoader(processingTypeConfig.classPath, dependencies.workingDirectoryOpt)
+  def apply(
+      processingTypeConfig: ProcessingTypeConfig,
+      dependencies: ModelDependencies,
+      modelClassLoader: ModelClassLoader
+  ): ModelData = {
     ClassLoaderModelData(
       _.resolveInputConfigDuringExecution(processingTypeConfig.modelConfig, modelClassLoader.classLoader),
       modelClassLoader,


### PR DESCRIPTION
## Describe your changes
Right now model classloaders are initialized each time the model is initialized or reloaded. They are not garbage collected as they are referenced in by something like this `ProtectionDomain[]`  <- `AccessControlContext` <- Netty Thread. Closing the classloaders doesn't help. This results in a metaspace leak.

If we initialize them only once, it stops being a problem at the price of not-reloadability of classpath of model.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
