### PR TITLE
[Nu-7393] Allow copying alert message when it is of an error type

### DIFF
--- a/designer/client/package-lock.json
+++ b/designer/client/package-lock.json
@@ -26,6 +26,7 @@
                 "@touk/window-manager": "1.9.1",
                 "ace-builds": "1.34.2",
                 "axios": "1.7.5",
+                "copy-to-clipboard": "3.3.1",
                 "d3-transition": "3.0.1",
                 "d3-zoom": "3.0.0",
                 "dagre": "0.8.5",
@@ -10355,6 +10356,14 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/copy-to-clipboard": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+            "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+            "dependencies": {
+                "toggle-selection": "^1.0.6"
             }
         },
         "node_modules/copy-webpack-plugin": {
@@ -26188,6 +26197,11 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/toggle-selection": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+            "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+        },
         "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -36095,6 +36109,14 @@
             "version": "0.1.1",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
+        },
+        "copy-to-clipboard": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+            "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+            "requires": {
+                "toggle-selection": "^1.0.6"
+            }
         },
         "copy-webpack-plugin": {
             "version": "11.0.0",
@@ -47972,6 +47994,11 @@
             "requires": {
                 "through2": "^2.0.3"
             }
+        },
+        "toggle-selection": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+            "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
         },
         "toidentifier": {
             "version": "1.0.1",

--- a/designer/client/package.json
+++ b/designer/client/package.json
@@ -19,6 +19,7 @@
         "@touk/window-manager": "1.9.1",
         "ace-builds": "1.34.2",
         "axios": "1.7.5",
+        "copy-to-clipboard": "3.3.1",
         "d3-transition": "3.0.1",
         "d3-zoom": "3.0.0",
         "dagre": "0.8.5",

--- a/designer/client/src/components/notifications/Notification.tsx
+++ b/designer/client/src/components/notifications/Notification.tsx
@@ -1,6 +1,8 @@
 import React, { ReactElement } from "react";
 import { Alert, AlertColor } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
+import { CopyTooltip } from "./copyTooltip";
+import { useTranslation } from "react-i18next";
 
 interface Props {
     icon: ReactElement;
@@ -10,9 +12,19 @@ interface Props {
 }
 
 export default function Notification({ icon, message, type }: Props): JSX.Element {
-    return (
+    const { t } = useTranslation();
+
+    const alertContent = (
         <Alert icon={icon} severity={type} action={<CloseIcon sx={{ fontSize: 12 }} />}>
             {message}
         </Alert>
+    );
+
+    return type === "error" ? (
+        <CopyTooltip text={message} title={t("error.copyMessage", "Copy message to clipboard")}>
+            {alertContent}
+        </CopyTooltip>
+    ) : (
+        alertContent
     );
 }

--- a/designer/client/src/components/notifications/copyTooltip.tsx
+++ b/designer/client/src/components/notifications/copyTooltip.tsx
@@ -1,0 +1,78 @@
+import React, { PropsWithChildren, useEffect, useState } from "react";
+import copy from "copy-to-clipboard";
+import { Button, Tooltip } from "@mui/material";
+import { CopyAll, Done } from "@mui/icons-material";
+
+export function useCopyClipboard(): [boolean, (value: string) => void] {
+    const [isCopied, setIsCopied] = useState<boolean>();
+    const [text, setText] = useState<string>();
+
+    useEffect(() => {
+        if (isCopied) {
+            const id = setTimeout(() => {
+                setIsCopied(false);
+            }, 1000);
+
+            return () => {
+                clearTimeout(id);
+            };
+        }
+    }, [isCopied, text]);
+
+    return [
+        isCopied,
+        (value: string) => {
+            setText(value);
+            setIsCopied(copy(value));
+        },
+    ];
+}
+
+export function CopyTooltip({
+    children,
+    text,
+    title,
+}: PropsWithChildren<{
+    text: string;
+    title: string;
+}>): JSX.Element {
+    const [isCopied, copy] = useCopyClipboard();
+    return (
+        <Tooltip
+            enterDelay={700}
+            leaveDelay={200}
+            title={
+                <Button
+                    size="small"
+                    variant="text"
+                    color="inherit"
+                    startIcon={isCopied ? <Done fontSize="small" /> : <CopyAll fontSize="small" />}
+                    onClick={(e) => {
+                        copy(text);
+                        e.stopPropagation();
+                    }}
+                >
+                    {title}
+                </Button>
+            }
+            componentsProps={{
+                popper: {
+                    sx: {
+                        opacity: 0.8,
+                    },
+                },
+                tooltip: {
+                    sx: {
+                        bgcolor: (t) => (t.palette.mode === "dark" ? t.palette.common.white : t.palette.common.black),
+                        color: (t) => (t.palette.mode === "dark" ? t.palette.common.black : t.palette.common.white),
+                    },
+                },
+                arrow: { sx: { color: (t) => (t.palette.mode === "dark" ? t.palette.common.white : t.palette.common.black) } },
+            }}
+            placement="bottom-start"
+            arrow
+        >
+            <span>{children}</span>
+        </Tooltip>
+    );
+}


### PR DESCRIPTION
## Describe your changes

My goal is to add possibility to easily copy an error message for alerts whenever it is of `error` type. It looks like in the provided image and copy popup shows whenever user hover on an alert:

![image](https://github.com/user-attachments/assets/664114af-bc5f-4cd9-8d99-2bb1bb82ec95)


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
