### PR TITLE
Fix Flink user config parsing

### DIFF
--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/NkGlobalParameters.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/NkGlobalParameters.scala
@@ -172,7 +172,8 @@ object NkGlobalParameters {
       private val prefix = "configParameters"
     }
 
-    private val namespaceTagsMapPrefix         = "namespaceTags"
+    private val namespaceTagsMapPrefix = "namespaceTags"
+    // When modifying this prefix, be sure to check and modify the `prefix` in FlinkRestManager
     private val additionalInformationMapPrefix = "additionalInformation"
   }
 


### PR DESCRIPTION
## Describe your changes

Flink DM was not correctly parsing user config, which, since before Nu 1.18 is prefixed with `additionalInformation` string. As a result, Periodic DM was not canceling scenarios running on Flink.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
