### PR TITLE
Workaround for different CanonicalProcess representations in periodic database and manin Nu database

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicProcessService.scala
@@ -396,6 +396,7 @@ class PeriodicProcessService(
       currentState <- periodicProcessesRepository.findProcessData(deployment.id).run
       canonicalProcessOpt <- periodicProcessesRepository
         .fetchCanonicalProcessWithVersion(
+          deployment.periodicProcessId,
           processName,
           versionId
         )
@@ -496,6 +497,7 @@ class PeriodicProcessService(
       versionId   = deploymentWithJarData.versionId
       canonicalProcessWithVersionOpt <- periodicProcessesRepository
         .fetchCanonicalProcessWithVersion(
+          deployment.periodicProcess.id,
           processName,
           versionId
         )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/legacy/db/LegacyPeriodicProcessesRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/legacy/db/LegacyPeriodicProcessesRepository.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.ui.process.periodic.legacy.db
 
 import cats.Monad
+import cats.data.OptionT
 import com.github.tminglei.slickpg.ExPostgresProfile
 import com.typesafe.scalalogging.LazyLogging
 import db.util.DBIOActionInstances.DB
@@ -415,10 +416,29 @@ class SlickLegacyPeriodicProcessesRepository(
   }
 
   override def fetchCanonicalProcessWithVersion(
+      periodicProcessId: PeriodicProcessId,
       processName: ProcessName,
       versionId: VersionId
-  ): Future[Option[(CanonicalProcess, ProcessVersion)]] =
-    fetchingProcessRepository.getCanonicalProcessWithVersion(processName, versionId)(NussknackerInternalUser.instance)
+  ): Future[Option[(CanonicalProcess, ProcessVersion)]] = (for {
+    // fixme: We should fetch CanonicalProcess from the main Nu db, not from the legacy table.
+    //        But it seems, that the process graph is different in legacy table and in main Nu database.
+    //        Until this issue is solved, we use the CanonicalProcess representation from legacy table.
+    canonicalProcessFromLegacyTable <- OptionT(
+      PeriodicProcessesWithJson
+        .filter(p => p.id === periodicProcessId)
+        .result
+        .headOption
+        .map(_.map(_.processJson))
+        .run
+    )
+    canonicalProcessWithProcessVersion <- OptionT(
+      fetchingProcessRepository
+        .getCanonicalProcessWithVersion(
+          processName,
+          versionId
+        )(NussknackerInternalUser.instance)
+    )
+  } yield (canonicalProcessFromLegacyTable, canonicalProcessWithProcessVersion._2)).value
 
   def fetchInputConfigDuringExecutionJson(periodicProcessId: PeriodicProcessId): Action[Option[String]] =
     PeriodicProcessesWithJson
@@ -464,6 +484,7 @@ class SlickLegacyPeriodicProcessesRepository(
   private def scheduleDeploymentData(deployment: PeriodicProcessDeploymentEntity): ScheduleDeploymentData = {
     ScheduleDeploymentData(
       deployment.id,
+      deployment.periodicProcessId,
       deployment.createdAt,
       deployment.runAt,
       deployment.deployedAt,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/model/SchedulesState.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/model/SchedulesState.scala
@@ -43,6 +43,7 @@ case class ScheduleId(processId: PeriodicProcessId, scheduleName: ScheduleName)
 
 case class ScheduleDeploymentData(
     id: PeriodicProcessDeploymentId,
+    periodicProcessId: PeriodicProcessId,
     createdAt: LocalDateTime,
     runAt: LocalDateTime,
     deployedAt: Option[LocalDateTime],

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/PeriodicProcessesRepository.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/repository/PeriodicProcessesRepository.scala
@@ -161,6 +161,7 @@ trait PeriodicProcessesRepository {
   ): Action[Option[String]]
 
   def fetchCanonicalProcessWithVersion(
+      periodicProcessId: PeriodicProcessId,
       processName: ProcessName,
       versionId: VersionId
   ): Future[Option[(CanonicalProcess, ProcessVersion)]]
@@ -539,6 +540,7 @@ class SlickPeriodicProcessesRepository(
   private def scheduleDeploymentData(deployment: PeriodicProcessDeploymentEntity): ScheduleDeploymentData = {
     ScheduleDeploymentData(
       deployment.id,
+      deployment.periodicProcessId,
       deployment.createdAt,
       deployment.runAt,
       deployment.deployedAt,
@@ -549,6 +551,7 @@ class SlickPeriodicProcessesRepository(
   }
 
   override def fetchCanonicalProcessWithVersion(
+      periodicProcessId: PeriodicProcessId,
       processName: ProcessName,
       versionId: VersionId
   ): Future[Option[(CanonicalProcess, ProcessVersion)]] =

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/db/InMemPeriodicProcessesRepository.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/db/InMemPeriodicProcessesRepository.scala
@@ -2,14 +2,13 @@ package pl.touk.nussknacker.ui.process.periodic.flink.db
 
 import io.circe.syntax.EncoderOps
 import pl.touk.nussknacker.engine.api.ProcessVersion
-import pl.touk.nussknacker.engine.api.deployment.scheduler.model.{DeploymentWithRuntimeParams, RuntimeParams}
 import pl.touk.nussknacker.engine.api.deployment.ProcessActionId
+import pl.touk.nussknacker.engine.api.deployment.scheduler.model.{DeploymentWithRuntimeParams, RuntimeParams}
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.ui.process.periodic._
 import pl.touk.nussknacker.ui.process.periodic.flink.db.InMemPeriodicProcessesRepository._
-import pl.touk.nussknacker.ui.process.periodic.flink.db.InMemPeriodicProcessesRepository.getLatestDeploymentQueryCount
 import pl.touk.nussknacker.ui.process.periodic.model.PeriodicProcessDeploymentStatus.PeriodicProcessDeploymentStatus
 import pl.touk.nussknacker.ui.process.periodic.model._
 import pl.touk.nussknacker.ui.process.repository.PeriodicProcessesRepository
@@ -347,6 +346,7 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
   }
 
   override def fetchCanonicalProcessWithVersion(
+      periodicProcessId: PeriodicProcessId,
       processName: ProcessName,
       versionId: VersionId
   ): Future[Option[(CanonicalProcess, ProcessVersion)]] = Future.successful {
@@ -469,6 +469,7 @@ object InMemPeriodicProcessesRepository {
   private def scheduleDeploymentData(deployment: TestPeriodicProcessDeploymentEntity): ScheduleDeploymentData = {
     ScheduleDeploymentData(
       deployment.id,
+      deployment.periodicProcessId,
       deployment.createdAt,
       deployment.runAt,
       deployment.deployedAt,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/db/InMemPeriodicProcessesRepository.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/db/InMemPeriodicProcessesRepository.scala
@@ -356,7 +356,7 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
   override def fetchInputConfigDuringExecutionJson(
       periodicProcessId: PeriodicProcessId,
   ): Future[Option[String]] =
-    Future.successful(Some("{}"))
+    Future.successful(Some(""))
 
 }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/db/InMemPeriodicProcessesRepository.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/db/InMemPeriodicProcessesRepository.scala
@@ -356,7 +356,7 @@ class InMemPeriodicProcessesRepository(processingType: String) extends PeriodicP
   override def fetchInputConfigDuringExecutionJson(
       periodicProcessId: PeriodicProcessId,
   ): Future[Option[String]] =
-    Future.successful(Some(""))
+    Future.successful(Some("{}"))
 
 }
 


### PR DESCRIPTION
## Describe your changes

The CanonicalProcess json representation differs between legacy periodic database and main Nu database. Until resolved, changed back to using json from legacy table.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
