### PR TITLE
Return scenario validation error when incompatible changes were introduced for a component

### DIFF
--- a/common-api/src/main/scala/pl/touk/nussknacker/engine/graph/expression/Expression.scala
+++ b/common-api/src/main/scala/pl/touk/nussknacker/engine/graph/expression/Expression.scala
@@ -4,13 +4,28 @@ import io.circe.{Decoder, Encoder}
 import io.circe.generic.JsonCodec
 import io.circe.syntax.EncoderOps
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language.{
+  DictKeyWithLabel,
+  Spel,
+  SpelTemplate,
+  TabularDataDefinition
+}
 
 // TODO in the future 'expression' should be a dedicated type rather than String, it would for example make DictKeyWithLabelExpression handling prettier
 @JsonCodec case class Expression(language: Language, expression: String)
 
 object Expression {
 
-  sealed trait Language extends Serializable
+  sealed trait Language extends Serializable {
+
+    override def toString: String = this match {
+      case Spel                  => "spel"
+      case SpelTemplate          => "spelTemplate"
+      case DictKeyWithLabel      => "dictKeyWithLabel"
+      case TabularDataDefinition => "tabularDataDefinition"
+    }
+
+  }
 
   object Language {
     object Spel                  extends Language
@@ -18,12 +33,7 @@ object Expression {
     object DictKeyWithLabel      extends Language
     object TabularDataDefinition extends Language
 
-    implicit val encoder: Encoder[Language] = Encoder.encodeString.contramap {
-      case Spel                  => "spel"
-      case SpelTemplate          => "spelTemplate"
-      case DictKeyWithLabel      => "dictKeyWithLabel"
-      case TabularDataDefinition => "tabularDataDefinition"
-    }
+    implicit val encoder: Encoder[Language] = Encoder.encodeString.contramap(_.toString)
 
     implicit val decoder: Decoder[Language] = Decoder.decodeString.emap {
       case "spel"                  => Right(Spel)

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -4,6 +4,7 @@ import cats.Applicative
 import cats.data.ValidatedNel
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.InASingleNode
+import pl.touk.nussknacker.engine.api.definition.ParameterEditor
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.ErrorDetails
 import pl.touk.nussknacker.engine.api.process.ProcessName
@@ -327,6 +328,14 @@ object ProcessCompilationError {
 
   final case class UnsupportedDictParameterEditorType(paramName: ParameterName, typ: String, nodeIds: Set[String])
       extends PartSubGraphCompilationError
+
+  final case class IncompatibleParameterDefinitionModification(
+      paramName: ParameterName,
+      language: Language,
+      parameterEditor: Option[ParameterEditor],
+      nodeId: String
+  ) extends PartSubGraphCompilationError
+      with InASingleNode
 
   final case class UnknownFragmentOutput(id: String, nodeIds: Set[String]) extends ProcessCompilationError
 

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -259,6 +259,14 @@ object PrettyValidationErrors {
           description = message,
           paramName = Some(paramName)
         )
+      case IncompatibleParameterDefinitionModification(paramName, language, parameterEditor, _) =>
+        node(
+          message =
+            "There was an incompatible change to the component's parameter definition. Please drag a new component from creator panel to use the current definition",
+          description =
+            s"Incompatible change to the parameter's definition detected. $parameterEditor editor doesn't support '$language' language",
+          paramName = Some(paramName)
+        )
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ProcessTestData.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ProcessTestData.scala
@@ -5,7 +5,7 @@ import pl.touk.nussknacker.engine.api.component.{ComponentGroupName, ProcessingM
 import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.api.dict.DictDefinition
 import pl.touk.nussknacker.engine.api.graph.{Edge, ProcessProperties, ScenarioGraph}
-import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.parameter.{ParameterName, ValueInputWithDictEditor}
 import pl.touk.nussknacker.engine.api.process.{ProcessName, ProcessingType, VersionId}
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, Unknown}
 import pl.touk.nussknacker.engine.api.{FragmentSpecificData, MetaData, ProcessAdditionalFields, StreamMetaData}
@@ -32,7 +32,6 @@ import pl.touk.nussknacker.test.mock.{
   StubModelDataWithModelDefinition,
   TestAdditionalUIConfigProvider
 }
-
 import pl.touk.nussknacker.ui.definition.ScenarioPropertiesConfigFinalizer
 import pl.touk.nussknacker.ui.definition.editor.JavaSampleEnum
 import pl.touk.nussknacker.ui.process.ProcessService.UpdateScenarioCommand
@@ -365,6 +364,26 @@ object ProcessTestData {
     ),
     List.empty
   )
+
+  val sampleFragmentWithPreset: CanonicalProcess =
+    CanonicalProcess(
+      MetaData(sampleFragmentName.value, FragmentSpecificData()),
+      List(
+        FlatNode(
+          FragmentInputDefinition(
+            "in",
+            List(
+              FragmentParameter(
+                ParameterName("param1"),
+                FragmentClazzRef[String]
+              ).copy(valueEditor = Some(ValueInputWithDictEditor("rgb", allowOtherValue = false)))
+            )
+          )
+        ),
+        canonicalnode.FlatNode(FragmentOutputDefinition("out1", "output", List.empty))
+      ),
+      List.empty
+    )
 
   val sampleFragment: CanonicalProcess = {
     CanonicalProcess(

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -66,6 +66,7 @@
 * [#7458](https://github.com/TouK/nussknacker/pull/7458) Flink scenario testing mechanism and scenario state verification mechanism: mini cluster created once and reused each time
 * [#7498](https://github.com/TouK/nussknacker/pull/7498) Support many migrations loaded using SPI. Loaded migration numbers
   cannot overlap, if they do, an exception is thrown.
+* [#7504](https://github.com/TouK/nussknacker/pull/7504) Return scenario validation error when an incompatible change was introduced in a fragment or component parameter definition.
 
 ## 1.18
 

--- a/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/scenariotesting/FlinkProcessTestRunnerSpec.scala
+++ b/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/scenariotesting/FlinkProcessTestRunnerSpec.scala
@@ -764,13 +764,15 @@ class FlinkProcessTestRunnerSpec
           )
           .emptySink("out", "valueMonitor", "Value" -> "#input.value1".spel)
 
-      val dictEditorException = intercept[IllegalStateException] {
+      val dictEditorException = intercept[IllegalArgumentException] {
         prepareTestRunner(useIOMonadInInterpreter).runTests(
           process,
           ScenarioTestData(List(createTestRecord(id = "2", value1 = 2)))
         )
       }
-      dictEditorException.getMessage shouldBe "DictKeyWithLabel expression can only be used with DictParameterEditor, got Some(DualParameterEditor(StringParameterEditor,RAW))"
+      dictEditorException.getMessage.startsWith(
+        "Compilation errors: IncompatibleParameterDefinitionModification(ParameterName(static),dictKeyWithLabel,Some(DualParameterEditor(StringParameterEditor,RAW))"
+      ) shouldBe true
     }
 
     "should run correctly when parameter was modified by AdditionalUiConfigProvider with dict editor and flink was provided with additional config" in {


### PR DESCRIPTION
## Describe your changes

Currently we can introduce incompatible changes to fragment and component parameter definitions which can result in weird errors during validation, displaying weird values and also in some cases passing validation when it shouldn't. The problem happens when we dynamically change editor type and language of a parameter. The simpliest reproduction steps would be:

1. Create a fragment with fixed values which uses a preset.
2. Use that fragment in a scenario and save it.
3. Modify the fragment so now the parameter's input mode is Any Value and save it.
4. Now when we enter the scenario there will be problems with the value, validation and saving the scenario.

<img width="1222" alt="Screenshot 2025-01-28 at 10 06 28" src="https://github.com/user-attachments/assets/59c18dbb-ab61-4de1-b84f-8f543005095c" />

The only solution right now is to remove the problematic node from scenario graph and use a new one from creation panel with current definitions.

This situation can be also replicated with regular components by using `AdditionalUIConfigProvider` and reloading the model. 

It happens because of inconsistency between expression's language which is saved in the scenario graph and component's current editor and expression. Fixing that would be nontrivial as it would actually require introducing versioning for fragments and components. Since that would be an overkill right now, I introduced additional validation on parameter level to detect such situations when changes to the component were incompatible. When such issue is detected scenario won't pass validation and informative message will be displayed.

<img width="831" alt="Screenshot 2025-01-28 at 11 54 34" src="https://github.com/user-attachments/assets/402920ad-f89d-4943-a50c-846259bfc0f5" />

Unfortunately users will still have to drag a new component, copy all the parameters into a new one and then delete the old one. At least now they will be informed about what happened, what to do and won't be able to deploy problematic scenarios.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
