### PR TITLE
[NU-1977] [NU-1949] Window components fixes

### DIFF
--- a/designer/client/src/components/graph/node-modal/editors/expression/Duration/DurationEditor.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/Duration/DurationEditor.tsx
@@ -9,7 +9,6 @@ import { isEmpty } from "lodash";
 import { ExtendedEditor } from "../Editor";
 
 export type Duration = {
-    months: number;
     days: number;
     hours: number;
     minutes: number;
@@ -30,8 +29,7 @@ type Props = {
 const SPEL_DURATION_SWITCHABLE_TO_REGEX =
     /^T\(java\.time\.Duration\)\.parse\('(-)?P([0-9]{1,}D)?(T((-)?[0-9]{1,}H)?((-)?[0-9]{1,}M)?((-)?[0-9]{1,}S)?)?'\)$/;
 const NONE_DURATION = {
-    months: () => null,
-    days: () => null,
+    asDays: () => null,
     hours: () => null,
     minutes: () => null,
     seconds: () => null,
@@ -65,8 +63,7 @@ export const DurationEditor: ExtendedEditor<Props> = (props: Props) => {
             const duration =
                 decodeExecResult == null || typeof decodeExecResult !== "string" ? NONE_DURATION : moment.duration(decodeExecResult);
             return {
-                months: 0,
-                days: duration.days() + duration.months() * 31,
+                days: duration.asDays() < 1 ? null : duration.asDays().toFixed(),
                 hours: duration.hours(),
                 minutes: duration.minutes(),
                 seconds: duration.seconds(),

--- a/designer/client/src/components/graph/node-modal/editors/expression/Duration/DurationEditor.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/Duration/DurationEditor.tsx
@@ -60,14 +60,7 @@ export const DurationEditor: ExtendedEditor<Props> = (props: Props) => {
         (expression: string): Duration => {
             const decodeExecResult = durationFormatter.decode(expression);
 
-            const duration =
-                decodeExecResult == null || typeof decodeExecResult !== "string" ? NONE_DURATION : moment.duration(decodeExecResult);
-            return {
-                days: duration.asDays() < 1 ? null : duration.asDays().toFixed(),
-                hours: duration.hours(),
-                minutes: duration.minutes(),
-                seconds: duration.seconds(),
-            };
+            return duration(decodeExecResult);
         },
         [durationFormatter],
     );
@@ -97,3 +90,13 @@ DurationEditor.notSwitchableToHint = () =>
         "editors.duration.noSwitchableToHint",
         "Expression must match pattern T(java.time.Duration).parse('P(n)DT(n)H(n)M') to switch to basic mode",
     );
+
+export function duration(decodeExecResult) {
+    const duration = decodeExecResult == null || typeof decodeExecResult !== "string" ? NONE_DURATION : moment.duration(decodeExecResult);
+    return {
+        days: Math.floor(duration.asDays()),
+        hours: duration.hours(),
+        minutes: duration.minutes(),
+        seconds: duration.seconds(),
+    };
+}

--- a/designer/client/src/components/graph/node-modal/editors/expression/Duration/DurationEditor.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/Duration/DurationEditor.tsx
@@ -9,6 +9,7 @@ import { isEmpty } from "lodash";
 import { ExtendedEditor } from "../Editor";
 
 export type Duration = {
+    months: number;
     days: number;
     hours: number;
     minutes: number;
@@ -29,6 +30,7 @@ type Props = {
 const SPEL_DURATION_SWITCHABLE_TO_REGEX =
     /^T\(java\.time\.Duration\)\.parse\('(-)?P([0-9]{1,}D)?(T((-)?[0-9]{1,}H)?((-)?[0-9]{1,}M)?((-)?[0-9]{1,}S)?)?'\)$/;
 const NONE_DURATION = {
+    months: () => null,
     days: () => null,
     hours: () => null,
     minutes: () => null,
@@ -63,7 +65,8 @@ export const DurationEditor: ExtendedEditor<Props> = (props: Props) => {
             const duration =
                 decodeExecResult == null || typeof decodeExecResult !== "string" ? NONE_DURATION : moment.duration(decodeExecResult);
             return {
-                days: duration.days(),
+                months: 0,
+                days: duration.days() + duration.months() * 31,
                 hours: duration.hours(),
                 minutes: duration.minutes(),
                 seconds: duration.seconds(),

--- a/designer/client/test/Editors/DurationEditor-test.tsx
+++ b/designer/client/test/Editors/DurationEditor-test.tsx
@@ -40,14 +40,18 @@ describe(`${duration.name} function`, () => {
         const formatter = typeFormatters[FormatterType.Duration];
         const oneMinute = "PT1M";
         const oneHour = "PT1H";
+        const almostOneDay = "PT23H";
+        const oneDayOneHour = "PT25H";
         const oneDay = "P1D";
         const fortyDays = "P40D";
         const mix = "P1DT1H1M";
 
-        const times = [oneMinute, oneHour, oneDay, fortyDays, mix];
+        const times = [oneMinute, oneHour, almostOneDay, oneDayOneHour, oneDay, fortyDays, mix];
         const results = [
             { ...emptyDuration, minutes: 1 },
             { ...emptyDuration, hours: 1 },
+            { ...emptyDuration, hours: 23 },
+            { ...emptyDuration, days: 1, hours: 1 },
             { ...emptyDuration, days: 1 },
             { ...emptyDuration, days: 40 },
             { days: 1, hours: 1, minutes: 1, seconds: 0 },

--- a/designer/client/test/Editors/DurationEditor-test.tsx
+++ b/designer/client/test/Editors/DurationEditor-test.tsx
@@ -2,11 +2,12 @@ import * as React from "react";
 
 import { render, screen } from "@testing-library/react";
 import { DualEditorMode, EditorType } from "../../src/components/graph/node-modal/editors/expression/Editor";
-import { DurationEditor } from "../../src/components/graph/node-modal/editors/expression/Duration/DurationEditor";
+import { DurationEditor, duration } from "../../src/components/graph/node-modal/editors/expression/Duration/DurationEditor";
 import { TimeRange } from "../../src/components/graph/node-modal/editors/expression/Duration/TimeRangeComponent";
 import { mockFormatter, mockFieldErrors, mockValueChange } from "./helpers";
 import { NuThemeProvider } from "../../src/containers/theme/nuThemeProvider";
-import { nodeInputWithError } from "../../src/components/graph/node-modal/NodeDetailsContent/NodeTableStyled";
+import { FormatterType, typeFormatters } from "../../src/components/graph/node-modal/editors/expression/Formatter";
+import type { Duration } from "../../src/components/graph/node-modal/editors/expression/Duration/DurationEditor";
 
 describe(DurationEditor.name, () => {
     it("should display validation error when the field is required", () => {
@@ -30,5 +31,27 @@ describe(DurationEditor.name, () => {
         );
 
         expect(screen.getByText("validation error")).toBeInTheDocument();
+    });
+});
+
+describe(`${duration.name} function`, () => {
+    it("should parse duration without loosing days if more than 31", () => {
+        const emptyDuration: Duration = { days: 0, hours: 0, minutes: 0, seconds: 0 };
+        const formatter = typeFormatters[FormatterType.Duration];
+        const oneMinute = "PT1M";
+        const oneHour = "PT1H";
+        const oneDay = "P1D";
+        const fortyDays = "P40D";
+        const mix = "P1DT1H1M";
+
+        const times = [oneMinute, oneHour, oneDay, fortyDays, mix];
+        const results = [
+            { ...emptyDuration, minutes: 1 },
+            { ...emptyDuration, hours: 1 },
+            { ...emptyDuration, days: 1 },
+            { ...emptyDuration, days: 40 },
+            { days: 1, hours: 1, minutes: 1, seconds: 0 },
+        ];
+        expect(times.map(formatter.decode).map(duration)).toStrictEqual(results);
     });
 });

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -69,6 +69,11 @@
   cannot overlap, if they do, an exception is thrown.
 * [#7504](https://github.com/TouK/nussknacker/pull/7504) Return scenario validation error when an incompatible change was introduced in a fragment or component parameter definition.
 * [#7468](https://github.com/TouK/nussknacker/pull/7468) Configurable namespace separator (was fixed to `_`), added namespace tag to Lite engine metrics and fixed namespacing of Kafka consumer groups.
+* [#7508](https://github.com/TouK/nussknacker/pull/7508) Fixes for window components:
+  * Can now pass more than 31 days as `windowLength` and it won't be reduced to remainder of 31 
+  * Introduced some default values:
+    * For all - default `windowLength` is 1 hour
+    * For `aggregate-session` - default `endSessionCondition` is now false
 
 ## 1.18
 

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
@@ -54,7 +54,7 @@ object sampleTransformers {
           defaultMode = DualEditorMode.SIMPLE
         ) aggregator: Aggregator,
         @ParamName("aggregateBy") aggregateBy: LazyParameter[AnyRef],
-        @ParamName("windowLength") length: java.time.Duration,
+        @ParamName("windowLength") @DefaultValue("T(java.time.Duration).parse('PT1H')") length: java.time.Duration,
         @ParamName("emitWhenEventLeft") @DefaultValue("false") emitWhenEventLeft: Boolean,
         @OutputVariableName variableName: String
     )(implicit nodeId: NodeId): ContextTransformation = {
@@ -112,7 +112,7 @@ object sampleTransformers {
           defaultMode = DualEditorMode.SIMPLE
         ) aggregator: Aggregator,
         @ParamName("aggregateBy") aggregateBy: LazyParameter[AnyRef],
-        @ParamName("windowLength") length: java.time.Duration,
+        @ParamName("windowLength") @DefaultValue("T(java.time.Duration).parse('PT1H')") length: java.time.Duration,
         @ParamName("emitWhen") trigger: TumblingWindowTrigger,
         @OutputVariableName variableName: String
     )(implicit nodeId: NodeId): ContextTransformation = {
@@ -174,8 +174,10 @@ object sampleTransformers {
           defaultMode = DualEditorMode.SIMPLE
         ) aggregator: Aggregator,
         @ParamName("aggregateBy") aggregateBy: LazyParameter[AnyRef],
-        @ParamName("endSessionCondition") endSessionCondition: LazyParameter[java.lang.Boolean],
-        @ParamName("sessionTimeout") sessionTimeout: java.time.Duration,
+        @ParamName("endSessionCondition") @DefaultValue("false") endSessionCondition: LazyParameter[java.lang.Boolean],
+        @ParamName("sessionTimeout") @DefaultValue(
+          "T(java.time.Duration).parse('PT1H')"
+        ) sessionTimeout: java.time.Duration,
         @ParamName("emitWhen") trigger: SessionWindowTrigger,
         @OutputVariableName variableName: String
     )(implicit nodeId: NodeId): ContextTransformation = {


### PR DESCRIPTION
## Describe your changes

- if more than 31 days is chosen in window components - the days won't be lost (previously after closing the node only remainder of 31 was left)
- changes in default values for window components 
  - for all - 1 hour is a default for `windowLength`
  - for aggregate-session - default value for `endSessionCondition` is now `false` 

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
