### PR TITLE
Dont pass notes to fragment preview

### DIFF
--- a/designer/client/src/components/graph/node-modal/node/FragmentContent.tsx
+++ b/designer/client/src/components/graph/node-modal/node/FragmentContent.tsx
@@ -41,7 +41,7 @@ export function FragmentContent({ nodeToDisplay }: { nodeToDisplay: FragmentNode
                 <FragmentGraphPreview
                     processCounts={fragmentCounts}
                     scenario={fragmentContent}
-                    stickyNotes={stickyNotes}
+                    stickyNotes={[]}
                     nodeIdPrefixForFragmentTests={getFragmentNodesPrefix(fragmentContent)}
                 />
             )}


### PR DESCRIPTION
## Describe your changes

In stickyNote MR I've passed notes to fragment preview which was not ok - we don't want to display notes in fragment preview while we browse scenario. 
 
![image](https://github.com/user-attachments/assets/7ed18e3e-67d0-43c1-8373-3ca394b6439f)


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
