### PR TITLE
[Nu-7520] Validate run off schedule comment on FE

### DIFF
--- a/designer/client/src/components/toolbars/scenarioActions/buttons/types.ts
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/types.ts
@@ -1,0 +1,10 @@
+export enum ScenarioActionResultType {
+    Success = "SUCCESS",
+    ValidationError = "VALIDATION_ERROR",
+    UnhandledError = "UNHANDLED_ERROR",
+}
+
+export type ScenarioActionResult = {
+    scenarioActionResultType: ScenarioActionResultType;
+    msg: string;
+};

--- a/designer/client/src/http/HttpService.ts
+++ b/designer/client/src/http/HttpService.ts
@@ -388,7 +388,7 @@ class HttpService {
                     msg: msg,
                 };
                 if (error?.response?.status != 400) return this.#addError(msg, error, false).then(() => result);
-                return result;
+                throw error;
             });
     }
 


### PR DESCRIPTION
## Describe your changes

I propose to throw an exception inside `HttpService#runOffSchedule` method instead of returning value from the catch block. This is then coherent with `deploy/cancel` methods in this service and solves the issue with omitting the validation of comment in the modal window (since it is based on error catching). 

closes #7520 

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
