### PR TITLE
Add posibility to choose valid value after editors inconsistencies

### DIFF
--- a/designer/client/src/components/graph/node-modal/editors/expression/EditorBasedLanguageDeterminer.ts
+++ b/designer/client/src/components/graph/node-modal/editors/expression/EditorBasedLanguageDeterminer.ts
@@ -1,0 +1,21 @@
+import { ExpressionLang } from "./types";
+import { EditorType } from "./Editor";
+
+// This determiner is used to fix potential language inconsistencies due to incompatible changes to editors in fragments
+// or components with AdditionalUIConfigProvider. It doesn't determine all editors as only a few of them can be affected
+// by said inconsistencies.
+export const determineLangaugeBasedOnEditor = (editor: $TodoType): ExpressionLang => {
+    switch (editor?.type) {
+        case EditorType.DICT_PARAMETER_EDITOR:
+            return ExpressionLang.DictKeyWithLabel;
+        case EditorType.FIXED_VALUES_PARAMETER_EDITOR:
+            return ExpressionLang.SpEL;
+        case EditorType.DUAL_PARAMETER_EDITOR:
+            if (editor.simpleEditor.type === EditorType.DICT_PARAMETER_EDITOR) return ExpressionLang.DictKeyWithLabel;
+            if (editor.simpleEditor.type === EditorType.FIXED_VALUES_PARAMETER_EDITOR) return ExpressionLang.SpEL;
+            if (editor.simpleEditor.type === EditorType.STRING_PARAMETER_EDITOR) return ExpressionLang.SpEL;
+            return null;
+        default:
+            return null;
+    }
+};

--- a/designer/client/src/components/graph/node-modal/editors/expression/ExpressionField.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/ExpressionField.tsx
@@ -64,7 +64,7 @@ function ExpressionField(props: Props): JSX.Element {
         [exprLanguagePath, exprTextPath, setNodeDataAt, editor],
     );
 
-    if (editor.type === EditorType.FIXED_VALUES_PARAMETER_EDITOR || editor.type === EditorType.FIXED_VALUES_WITH_ICON_PARAMETER_EDITOR) {
+    if (editor?.type === EditorType.FIXED_VALUES_PARAMETER_EDITOR || editor?.type === EditorType.FIXED_VALUES_WITH_ICON_PARAMETER_EDITOR) {
         return (
             <EditableEditor
                 fieldLabel={fieldLabel}

--- a/designer/client/src/components/graph/node-modal/editors/expression/ExpressionField.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/ExpressionField.tsx
@@ -8,6 +8,7 @@ import { useDiffMark } from "../../PathsToMark";
 import { get } from "lodash";
 import { FieldError } from "../Validators";
 import { ExpressionObj } from "./types";
+import { determineLangaugeBasedOnEditor } from "./EditorBasedLanguageDeterminer";
 
 type Props = {
     fieldName: string;
@@ -46,17 +47,21 @@ function ExpressionField(props: Props): JSX.Element {
     const exprTextPath = `${exprPath}.expression`;
     const exprLanguagePath = `${exprPath}.language`;
     const expressionObj = get(editedNode, exprPath);
-    const editor = parameterDefinition?.editor || {};
+    const editor = parameterDefinition?.editor;
 
     const onValueChange: OnValueChange = useCallback(
         (value: ExpressionObj | string) => {
+            const adjustedExpressionLanguage = determineLangaugeBasedOnEditor(editor);
             if (typeof value === "string") {
+                if (adjustedExpressionLanguage) {
+                    setNodeDataAt(exprLanguagePath, adjustedExpressionLanguage);
+                }
                 return setNodeDataAt(exprTextPath, value);
             }
             setNodeDataAt(exprTextPath, value.expression);
-            setNodeDataAt(exprLanguagePath, value.language);
+            setNodeDataAt(exprLanguagePath, adjustedExpressionLanguage ?? value.language);
         },
-        [exprLanguagePath, exprTextPath, setNodeDataAt],
+        [exprLanguagePath, exprTextPath, setNodeDataAt, editor],
     );
 
     if (editor.type === EditorType.FIXED_VALUES_PARAMETER_EDITOR || editor.type === EditorType.FIXED_VALUES_WITH_ICON_PARAMETER_EDITOR) {

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -262,7 +262,7 @@ object PrettyValidationErrors {
       case IncompatibleParameterDefinitionModification(paramName, language, parameterEditor, _) =>
         node(
           message =
-            "There was an incompatible change to the component's parameter definition. Please choose new valid value",
+            "There was an incompatible change to the component's parameter definition. Please choose a new valid value",
           description =
             s"Incompatible change to the parameter's definition detected. $parameterEditor editor doesn't support '$language' language",
           paramName = Some(paramName)

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -262,7 +262,7 @@ object PrettyValidationErrors {
       case IncompatibleParameterDefinitionModification(paramName, language, parameterEditor, _) =>
         node(
           message =
-            "There was an incompatible change to the component's parameter definition. Please drag a new component from creator panel to use the current definition",
+            "There was an incompatible change to the component's parameter definition. Please choose new valid value",
           description =
             s"Incompatible change to the parameter's definition detected. $parameterEditor editor doesn't support '$language' language",
           paramName = Some(paramName)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -76,6 +76,7 @@
     * For `aggregate-session` - default `endSessionCondition` is now false
 * Improved scenario visualization loading time
     * [#7516](https://github.com/TouK/nussknacker/pull/7516) Scenario testing endpoints no longer perform full scenario compilation and validation
+* [#7524](https://github.com/TouK/nussknacker/pull/7524) Add a possibility to choose a new valid value in node details when inconsistencies in parameter's definition were detected.
 
 ## 1.18
 


### PR DESCRIPTION
## Describe your changes

In Nussknacker we can have inconsistencies in parameter exression's language due to incompatible changes made to fragments or components which i described in [this PR](https://github.com/TouK/nussknacker/pull/7504)

Currently the only way to "fix" these inconsistencies is to drag a new node from the creator panel, copy all the values and then delete the old inconsistent node. This is quite problemtic for the users. With these changes when user chooses a new valid value the language in the scenario graph will be adjusted based on current editor type (similar detecting based on editor's type is already done in `EditorBasedLanguageDeterminer.scala`). 

![ezgif-412a015994e9b](https://github.com/user-attachments/assets/8b5b8cc0-0636-445c-9781-fb3cd6323809)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
