### PR TITLE
Fix switching expression languages in dictionary dual editor

### DIFF
--- a/designer/client/src/components/graph/node-modal/editors/expression/EditorBasedLanguageDeterminer.ts
+++ b/designer/client/src/components/graph/node-modal/editors/expression/EditorBasedLanguageDeterminer.ts
@@ -11,7 +11,6 @@ export const determineLangaugeBasedOnEditor = (editor: $TodoType): ExpressionLan
         case EditorType.FIXED_VALUES_PARAMETER_EDITOR:
             return ExpressionLang.SpEL;
         case EditorType.DUAL_PARAMETER_EDITOR:
-            if (editor.simpleEditor.type === EditorType.DICT_PARAMETER_EDITOR) return ExpressionLang.DictKeyWithLabel;
             if (editor.simpleEditor.type === EditorType.FIXED_VALUES_PARAMETER_EDITOR) return ExpressionLang.SpEL;
             if (editor.simpleEditor.type === EditorType.STRING_PARAMETER_EDITOR) return ExpressionLang.SpEL;
             return null;


### PR DESCRIPTION
## Describe your changes

The check introduced in [this PR](https://github.com/TouK/nussknacker/pull/7524) was too strict for dual editor with dictionaries as that editor can use two languages `dictKeyWithLabel` and `spel` depending on current editor type. This made it impossible to add some `RAW` input for editor as it was recognized as `dictKeyWithLabel`. 

<img width="892" alt="Screenshot 2025-02-06 at 12 57 55" src="https://github.com/user-attachments/assets/949b6584-0895-4414-a3ce-0a2037d6aa52" />

The editor manages its language on its own with `ExpressionObj` and it's not neceseary to use `EditorBasedLanguageDeterminer` for that. I removed that one check and now it works properly.

<img width="892" alt="Screenshot 2025-02-06 at 12 59 44" src="https://github.com/user-attachments/assets/5d3216fa-92eb-4153-aaae-d07e3c33faf9" />

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
