### PR TITLE
Collection helpers improvements

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -84,6 +84,9 @@
 * [#7517](https://github.com/TouK/nussknacker/pull/7517) Log unhandled errors and remove logback json libraries
 * [#7539](https://github.com/TouK/nussknacker/pull/7539) Remove old workaround for passing job arguments to Flink, now they are sent using `programArgsList`
 * [#7542](https://github.com/TouK/nussknacker/pull/7542) Use `restart-strategy.type` Flink config key instead of the deprecated `restart-strategy`
+* [#7537](https://github.com/TouK/nussknacker/pull/7537) Collection helper improvements:
+    * preserved elements order in #COLLECTION.merge and #COLLECTION.distinct functions
+    * additional check for #COLLECTION.min and #COLLECTION.max if elements have a Comparable type
 
 ## 1.18
 

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/collection.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/collection.scala
@@ -51,7 +51,7 @@ trait CollectionUtils extends HideToString {
       @ParamName("map") map: java.util.Map[K, V],
       @ParamName("maps") maps: java.util.Map[K, V]*
   ): java.util.Map[K, V] = {
-    val merged = new java.util.HashMap[K, V](map.size() + maps.map(_.size()).sum)
+    val merged = new java.util.LinkedHashMap[K, V](map.size() + maps.map(_.size()).sum)
     merged.putAll(map)
     maps.foreach(merged.putAll)
     merged
@@ -59,11 +59,17 @@ trait CollectionUtils extends HideToString {
 
   @Documentation(description = "Returns the smallest element (elements must be comparable)")
   @GenericType(typingFunction = classOf[ListElementTyping])
-  def min[T <: Comparable[T]](@ParamName("list") list: java.util.Collection[T]): T = Collections.min[T](list)
+  def min[T <: Comparable[T]](@ParamName("list") list: java.util.Collection[T]): T = {
+    checkIfComparable(list)
+    Collections.min[T](list)
+  }
 
   @Documentation(description = "Returns the largest element (elements must be comparable)")
   @GenericType(typingFunction = classOf[ListElementTyping])
-  def max[T <: Comparable[T]](@ParamName("list") list: java.util.Collection[T]): T = Collections.max[T](list)
+  def max[T <: Comparable[T]](@ParamName("list") list: java.util.Collection[T]): T = {
+    checkIfComparable(list)
+    Collections.max[T](list)
+  }
 
   @Documentation(description =
     "Returns a slice of the list starting with start index (inclusive) and ending at stop index (exclusive)"
@@ -212,7 +218,7 @@ trait CollectionUtils extends HideToString {
   @Documentation(description = "Returns a list that contains unique elements from the given list")
   @GenericType(typingFunction = classOf[ListTyping])
   def distinct[T](@ParamName("list") list: java.util.List[T]): java.util.List[T] =
-    new java.util.ArrayList(new java.util.HashSet[T](list))
+    new java.util.ArrayList(new java.util.LinkedHashSet[T](list))
 
   @Documentation(description = "Returns a copy of the list with its elements shuffled")
   @GenericType(typingFunction = classOf[ListTyping])

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/numeric.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/numeric.scala
@@ -22,6 +22,7 @@ import pl.touk.nussknacker.engine.util.functions.NumericUtils.{
   ToNumberTypingFunction
 }
 
+import scala.collection.compat.immutable.LazyList
 import scala.util.{Success, Try}
 
 object numeric extends NumericUtils

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/numeric.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/numeric.scala
@@ -63,7 +63,7 @@ trait NumericUtils extends MathUtils with HideToString {
     case s: CharSequence =>
       val ss = s.toString
       // we pick the narrowest type as possible to reduce the amount of memory and computations overheads
-      val tries: List[Try[java.lang.Number]] = List(
+      val tries: LazyList[Try[java.lang.Number]] = LazyList(
         Try(java.lang.Integer.parseInt(ss)),
         Try(java.lang.Long.parseLong(ss)),
         Try(java.lang.Double.parseDouble(ss)),

--- a/utils/default-helpers/src/test/scala/pl/touk/nussknacker/engine/util/functions/CollectionUtilsSpec.scala
+++ b/utils/default-helpers/src/test/scala/pl/touk/nussknacker/engine/util/functions/CollectionUtilsSpec.scala
@@ -56,6 +56,11 @@ class CollectionUtilsSpec extends AnyFunSuite with BaseSpelSpec with Matchers {
       evaluateAny(expression) shouldBe expected
     }
 
+    // should preserve maps order
+    val result = evaluateAny("#COLLECTION.merge({a: 1, c: 1}, {a: 2, b: 2}, {b: 3, d: 3})")
+    result shouldBe Map("a" -> 2, "b" -> 3, "c" -> 1, "d" -> 3).asJava
+    result.asInstanceOf[java.util.Map[String, Int]].asScala.toList shouldBe List("a" -> 2, "c" -> 1, "b" -> 3, "d" -> 3)
+
     Table(
       ("expression", "expected"),
       (
@@ -320,7 +325,14 @@ class CollectionUtilsSpec extends AnyFunSuite with BaseSpelSpec with Matchers {
   }
 
   test("distinct") {
-    evaluateAny("#COLLECTION.distinct({'1','2','2','3'})") shouldBe List("1", "2", "3").asJava
+    evaluateAny("#COLLECTION.distinct({'1','5','4','6','5','6','2','2','3'})") shouldBe List(
+      "1",
+      "5",
+      "4",
+      "6",
+      "2",
+      "3"
+    ).asJava
 
     evaluateType("#COLLECTION.distinct({'1','2','3'})") shouldBe "List[String]".valid
     evaluateType("#COLLECTION.distinct({1,2,3})") shouldBe "List[Integer]".valid


### PR DESCRIPTION
## Describe your changes

* preserved elements order in `#COLLECTION.merge` and `#COLLECTION.distinct` functions
* additional check for `#COLLECTION.min` and `#COLLECTION.max` if elements have a `Comparable` type

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
