### PR TITLE
Use `restart-strategy.type` Flink config key instead of the deprecated `restart-strategy`

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -82,6 +82,7 @@
 * [#7511](https://github.com/TouK/nussknacker/pull/7511) `flink-components-testkit` rework: easier `ScenarioTestRunner` creation - see [Migration guide](MigrationGuide.md) for details
 * [#7517](https://github.com/TouK/nussknacker/pull/7517) Log unhandled errors and remove logback json libraries
 * [#7539](https://github.com/TouK/nussknacker/pull/7539) Remove old workaround for passing job arguments to Flink, now they are sent using `programArgsList`
+* [#7542](https://github.com/TouK/nussknacker/pull/7542) Use `restart-strategy.type` Flink config key instead of the deprecated `restart-strategy`
 
 ## 1.18
 

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/exception/RestartStrategyFromConfiguration.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/exception/RestartStrategyFromConfiguration.scala
@@ -61,7 +61,7 @@ object RestartStrategyFromConfiguration {
     val flinkConfig = new Configuration
     // restart-strategy.fixed-delay.attempts
     val strategy = config.getString(strategyPath)
-    flinkConfig.setString(restartStrategyFlinkConfigPrefix, strategy)
+    flinkConfig.setString(s"$restartStrategyFlinkConfigPrefix.type", strategy)
     config.entrySet().asScala.foreach { entry =>
       flinkConfig.setString(s"$restartStrategyFlinkConfigPrefix.$strategy.${entry.getKey}", toString(entry.getValue))
     }


### PR DESCRIPTION
## Describe your changes

Remove use of deprecated config name, this will reduce the number of WARN logs from Flink.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
