### PR TITLE
[Nu-7557] Relax validation of initial value in fragment input definition while validation flag is disabled

### DIFF
--- a/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/fields/InitialValue.tsx
+++ b/designer/client/src/components/graph/node-modal/fragment-input-definition/settings/variants/fields/InitialValue.tsx
@@ -27,6 +27,8 @@ export default function InitialValue({ onChange, item, path, options, readOnly, 
     const emptyOption = { label: "", value: "" };
     const optionsToDisplay: Option[] = [emptyOption, ...(options ?? []).map(({ label }) => ({ label, value: label }))];
 
+    const validationEnabled = Boolean(item.valueCompileTimeValidation);
+
     return (
         <FormControl>
             <SettingLabelStyled>{t("fragment.initialValue", "Initial value:")}</SettingLabelStyled>
@@ -46,7 +48,7 @@ export default function InitialValue({ onChange, item, path, options, readOnly, 
                 <DictParameterEditor
                     key={item.valueEditor.dictId}
                     fieldErrors={fieldErrors}
-                    showValidation
+                    showValidation={validationEnabled}
                     expressionObj={{ language: ExpressionLang.SpEL, expression: item?.initialValue?.expression }}
                     onValueChange={(value) => onChange(`${path}.initialValue`, { label: item.valueEditor.dictId, expression: value })}
                     param={{ editor: { dictId: item.valueEditor.dictId } }}
@@ -59,7 +61,7 @@ export default function InitialValue({ onChange, item, path, options, readOnly, 
                     variableTypes={variableTypes}
                     readOnly={readOnly}
                     param={{ editor: { type: EditorType.RAW_PARAMETER_EDITOR } }}
-                    showValidation
+                    showValidation={validationEnabled}
                     fieldErrors={fieldErrors}
                 />
             )}


### PR DESCRIPTION
## Describe your changes

closes #7557

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
