### PR TITLE
[NU-1979] `ProcessingTypeDataProvider`: fix for synchronization didn't work + some simplifications

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/AppApiHttpService.scala
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 class AppApiHttpService(
     config: Config,
     authManager: AuthManager,
-    processingTypeDataReloader: ReloadableProcessingTypeDataProvider,
+    processingTypeDataReloader: ReloadableProcessingTypeDataProvider[_, _],
     modelInfos: ProcessingTypeDataProvider[ModelInfo, _],
     categories: ProcessingTypeDataProvider[String, _],
     processService: ProcessService,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/CombinedProcessingTypeData.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/CombinedProcessingTypeData.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.ui.process.processingtype
 
+import cats.data.Validated
 import pl.touk.nussknacker.engine.api.deployment.StateStatus.StatusName
 import pl.touk.nussknacker.engine.api.process.ProcessingType
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
@@ -17,14 +18,14 @@ object CombinedProcessingTypeData {
 
   def create(
       processingTypes: Map[ProcessingType, ProcessingTypeData]
-  ): CombinedProcessingTypeData = {
-    val parametersService =
-      ScenarioParametersService.createUnsafe(processingTypes.mapValuesNow(_.scenarioParameters))
-    CombinedProcessingTypeData(
-      statusNameToStateDefinitionsMapping =
-        ProcessStateDefinitionService.createDefinitionsMappingUnsafe(processingTypes),
-      parametersService = parametersService
-    )
+  ): Validated[ScenarioParametersConfigurationError, CombinedProcessingTypeData] = {
+    ScenarioParametersService.create(processingTypes.mapValuesNow(_.scenarioParameters)).map { parametersService =>
+      CombinedProcessingTypeData(
+        statusNameToStateDefinitionsMapping =
+          ProcessStateDefinitionService.createDefinitionsMappingUnsafe(processingTypes),
+        parametersService = parametersService
+      )
+    }
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeData.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeData.scala
@@ -25,7 +25,7 @@ final case class ProcessingTypeData private (
     designerModelData: DesignerModelData,
     deploymentData: DeploymentData,
     category: String,
-) {
+) extends AutoCloseable {
 
   // TODO: We should allow to have >1 processing mode configured inside one model and return a List here
   //       But for now, we throw an error when there is >1 processing mode and use have to split such a configuration
@@ -40,7 +40,7 @@ final case class ProcessingTypeData private (
       deploymentData.engineSetupErrors
     )
 
-  def close(): Unit = {
+  override def close(): Unit = {
     designerModelData.close()
     deploymentData.close()
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/LocalProcessingTypeDataLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/LocalProcessingTypeDataLoader.scala
@@ -29,7 +29,7 @@ class LocalProcessingTypeDataLoader(
       deploymentManagersClassLoader: DeploymentManagersClassLoader,
       modelClassLoaderProvider: ModelClassLoaderProvider,
       dbRef: Option[DbRef],
-  ): IO[ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData]] = IO {
+  ): IO[ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData]] = {
     val processingTypes = modelData.map { case (processingType, (category, model)) =>
       val deploymentManagerDependencies = getDeploymentManagerDependencies(processingType)
       val data = ProcessingTypeData.createProcessingTypeData(
@@ -46,8 +46,9 @@ class LocalProcessingTypeDataLoader(
       processingType -> data
     }
 
-    val combinedData = CombinedProcessingTypeData.create(processingTypes)
-    new ProcessingTypeDataState(processingTypes.mapValuesNow(toValueWithRestriction), Success(combinedData))
+    IO.fromEither(CombinedProcessingTypeData.create(processingTypes).toEither).map { combinedData =>
+      new ProcessingTypeDataState(processingTypes.mapValuesNow(toValueWithRestriction), Success(combinedData))
+    }
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/LocalProcessingTypeDataLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/LocalProcessingTypeDataLoader.scala
@@ -16,6 +16,8 @@ import pl.touk.nussknacker.ui.process.processingtype.ProcessingTypeData.Scheduli
 import pl.touk.nussknacker.ui.process.processingtype.loader.ProcessingTypeDataLoader.toValueWithRestriction
 import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataState
 
+import scala.util.Success
+
 class LocalProcessingTypeDataLoader(
     modelData: Map[ProcessingType, (String, ModelData)],
     deploymentManagerProvider: DeploymentManagerProvider
@@ -45,7 +47,7 @@ class LocalProcessingTypeDataLoader(
     }
 
     val combinedData = CombinedProcessingTypeData.create(processingTypes)
-    ProcessingTypeDataState(processingTypes.mapValuesNow(toValueWithRestriction), () => combinedData, new Object)
+    new ProcessingTypeDataState(processingTypes.mapValuesNow(toValueWithRestriction), Success(combinedData), new Object)
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/LocalProcessingTypeDataLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/LocalProcessingTypeDataLoader.scala
@@ -47,7 +47,7 @@ class LocalProcessingTypeDataLoader(
     }
 
     val combinedData = CombinedProcessingTypeData.create(processingTypes)
-    new ProcessingTypeDataState(processingTypes.mapValuesNow(toValueWithRestriction), Success(combinedData), new Object)
+    new ProcessingTypeDataState(processingTypes.mapValuesNow(toValueWithRestriction), Success(combinedData))
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/ProcessingTypesConfigBasedProcessingTypeDataLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/ProcessingTypesConfigBasedProcessingTypeDataLoader.scala
@@ -13,6 +13,8 @@ import pl.touk.nussknacker.ui.process.processingtype.ProcessingTypeData.Scheduli
 import pl.touk.nussknacker.ui.process.processingtype.loader.ProcessingTypeDataLoader.toValueWithRestriction
 import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataState
 
+import scala.util.Success
+
 class ProcessingTypesConfigBasedProcessingTypeDataLoader(
     processingTypeConfigsLoader: ProcessingTypeConfigsLoader
 ) extends ProcessingTypeDataLoader
@@ -103,9 +105,10 @@ class ProcessingTypesConfigBasedProcessingTypeDataLoader(
     // to assert the loaded configuration is correct (fail-fast approach).
     val combinedData = CombinedProcessingTypeData.create(processingTypesData)
 
-    ProcessingTypeDataState(
+    new ProcessingTypeDataState(
       processingTypesData.mapValuesNow(toValueWithRestriction),
-      () => combinedData,
+      // We want to fail fast - because of that we don't return Try in CombinedProcessingTypeData.create
+      Success(combinedData),
       // We pass here new Object to enforce update of observers
       new Object
     )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/ProcessingTypesConfigBasedProcessingTypeDataLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/ProcessingTypesConfigBasedProcessingTypeDataLoader.scala
@@ -108,9 +108,7 @@ class ProcessingTypesConfigBasedProcessingTypeDataLoader(
     new ProcessingTypeDataState(
       processingTypesData.mapValuesNow(toValueWithRestriction),
       // We want to fail fast - because of that we don't return Try in CombinedProcessingTypeData.create
-      Success(combinedData),
-      // We pass here new Object to enforce update of observers
-      new Object
+      Success(combinedData)
     )
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/ProcessingTypesConfigBasedProcessingTypeDataLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/loader/ProcessingTypesConfigBasedProcessingTypeDataLoader.scala
@@ -13,7 +13,7 @@ import pl.touk.nussknacker.ui.process.processingtype.ProcessingTypeData.Scheduli
 import pl.touk.nussknacker.ui.process.processingtype.loader.ProcessingTypeDataLoader.toValueWithRestriction
 import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataState
 
-import scala.util.Success
+import scala.util.{Success, Try}
 
 class ProcessingTypesConfigBasedProcessingTypeDataLoader(
     processingTypeConfigsLoader: ProcessingTypeConfigsLoader
@@ -29,7 +29,7 @@ class ProcessingTypesConfigBasedProcessingTypeDataLoader(
   ): IO[ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData]] = {
     processingTypeConfigsLoader
       .loadProcessingTypeConfigs()
-      .map(
+      .flatMap(
         createProcessingTypeData(
           _,
           getModelDependencies,
@@ -48,7 +48,7 @@ class ProcessingTypesConfigBasedProcessingTypeDataLoader(
       deploymentManagersClassLoader: DeploymentManagersClassLoader,
       modelClassLoaderProvider: ModelClassLoaderProvider,
       dbRef: Option[DbRef],
-  ): ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData] = {
+  ): IO[ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData]] = {
     // This step with splitting DeploymentManagerProvider loading for all processing types
     // and after that creating ProcessingTypeData is done because of the deduplication of deployments
     // See DeploymentManagerProvider.engineSetupIdentity
@@ -103,13 +103,15 @@ class ProcessingTypesConfigBasedProcessingTypeDataLoader(
 
     // Here all processing types are loaded and we are ready to perform additional configuration validations
     // to assert the loaded configuration is correct (fail-fast approach).
-    val combinedData = CombinedProcessingTypeData.create(processingTypesData)
-
-    new ProcessingTypeDataState(
-      processingTypesData.mapValuesNow(toValueWithRestriction),
-      // We want to fail fast - because of that we don't return Try in CombinedProcessingTypeData.create
-      Success(combinedData)
-    )
+    IO.fromEither(CombinedProcessingTypeData.create(processingTypesData).toEither.map { combinedData =>
+      new ProcessingTypeDataState(
+        processingTypesData.mapValuesNow(toValueWithRestriction),
+        // We return Success instead of passing here Try result of CombinedProcessingTypeData.create because
+        // we want to break reloading logic instead of creating a new state with failing combined date
+        // Try in ProcessingTypeDataState.combinedDataTry is only for initial state purpose when this data are not initialized yet
+        Success(combinedData)
+      )
+    })
   }
 
   private def createDeploymentManagerProvider(

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
@@ -1,5 +1,10 @@
 package pl.touk.nussknacker.ui.process.processingtype.provider
 
+import cats.effect.std.Mutex
+import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, Ref}
+import cats.implicits.toTraverseOps
+import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.process.ProcessingType
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.security.Permission
@@ -7,8 +12,9 @@ import pl.touk.nussknacker.ui.UnauthorizedError
 import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
-import java.util.concurrent.atomic.AtomicReference
-import scala.util.Try
+import java.util.concurrent.CopyOnWriteArrayList
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Try}
 
 /**
   * ProcessingType is a context of application. One ProcessingType can't see data from another ProcessingType.
@@ -16,21 +22,29 @@ import scala.util.Try
   *
   * This class is meant to provide access to some scope of data inside context of application to the user.
   * We don't want to pass all ProcessingType's data to every service because it would complicate testing of services
-  * and would broke isolation between areas of application. Due to that, this class is a `Functor`
+  * and would brake isolation between areas of application. Due to that, this class is a `Functor`
   * (to be precise `BiFunctor` but more on that below) which allows to transform the scope of `Data`.
   *
   * Sometimes it is necessary to have access also to combination of data across all ProcessingTypes. Due to that
   * this class is a `BiFunctor` which second value named as `CombinedData`
   *
   * This class caches `Data` and `CombinedData` wrapped in `ProcessingTypeDataState` to avoid computations of
-  * transformations during each lookup to `Data`/`CombinedData`. It behave similar to `Observable` where given
-  * transformed `ProcessingTypeDataProvider` check its parent if `ProcessingTypeDataState.stateIdentity` changed.
+  * transformations during each lookup to `Data`/`CombinedData`.
   *
   * ProcessingType is associated with Category e.g. Fraud Detection, Marketing. Given user has access to certain
-  * categories see `LoggedUser.can`. Due to that, during each access to `Data`, user is authorized if he/she
+  * categories see `LoggedUser.can`. Due to that, during each access to `Data`, user is authorized if their
   * has access to category.
   */
-trait ProcessingTypeDataProvider[Data, CombinedData] {
+abstract class ProcessingTypeDataProvider[Data, CombinedData](initialState: ProcessingTypeDataState[Data, CombinedData])
+    extends LazyLogging {
+
+  // TODO: get rid of unsafeRunSync for Ref and Mutex
+  protected val stateRef: Ref[IO, ProcessingTypeDataState[Data, CombinedData]] =
+    Ref.of[IO, ProcessingTypeDataState[Data, CombinedData]](initialState).unsafeRunSync()(IORuntime.global)
+
+  protected val stateMutex: Mutex[IO] = Mutex[IO].unsafeRunSync()(IORuntime.global)
+
+  private val observers = new CopyOnWriteArrayList[Observer[ProcessingTypeDataState[Data, CombinedData]]]()
 
   // TODO: replace with proper forType handling
   final def forProcessingTypeUnsafe(processingType: ProcessingType)(implicit user: LoggedUser): Data =
@@ -89,31 +103,57 @@ trait ProcessingTypeDataProvider[Data, CombinedData] {
   //       Thanks to that we will be sure that no sensitive data leak
   final def combined: CombinedData = state.combinedDataTry.get
 
-  protected[provider] def state: ProcessingTypeDataState[Data, CombinedData]
+  final protected[provider] def setStateValueAndNotifyObservers(
+      newValue: ProcessingTypeDataState[Data, CombinedData]
+  ): IO[Unit] = {
+    for {
+      _ <- stateRef.set(newValue)
+      _ <- observers.asScala
+        .map { observer =>
+          observer.notifyChange(newValue)
+        }
+        .toList
+        .sequence
+    } yield ()
+  }
 
-  final def mapValues[TT](fun: Data => TT): ProcessingTypeDataProvider[TT, CombinedData] =
-    new TransformingProcessingTypeDataProvider[Data, CombinedData, TT, CombinedData](this, _.mapValues(fun))
+  private def state: ProcessingTypeDataState[Data, CombinedData] = {
+    stateMutex.lock
+      .surround {
+        stateRef.get
+      }
+      .unsafeRunSync()(IORuntime.global) // TODO: get rid of unsafeRunSync
+  }
 
-  final def mapCombined[CC](fun: CombinedData => CC): ProcessingTypeDataProvider[Data, CC] =
-    new TransformingProcessingTypeDataProvider[Data, CombinedData, Data, CC](this, _.mapCombined(fun))
+  final def mapValues[TT](fun: Data => TT): ProcessingTypeDataProvider[TT, CombinedData] = {
+    val childProvider =
+      new TransformingProcessingTypeDataProvider[Data, CombinedData, TT, CombinedData](this.state, _.mapValues(fun))
+    observers.add(childProvider)
+    childProvider
+  }
+
+  final def mapCombined[CC](fun: CombinedData => CC): ProcessingTypeDataProvider[Data, CC] = {
+    val childProvider =
+      new TransformingProcessingTypeDataProvider[Data, CombinedData, Data, CC](this.state, _.mapCombined(fun))
+    observers.add(childProvider)
+    childProvider
+  }
 
 }
 
+trait Observer[V] {
+  def notifyChange(newValue: V): IO[Unit]
+}
+
 private[provider] class TransformingProcessingTypeDataProvider[T, C, TT, CC](
-    observed: ProcessingTypeDataProvider[T, C],
+    initialValue: ProcessingTypeDataState[T, C],
     transformState: ProcessingTypeDataState[T, C] => ProcessingTypeDataState[TT, CC]
-) extends ProcessingTypeDataProvider[TT, CC] {
+) extends ProcessingTypeDataProvider[TT, CC](transformState(initialValue))
+    with Observer[ProcessingTypeDataState[T, C]] {
 
-  private val stateValue = new AtomicReference(transformState(observed.state))
-
-  override protected[provider] def state: ProcessingTypeDataState[TT, CC] = {
-    stateValue.updateAndGet { currentValue =>
-      val currentObservedState = observed.state
-      if (currentObservedState.stateIdentity != currentValue.stateIdentity) {
-        transformState(currentObservedState)
-      } else {
-        currentValue
-      }
+  override def notifyChange(newValue: ProcessingTypeDataState[T, C]): IO[Unit] = {
+    stateMutex.lock.surround {
+      setStateValueAndNotifyObservers(transformState(newValue))
     }
   }
 
@@ -122,18 +162,24 @@ private[provider] class TransformingProcessingTypeDataProvider[T, C, TT, CC](
 // It keeps a state (Data and CombinedData) that is cached and restricted by ProcessingTypeDataProvider
 final class ProcessingTypeDataState[+Data, +CombinedData](
     private[provider] val all: Map[ProcessingType, ValueWithRestriction[Data]],
-    private[processingtype] val combinedDataTry: Try[CombinedData],
-    // We keep stateIdentity as a separate value to avoid frequent computation of this.all.equals(that.all)
-    // Also, it is easier to provide one (source) state identity than provide it for all observers
-    private[provider] val stateIdentity: Any
+    private[processingtype] val combinedDataTry: Try[CombinedData]
 ) {
 
   def mapValues[TT](fun: Data => TT): ProcessingTypeDataState[TT, CombinedData] =
-    new ProcessingTypeDataState[TT, CombinedData](all.mapValuesNow(_.map(fun)), combinedDataTry, stateIdentity)
+    new ProcessingTypeDataState[TT, CombinedData](all.mapValuesNow(_.map(fun)), combinedDataTry)
 
   def mapCombined[CC](fun: CombinedData => CC): ProcessingTypeDataState[Data, CC] = {
     val newCombined = combinedDataTry.map(fun)
-    new ProcessingTypeDataState[Data, CC](all, newCombined, stateIdentity)
+    new ProcessingTypeDataState[Data, CC](all, newCombined)
   }
+
+}
+
+object ProcessingTypeDataState {
+
+  val uninitialized = new ProcessingTypeDataState(
+    all = Map.empty,
+    combinedDataTry = Failure(new IllegalAccessException("ProcessingTypeData is not initialized"))
+  )
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
@@ -30,7 +30,7 @@ import scala.util.Try
   * categories see `LoggedUser.can`. Due to that, during each access to `Data`, user is authorized if he/she
   * has access to category.
   */
-trait ProcessingTypeDataProvider[+Data, +CombinedData] {
+trait ProcessingTypeDataProvider[Data, CombinedData] {
 
   // TODO: replace with proper forType handling
   final def forProcessingTypeUnsafe(processingType: ProcessingType)(implicit user: LoggedUser): Data =

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
@@ -40,10 +40,10 @@ abstract class ProcessingTypeDataProvider[Data, CombinedData](initialState: Proc
 
   // We use unsafeRunSync because IO-based solution would complicate a lot our application initialization logic where
   // we pass to every service, various views for our ProcessingTypeData
-  protected val stateRef: Ref[IO, ProcessingTypeDataState[Data, CombinedData]] =
+  private val stateRef: Ref[IO, ProcessingTypeDataState[Data, CombinedData]] =
     Ref.of[IO, ProcessingTypeDataState[Data, CombinedData]](initialState).unsafeRunSync()(IORuntime.global)
 
-  protected val stateMutex: Mutex[IO] = Mutex[IO].unsafeRunSync()(IORuntime.global)
+  private val stateMutex: Mutex[IO] = Mutex[IO].unsafeRunSync()(IORuntime.global)
 
   private val observers = new CopyOnWriteArrayList[Observer[ProcessingTypeDataState[Data, CombinedData]]]()
 
@@ -105,10 +105,7 @@ abstract class ProcessingTypeDataProvider[Data, CombinedData](initialState: Proc
   }
 
   private def state: ProcessingTypeDataState[Data, CombinedData] = {
-    stateMutex.lock
-      .surround {
-        stateRef.get
-      }
+    accessStateInCriticalSection(_.get)
       .unsafeRunSync()(IORuntime.global) // TODO: get rid of unsafeRunSync
   }
 
@@ -126,10 +123,41 @@ abstract class ProcessingTypeDataProvider[Data, CombinedData](initialState: Proc
     childProvider
   }
 
+  def close(): IO[Unit] = {
+    closeObservers.flatMap { _ =>
+      accessStateInCriticalSection { stateRefValue =>
+        for {
+          beforeSetToEmpty <- stateRefValue.get
+          // It is better to return uninitialized state than closed state
+          _ <- stateRefValue.set(ProcessingTypeDataState.uninitialized)
+          _ <- closeState(beforeSetToEmpty)
+        } yield ()
+      }
+    }
+  }
+
+  protected def accessStateInCriticalSection[T](
+      doWithStateRef: Ref[IO, ProcessingTypeDataState[Data, CombinedData]] => IO[T]
+  ): IO[T] = {
+    stateMutex.lock.surround {
+      doWithStateRef(stateRef)
+    }
+  }
+
+  private def closeObservers: IO[Unit] = {
+    observers.asScala.toList.map(_.close()).sequence.map(_ => observers.clear())
+  }
+
+  protected def closeState(state: ProcessingTypeDataState[Data, CombinedData]): IO[Unit] = {
+    IO.pure(())
+  }
+
 }
 
 trait Observer[V] {
   def notifyChange(newValue: V): IO[Unit]
+
+  def close(): IO[Unit]
 }
 
 private[provider] class TransformingProcessingTypeDataProvider[T, C, TT, CC](
@@ -139,7 +167,7 @@ private[provider] class TransformingProcessingTypeDataProvider[T, C, TT, CC](
     with Observer[ProcessingTypeDataState[T, C]] {
 
   override def notifyChange(newValue: ProcessingTypeDataState[T, C]): IO[Unit] = {
-    stateMutex.lock.surround {
+    accessStateInCriticalSection { _ =>
       setStateValueAndNotifyObservers(transformState(newValue))
     }
   }
@@ -166,7 +194,10 @@ object ProcessingTypeDataState {
 
   val uninitialized = new ProcessingTypeDataState(
     all = Map.empty,
-    combinedDataTry = Failure(new IllegalAccessException("ProcessingTypeData is not initialized"))
+    combinedDataTry = Failure(UninitializedCombinedDataException)
   )
+
+  private[provider] object UninitializedCombinedDataException
+      extends IllegalAccessException("ProcessingTypeData is not initialized")
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
@@ -12,6 +12,7 @@ import pl.touk.nussknacker.ui.UnauthorizedError
 import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
+import java.util.{List => JList}
 import java.util.concurrent.CopyOnWriteArrayList
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Try}
@@ -40,14 +41,18 @@ abstract class ProcessingTypeDataProvider[Data, CombinedData](
 )(implicit ioRuntime: IORuntime)
     extends LazyLogging {
 
+  type State = ProcessingTypeDataState[Data, CombinedData]
+
   // We use unsafeRunSync because IO-based solution would complicate a lot our application initialization logic where
   // we pass to every service, various views for our ProcessingTypeData
-  private val stateRef: Ref[IO, ProcessingTypeDataState[Data, CombinedData]] =
-    Ref.of[IO, ProcessingTypeDataState[Data, CombinedData]](initialState).unsafeRunSync()
+  private val stateRef: Ref[IO, State] =
+    Ref.of[IO, State](initialState).unsafeRunSync()
 
   private val stateMutex: Mutex[IO] = Mutex[IO].unsafeRunSync()
 
-  private val observers = new CopyOnWriteArrayList[Observer[ProcessingTypeDataState[Data, CombinedData]]]()
+  private val observers = new CopyOnWriteArrayList[Observer[State]]()
+
+  private val stateOps = new StateOperations(stateRef, observers)
 
   final def forProcessingTypeUnsafe(processingType: ProcessingType)(implicit user: LoggedUser): Data =
     forProcessingTypeEUnsafe(processingType).toTry.get
@@ -92,25 +97,11 @@ abstract class ProcessingTypeDataProvider[Data, CombinedData](
   //       Thanks to that we will be sure that no sensitive data leak
   final def combined: CombinedData = state.combinedDataTry.get
 
-  final protected[provider] def setStateValueAndNotifyObservers(
-      newValue: ProcessingTypeDataState[Data, CombinedData]
-  ): IO[Unit] = {
-    for {
-      _ <- stateRef.set(newValue)
-      _ <- observers.asScala
-        .map { observer =>
-          observer.notifyChange(newValue)
-        }
-        .toList
-        .sequence
-    } yield ()
-  }
-
   // Currently the whole application use this state synchronously, inside Future, because of that we unsafeRunSync()
   // It is not so risky because we use separate IORuntime in ProcessingTypeDataProviders
   // TODO: migrate application to IO
-  private def state: ProcessingTypeDataState[Data, CombinedData] = {
-    accessStateInCriticalSection(_.get).unsafeRunSync()
+  private def state: State = {
+    accessStateInCriticalSection(_.value).unsafeRunSync()
   }
 
   final def mapValues[TT](fun: Data => TT): ProcessingTypeDataProvider[TT, CombinedData] = {
@@ -127,33 +118,57 @@ abstract class ProcessingTypeDataProvider[Data, CombinedData](
     childProvider
   }
 
-  def close(): IO[Unit] = {
-    closeObservers.flatMap { _ =>
-      accessStateInCriticalSection { stateRefValue =>
-        for {
-          beforeSetToEmpty <- stateRefValue.get
-          // It is better to return uninitialized state than closed state
-          _ <- stateRefValue.set(ProcessingTypeDataState.uninitialized)
-          _ <- closeState(beforeSetToEmpty)
-        } yield ()
-      }
-    }
-  }
-
-  protected def accessStateInCriticalSection[T](
-      doWithStateRef: Ref[IO, ProcessingTypeDataState[Data, CombinedData]] => IO[T]
-  ): IO[T] = {
-    stateMutex.lock.surround {
-      doWithStateRef(stateRef)
-    }
+  final def close(): IO[Unit] = {
+    for {
+      _ <- closeObservers
+      _ <- closeStateInCriticalSection
+      _ <- finalizeAfterClosingObserversAndState
+    } yield ()
   }
 
   private def closeObservers: IO[Unit] = {
     observers.asScala.toList.map(_.close()).sequence.map(_ => observers.clear())
   }
 
-  protected def closeState(state: ProcessingTypeDataState[Data, CombinedData]): IO[Unit] = {
-    IO.pure(())
+  private def closeStateInCriticalSection: IO[Unit] = {
+    accessStateInCriticalSection { stateOps =>
+      for {
+        beforeSetToEmpty <- stateOps.value
+        // It is better to return uninitialized state than closed state
+        _ <- stateOps.setValue(ProcessingTypeDataState.uninitialized)
+        _ <- closeState(beforeSetToEmpty)
+      } yield ()
+    }
+  }
+
+  protected def closeState(state: State): IO[Unit] = IO.unit
+
+  protected def finalizeAfterClosingObserversAndState: IO[Unit] = IO.unit
+
+  protected def accessStateInCriticalSection[T](
+      doWithState: StateOperations[State] => IO[T]
+  ): IO[T] = {
+    stateMutex.lock.surround {
+      doWithState(stateOps)
+    }
+  }
+
+}
+
+class StateOperations[State](stateRef: Ref[IO, State], observers: JList[Observer[State]]) {
+
+  def value: IO[State] = stateRef.get
+
+  def setValue(newValue: State): IO[Unit] = {
+    for {
+      _ <- stateRef.set(newValue)
+      _ <- observers.asScala
+        .map { observer =>
+          observer.notifyChange(newValue)
+        }
+        .toList
+        .sequence
+    } yield ()
   }
 
 }
@@ -172,9 +187,7 @@ private[provider] class TransformingProcessingTypeDataProvider[T, C, TT, CC](
     with Observer[ProcessingTypeDataState[T, C]] {
 
   override def notifyChange(newValue: ProcessingTypeDataState[T, C]): IO[Unit] = {
-    accessStateInCriticalSection { _ =>
-      setStateValueAndNotifyObservers(transformState(newValue))
-    }
+    accessStateInCriticalSection(_.setValue(transformState(newValue)))
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
@@ -35,15 +35,17 @@ import scala.util.{Failure, Try}
   * categories see `LoggedUser.can`. Due to that, during each access to `Data`, user is authorized if they
   * have access to category.
   */
-abstract class ProcessingTypeDataProvider[Data, CombinedData](initialState: ProcessingTypeDataState[Data, CombinedData])
+abstract class ProcessingTypeDataProvider[Data, CombinedData](
+    initialState: ProcessingTypeDataState[Data, CombinedData]
+)(implicit ioRuntime: IORuntime)
     extends LazyLogging {
 
   // We use unsafeRunSync because IO-based solution would complicate a lot our application initialization logic where
   // we pass to every service, various views for our ProcessingTypeData
   private val stateRef: Ref[IO, ProcessingTypeDataState[Data, CombinedData]] =
-    Ref.of[IO, ProcessingTypeDataState[Data, CombinedData]](initialState).unsafeRunSync()(IORuntime.global)
+    Ref.of[IO, ProcessingTypeDataState[Data, CombinedData]](initialState).unsafeRunSync()
 
-  private val stateMutex: Mutex[IO] = Mutex[IO].unsafeRunSync()(IORuntime.global)
+  private val stateMutex: Mutex[IO] = Mutex[IO].unsafeRunSync()
 
   private val observers = new CopyOnWriteArrayList[Observer[ProcessingTypeDataState[Data, CombinedData]]]()
 
@@ -104,9 +106,11 @@ abstract class ProcessingTypeDataProvider[Data, CombinedData](initialState: Proc
     } yield ()
   }
 
+  // Currently the whole application use this state synchronously, inside Future, because of that we unsafeRunSync()
+  // It is not so risky because we use separate IORuntime in ProcessingTypeDataProviders
+  // TODO: migrate application to IO
   private def state: ProcessingTypeDataState[Data, CombinedData] = {
-    accessStateInCriticalSection(_.get)
-      .unsafeRunSync()(IORuntime.global) // TODO: get rid of unsafeRunSync
+    accessStateInCriticalSection(_.get).unsafeRunSync()
   }
 
   final def mapValues[TT](fun: Data => TT): ProcessingTypeDataProvider[TT, CombinedData] = {
@@ -163,7 +167,8 @@ trait Observer[V] {
 private[provider] class TransformingProcessingTypeDataProvider[T, C, TT, CC](
     initialValue: ProcessingTypeDataState[T, C],
     transformState: ProcessingTypeDataState[T, C] => ProcessingTypeDataState[TT, CC]
-) extends ProcessingTypeDataProvider[TT, CC](transformState(initialValue))
+)(implicit ioRuntime: IORuntime)
+    extends ProcessingTypeDataProvider[TT, CC](transformState(initialValue))
     with Observer[ProcessingTypeDataState[T, C]] {
 
   override def notifyChange(newValue: ProcessingTypeDataState[T, C]): IO[Unit] = {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProvider.scala
@@ -1,8 +1,8 @@
 package pl.touk.nussknacker.ui.process.processingtype.provider
 
+import cats.effect.{IO, Ref}
 import cats.effect.std.Mutex
 import cats.effect.unsafe.IORuntime
-import cats.effect.{IO, Ref}
 import cats.implicits.toTraverseOps
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.process.ProcessingType
@@ -32,13 +32,14 @@ import scala.util.{Failure, Try}
   * transformations during each lookup to `Data`/`CombinedData`.
   *
   * ProcessingType is associated with Category e.g. Fraud Detection, Marketing. Given user has access to certain
-  * categories see `LoggedUser.can`. Due to that, during each access to `Data`, user is authorized if their
-  * has access to category.
+  * categories see `LoggedUser.can`. Due to that, during each access to `Data`, user is authorized if they
+  * have access to category.
   */
 abstract class ProcessingTypeDataProvider[Data, CombinedData](initialState: ProcessingTypeDataState[Data, CombinedData])
     extends LazyLogging {
 
-  // TODO: get rid of unsafeRunSync for Ref and Mutex
+  // We use unsafeRunSync because IO-based solution would complicate a lot our application initialization logic where
+  // we pass to every service, various views for our ProcessingTypeData
   protected val stateRef: Ref[IO, ProcessingTypeDataState[Data, CombinedData]] =
     Ref.of[IO, ProcessingTypeDataState[Data, CombinedData]](initialState).unsafeRunSync()(IORuntime.global)
 
@@ -46,49 +47,35 @@ abstract class ProcessingTypeDataProvider[Data, CombinedData](initialState: Proc
 
   private val observers = new CopyOnWriteArrayList[Observer[ProcessingTypeDataState[Data, CombinedData]]]()
 
-  // TODO: replace with proper forType handling
   final def forProcessingTypeUnsafe(processingType: ProcessingType)(implicit user: LoggedUser): Data =
-    forProcessingType(processingType)
-      .getOrElse(
-        throw new IllegalArgumentException(
+    forProcessingTypeEUnsafe(processingType).toTry.get
+
+  final def forProcessingType(processingType: ProcessingType)(implicit user: LoggedUser): Option[Data] = {
+    forProcessingTypeE(processingType).toTry.get
+  }
+
+  final def forProcessingTypeEUnsafe(
+      processingType: ProcessingType
+  )(implicit user: LoggedUser): Either[UnauthorizedError, Data] = {
+    forProcessingTypeE(processingType).map(
+      _.getOrElse(
+        throw new IllegalStateException(
           s"Unknown ProcessingType: $processingType, known ProcessingTypes are: ${all.keys.mkString(", ")}"
         )
       )
-
-  final def forProcessingType(processingType: ProcessingType)(implicit user: LoggedUser): Option[Data] = {
-    allAuthorized
-      .get(processingType)
-      .map(_.getOrElse(throw new UnauthorizedError(user)))
+    )
   }
 
   final def forProcessingTypeE(
       processingType: ProcessingType
   )(implicit user: LoggedUser): Either[UnauthorizedError, Option[Data]] = {
-    allAuthorized
-      .get(processingType) match {
+    allAuthorized.get(processingType) match {
       case Some(dataO) =>
         dataO match {
           case Some(data) => Right(Some(data))
           case None       => Left(new UnauthorizedError(user))
         }
       case None => Right(None)
-    }
-  }
-
-  final def forProcessingTypeEUnsafe(
-      processingType: ProcessingType
-  )(implicit user: LoggedUser): Either[UnauthorizedError, Data] = {
-    allAuthorized
-      .get(processingType) match {
-      case Some(dataO) =>
-        dataO match {
-          case Some(data) => Right(data)
-          case None       => Left(new UnauthorizedError(user))
-        }
-      case None =>
-        throw new IllegalStateException(
-          s"Error while providing process resolver for processing type $processingType requested by user ${user.username}"
-        )
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.ui.security.api.NussknackerInternalUser
 
-import scala.util.Failure
+import scala.util.control.NonFatal
 
 /**
  * This implements *simplistic* reloading of ProcessingTypeData - treat it as experimental/working PoC
@@ -21,50 +21,48 @@ import scala.util.Failure
  */
 class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
     loadMethod: IO[ProcessingTypeDataState[Data, CombinedData]]
-) extends ProcessingTypeDataProvider[Data, CombinedData]
+) extends ProcessingTypeDataProvider[Data, CombinedData](ProcessingTypeDataState.uninitialized)
     with LazyLogging {
 
-  // We initiate state with dumb value instead of calling loadMethod() to avoid problems with dependency injection
-  // cycle - see NusskanckerDefaultAppRouter.create
-  private var stateValue: ProcessingTypeDataState[Data, CombinedData] = emptyState
-
-  override protected[provider] def state: ProcessingTypeDataState[Data, CombinedData] = {
-    synchronized {
-      stateValue
+  def reloadAll(): IO[Unit] = {
+    stateMutex.lock.surround {
+      for {
+        beforeReload <- stateRef.get
+        _ <- IO(
+          logger.info(
+            s"Closing state with old processing types [${beforeReload.all.keys.toList.sorted.mkString(", ")}]"
+          )
+        )
+        _ <- close(beforeReload)
+        _ <- IO(
+          logger.info("Reloading processing type data...")
+        )
+        newState <- loadMethod
+        _ <- setStateValueAndNotifyObservers(newState)
+          .map { _ =>
+            logger.info(
+              s"New state with processing types [${newState.all.keys.toList.sorted.mkString(", ")}] reload finished"
+            )
+          }
+          .recoverWith { case NonFatal(ex) =>
+            logger.error("Error occurred during reloading state. Rolling back previous state value", ex)
+            setStateValueAndNotifyObservers(beforeReload).map { _ =>
+              throw ex
+            }
+          }
+      } yield ()
     }
   }
 
-  def reloadAll(): IO[Unit] = synchronized {
-    for {
-      beforeReload <- IO.pure(stateValue)
-      _ <- IO(
-        logger.info(
-          s"Closing state with old processing types [${beforeReload.all.keys.toList.sorted
-              .mkString(", ")}] and identity [${beforeReload.stateIdentity}]"
-        )
-      )
-      _ <- close(beforeReload)
-      _ <- IO(
-        logger.info("Reloading processing type data...")
-      )
-      newState <- loadMethod
-      _ <- IO(
-        logger.info(
-          s"New state with processing types [${state.all.keys.toList.sorted.mkString(", ")}] and identity [${state.stateIdentity}] reloaded finished"
-        )
-      )
-    } yield {
-      stateValue = newState
+  def close(): IO[Unit] = {
+    stateMutex.lock.surround {
+      for {
+        beforeSetToEmpty <- stateRef.get
+        // It is better to return empty state than closed state
+        _ <- stateRef.set(ProcessingTypeDataState.uninitialized)
+        _ <- close(beforeSetToEmpty)
+      } yield ()
     }
-  }
-
-  def close(): IO[Unit] = synchronized {
-    for {
-      _ <- IO {
-        stateValue = emptyState
-      }
-      _ <- close(stateValue)
-    } yield ()
   }
 
   private def close(state: ProcessingTypeDataState[Data, CombinedData]) = IO {
@@ -76,11 +74,5 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
         .close()
     )
   }
-
-  private def emptyState = new ProcessingTypeDataState(
-    all = Map.empty,
-    combinedDataTry = Failure(new IllegalAccessException("ProcessingTypeData is not initialized")),
-    stateIdentity = new Object
-  )
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
@@ -6,6 +6,8 @@ import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.ui.process.processingtype.{CombinedProcessingTypeData, ProcessingTypeData}
 import pl.touk.nussknacker.ui.security.api.NussknackerInternalUser
 
+import scala.util.Success
+
 /**
  * This implements *simplistic* reloading of ProcessingTypeData - treat it as experimental/working PoC
  *
@@ -27,8 +29,7 @@ class ReloadableProcessingTypeDataProvider(
   // cycle - see NusskanckerDefaultAppRouter.create
   private var stateValue: ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData] = emptyState
 
-  override private[processingtype] def state
-      : ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData] = {
+  override protected[provider] def state: ProcessingTypeDataState[ProcessingTypeData, CombinedProcessingTypeData] = {
     synchronized {
       stateValue
     }
@@ -77,10 +78,10 @@ class ReloadableProcessingTypeDataProvider(
     )
   }
 
-  private def emptyState = ProcessingTypeDataState(
-    allValues = Map.empty,
-    getCombinedValue = () => CombinedProcessingTypeData.create(Map.empty),
-    stateIdentityValue = new Object
+  private def emptyState = new ProcessingTypeDataState(
+    all = Map.empty,
+    combinedDataTry = Success(CombinedProcessingTypeData.create(Map.empty)),
+    stateIdentity = new Object
   )
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
@@ -20,7 +20,7 @@ import scala.util.control.NonFatal
  * Another thing that needs careful consideration is handling exception during ProcessingTypeData creation/closing - probably during
  * close we want to catch exception and try to proceed, but during creation it can be a bit tricky...
  */
-class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
+class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData] private (
     loadMethod: IO[ProcessingTypeDataState[Data, CombinedData]]
 )(implicit ioRuntime: IORuntime)
     extends ProcessingTypeDataProvider[Data, CombinedData](ProcessingTypeDataState.uninitialized)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
@@ -27,9 +27,9 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
     with LazyLogging {
 
   def reloadAll(): IO[Unit] = {
-    accessStateInCriticalSection { stateRef =>
+    accessStateInCriticalSection { stateOps =>
       for {
-        beforeReload <- stateRef.get
+        beforeReload <- stateOps.value
         _ <- IO(
           logger.info(
             s"Closing state with old processing types [${beforeReload.all.keys.toList.sorted.mkString(", ")}]"
@@ -40,7 +40,8 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
           logger.info("Reloading processing type data...")
         )
         newState <- loadMethod
-        _ <- setStateValueAndNotifyObservers(newState)
+        _ <- stateOps
+          .setValue(newState)
           .map { _ =>
             logger.info(
               s"New state with processing types [${newState.all.keys.toList.sorted.mkString(", ")}] reload finished"
@@ -48,7 +49,7 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
           }
           .recoverWith { case NonFatal(ex) =>
             logger.error("Error occurred during reloading state. Rolling back previous state value", ex)
-            setStateValueAndNotifyObservers(beforeReload).map { _ =>
+            stateOps.setValue(beforeReload).map { _ =>
               throw ex
             }
           }
@@ -56,9 +57,9 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
     }
   }
 
-  override def close(): IO[Unit] = {
-    // We have to shut down IORuntime in one place, after closing all observers to ensure that nobody will use closed IORuntime
-    super.close().map { _ => ioRuntime.shutdown() }
+  // We have to shut down IORuntime in one place, after closing all observers to ensure that nobody will use closed IORuntime
+  override protected def finalizeAfterClosingObserversAndState: IO[Unit] = {
+    IO(ioRuntime.shutdown())
   }
 
   override protected def closeState(state: ProcessingTypeDataState[Data, CombinedData]): IO[Unit] = IO {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
@@ -25,7 +25,7 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
     with LazyLogging {
 
   def reloadAll(): IO[Unit] = {
-    stateMutex.lock.surround {
+    accessStateInCriticalSection { stateRef =>
       for {
         beforeReload <- stateRef.get
         _ <- IO(
@@ -33,7 +33,7 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
             s"Closing state with old processing types [${beforeReload.all.keys.toList.sorted.mkString(", ")}]"
           )
         )
-        _ <- close(beforeReload)
+        _ <- closeState(beforeReload)
         _ <- IO(
           logger.info("Reloading processing type data...")
         )
@@ -54,18 +54,7 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
     }
   }
 
-  def close(): IO[Unit] = {
-    stateMutex.lock.surround {
-      for {
-        beforeSetToEmpty <- stateRef.get
-        // It is better to return empty state than closed state
-        _ <- stateRef.set(ProcessingTypeDataState.uninitialized)
-        _ <- close(beforeSetToEmpty)
-      } yield ()
-    }
-  }
-
-  private def close(state: ProcessingTypeDataState[Data, CombinedData]) = IO {
+  override protected def closeState(state: ProcessingTypeDataState[Data, CombinedData]): IO[Unit] = IO {
     state.all.values.foreach(
       _.valueWithAllowedAccess(Permission.Read)(NussknackerInternalUser.instance)
         .getOrElse(

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProvider.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.ui.process.processingtype.provider
 
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.ui.security.api.NussknackerInternalUser
@@ -21,7 +22,8 @@ import scala.util.control.NonFatal
  */
 class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
     loadMethod: IO[ProcessingTypeDataState[Data, CombinedData]]
-) extends ProcessingTypeDataProvider[Data, CombinedData](ProcessingTypeDataState.uninitialized)
+)(implicit ioRuntime: IORuntime)
+    extends ProcessingTypeDataProvider[Data, CombinedData](ProcessingTypeDataState.uninitialized)
     with LazyLogging {
 
   def reloadAll(): IO[Unit] = {
@@ -54,6 +56,11 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
     }
   }
 
+  override def close(): IO[Unit] = {
+    // We have to shut down IORuntime in one place, after closing all observers to ensure that nobody will use closed IORuntime
+    super.close().map { _ => ioRuntime.shutdown() }
+  }
+
   override protected def closeState(state: ProcessingTypeDataState[Data, CombinedData]): IO[Unit] = IO {
     state.all.values.foreach(
       _.valueWithAllowedAccess(Permission.Read)(NussknackerInternalUser.instance)
@@ -62,6 +69,19 @@ class ReloadableProcessingTypeDataProvider[Data <: AutoCloseable, CombinedData](
         )
         .close()
     )
+  }
+
+}
+
+object ReloadableProcessingTypeDataProvider {
+
+  def apply[Data <: AutoCloseable, CombinedData](
+      loadMethod: IO[ProcessingTypeDataState[Data, CombinedData]]
+  ): ReloadableProcessingTypeDataProvider[Data, CombinedData] = {
+    // We create separate ioRuntime to ensure that we don't have some deadlocks during reading state where is used unsafeRunSync()
+    // See ProcessingTypeDataProvider.state method
+    implicit val ioRuntime: IORuntime = IORuntime.builder().build()
+    new ReloadableProcessingTypeDataProvider[Data, CombinedData](loadMethod)
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
@@ -82,14 +82,14 @@ import pl.touk.nussknacker.ui.process.newdeployment.synchronize.{
   DeploymentsStatusesSynchronizationScheduler,
   DeploymentsStatusesSynchronizer
 }
-import pl.touk.nussknacker.ui.process.processingtype.{ModelClassLoaderProvider, ProcessingTypeData}
-import pl.touk.nussknacker.ui.process.processingtype.loader.ProcessingTypeDataLoader
-import pl.touk.nussknacker.ui.process.processingtype.provider.ReloadableProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.process.processingtype.{
   CombinedProcessingTypeData,
   ModelClassLoaderProvider,
   ProcessingTypeData
 }
+import pl.touk.nussknacker.ui.process.processingtype.{ModelClassLoaderProvider, ProcessingTypeData}
+import pl.touk.nussknacker.ui.process.processingtype.loader.ProcessingTypeDataLoader
+import pl.touk.nussknacker.ui.process.processingtype.provider.ReloadableProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.process.repository._
 import pl.touk.nussknacker.ui.process.repository.activities.{DbScenarioActivityRepository, ScenarioActivityRepository}
 import pl.touk.nussknacker.ui.process.repository.stickynotes.DbStickyNotesRepository
@@ -819,7 +819,7 @@ class AkkaHttpBasedRouteProvider(
               globalNotificationRepository.saveEntry(Notification.configurationReloaded)
               state
             }
-          new ReloadableProcessingTypeDataProvider(loadAndNotifyIO)
+          ReloadableProcessingTypeDataProvider(loadAndNotifyIO)
         }
       )(
         release = _.close()

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/AkkaHttpBasedRouteProvider.scala
@@ -85,6 +85,11 @@ import pl.touk.nussknacker.ui.process.newdeployment.synchronize.{
 import pl.touk.nussknacker.ui.process.processingtype.{ModelClassLoaderProvider, ProcessingTypeData}
 import pl.touk.nussknacker.ui.process.processingtype.loader.ProcessingTypeDataLoader
 import pl.touk.nussknacker.ui.process.processingtype.provider.ReloadableProcessingTypeDataProvider
+import pl.touk.nussknacker.ui.process.processingtype.{
+  CombinedProcessingTypeData,
+  ModelClassLoaderProvider,
+  ProcessingTypeData
+}
 import pl.touk.nussknacker.ui.process.repository._
 import pl.touk.nussknacker.ui.process.repository.activities.{DbScenarioActivityRepository, ScenarioActivityRepository}
 import pl.touk.nussknacker.ui.process.repository.stickynotes.DbStickyNotesRepository
@@ -787,7 +792,7 @@ class AkkaHttpBasedRouteProvider(
       modelClassLoaderProvider: ModelClassLoaderProvider
   )(
       implicit executionContextWithIORuntime: ExecutionContextWithIORuntime
-  ): Resource[IO, ReloadableProcessingTypeDataProvider] = {
+  ): Resource[IO, ReloadableProcessingTypeDataProvider[ProcessingTypeData, CombinedProcessingTypeData]] = {
     Resource
       .make(
         acquire = IO {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/NuResourcesTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/NuResourcesTest.scala
@@ -24,8 +24,8 @@ import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.process.VersionId.initialVersionId
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.definition.test.{ModelDataTestInfoProvider, TestInfoProvider}
-import pl.touk.nussknacker.restmodel.{CancelRequest, DeployRequest}
 import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
+import pl.touk.nussknacker.restmodel.{CancelRequest, DeployRequest}
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
 import pl.touk.nussknacker.test.base.db.WithHsqlDbTesting
@@ -40,6 +40,8 @@ import pl.touk.nussknacker.test.mock.{
   TestProcessChangeListener,
   WithTestDeploymentManagerClassLoader
 }
+import pl.touk.nussknacker.test.utils.domain.TestFactory._
+import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory, TestProcessingTypeDataProviderFactory}
 import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory}
 import pl.touk.nussknacker.test.utils.domain.TestFactory._
 import pl.touk.nussknacker.test.utils.scalas.AkkaHttpExtensions.toRequestEntity
@@ -185,7 +187,7 @@ trait NuResourcesTest
 
   protected val typeToConfig: ProcessingTypeDataProvider[ProcessingTypeData, CombinedProcessingTypeData] = {
     val designerConfig = DesignerConfig.from(testConfig)
-    ProcessingTypeDataProvider(
+    TestProcessingTypeDataProviderFactory.fromState(
       new ProcessingTypesConfigBasedProcessingTypeDataLoader(() => IO.pure(designerConfig.processingTypeConfigs))
         .loadProcessingTypeData(
           _ => modelDependencies,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/NuResourcesTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/NuResourcesTest.scala
@@ -24,8 +24,8 @@ import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.process.VersionId.initialVersionId
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.definition.test.{ModelDataTestInfoProvider, TestInfoProvider}
-import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
 import pl.touk.nussknacker.restmodel.{CancelRequest, DeployRequest}
+import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
 import pl.touk.nussknacker.test.base.db.WithHsqlDbTesting
@@ -40,9 +40,7 @@ import pl.touk.nussknacker.test.mock.{
   TestProcessChangeListener,
   WithTestDeploymentManagerClassLoader
 }
-import pl.touk.nussknacker.test.utils.domain.TestFactory._
 import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory, TestProcessingTypeDataProviderFactory}
-import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory}
 import pl.touk.nussknacker.test.utils.domain.TestFactory._
 import pl.touk.nussknacker.test.utils.scalas.AkkaHttpExtensions.toRequestEntity
 import pl.touk.nussknacker.ui.api._

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
@@ -15,7 +15,6 @@ import pl.touk.nussknacker.ui.db.DbRef
 import pl.touk.nussknacker.ui.definition.ScenarioPropertiesConfigFinalizer
 import pl.touk.nussknacker.ui.process.NewProcessPreparer
 import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
-import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.process.repository._
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.{
   CreateProcessAction,
@@ -245,7 +244,7 @@ private[test] class ScenarioHelper(dbRef: DbRef, clock: Clock, designerConfig: C
   }
 
   private def mapProcessingTypeDataProvider[T](value: T) = {
-    TestProcessingTypeDataProviderFactory.withEmptyCombinedData(
+    TestProcessingTypeDataProviderFactory.createWithEmptyCombinedData(
       processingTypeWithCategories.map { case (processingType, _) =>
         (processingType, ValueWithRestriction.anyUser(value))
       }.toMap

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
@@ -245,7 +245,7 @@ private[test] class ScenarioHelper(dbRef: DbRef, clock: Clock, designerConfig: C
   }
 
   private def mapProcessingTypeDataProvider[T](value: T) = {
-    ProcessingTypeDataProvider.withEmptyCombinedData(
+    TestProcessingTypeDataProviderFactory.withEmptyCombinedData(
       processingTypeWithCategories.map { case (processingType, _) =>
         (processingType, ValueWithRestriction.anyUser(value))
       }.toMap

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestFactory.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestFactory.scala
@@ -103,7 +103,7 @@ object TestFactory {
   }
 
   val scenarioParametersServiceProvider: ProcessingTypeDataProvider[_, ScenarioParametersService] =
-    TestProcessingTypeDataProviderFactory.withIdentityFromValues(Map.empty, scenarioParametersService)
+    TestProcessingTypeDataProviderFactory.create(Map.empty, scenarioParametersService)
 
   // It should be defined as method, because when it's defined as val then there is bug in IDEA at DefinitionPreparerSpec - it returns null
   def prepareSampleFragmentRepository: StubFragmentRepository = new StubFragmentRepository(
@@ -241,7 +241,7 @@ object TestFactory {
 
   def mapProcessingTypeDataProvider[T](data: (String, T)*): ProcessingTypeDataProvider[T, Nothing] = {
     // TODO: tests for user privileges
-    TestProcessingTypeDataProviderFactory.withEmptyCombinedData(
+    TestProcessingTypeDataProviderFactory.createWithEmptyCombinedData(
       Map(data: _*).mapValuesNow(ValueWithRestriction.anyUser)
     )
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestFactory.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestFactory.scala
@@ -103,7 +103,7 @@ object TestFactory {
   }
 
   val scenarioParametersServiceProvider: ProcessingTypeDataProvider[_, ScenarioParametersService] =
-    ProcessingTypeDataProvider(Map.empty, scenarioParametersService)
+    TestProcessingTypeDataProviderFactory.withIdentityFromValues(Map.empty, scenarioParametersService)
 
   // It should be defined as method, because when it's defined as val then there is bug in IDEA at DefinitionPreparerSpec - it returns null
   def prepareSampleFragmentRepository: StubFragmentRepository = new StubFragmentRepository(
@@ -241,7 +241,7 @@ object TestFactory {
 
   def mapProcessingTypeDataProvider[T](data: (String, T)*): ProcessingTypeDataProvider[T, Nothing] = {
     // TODO: tests for user privileges
-    ProcessingTypeDataProvider.withEmptyCombinedData(
+    TestProcessingTypeDataProviderFactory.withEmptyCombinedData(
       Map(data: _*).mapValuesNow(ValueWithRestriction.anyUser)
     )
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestProcessingTypeDataProviderFactory.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestProcessingTypeDataProviderFactory.scala
@@ -1,0 +1,43 @@
+package pl.touk.nussknacker.test.utils.domain
+
+import pl.touk.nussknacker.engine.api.process.ProcessingType
+import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
+import pl.touk.nussknacker.ui.process.processingtype.provider.{ProcessingTypeDataProvider, ProcessingTypeDataState}
+
+import scala.util.{Failure, Success}
+
+object TestProcessingTypeDataProviderFactory {
+
+  def withIdentityFromValues[T, C](
+      allValues: Map[ProcessingType, ValueWithRestriction[T]],
+      combinedValue: C
+  ): ProcessingTypeDataProvider[T, C] =
+    fromState(
+      new ProcessingTypeDataState(
+        allValues,
+        Success(combinedValue),
+        allValues
+      )
+    )
+
+  def withEmptyCombinedData[T](
+      allValues: Map[ProcessingType, ValueWithRestriction[T]]
+  ): ProcessingTypeDataProvider[T, Nothing] =
+    fromState(
+      new ProcessingTypeDataState(
+        allValues,
+        Failure(
+          new IllegalStateException(
+            "Processing type data provider does not have combined data!"
+          )
+        ),
+        allValues
+      )
+    )
+
+  def fromState[T, C](stateValue: ProcessingTypeDataState[T, C]): ProcessingTypeDataProvider[T, C] =
+    new ProcessingTypeDataProvider[T, C] {
+      override def state: ProcessingTypeDataState[T, C] = stateValue
+    }
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestProcessingTypeDataProviderFactory.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestProcessingTypeDataProviderFactory.scala
@@ -8,7 +8,7 @@ import scala.util.{Failure, Success}
 
 object TestProcessingTypeDataProviderFactory {
 
-  def withIdentityFromValues[T, C](
+  def create[T, C](
       allValues: Map[ProcessingType, ValueWithRestriction[T]],
       combinedValue: C
   ): ProcessingTypeDataProvider[T, C] =
@@ -16,11 +16,10 @@ object TestProcessingTypeDataProviderFactory {
       new ProcessingTypeDataState(
         allValues,
         Success(combinedValue),
-        allValues
       )
     )
 
-  def withEmptyCombinedData[T](
+  def createWithEmptyCombinedData[T](
       allValues: Map[ProcessingType, ValueWithRestriction[T]]
   ): ProcessingTypeDataProvider[T, Nothing] =
     fromState(
@@ -31,13 +30,10 @@ object TestProcessingTypeDataProviderFactory {
             "Processing type data provider does not have combined data!"
           )
         ),
-        allValues
       )
     )
 
   def fromState[T, C](stateValue: ProcessingTypeDataState[T, C]): ProcessingTypeDataProvider[T, C] =
-    new ProcessingTypeDataProvider[T, C] {
-      override def state: ProcessingTypeDataState[T, C] = stateValue
-    }
+    new ProcessingTypeDataProvider[T, C](stateValue) {}
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestProcessingTypeDataProviderFactory.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/TestProcessingTypeDataProviderFactory.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.test.utils.domain
 
+import cats.effect.unsafe.IORuntime
 import pl.touk.nussknacker.engine.api.process.ProcessingType
 import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
 import pl.touk.nussknacker.ui.process.processingtype.provider.{ProcessingTypeDataProvider, ProcessingTypeDataState}
@@ -34,6 +35,6 @@ object TestProcessingTypeDataProviderFactory {
     )
 
   def fromState[T, C](stateValue: ProcessingTypeDataState[T, C]): ProcessingTypeDataProvider[T, C] =
-    new ProcessingTypeDataProvider[T, C](stateValue) {}
+    new ProcessingTypeDataProvider[T, C](stateValue)(IORuntime.global) {}
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/DefaultComponentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/DefaultComponentServiceSpec.scala
@@ -26,9 +26,8 @@ import pl.touk.nussknacker.restmodel.component.NodeUsageData.{FragmentUsageData,
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, PatientScalaFutures, ValidatedValuesDetailedMessage}
 import pl.touk.nussknacker.test.mock.{MockFetchingProcessRepository, MockManagerProvider}
-import pl.touk.nussknacker.test.utils.domain.TestProcessUtil.createFragmentEntity
 import pl.touk.nussknacker.test.utils.domain.{TestFactory, TestProcessingTypeDataProviderFactory}
-import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, PatientScalaFutures, ValidatedValuesDetailedMessage}
+import pl.touk.nussknacker.test.utils.domain.TestProcessUtil.createFragmentEntity
 import pl.touk.nussknacker.ui.api.ScenarioStatusPresenter
 import pl.touk.nussknacker.ui.config.{ComponentLinkConfig, ComponentLinksConfigExtractor}
 import pl.touk.nussknacker.ui.config.ComponentLinkConfig._
@@ -50,10 +49,8 @@ import pl.touk.nussknacker.ui.process.processingtype.ProcessingTypeData.Scheduli
 import pl.touk.nussknacker.ui.process.processingtype.loader.ProcessingTypeDataLoader
 import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.process.repository.ScenarioWithDetailsEntity
-import pl.touk.nussknacker.ui.security.api.{AdminUser, CommonUser, ImpersonatedUser, LoggedUser, RealLoggedUser}
-import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
-import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
 import pl.touk.nussknacker.ui.security.api._
+import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
 
 import java.net.URI
 import scala.annotation.tailrec
@@ -886,7 +883,7 @@ class DefaultComponentServiceSpec
     }
 
     TestProcessingTypeDataProviderFactory
-      .withIdentityFromValues(
+      .create(
         processingTypeDataMap.mapValuesNow(ProcessingTypeDataLoader.toValueWithRestriction),
         ScenarioParametersService.createUnsafe(processingTypeDataMap.mapValuesNow(_.scenarioParameters))
       )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/DefaultComponentServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/definition/component/DefaultComponentServiceSpec.scala
@@ -26,8 +26,9 @@ import pl.touk.nussknacker.restmodel.component.NodeUsageData.{FragmentUsageData,
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, PatientScalaFutures, ValidatedValuesDetailedMessage}
 import pl.touk.nussknacker.test.mock.{MockFetchingProcessRepository, MockManagerProvider}
-import pl.touk.nussknacker.test.utils.domain.TestFactory
 import pl.touk.nussknacker.test.utils.domain.TestProcessUtil.createFragmentEntity
+import pl.touk.nussknacker.test.utils.domain.{TestFactory, TestProcessingTypeDataProviderFactory}
+import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, PatientScalaFutures, ValidatedValuesDetailedMessage}
 import pl.touk.nussknacker.ui.api.ScenarioStatusPresenter
 import pl.touk.nussknacker.ui.config.{ComponentLinkConfig, ComponentLinksConfigExtractor}
 import pl.touk.nussknacker.ui.config.ComponentLinkConfig._
@@ -51,6 +52,8 @@ import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeData
 import pl.touk.nussknacker.ui.process.repository.ScenarioWithDetailsEntity
 import pl.touk.nussknacker.ui.security.api.{AdminUser, CommonUser, ImpersonatedUser, LoggedUser, RealLoggedUser}
 import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
+import pl.touk.nussknacker.ui.security.api.GlobalPermission.GlobalPermission
+import pl.touk.nussknacker.ui.security.api._
 
 import java.net.URI
 import scala.annotation.tailrec
@@ -882,15 +885,17 @@ class DefaultComponentServiceSpec
         )
     }
 
-    ProcessingTypeDataProvider(
-      processingTypeDataMap.mapValuesNow(ProcessingTypeDataLoader.toValueWithRestriction),
-      ScenarioParametersService.createUnsafe(processingTypeDataMap.mapValuesNow(_.scenarioParameters))
-    ).mapValues { processingTypeData =>
-      val modelDefinitionEnricher = AlignedComponentsDefinitionProvider(
-        processingTypeData.designerModelData
+    TestProcessingTypeDataProviderFactory
+      .withIdentityFromValues(
+        processingTypeDataMap.mapValuesNow(ProcessingTypeDataLoader.toValueWithRestriction),
+        ScenarioParametersService.createUnsafe(processingTypeDataMap.mapValuesNow(_.scenarioParameters))
       )
-      ComponentServiceProcessingTypeData(modelDefinitionEnricher, processingTypeData.category)
-    }
+      .mapValues { processingTypeData =>
+        val modelDefinitionEnricher = AlignedComponentsDefinitionProvider(
+          processingTypeData.designerModelData
+        )
+        ComponentServiceProcessingTypeData(modelDefinitionEnricher, processingTypeData.category)
+      }
   }
 
   private def createDbProcessService(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/initialization/InitializationOnDbItSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/initialization/InitializationOnDbItSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.tags.Slow
 import pl.touk.nussknacker.engine.api.process.ProcessName
+import pl.touk.nussknacker.engine.migration.ProcessMigrations
 import pl.touk.nussknacker.test.PatientScalaFutures
 import pl.touk.nussknacker.test.base.db.{DbTesting, WithHsqlDbTesting, WithPostgresDbTesting, WithTestDb}
 import pl.touk.nussknacker.test.base.it.WithClock
@@ -33,7 +34,7 @@ abstract class InitializationOnDbItSpec
 
   private val processName = ProcessName("proc1")
 
-  private val migrations = mapProcessingTypeDataProvider("streaming" -> new TestMigrations(1, 2))
+  private val migrations = mapProcessingTypeDataProvider[ProcessMigrations]("streaming" -> new TestMigrations(1, 2))
 
   private lazy val scenarioActivityRepository = TestFactory.newScenarioActivityRepository(testDbRef, clock)
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/ProcessStateDefinitionServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/ProcessStateDefinitionServiceSpec.scala
@@ -13,12 +13,10 @@ import pl.touk.nussknacker.engine.deployment.EngineSetupName
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.test.mock.{MockDeploymentManager, MockManagerProvider}
-import pl.touk.nussknacker.test.utils.domain.TestFactory.modelDependencies
 import pl.touk.nussknacker.test.utils.domain.{TestFactory, TestProcessingTypeDataProviderFactory}
+import pl.touk.nussknacker.test.utils.domain.TestFactory.modelDependencies
 import pl.touk.nussknacker.ui.process.processingtype.{ProcessingTypeData, ValueWithRestriction}
 import pl.touk.nussknacker.ui.process.processingtype.ProcessingTypeData.SchedulingForProcessingType
-import pl.touk.nussknacker.ui.process.processingtype.{ProcessingTypeData, ValueWithRestriction}
-import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.security.api.{AdminUser, CommonUser, LoggedUser}
 
 class ProcessStateDefinitionServiceSpec extends AnyFunSuite with Matchers {
@@ -145,7 +143,7 @@ class ProcessStateDefinitionServiceSpec extends AnyFunSuite with Matchers {
       createProcessingTypeDataMap(streamingProcessStateDefinitionManager, fraudProcessStateDefinitionManager)
     val stateDefinitions = ProcessStateDefinitionService.createDefinitionsMappingUnsafe(processingTypeDataMap)
     val service = new ProcessStateDefinitionService(
-      TestProcessingTypeDataProviderFactory.withIdentityFromValues(
+      TestProcessingTypeDataProviderFactory.create(
         Map(
           "Streaming" -> ValueWithRestriction
             .userWithAccessRightsToAnyOfCategories("Category1", Set("Category1")),

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/ProcessStateDefinitionServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/ProcessStateDefinitionServiceSpec.scala
@@ -13,10 +13,11 @@ import pl.touk.nussknacker.engine.deployment.EngineSetupName
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.test.mock.{MockDeploymentManager, MockManagerProvider}
-import pl.touk.nussknacker.test.utils.domain.TestFactory
 import pl.touk.nussknacker.test.utils.domain.TestFactory.modelDependencies
+import pl.touk.nussknacker.test.utils.domain.{TestFactory, TestProcessingTypeDataProviderFactory}
 import pl.touk.nussknacker.ui.process.processingtype.{ProcessingTypeData, ValueWithRestriction}
 import pl.touk.nussknacker.ui.process.processingtype.ProcessingTypeData.SchedulingForProcessingType
+import pl.touk.nussknacker.ui.process.processingtype.{ProcessingTypeData, ValueWithRestriction}
 import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.security.api.{AdminUser, CommonUser, LoggedUser}
 
@@ -144,7 +145,7 @@ class ProcessStateDefinitionServiceSpec extends AnyFunSuite with Matchers {
       createProcessingTypeDataMap(streamingProcessStateDefinitionManager, fraudProcessStateDefinitionManager)
     val stateDefinitions = ProcessStateDefinitionService.createDefinitionsMappingUnsafe(processingTypeDataMap)
     val service = new ProcessStateDefinitionService(
-      ProcessingTypeDataProvider(
+      TestProcessingTypeDataProviderFactory.withIdentityFromValues(
         Map(
           "Streaming" -> ValueWithRestriction
             .userWithAccessRightsToAnyOfCategories("Category1", Set("Category1")),

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/TestDeploymentServiceFactory.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/TestDeploymentServiceFactory.scala
@@ -16,6 +16,7 @@ import pl.touk.nussknacker.test.mock.{StubModelDataWithModelDefinition, TestProc
 import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory}
 import pl.touk.nussknacker.test.utils.domain.ProcessTestData.modelDefinition
 import pl.touk.nussknacker.test.utils.domain.TestFactory._
+import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory, TestProcessingTypeDataProviderFactory}
 import pl.touk.nussknacker.ui.api.DeploymentCommentSettings
 import pl.touk.nussknacker.ui.db.DbRef
 import pl.touk.nussknacker.ui.process.deployment.TestDeploymentServiceFactory.{actorSystem, clock, ec, processingType}
@@ -56,7 +57,7 @@ class TestDeploymentServiceFactory(dbRef: DbRef) {
       scenarioStateTimeout: Option[FiniteDuration] = None,
       deploymentCommentSettings: Option[DeploymentCommentSettings] = None
   ): TestDeploymentServiceServices = {
-    val processingTypeDataProvider = ProcessingTypeDataProvider.withEmptyCombinedData(
+    val processingTypeDataProvider = TestProcessingTypeDataProviderFactory.withEmptyCombinedData(
       Map(processingType.stringify -> ValueWithRestriction.anyUser(deploymentManager))
     )
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/TestDeploymentServiceFactory.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/deployment/TestDeploymentServiceFactory.scala
@@ -13,10 +13,9 @@ import pl.touk.nussknacker.engine.compile.ProcessValidator
 import pl.touk.nussknacker.test.config.WithSimplifiedDesignerConfig.TestProcessingType
 import pl.touk.nussknacker.test.config.WithSimplifiedDesignerConfig.TestProcessingType.Streaming
 import pl.touk.nussknacker.test.mock.{StubModelDataWithModelDefinition, TestProcessChangeListener}
-import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory}
+import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory, TestProcessingTypeDataProviderFactory}
 import pl.touk.nussknacker.test.utils.domain.ProcessTestData.modelDefinition
 import pl.touk.nussknacker.test.utils.domain.TestFactory._
-import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory, TestProcessingTypeDataProviderFactory}
 import pl.touk.nussknacker.ui.api.DeploymentCommentSettings
 import pl.touk.nussknacker.ui.db.DbRef
 import pl.touk.nussknacker.ui.process.deployment.TestDeploymentServiceFactory.{actorSystem, clock, ec, processingType}
@@ -24,7 +23,6 @@ import pl.touk.nussknacker.ui.process.deployment.deploymentstatus.EngineSideDepl
 import pl.touk.nussknacker.ui.process.deployment.reconciliation.ScenarioDeploymentReconciler
 import pl.touk.nussknacker.ui.process.deployment.scenariostatus.ScenarioStatusProvider
 import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
-import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.process.repository.{DBFetchingProcessRepository, ScenarioActionRepository}
 import pl.touk.nussknacker.ui.process.repository.activities.ScenarioActivityRepository
 import sttp.client3.testing.SttpBackendStub
@@ -57,7 +55,7 @@ class TestDeploymentServiceFactory(dbRef: DbRef) {
       scenarioStateTimeout: Option[FiniteDuration] = None,
       deploymentCommentSettings: Option[DeploymentCommentSettings] = None
   ): TestDeploymentServiceServices = {
-    val processingTypeDataProvider = TestProcessingTypeDataProviderFactory.withEmptyCombinedData(
+    val processingTypeDataProvider = TestProcessingTypeDataProviderFactory.createWithEmptyCombinedData(
       Map(processingType.stringify -> ValueWithRestriction.anyUser(deploymentManager))
     )
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/newdeployment/DeploymentServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/newdeployment/DeploymentServiceTest.scala
@@ -50,7 +50,7 @@ class DeploymentServiceTest
       TestFactory.newScenarioGraphVersionService(testDbRef),
       TestFactory.newDeploymentRepository(testDbRef, clock),
       new DeploymentManagerDispatcher(
-        TestProcessingTypeDataProviderFactory.withEmptyCombinedData(
+        TestProcessingTypeDataProviderFactory.createWithEmptyCombinedData(
           Map(Streaming.stringify -> ValueWithRestriction.anyUser(new MockableDeploymentManager(modelDataOpt = None)))
         ),
         TestFactory.newFutureFetchingScenarioRepository(testDbRef)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/newdeployment/DeploymentServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/newdeployment/DeploymentServiceTest.scala
@@ -14,11 +14,10 @@ import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, PatientScalaFuture
 import pl.touk.nussknacker.test.base.db.WithHsqlDbTesting
 import pl.touk.nussknacker.test.base.it.WithClock
 import pl.touk.nussknacker.test.config.WithSimplifiedDesignerConfig.TestProcessingType.Streaming
-import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory}
+import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory, TestProcessingTypeDataProviderFactory}
 import pl.touk.nussknacker.test.utils.scalas.DBIOActionValues
 import pl.touk.nussknacker.ui.process.deployment.DeploymentManagerDispatcher
 import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
-import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.process.repository.DBIOActionRunner
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.CreateProcessAction
 
@@ -51,7 +50,7 @@ class DeploymentServiceTest
       TestFactory.newScenarioGraphVersionService(testDbRef),
       TestFactory.newDeploymentRepository(testDbRef, clock),
       new DeploymentManagerDispatcher(
-        ProcessingTypeDataProvider.withEmptyCombinedData(
+        TestProcessingTypeDataProviderFactory.withEmptyCombinedData(
           Map(Streaming.stringify -> ValueWithRestriction.anyUser(new MockableDeploymentManager(modelDataOpt = None)))
         ),
         TestFactory.newFutureFetchingScenarioRepository(testDbRef)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeDataProviderSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeDataProviderSpec.scala
@@ -9,16 +9,15 @@ import pl.touk.nussknacker.engine.api.process.{Source, SourceFactory}
 import pl.touk.nussknacker.engine.testing.{DeploymentManagerProviderStub, LocalModelData}
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.test.mock.WithTestDeploymentManagerClassLoader
-import pl.touk.nussknacker.test.utils.domain.TestFactory
+import pl.touk.nussknacker.test.utils.domain.{TestFactory, TestProcessingTypeDataProviderFactory}
 import pl.touk.nussknacker.ui.UnauthorizedError
 import pl.touk.nussknacker.ui.process.processingtype.loader.LocalProcessingTypeDataLoader
-import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.security.api.RealLoggedUser
 
 class ProcessingTypeDataProviderSpec extends AnyFunSuite with WithTestDeploymentManagerClassLoader with Matchers {
 
   test("allow to access to processing type data only users that has read access to associated category") {
-    val provider = ProcessingTypeDataProvider(mockProcessingTypeData("foo", "bar"))
+    val provider = TestProcessingTypeDataProviderFactory.fromState(mockProcessingTypeData("foo", "bar"))
 
     val fooCategoryUser =
       RealLoggedUser("fooCategoryUser", "fooCategoryUser", Map("fooCategory" -> Set(Permission.Read)))

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeDataProviderTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeDataProviderTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.ui.process.processingtype.provider.{ProcessingTypeDataProvider, ProcessingTypeDataState}
 import pl.touk.nussknacker.ui.security.api.{AdminUser, LoggedUser}
 
+import scala.util.Success
+
 class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
 
   private implicit val user: LoggedUser = AdminUser("admin", "admin")
@@ -75,7 +77,7 @@ class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
   }
 
   private def createState(value: String, combined: Int, identity: Int) = {
-    ProcessingTypeDataState(Map("foo" -> ValueWithRestriction.anyUser(value)), () => combined, identity)
+    new ProcessingTypeDataState(Map("foo" -> ValueWithRestriction.anyUser(value)), Success(combined), identity)
   }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ScenarioParametersServiceTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ScenarioParametersServiceTest.scala
@@ -315,7 +315,7 @@ class ScenarioParametersServiceTest
                 dbRef = None,
               )
               .unsafeRunSync()
-          val parametersService = processingTypeData.getCombined().parametersService
+          val parametersService = processingTypeData.combinedDataTry.get.parametersService
 
           parametersService.scenarioParametersCombinationsWithWritePermission(
             TestFactory.adminUser()

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderAccessRestrictionTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderAccessRestrictionTest.scala
@@ -1,4 +1,4 @@
-package pl.touk.nussknacker.ui.process.processingtype
+package pl.touk.nussknacker.ui.process.processingtype.provider
 
 import cats.effect.unsafe.implicits.global
 import com.typesafe.config.ConfigFactory
@@ -12,9 +12,10 @@ import pl.touk.nussknacker.test.mock.WithTestDeploymentManagerClassLoader
 import pl.touk.nussknacker.test.utils.domain.{TestFactory, TestProcessingTypeDataProviderFactory}
 import pl.touk.nussknacker.ui.UnauthorizedError
 import pl.touk.nussknacker.ui.process.processingtype.loader.LocalProcessingTypeDataLoader
+import pl.touk.nussknacker.ui.process.processingtype.{ModelClassLoaderDependencies, ModelClassLoaderProvider}
 import pl.touk.nussknacker.ui.security.api.RealLoggedUser
 
-class ProcessingTypeDataProviderSpec extends AnyFunSuite with WithTestDeploymentManagerClassLoader with Matchers {
+class ProcessingTypeDataProviderAccessRestrictionTest extends AnyFunSuite with WithTestDeploymentManagerClassLoader with Matchers {
 
   test("allow to access to processing type data only users that has read access to associated category") {
     val provider = TestProcessingTypeDataProviderFactory.fromState(mockProcessingTypeData("foo", "bar"))

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderTest.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.ui.process.processingtype.provider
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
@@ -11,17 +12,11 @@ class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
 
   private implicit val user: LoggedUser = AdminUser("admin", "admin")
 
-  class MutableProcessingTypeDataProvider(@volatile var state: ProcessingTypeDataState[String, Int])
-      extends ProcessingTypeDataProvider[String, Int] {
+  class MutableProcessingTypeDataProvider(state: ProcessingTypeDataState[String, Int])
+      extends ProcessingTypeDataProvider[String, Int](state)
 
-    def setState(newState: ProcessingTypeDataState[String, Int]): Unit = {
-      state = newState
-    }
-
-  }
-
-  test("should cache computed values until source state identity is change") {
-    val provider     = new MutableProcessingTypeDataProvider(createState("initial", -1, 1))
+  test("should cache computed values until source state is change") {
+    val provider     = new MutableProcessingTypeDataProvider(createState("initial", -1))
     var invoked: Int = 0
 
     def identityWithCounting(s: String) = {
@@ -31,20 +26,17 @@ class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
 
     val transformed = provider.mapValues(identityWithCounting)
     transformed.all.head._2 shouldEqual "initial"
-    invoked shouldEqual 1
-
-    provider.setState(createState("newValue", -1, 1))
     transformed.all.head._2 shouldEqual "initial"
     invoked shouldEqual 1
 
-    provider.setState(createState("newValue", -1, 2))
+    provider.setStateValueAndNotifyObservers(createState("newValue", -1)).unsafeRunSync()
     transformed.all.head._2 shouldEqual "newValue"
     transformed.all.head._2 shouldEqual "newValue"
     invoked shouldEqual 2
   }
 
-  test("should cache computed combined value until source state identity is change") {
-    val provider     = new MutableProcessingTypeDataProvider(createState("", 123, 1))
+  test("should cache computed combined value until source state is change") {
+    val provider     = new MutableProcessingTypeDataProvider(createState("", 123))
     var invoked: Int = 0
 
     def identityWithCounting(s: Int) = {
@@ -54,30 +46,27 @@ class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
 
     val transformed = provider.mapCombined(identityWithCounting)
     transformed.combined shouldEqual 123
-    invoked shouldEqual 1
-
-    provider.setState(createState("", 234, 1))
     transformed.combined shouldEqual 123
     invoked shouldEqual 1
 
-    provider.setState(createState("", 234, 2))
+    provider.setStateValueAndNotifyObservers(createState("", 234)).unsafeRunSync()
     transformed.combined shouldEqual 234
     transformed.combined shouldEqual 234
     invoked shouldEqual 2
   }
 
   test("should invalidate more than one level of observers") {
-    val provider = new MutableProcessingTypeDataProvider(createState("initial", -1, 1))
+    val provider = new MutableProcessingTypeDataProvider(createState("initial", -1))
 
     val transformed = provider.mapValues(identity).mapValues(identity)
     transformed.all.head._2 shouldEqual "initial"
 
-    provider.setState(createState("newValue", -1, 2))
+    provider.setStateValueAndNotifyObservers(createState("newValue", -1)).unsafeRunSync()
     transformed.all.head._2 shouldEqual "newValue"
   }
 
-  private def createState(value: String, combined: Int, identity: Int) = {
-    new ProcessingTypeDataState(Map("foo" -> ValueWithRestriction.anyUser(value)), Success(combined), identity)
+  private def createState(value: String, combined: Int) = {
+    new ProcessingTypeDataState(Map("foo" -> ValueWithRestriction.anyUser(value)), Success(combined))
   }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderTest.scala
@@ -1,8 +1,8 @@
-package pl.touk.nussknacker.ui.process.processingtype
+package pl.touk.nussknacker.ui.process.processingtype.provider
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.ui.process.processingtype.provider.{ProcessingTypeDataProvider, ProcessingTypeDataState}
+import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
 import pl.touk.nussknacker.ui.security.api.{AdminUser, LoggedUser}
 
 import scala.util.Success

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderTest.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.ui.process.processingtype.provider
 
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -14,7 +15,13 @@ class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
   private implicit val user: LoggedUser = AdminUser("admin", "admin")
 
   class MutableProcessingTypeDataProvider(state: ProcessingTypeDataState[String, Int])
-      extends ProcessingTypeDataProvider[String, Int](state)
+      extends ProcessingTypeDataProvider[String, Int](state) {
+
+    def setValue(stateValue: State): IO[Unit] = accessStateInCriticalSection(
+      _.setValue(stateValue)
+    )
+
+  }
 
   test("should cache computed values until source state is change") {
     val provider     = new MutableProcessingTypeDataProvider(createState("initial", -1))
@@ -30,7 +37,7 @@ class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
     transformed.all.head._2 shouldEqual "initial"
     invoked shouldEqual 1
 
-    provider.setStateValueAndNotifyObservers(createState("newValue", -1)).unsafeRunSync()
+    provider.setValue(createState("newValue", -1)).unsafeRunSync()
     transformed.all.head._2 shouldEqual "newValue"
     transformed.all.head._2 shouldEqual "newValue"
     invoked shouldEqual 2
@@ -50,7 +57,7 @@ class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
     transformed.combined shouldEqual 123
     invoked shouldEqual 1
 
-    provider.setStateValueAndNotifyObservers(createState("", 234)).unsafeRunSync()
+    provider.setValue(createState("", 234)).unsafeRunSync()
     transformed.combined shouldEqual 234
     transformed.combined shouldEqual 234
     invoked shouldEqual 2
@@ -62,7 +69,7 @@ class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
     val transformed = provider.mapValues(identity).mapValues(identity)
     transformed.all.head._2 shouldEqual "initial"
 
-    provider.setStateValueAndNotifyObservers(createState("newValue", -1)).unsafeRunSync()
+    provider.setValue(createState("newValue", -1)).unsafeRunSync()
     transformed.all.head._2 shouldEqual "newValue"
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ProcessingTypeDataProviderTest.scala
@@ -4,6 +4,7 @@ import cats.effect.unsafe.implicits.global
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
+import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataState.UninitializedCombinedDataException
 import pl.touk.nussknacker.ui.security.api.{AdminUser, LoggedUser}
 
 import scala.util.Success
@@ -63,6 +64,17 @@ class ProcessingTypeDataProviderTest extends AnyFunSuite with Matchers {
 
     provider.setStateValueAndNotifyObservers(createState("newValue", -1)).unsafeRunSync()
     transformed.all.head._2 shouldEqual "newValue"
+  }
+
+  test("should close dependant observers") {
+    val provider = new MutableProcessingTypeDataProvider(createState("initial", -1))
+
+    val transformed = provider.mapValues(identity).mapValues(identity)
+
+    provider.close().unsafeRunSync()
+
+    an[UninitializedCombinedDataException.type] shouldBe thrownBy(provider.combined)
+    an[UninitializedCombinedDataException.type] shouldBe thrownBy(transformed.combined)
   }
 
   private def createState(value: String, combined: Int) = {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProviderTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProviderTest.scala
@@ -1,0 +1,89 @@
+package pl.touk.nussknacker.ui.process.processingtype.provider
+
+import cats.effect.IO
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.test.utils.domain.TestFactory
+import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
+import pl.touk.nussknacker.ui.security.api.LoggedUser
+import cats.effect.unsafe.implicits.global
+
+import scala.util.Success
+
+class ReloadableProcessingTypeDataProviderTest extends AnyFunSuiteLike with Matchers {
+
+  private implicit val user: LoggedUser = TestFactory.adminUser()
+
+  test("should reload values") {
+    val givenProcessingType      = "fooProcessingType"
+    val givenInitialValue        = "fooValue"
+    val givenInitialCombinedData = "fooCombined"
+
+    var valueHolder   = new AutoClosableWithValue(givenInitialValue)
+    var combinedValue = givenInitialCombinedData
+    val reloadableProvider = new ReloadableProcessingTypeDataProvider(IO {
+      new ProcessingTypeDataState(
+        Map(givenProcessingType -> ValueWithRestriction.anyUser(valueHolder)),
+        Success(combinedValue),
+        valueHolder
+      )
+    })
+    val reloadableValueProvider = reloadableProvider.mapValues(_.value)
+
+    // before first load
+    val allDataBeforeLoad = reloadableProvider.all
+    allDataBeforeLoad shouldBe empty
+    valueHolder.closeWasInvoked shouldBe false
+    an[Exception] shouldBe thrownBy {
+      reloadableProvider.combined
+    }
+
+    // first load
+    reloadableProvider.reloadAll().unsafeRunSync()
+    reloadableValueProvider.all shouldBe Map(givenProcessingType -> givenInitialValue)
+    reloadableProvider.combined shouldBe combinedValue
+    valueHolder.closeWasInvoked shouldBe false
+
+    // first reload = second load
+    val savedValueHolder = valueHolder
+    valueHolder = new AutoClosableWithValue("newValue")
+    combinedValue = "newCombinedValue"
+    reloadableProvider.reloadAll().unsafeRunSync()
+    reloadableValueProvider.all shouldBe Map(givenProcessingType -> "newValue")
+    reloadableProvider.combined shouldBe "newCombinedValue"
+    savedValueHolder.closeWasInvoked shouldBe true
+    valueHolder.closeWasInvoked shouldBe false
+  }
+
+  test("should fail reload if error during combined data mapping ocurred") {
+    val givenProcessingType      = "fooProcessingType"
+    val givenInitialValue        = "fooValue"
+    val givenInitialCombinedData = "fooCombined"
+
+    var valueHolder   = new AutoClosableWithValue(givenInitialValue)
+    var combinedValue = givenInitialCombinedData
+    val reloadableProvider = new ReloadableProcessingTypeDataProvider(IO {
+      new ProcessingTypeDataState(
+        Map(givenProcessingType -> ValueWithRestriction.anyUser(valueHolder)),
+        Success(combinedValue),
+        valueHolder
+      )
+    })
+    val reloadableValueProvider = reloadableProvider.mapValues { _ =>
+      throw new Exception("some error happen")
+    }
+
+    // first load
+    // FIXME
+    reloadableProvider.reloadAll().unsafeRunSync()
+    reloadableValueProvider.all
+  }
+
+  class AutoClosableWithValue(val value: String) extends AutoCloseable {
+    @volatile
+    var closeWasInvoked = false
+
+    override def close(): Unit = closeWasInvoked = true
+  }
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProviderTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProviderTest.scala
@@ -21,7 +21,7 @@ class ReloadableProcessingTypeDataProviderTest extends AnyFunSuiteLike with Matc
 
     var valueHolder   = new AutoClosableWithValue(givenInitialValue)
     var combinedValue = givenInitialCombinedData
-    val reloadableProvider = new ReloadableProcessingTypeDataProvider(IO {
+    val reloadableProvider = ReloadableProcessingTypeDataProvider(IO {
       new ProcessingTypeDataState(
         Map(givenProcessingType -> ValueWithRestriction.anyUser(valueHolder)),
         Success(combinedValue),
@@ -61,7 +61,7 @@ class ReloadableProcessingTypeDataProviderTest extends AnyFunSuiteLike with Matc
 
     val valueHolder   = new AutoClosableWithValue(givenInitialValue)
     val combinedValue = givenInitialCombinedData
-    val reloadableProvider = new ReloadableProcessingTypeDataProvider(IO {
+    val reloadableProvider = ReloadableProcessingTypeDataProvider(IO {
       new ProcessingTypeDataState(
         Map(givenProcessingType -> ValueWithRestriction.anyUser(valueHolder)),
         Success(combinedValue),

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProviderTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/provider/ReloadableProcessingTypeDataProviderTest.scala
@@ -1,12 +1,12 @@
 package pl.touk.nussknacker.ui.process.processingtype.provider
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.test.utils.domain.TestFactory
 import pl.touk.nussknacker.ui.process.processingtype.ValueWithRestriction
 import pl.touk.nussknacker.ui.security.api.LoggedUser
-import cats.effect.unsafe.implicits.global
 
 import scala.util.Success
 
@@ -82,7 +82,7 @@ class ReloadableProcessingTypeDataProviderTest extends AnyFunSuiteLike with Matc
     allDataAfterFailedLoad shouldBe empty
   }
 
-  class AutoClosableWithValue(val value: String) extends AutoCloseable {
+  private class AutoClosableWithValue(val value: String) extends AutoCloseable {
     @volatile
     var closeWasInvoked = false
 


### PR DESCRIPTION
## Describe your changes

The PR contains two changes:

1. After switching implementation of `ProcessingTypeDataProvider.reloadAll()` to `IO`-based,  the approach with `synchronized` stopped working - access to `stateValue` is not synchronized. The purpose of this change is to repair this situation.

2. Also, in the near future, we want to do significant changes around `ProcessingTypeDataProvider` - we want to reload only model, without deployment manager's. To do that it is necessary to reduce the complexity of this solution. As a step towards that, I changed `ProcessingTypeDataState.getCombined` from a function to `Try`, and replaced `ProcessingTypeDataState.stateIdentityValue` by other, eager, observer-based approach of reloading the data.  

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
