### PR TITLE
Use scenario slug in URLs

### DIFF
--- a/docs/integration/RequestResponse.mdx
+++ b/docs/integration/RequestResponse.mdx
@@ -15,18 +15,22 @@ When you use default [source and sink](../scenarios_authoring/RRDataSourcesAndSi
 In case of `service` you can trigger your scenario with example curl command:
 
 ```bash
-curl -X POST -d "payload_based_on_input_schema" 'http://<scenario_name>'
+curl -X POST -d "payload_based_on_input_schema" 'http://<scenario_slug>'
 ```
 
 For `ingress` configuration it looks quite similar:
 
 ```bash
-curl -X POST -d "payload_based_on_input_schema" 'http://<ingress_domain><scenario_name>'
+curl -X POST -d "payload_based_on_input_schema" 'http://<ingress_domain>/<scenario_slug>'
 ```
+
+## Swagger UI
+
+For each saved scenario Swagger UI will be available at `http://<ingress_domain>/<scenario_slug>/swagger-ui` (ingress case).
 
 ## OpenAPI interface definition
 
-For each deployed `Request-Response` scenario an OpenAPI interface definition will be available at `http://<scenario_name>/definition`
+For each deployed `Request-Response` scenario an OpenAPI interface definition will be available at `http://<ingress_domain>/<scenario_slug>/definition` (ingress case).
 
 You can see example definition below:
 

--- a/docs/integration/RequestResponse.mdx
+++ b/docs/integration/RequestResponse.mdx
@@ -26,11 +26,11 @@ curl -X POST -d "payload_based_on_input_schema" 'http://<ingress_domain>/<scenar
 
 ## Swagger UI
 
-For each saved scenario Swagger UI will be available at `http://<ingress_domain>/<scenario_slug>/swagger-ui` (ingress case).
+For each saved scenario Swagger UI will be available at `http://<ingress_domain>/<scenario_slug>/swagger-ui` (ingress case). In the service case, Swagger UI will be availabe at `http://<scenario_slug>/swagger-ui`.
 
 ## OpenAPI interface definition
 
-For each deployed `Request-Response` scenario an OpenAPI interface definition will be available at `http://<ingress_domain>/<scenario_slug>/definition` (ingress case).
+For each deployed `Request-Response` scenario an OpenAPI interface definition will be available at `http://<ingress_domain>/<scenario_slug>/definition` (ingress case). In the service case it will be availabe at `http://<scenario_slug>/definition`.
 
 You can see example definition below:
 


### PR DESCRIPTION
changed "scenario name" to "scenario slug" in URLs