### PR TITLE
[NU-2048] (K8s DM) Fix for: k8s object name sanitizing strategy

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -109,6 +109,8 @@
     * Nussknacker provides some limited set of services that can be invoked from inside the `CustomHttpServiceProvider` implementation
     * the service is created and started alongside Nu Designer, endpoints are exposed on path `/api/custom/*`
 * [#7578](https://github.com/TouK/nussknacker/pull/7578) Component labels are now independent of component Id. Labels can be set during the component defining or can be set in ui configuration in application config 
+* [#7616](https://github.com/TouK/nussknacker/pull/7616) (K8s DM) Fix for: k8s object name sanitizing strategy sometimes generated invalid object names, in other cases, 
+  it generated names with unnecessary characters appended
 
 ## 1.18
 

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
@@ -13,7 +13,7 @@ import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.ExternalDeploymentId
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.k8s.manager.K8sDeploymentManager._
-import pl.touk.nussknacker.k8s.manager.K8sUtils.{sanitizeLabel, sanitizeObjectName, shortHash}
+import pl.touk.nussknacker.k8s.manager.K8sUtils.{sanitizeLabel, shortHash}
 import pl.touk.nussknacker.k8s.manager.deployment._
 import pl.touk.nussknacker.k8s.manager.deployment.K8sScalingConfig.DividingParallelismConfig
 import pl.touk.nussknacker.k8s.manager.ingress.IngressPreparer
@@ -332,7 +332,7 @@ class K8sDeploymentManager(
   private def configMapForData(
       processVersion: ProcessVersion,
       canonicalProcess: CanonicalProcess,
-      nussknackerInstanceName: Option[String]
+      nussknackerInstanceName: OptionalNussknackerInstanceName
   )(
       data: Map[String, String],
       additionalLabels: Map[String, String] = Map.empty,
@@ -361,7 +361,7 @@ class K8sDeploymentManager(
   private def secretForData(
       processVersion: ProcessVersion,
       canonicalProcess: CanonicalProcess,
-      nussknackerInstanceName: Option[String]
+      nussknackerInstanceName: OptionalNussknackerInstanceName
   )(data: Map[String, String], additionalLabels: Map[String, String] = Map.empty): Secret = {
     val scenario = canonicalProcess.asJson.spaces2
     val objectName =
@@ -441,11 +441,14 @@ object K8sDeploymentManager {
   /*
     Labels contain scenario name, scenario id and version.
    */
-  private[manager] def labelsForScenario(processVersion: ProcessVersion, nussknackerInstanceName: Option[String]) = Map(
+  private[manager] def labelsForScenario(
+      processVersion: ProcessVersion,
+      nussknackerInstanceName: OptionalNussknackerInstanceName
+  ) = Map(
     scenarioNameLabel    -> scenarioNameLabelValue(processVersion.processName),
     scenarioIdLabel      -> processVersion.processId.value.toString,
     scenarioVersionLabel -> processVersion.versionId.value.toString
-  ) ++ nussknackerInstanceName.map(nussknackerInstanceNameLabel -> _)
+  ) ++ nussknackerInstanceName.valueOpt.map(nussknackerInstanceNameLabel -> _)
 
   private[manager] def versionAnnotationForScenario(processVersion: ProcessVersion) =
     Map(scenarioVersionAnnotation -> processVersion.asJson.spaces2)
@@ -458,32 +461,17 @@ object K8sDeploymentManager {
    */
   private[manager] def objectNameForScenario(
       processVersion: ProcessVersion,
-      nussknackerInstanceName: Option[String],
+      nussknackerInstanceName: OptionalNussknackerInstanceName,
       hashInput: Option[String]
   ): String = {
     // we simulate (more or less) --append-hash kubectl behaviour...
     val hashToAppend      = hashInput.map(input => "-" + shortHash(input)).getOrElse("")
     val plainScenarioName = s"scenario-${processVersion.processId.value}-${processVersion.processName}"
-    val scenarioName      = objectNamePrefixedWithNussknackerInstanceName(nussknackerInstanceName, plainScenarioName)
-    sanitizeObjectName(scenarioName, hashToAppend)
-  }
-
-  private[manager] def objectNamePrefixedWithNussknackerInstanceName(
-      nussknackerInstanceName: Option[String],
-      objectName: String
-  ) =
-    sanitizeObjectName(
-      objectNamePrefixedWithNussknackerInstanceNameWithoutSanitization(nussknackerInstanceName, objectName)
+    K8sUtils.sanitizeObjectName(
+      nussknackerInstanceName.objectNameWithoutSanitization(plainScenarioName),
+      hashToAppend
     )
-
-  private[manager] def objectNamePrefixedWithNussknackerInstanceNameWithoutSanitization(
-      nussknackerInstanceName: Option[String],
-      objectName: String
-  ) =
-    nussknackerInstanceNamePrefix(nussknackerInstanceName) + objectName
-
-  private[manager] def nussknackerInstanceNamePrefix(nussknackerInstanceName: Option[String]) =
-    nussknackerInstanceName.map(_ + "-").getOrElse("")
+  }
 
   private[manager] def parseVersionAnnotation(deployment: ObjectResource): Option[ProcessVersion] = {
     deployment.metadata.annotations

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerConfig.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerConfig.scala
@@ -1,8 +1,7 @@
 package pl.touk.nussknacker.k8s.manager
 
 import com.typesafe.config.{Config, ConfigFactory}
-import net.ceedubs.ficus.Ficus._
-import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+import net.ceedubs.ficus.readers.ValueReader
 import pl.touk.nussknacker.engine.util.config.ConfigEnrichments.RichConfig
 import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
 import pl.touk.nussknacker.engine.version.BuildInfo
@@ -11,10 +10,18 @@ import pl.touk.nussknacker.k8s.manager.ingress.IngressConfig
 
 import scala.concurrent.duration._
 
-import K8sScalingConfig.valueReader
-
 object K8sDeploymentManagerConfig {
+
+  import net.ceedubs.ficus.Ficus._
+  import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+
+  private implicit val scalingConfigValueReader: ValueReader[K8sScalingConfig] = K8sScalingConfig.valueReader
+
+  private implicit val optionalNussknackerInstanceNameValueReader: ValueReader[OptionalNussknackerInstanceName] =
+    OptionalNussknackerInstanceName.valueReader
+
   def parse(config: Config): K8sDeploymentManagerConfig = config.rootAs[K8sDeploymentManagerConfig]
+
 }
 
 case class K8sDeploymentManagerConfig(
@@ -23,7 +30,7 @@ case class K8sDeploymentManagerConfig(
     scalingConfig: Option[K8sScalingConfig] = None,
     configExecutionOverrides: Config = ConfigFactory.empty(),
     k8sDeploymentConfig: Config = ConfigFactory.empty(),
-    nussknackerInstanceName: Option[String] = None,
+    nussknackerInstanceName: OptionalNussknackerInstanceName = OptionalNussknackerInstanceName.empty,
     logbackConfigPath: Option[String] = None,
     commonConfigMapForLogback: Option[String] = None,
     ingress: Option[IngressConfig] = None,

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sUtils.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sUtils.scala
@@ -38,26 +38,68 @@ object K8sUtils {
 
   // Object names cannot have underscores in name...
   def sanitizeObjectName(original: String, append: String = ""): String = {
-    sanitizeName(original, canHaveUnderscore = false, append = append)
+    sanitizeName(
+      original,
+      canHaveUnderscore = false,
+      firstCharacterShouldBeAlphaNumer = true,
+      lastCharacterShouldBeAlphaNumer = append.isEmpty,
+      maxObjectNameLength - append.length
+    ) + append
+  }
+
+  def sanitizeObjectName(
+      name: String,
+      firstCharacterShouldBeAlphaNumer: Boolean,
+      lastCharacterShouldBeAlphaNumer: Boolean,
+      maxLength: Int
+  ): String = {
+    sanitizeName(
+      name,
+      canHaveUnderscore = false,
+      firstCharacterShouldBeAlphaNumer = firstCharacterShouldBeAlphaNumer,
+      lastCharacterShouldBeAlphaNumer = lastCharacterShouldBeAlphaNumer,
+      maxLength
+    )
   }
 
   // Value label: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
   def sanitizeLabel(original: String, append: String = ""): String = {
-    sanitizeName(original, canHaveUnderscore = true, append = append)
+    sanitizeName(
+      original,
+      canHaveUnderscore = true,
+      firstCharacterShouldBeAlphaNumer = true,
+      lastCharacterShouldBeAlphaNumer = append.isEmpty,
+      maxObjectNameLength - append.length
+    ) + append
   }
 
-  // TODO: generate better correct name for 'strange' scenario names?
-  private[manager] def sanitizeName(base: String, canHaveUnderscore: Boolean, append: String = ""): String = {
-    val underscores = if (canHaveUnderscore) "_" else ""
-    base.toLowerCase
-      .replaceAll(s"[^a-zA-Z0-9${underscores}\\-.]+", "-")
-      // need to have alphanumeric at beginning and end...
-      .replaceAll("^([^a-zA-Z0-9])", "x$1")
-      .replaceAll("([^a-zA-Z0-9])$", "$1x")
-      .take(maxObjectNameLength - append.length) + append
+  private def sanitizeName(
+      name: String,
+      canHaveUnderscore: Boolean,
+      firstCharacterShouldBeAlphaNumer: Boolean,
+      lastCharacterShouldBeAlphaNumer: Boolean,
+      maxLength: Int
+  ): String = {
+    val withCorrectCharsInTheMiddle = name.toLowerCase.replaceAll(s"[^a-zA-Z0-9_\\-.]+", "-")
+    val withCorrectFirstChar =
+      if (firstCharacterShouldBeAlphaNumer)
+        withCorrectCharsInTheMiddle.replaceAll("^([^a-zA-Z0-9])", "x$1")
+      else
+        withCorrectCharsInTheMiddle
+    val truncated = withCorrectFirstChar.take(maxLength)
+    if (lastCharacterShouldBeAlphaNumer) {
+      val canAddAnotherCharacter = truncated.length < maxLength
+      if (canAddAnotherCharacter) {
+        truncated.replaceAll("([^a-zA-Z0-9])$", "$1x")
+      } else {
+        truncated.replaceAll("([^a-zA-Z0-9])$", "x")
+      }
+    } else {
+      truncated
+    }
   }
 
   // https://github.com/kubernetes/kubectl/blob/master/pkg/util/hash/hash.go#L105 - we don't care about bad words...
-  private[manager] def shortHash(data: String): String = DigestUtils.sha256Hex(data).take(10)
+  def shortHash(data: String): String = DigestUtils.sha256Hex(data).take(10)
 
 }

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/OptionalNussknackerInstanceName.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/OptionalNussknackerInstanceName.scala
@@ -1,0 +1,24 @@
+package pl.touk.nussknacker.k8s.manager
+
+import net.ceedubs.ficus.Ficus
+import net.ceedubs.ficus.Ficus._
+import net.ceedubs.ficus.readers.ValueReader
+
+class OptionalNussknackerInstanceName private (val valueOpt: Option[String]) {
+  def isEmpty: Boolean = valueOpt.isEmpty
+
+  def objectNameWithoutSanitization(mainObjectNamePart: String): String =
+    instanceNamePrefix + mainObjectNamePart
+
+  def instanceNamePrefix: String = valueOpt.map(_ + "-").getOrElse("")
+}
+
+object OptionalNussknackerInstanceName {
+  val empty: OptionalNussknackerInstanceName = new OptionalNussknackerInstanceName(None)
+
+  // This method is for unit tests purpose only, for production usage, this name is parsed from configuration
+  def forInstanceName(value: String): OptionalNussknackerInstanceName = new OptionalNussknackerInstanceName(Some(value))
+
+  implicit val valueReader: ValueReader[OptionalNussknackerInstanceName] =
+    Ficus.optionValueReader[String].map(new OptionalNussknackerInstanceName(_))
+}

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/RequestResponseScenarioValidator.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/RequestResponseScenarioValidator.scala
@@ -11,7 +11,8 @@ import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.k8s.manager.service.ServicePreparer
 
-class RequestResponseScenarioValidator(nussknackerInstanceName: Option[String]) extends CustomProcessValidator {
+class RequestResponseScenarioValidator(nussknackerInstanceName: OptionalNussknackerInstanceName)
+    extends CustomProcessValidator {
 
   def validate(scenario: CanonicalProcess): ValidatedNel[ProcessCompilationError, Unit] = {
     scenario.metaData.typeSpecificData match {
@@ -33,7 +34,7 @@ class RequestResponseScenarioValidator(nussknackerInstanceName: Option[String]) 
     // We don't sanitize / validate against url because k8s object names are more restrictively validated than urls, see https://datatracker.ietf.org/doc/html/rfc3986
     val withoutSanitization = ServicePreparer.serviceNameWithoutSanitization(nussknackerInstanceName, slug)
     val withSanitization    = ServicePreparer.serviceName(nussknackerInstanceName, slug)
-    val prefix              = K8sDeploymentManager.nussknackerInstanceNamePrefix(nussknackerInstanceName)
+    val prefix              = nussknackerInstanceName.instanceNamePrefix
     Validated.cond(
       withSanitization == withoutSanitization,
       (),
@@ -41,7 +42,7 @@ class RequestResponseScenarioValidator(nussknackerInstanceName: Option[String]) 
         SpecificDataValidationError(
           ParameterName(RequestResponseMetaData.slugName),
           "Allowed characters include lowercase letters, digits, hyphen, " +
-            s"name must start and end alphanumeric character, total length ${if (prefix.isEmpty) s"(including prefix '$prefix') "
+            s"name must start and end alphanumeric character, total length ${if (nussknackerInstanceName.isEmpty) s"(including prefix '$prefix') "
               else ""}cannot be more than ${K8sUtils.maxObjectNameLength}"
         )
       )

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/RequestResponseSlugUtils.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/RequestResponseSlugUtils.scala
@@ -2,24 +2,32 @@ package pl.touk.nussknacker.k8s.manager
 
 import pl.touk.nussknacker.engine.api.RequestResponseMetaData
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.k8s.manager.service.ServicePreparer.serviceName
 
 object RequestResponseSlugUtils {
 
   private[manager] def determineSlug(
       scenarioName: ProcessName,
       rrMetaData: RequestResponseMetaData,
-      nussknackerInstanceName: Option[String]
+      nussknackerInstanceName: OptionalNussknackerInstanceName
   ) = {
     rrMetaData.slug.filterNot(_.isEmpty).getOrElse(defaultSlug(scenarioName, nussknackerInstanceName))
   }
 
   // We don't encode url because k8s object names are more restrictively validated than urls, see https://datatracker.ietf.org/doc/html/rfc3986
   // and all invalid characters will be clean
-  private[manager] def defaultSlug(scenarioName: ProcessName, nussknackerInstanceName: Option[String]): String = {
+  private[manager] def defaultSlug(
+      scenarioName: ProcessName,
+      nussknackerInstanceName: OptionalNussknackerInstanceName
+  ): String = {
     val maxSlugLength =
-      K8sUtils.maxObjectNameLength - K8sDeploymentManager.nussknackerInstanceNamePrefix(nussknackerInstanceName).length
-    serviceName(None, scenarioName.value).take(maxSlugLength)
+      K8sUtils.maxObjectNameLength - nussknackerInstanceName.instanceNamePrefix.length
+    K8sUtils
+      .sanitizeObjectName(
+        scenarioName.value,
+        firstCharacterShouldBeAlphaNumer = false, // because we will add instance name in final service name
+        lastCharacterShouldBeAlphaNumer = true,
+        maxSlugLength
+      )
   }
 
 }

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparer.scala
@@ -6,6 +6,7 @@ import monocle.Iso
 import monocle.macros.GenLens
 import monocle.std.option._
 import pl.touk.nussknacker.engine.api.{LiteStreamMetaData, ProcessVersion, RequestResponseMetaData, TypeSpecificData}
+import pl.touk.nussknacker.k8s.manager.{K8sDeploymentManagerConfig, OptionalNussknackerInstanceName}
 import pl.touk.nussknacker.k8s.manager.K8sDeploymentManager.{
   labelsForScenario,
   objectNameForScenario,
@@ -13,7 +14,6 @@ import pl.touk.nussknacker.k8s.manager.K8sDeploymentManager.{
   scenarioVersionAnnotation,
   versionAnnotationForScenario
 }
-import pl.touk.nussknacker.k8s.manager.K8sDeploymentManagerConfig
 import skuber.{Container, EnvVar, HTTPGetAction, LabelSelector, Pod, Probe, Volume}
 import skuber.EnvVar.FieldRef
 import skuber.LabelSelector.IsEqualRequirement
@@ -58,7 +58,7 @@ class DeploymentPreparer(config: K8sDeploymentManagerConfig) extends LazyLogging
       typeSpecificData: TypeSpecificData,
       resourcesToMount: MountableResources,
       determinedReplicasCount: Int,
-      nussknackerInstanceName: Option[String]
+      nussknackerInstanceName: OptionalNussknackerInstanceName
   ) = {
     val objectName  = objectNameForScenario(processVersion, config.nussknackerInstanceName, None)
     val annotations = versionAnnotationForScenario(processVersion)

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/ingress/IngressPreparer.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/ingress/IngressPreparer.scala
@@ -4,7 +4,7 @@ import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
 import monocle.macros.GenLens
 import monocle.std.option.some
 import pl.touk.nussknacker.engine.api.{LiteStreamMetaData, ProcessVersion, RequestResponseMetaData, TypeSpecificData}
-import pl.touk.nussknacker.k8s.manager.{K8sDeploymentManager, RequestResponseSlugUtils}
+import pl.touk.nussknacker.k8s.manager.{K8sDeploymentManager, OptionalNussknackerInstanceName, RequestResponseSlugUtils}
 import pl.touk.nussknacker.k8s.manager.K8sDeploymentManager.labelsForScenario
 import pl.touk.nussknacker.k8s.manager.ingress.IngressPreparer.rewriteAnnotation
 import play.api.libs.json.Json
@@ -17,7 +17,7 @@ case class IngressConfig(
     config: Config = ConfigFactory.empty()
 )
 
-class IngressPreparer(config: IngressConfig, nuInstanceName: Option[String]) {
+class IngressPreparer(config: IngressConfig, nuInstanceName: OptionalNussknackerInstanceName) {
 
   def prepare(
       processVersion: ProcessVersion,

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/service/ServicePreparer.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/service/ServicePreparer.scala
@@ -1,11 +1,11 @@
 package pl.touk.nussknacker.k8s.manager.service
 
 import pl.touk.nussknacker.engine.api.{LiteStreamMetaData, MetaData, ProcessVersion, RequestResponseMetaData}
+import pl.touk.nussknacker.k8s.manager.{K8sDeploymentManagerConfig, K8sUtils, OptionalNussknackerInstanceName}
 import pl.touk.nussknacker.k8s.manager.K8sDeploymentManager._
-import pl.touk.nussknacker.k8s.manager.K8sDeploymentManagerConfig
 import pl.touk.nussknacker.k8s.manager.K8sUtils.sanitizeObjectName
 import pl.touk.nussknacker.k8s.manager.RequestResponseSlugUtils.determineSlug
-import pl.touk.nussknacker.k8s.manager.service.ServicePreparer.{runtimePodTargetPort, serviceName}
+import pl.touk.nussknacker.k8s.manager.service.ServicePreparer.runtimePodTargetPort
 import skuber.{ObjectMeta, Service}
 import skuber.Service.Port
 
@@ -26,7 +26,7 @@ class ServicePreparer(config: K8sDeploymentManagerConfig) {
       processVersion: ProcessVersion,
       rrMetaData: RequestResponseMetaData
   ): Service = {
-    val objectName = serviceName(
+    val objectName = ServicePreparer.serviceName(
       config.nussknackerInstanceName,
       determineSlug(processVersion.processName, rrMetaData, config.nussknackerInstanceName)
     )
@@ -35,7 +35,7 @@ class ServicePreparer(config: K8sDeploymentManagerConfig) {
     val selectors = Map(
       // here we use id to avoid sanitization problems
       scenarioIdLabel -> processVersion.processId.value.toString
-    ) ++ config.nussknackerInstanceName.map(nussknackerInstanceNameLabel -> _)
+    ) ++ config.nussknackerInstanceName.valueOpt.map(nussknackerInstanceNameLabel -> _)
 
     Service(
       metadata = ObjectMeta(name = objectName, labels = labels, annotations = annotations),
@@ -54,10 +54,13 @@ object ServicePreparer {
   // see http.port in runtimes image's application.conf
   val runtimePodTargetPort = 8080
 
-  private[manager] def serviceName(nussknackerInstanceName: Option[String], slug: String): String =
-    sanitizeObjectName(serviceNameWithoutSanitization(nussknackerInstanceName, slug))
+  private[manager] def serviceName(nussknackerInstanceName: OptionalNussknackerInstanceName, slug: String): String =
+    K8sUtils.sanitizeObjectName(serviceNameWithoutSanitization(nussknackerInstanceName, slug))
 
-  private[manager] def serviceNameWithoutSanitization(nussknackerInstanceName: Option[String], slug: String): String =
-    objectNamePrefixedWithNussknackerInstanceNameWithoutSanitization(nussknackerInstanceName, slug)
+  private[manager] def serviceNameWithoutSanitization(
+      nussknackerInstanceName: OptionalNussknackerInstanceName,
+      slug: String
+  ): String =
+    nussknackerInstanceName.objectNameWithoutSanitization(slug)
 
 }

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerUnitTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerUnitTest.scala
@@ -41,7 +41,7 @@ class K8sDeploymentManagerUnitTest extends AnyFunSuite with Matchers {
       (nameOfLength(80), s"${nameOfLength(52)}-0f45e858fb"),
     )
     forAll(names) { (scenarioName: String, nameLabel: String) =>
-      val generated = labelsForScenario(versionForName(scenarioName), None)
+      val generated = labelsForScenario(versionForName(scenarioName), OptionalNussknackerInstanceName.empty)
       generated.values.foreach { value =>
         value.length should be <= K8sUtils.maxObjectNameLength
       }
@@ -52,7 +52,10 @@ class K8sDeploymentManagerUnitTest extends AnyFunSuite with Matchers {
 
   test("should generate labels with instance name when instance name is provided") {
     val nussknackerInstanceName = "foo-release"
-    val generated               = labelsForScenario(versionForName("standard"), Some(nussknackerInstanceName))
+    val generated = labelsForScenario(
+      versionForName("standard"),
+      OptionalNussknackerInstanceName.forInstanceName(nussknackerInstanceName)
+    )
 
     generated shouldBe commonLabels +
       (scenarioNameLabel            -> "standard-fe6d3468cf") +
@@ -74,7 +77,8 @@ class K8sDeploymentManagerUnitTest extends AnyFunSuite with Matchers {
     )
 
     forAll(names) { (scenarioName: String, hashInput: Option[String], expectedId: String) =>
-      val generated = objectNameForScenario(versionForName(scenarioName), None, hashInput)
+      val generated =
+        objectNameForScenario(versionForName(scenarioName), OptionalNussknackerInstanceName.empty, hashInput)
       generated.length should be <= K8sUtils.maxObjectNameLength
       generated shouldBe expectedId
     }
@@ -84,12 +88,17 @@ class K8sDeploymentManagerUnitTest extends AnyFunSuite with Matchers {
 
     val names = Table(
       ("scenario name", "hashInput", "object id", "nussknacker instance name"),
-      ("standard", None, "x-scenario-256-standard", Some("")),
-      ("standard", None, "nu1-scenario-256-standard", Some("nu1"))
+      ("standard", None, "x-scenario-256-standard", OptionalNussknackerInstanceName.forInstanceName("")),
+      ("standard", None, "nu1-scenario-256-standard", OptionalNussknackerInstanceName.forInstanceName("nu1"))
     )
 
     forAll(names) {
-      (scenarioName: String, hashInput: Option[String], expectedId: String, nussknackerInstanceName: Option[String]) =>
+      (
+          scenarioName: String,
+          hashInput: Option[String],
+          expectedId: String,
+          nussknackerInstanceName: OptionalNussknackerInstanceName
+      ) =>
         val generated = objectNameForScenario(versionForName(scenarioName), nussknackerInstanceName, hashInput)
         generated.length should be <= K8sUtils.maxObjectNameLength
         generated shouldBe expectedId

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sUtilsTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sUtilsTest.scala
@@ -1,0 +1,34 @@
+package pl.touk.nussknacker.k8s.manager
+
+import org.scalatest.Inspectors.forAll
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.Tables.Table
+
+class K8sUtilsTest extends AnyFunSuiteLike with Matchers {
+
+  test("should sanitize illegal characters in the middle") {
+    K8sUtils.sanitizeObjectName("foo$!?a") shouldBe "foo-a"
+  }
+
+  test("should sanitize illegal characters at the beginning and at the end") {
+    K8sUtils.sanitizeObjectName("foo-") shouldBe "foo-x"
+    K8sUtils.sanitizeObjectName("foo???") shouldBe "foo-x"
+    K8sUtils.sanitizeObjectName("-foo") shouldBe "x-foo"
+    K8sUtils.sanitizeObjectName("???foo") shouldBe "x-foo"
+  }
+
+  test("should truncate name") {
+    forAll(Table("input", 0.to(100).map(_ => "a").mkString, 0.to(100).map(_ => "-").mkString)) { input =>
+      val afterTruncation = K8sUtils.sanitizeObjectName(input)
+      afterTruncation should have length K8sUtils.maxObjectNameLength
+      afterTruncation.head.isLetterOrDigit shouldBe true
+      afterTruncation.last.isLetterOrDigit shouldBe true
+    }
+  }
+
+  test("shouldn't sanitize last character if some text is appended") {
+    K8sUtils.sanitizeObjectName("foo-", "append") shouldBe "foo-append"
+  }
+
+}

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/RequestResponseScenarioValidatorTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/RequestResponseScenarioValidatorTest.scala
@@ -12,7 +12,7 @@ class RequestResponseScenarioValidatorTest extends AnyFunSuite with Matchers {
   private val notImportantScenarioName = ProcessName("fooScenario")
   private val validSlug                = "asdf"
   private val invalidK8sServiceName    = (1 to (K8sUtils.maxObjectNameLength + 10)).map(_ => "a").mkString
-  private val noInstanceNameValidator  = new RequestResponseScenarioValidator(None)
+  private val noInstanceNameValidator  = new RequestResponseScenarioValidator(OptionalNussknackerInstanceName.empty)
 
   test("validate against service name for not defined instance name") {
     val scenarioWithLongName = ScenarioBuilder
@@ -31,8 +31,9 @@ class RequestResponseScenarioValidatorTest extends AnyFunSuite with Matchers {
   }
 
   test("validate against service name for defined instance name") {
-    val nussknackerInstanceName   = (1 to (K8sUtils.maxObjectNameLength - 3)).map(_ => "a").mkString
-    val longInstanceNameValidator = new RequestResponseScenarioValidator(Some(nussknackerInstanceName))
+    val nussknackerInstanceName = (1 to (K8sUtils.maxObjectNameLength - 3)).map(_ => "a").mkString
+    val longInstanceNameValidator =
+      new RequestResponseScenarioValidator(OptionalNussknackerInstanceName.forInstanceName(nussknackerInstanceName))
     longInstanceNameValidator.validateRequestResponse(
       notImportantScenarioName,
       RequestResponseMetaData(Some("a"))

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/RequestResponseSlugUtilsTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/RequestResponseSlugUtilsTest.scala
@@ -11,12 +11,12 @@ class RequestResponseSlugUtilsTest extends AnyFunSuite with Matchers {
   private val invalidK8sServiceName = (1 to (K8sUtils.maxObjectNameLength + 10)).map(_ => "a").mkString
 
   test("determine default slug using scenario name") {
-    RequestResponseSlugUtils.defaultSlug(ProcessName("foo"), None) shouldEqual "foo"
+    RequestResponseSlugUtils.defaultSlug(ProcessName("foo"), OptionalNussknackerInstanceName.empty) shouldEqual "foo"
   }
 
   test("sanitize scenario name for purpose of default slug preparation") {
     val longScenarioNameWithoutNuInstanceIdDefaultSlug =
-      RequestResponseSlugUtils.defaultSlug(ProcessName(invalidK8sServiceName), None)
+      RequestResponseSlugUtils.defaultSlug(ProcessName(invalidK8sServiceName), OptionalNussknackerInstanceName.empty)
     longScenarioNameWithoutNuInstanceIdDefaultSlug should contain only 'a'
     longScenarioNameWithoutNuInstanceIdDefaultSlug should have length K8sUtils.maxObjectNameLength
   }
@@ -26,25 +26,61 @@ class RequestResponseSlugUtilsTest extends AnyFunSuite with Matchers {
   ) {
     val nuInstanceId = (1 to 10).map(_ => "b").mkString
     val longScenarioNameWithNuInstanceIdDefaultSlug =
-      RequestResponseSlugUtils.defaultSlug(ProcessName(invalidK8sServiceName), Some(nuInstanceId))
+      RequestResponseSlugUtils.defaultSlug(
+        ProcessName(invalidK8sServiceName),
+        OptionalNussknackerInstanceName.forInstanceName(nuInstanceId)
+      )
     ServicePreparer.serviceNameWithoutSanitization(
-      Some(nuInstanceId),
+      OptionalNussknackerInstanceName.forInstanceName(nuInstanceId),
       longScenarioNameWithNuInstanceIdDefaultSlug
     ) shouldEqual
-      ServicePreparer.serviceName(Some(nuInstanceId), longScenarioNameWithNuInstanceIdDefaultSlug)
+      ServicePreparer.serviceName(
+        OptionalNussknackerInstanceName.forInstanceName(nuInstanceId),
+        longScenarioNameWithNuInstanceIdDefaultSlug
+      )
   }
 
   test("replace special characters during default slug preparation") {
-    RequestResponseSlugUtils.defaultSlug(ProcessName("a żółć"), None) shouldEqual "a-x"
+    RequestResponseSlugUtils.defaultSlug(ProcessName("a żółć"), OptionalNussknackerInstanceName.empty) shouldEqual "a-x"
   }
 
   test(
     "lazy determineSlug method uses the same default slug logic sanitization as eager version (determined during scenario creation)"
   ) {
     val longScenarioNameWithoutNuInstanceIdDefaultSlug =
-      RequestResponseSlugUtils.determineSlug(ProcessName(invalidK8sServiceName), RequestResponseMetaData(None), None)
+      RequestResponseSlugUtils.determineSlug(
+        ProcessName(invalidK8sServiceName),
+        RequestResponseMetaData(None),
+        OptionalNussknackerInstanceName.empty
+      )
     longScenarioNameWithoutNuInstanceIdDefaultSlug should contain only 'a'
     longScenarioNameWithoutNuInstanceIdDefaultSlug should have length K8sUtils.maxObjectNameLength
+  }
+
+  test("should generate slug which is a correct service name for long scenario name and given instance name") {
+    val longScenarioName = ProcessName((0.to(100)).map(_ => "x").mkString)
+    RequestResponseSlugUtils
+      .determineSlug(
+        longScenarioName,
+        RequestResponseMetaData(None),
+        OptionalNussknackerInstanceName.forInstanceName("nussknacker")
+      )
+      .length shouldBe K8sUtils.maxObjectNameLength - "nussknacker-".length
+  }
+
+  test(
+    "should generate slug which is a correct service name for scenario name with non alphanumerics and given instance name"
+  ) {
+    val longScenarioName = ProcessName(0.to(100).map(_ => "_").mkString)
+    val determinedSlug =
+      RequestResponseSlugUtils.determineSlug(
+        longScenarioName,
+        RequestResponseMetaData(None),
+        OptionalNussknackerInstanceName.forInstanceName("nussknacker")
+      )
+    // we add instance name (nussknacker-) at the beginning, so first character is not sanitized
+    determinedSlug.head.isLetterOrDigit shouldBe false
+    determinedSlug.last.isLetterOrDigit shouldBe true
   }
 
 }

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparerTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/deployment/DeploymentPreparerTest.scala
@@ -14,7 +14,11 @@ import pl.touk.nussknacker.engine.api.{
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
 import pl.touk.nussknacker.engine.version.BuildInfo
-import pl.touk.nussknacker.k8s.manager.{K8sDeploymentManager, K8sDeploymentManagerConfig}
+import pl.touk.nussknacker.k8s.manager.{
+  K8sDeploymentManager,
+  K8sDeploymentManagerConfig,
+  OptionalNussknackerInstanceName
+}
 import skuber.{Container, EnvVar, HTTPGetAction, LabelSelector, ObjectMeta, Pod, Probe, Volume}
 import skuber.EnvVar.{FieldRef, SecretKeyRef}
 import skuber.Resource.Quantity
@@ -181,7 +185,7 @@ class DeploymentPreparerTest extends AnyFunSuite {
             ).asJava
           )
         ),
-      nussknackerInstanceName = Some(nussknackerInstanceName)
+      nussknackerInstanceName = OptionalNussknackerInstanceName.forInstanceName(nussknackerInstanceName)
     )
 
     val deploymentPreparer = new DeploymentPreparer(config)

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/ingress/IngressPreparerTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/ingress/IngressPreparerTest.scala
@@ -6,6 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import pl.touk.nussknacker.engine.api.{LiteStreamMetaData, ProcessVersion, RequestResponseMetaData, TypeSpecificData}
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId}
+import pl.touk.nussknacker.k8s.manager.OptionalNussknackerInstanceName
 import skuber.ObjectMeta
 import skuber.networking.v1.Ingress
 
@@ -27,7 +28,7 @@ class IngressPreparerTest extends AnyFunSuite {
   test("should prepare ingress") {
     val preparer = new IngressPreparer(
       config = IngressConfig(enabled = true, Some(hostname)),
-      nuInstanceName = Some(nussknackerInstanceName)
+      nuInstanceName = OptionalNussknackerInstanceName.forInstanceName(nussknackerInstanceName)
     )
 
     preparer.prepare(processVersion, requestResponseMetaData, serviceName, servicePort) shouldBe Some(
@@ -86,7 +87,10 @@ class IngressPreparerTest extends AnyFunSuite {
       )
 
     val preparer =
-      new IngressPreparer(config = IngressConfig(enabled = true, Some(hostname), "/", tlsConf), nuInstanceName = None)
+      new IngressPreparer(
+        config = IngressConfig(enabled = true, Some(hostname), "/", tlsConf),
+        nuInstanceName = OptionalNussknackerInstanceName.empty
+      )
 
     preparer.prepare(processVersion, requestResponseMetaData, serviceName, servicePort) shouldBe Some(
       Ingress(
@@ -143,7 +147,7 @@ class IngressPreparerTest extends AnyFunSuite {
 
     val preparer = new IngressPreparer(
       config = IngressConfig(enabled = true, Some(hostname), "/", annotationConf),
-      nuInstanceName = None
+      nuInstanceName = OptionalNussknackerInstanceName.empty
     )
 
     preparer
@@ -154,13 +158,19 @@ class IngressPreparerTest extends AnyFunSuite {
   }
 
   test("should not prepare ingress for lite-streaming") {
-    val preparer = new IngressPreparer(config = IngressConfig(enabled = true, Some(hostname)), nuInstanceName = None)
+    val preparer = new IngressPreparer(
+      config = IngressConfig(enabled = true, Some(hostname)),
+      nuInstanceName = OptionalNussknackerInstanceName.empty
+    )
 
     preparer.prepare(processVersion, liteStreamMetaData, serviceName, servicePort) shouldBe None
   }
 
   test("should not prepare ingress when disabled") {
-    val preparer = new IngressPreparer(config = IngressConfig(enabled = false, Some(hostname)), nuInstanceName = None)
+    val preparer = new IngressPreparer(
+      config = IngressConfig(enabled = false, Some(hostname)),
+      nuInstanceName = OptionalNussknackerInstanceName.empty
+    )
 
     preparer.prepare(processVersion, requestResponseMetaData, serviceName, servicePort) shouldBe None
   }


### PR DESCRIPTION
Sometimes it generated invalid object names, in other cases, it generated names with unnecessary characters appended

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
