### PR TITLE
[Nu-7624] Hide scenario labels when their number exceeds threshold

### DIFF
--- a/designer/client/src/components/toolbars/scenarioDetails/ScenarioLabels.tsx
+++ b/designer/client/src/components/toolbars/scenarioDetails/ScenarioLabels.tsx
@@ -16,7 +16,7 @@ import {
     useTheme,
 } from "@mui/material";
 import { selectStyled } from "../../../stylesheets/SelectStyled";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { createRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import HttpService from "../../../http/HttpService";
 import i18next from "i18next";
 import { editScenarioLabels } from "../../../actions/nk";
@@ -28,6 +28,18 @@ import { useDelayedEnterAction } from "./useDelayedEnterAction";
 interface AddLabelProps {
     onClick: () => void;
 }
+
+const isValidWidthsArray = (widths: number[]): boolean => widths.every((w) => w >= 0 && w !== undefined);
+
+const findThresholdIndex = (numbers: number[], threshold: number): number => {
+    console.log(threshold);
+    let sum = 0;
+    for (let i = 0; i < numbers.length; i++) {
+        sum += numbers[i];
+        if (sum > threshold) return i;
+    }
+    return -1;
+};
 
 const labelUniqueValidation = (label: string) => ({
     label,
@@ -111,7 +123,7 @@ interface Props {
 
 export const ScenarioLabels = ({ readOnly }: Props) => {
     const { t } = useTranslation();
-    const autocompleteRef = useRef(null);
+    const autocompleteRef = useRef<HTMLInputElement | null>(null);
     const scenarioLabels = useSelector(getScenarioLabels);
     const scenarioLabelOptions: LabelOption[] = useMemo(() => scenarioLabels.map(toLabelOption), [scenarioLabels]);
     const initialScenarioLabelOptionsErrors = useSelector(getScenarioLabelsErrors).filter((error) =>
@@ -131,6 +143,10 @@ export const ScenarioLabels = ({ readOnly }: Props) => {
 
     const [inputTyping, setInputTyping] = useState(false);
     const [inputErrors, setInputErrors] = useState<ScenarioLabelValidationError[]>([]);
+
+    const labelsRefs: React.RefObject<HTMLDivElement>[] = Array.from({ length: scenarioLabels.length }, () => createRef<HTMLDivElement>());
+    const [labelsInputWidth, setLabelsInputWidth] = useState<number>(200);
+    const [dynamicTagsLimit, setDynamicTagsLimit] = useState(999);
 
     const handleAddLabelClick = (): void => {
         setShowEditor(true);
@@ -203,6 +219,16 @@ export const ScenarioLabels = ({ readOnly }: Props) => {
         },
         [dispatch],
     );
+
+    useEffect(() => {
+        const widths = labelsRefs.map((ref) =>
+            !autocompleteRef.current.classList.contains("Mui-focused") ? ref.current?.offsetWidth : -1,
+        );
+
+        if (isValidWidthsArray(widths)) {
+            setDynamicTagsLimit(findThresholdIndex(widths, labelsInputWidth));
+        }
+    }, [labelsRefs, labelsInputWidth]);
 
     useEffect(() => {
         validateSelectedOptions(scenarioLabelOptions);
@@ -290,6 +316,7 @@ export const ScenarioLabels = ({ readOnly }: Props) => {
                     clearOnBlur
                     loadingText={<CircularProgress size={"1rem"} />}
                     multiple
+                    limitTags={dynamicTagsLimit}
                     noOptionsText={i18next.t("panels.scenarioDetails.labels.noAvailableLabels", "No labels")}
                     onBlur={() => {
                         setIsEdited(false);
@@ -326,6 +353,7 @@ export const ScenarioLabels = ({ readOnly }: Props) => {
                     }}
                     onOpen={async () => {
                         const fetchedOptions = await fetchAvailableLabelOptions();
+                        setLabelsInputWidth(autocompleteRef.current.offsetWidth * 0.8);
                         setOptions(fetchedOptions);
                         setIsOpen(true);
                     }}
@@ -375,6 +403,7 @@ export const ScenarioLabels = ({ readOnly }: Props) => {
                                 return (
                                     <StyledLabelChip
                                         title={t("panels.scenarioDetails.tooltip.label", "Label")}
+                                        ref={labelsRefs[index]}
                                         key={key}
                                         data-testid={`scenario-label-${index}`}
                                         color={labelError ? "error" : "default"}


### PR DESCRIPTION
## Describe your changes

I propose to hide tags under `+N` button when their number exceeds some dynamically computed value (based on width of parent input component). 
![image](https://github.com/user-attachments/assets/f42f089b-c754-492b-bb07-209cfdb8e60e)
![image](https://github.com/user-attachments/assets/b8a5bd79-302f-4521-ab25-adf7316daa99)


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
