### PR TITLE
NU-2084 fix info text visibility

### DIFF
--- a/designer/client/src/components/graph/node-modal/editors/expression/RawEditor.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/RawEditor.tsx
@@ -7,16 +7,6 @@ import { InfoTooltip } from "./InfoTooltip";
 import { EditorMode, ExpressionLang, ExpressionObj } from "./types";
 import { useTranslation } from "react-i18next";
 
-const spelEditorInfoText = `You are using an expression-based approach, allowing calculations and conditions. Access variables with **#**, e.g., **#input.someField == 'value'**. \n 
-Use **#input['dynamicField'].toTargetType** for dynamic fields. Helpers (e.g., **#UTILS**) provide additional functionality.  \n
-Strings need to be quoted; use **+** to concatenate strings. \n
-Use autocompletion to explore available options. To read more see [Documentation](https://nussknacker.io/documentation/docs/scenarios_authoring/Spel).`;
-
-const spelTemplateEditorInfoText = `You are using a string-template-based approach, allowing text with embedded expressions. Text should not be quoted. \n 
-Embed expression with **#{ }**, e.g., Hello **#{ #input.name }**. For dynamic fields, use **#input['dynamicField'].toTargetType**. \n
-You can also use built-in helpers like **#UTILS** for additional functionality. \n
-Use autocompletion for available options. To read more see [Documentation](https://nussknacker.io/documentation/docs/scenarios_authoring/Spel)`;
-
 export type RawEditorProps = {
     expressionObj: ExpressionObj;
     fieldErrors: FieldError[];
@@ -68,12 +58,32 @@ const RawEditorComponent = (props: RawEditorProps, forwardedRef: ForwardedRef<Re
 
         if (expressionObj.language === ExpressionLang.SpEL) {
             properties.placeholder = placeholder || t("editors.spelEditor.placeholder", "e.g. #input.someField");
-            properties.InputAdornmentEnd = <InfoTooltip text={t("editors.spelEditor.infoText", spelEditorInfoText)} />;
+            properties.InputAdornmentEnd = (
+                <InfoTooltip
+                    text={t(
+                        "editors.spelEditor.infoText",
+                        `You are using an expression-based approach, allowing calculations and conditions. Access variables with **#**, e.g., **#input.someField == 'value'**. \n 
+Use **#input['dynamicField'].toTargetType** for dynamic fields. Helpers (e.g., **#UTILS**) provide additional functionality.  \n
+Strings need to be quoted; use **+** to concatenate strings. \n
+Use autocompletion to explore available options. To read more see [Documentation](https://nussknacker.io/documentation/docs/scenarios_authoring/Spel).`,
+                    )}
+                />
+            );
         }
 
         if (editorMode === EditorMode.SpELTemplate) {
             properties.placeholder = placeholder || t("editors.spelTemplateEditor.placeholder", "e.g. Hello #{ #input.someField }");
-            properties.InputAdornmentEnd = <InfoTooltip text={t("editors.spelTemplateEditor.infoText", spelTemplateEditorInfoText)} />;
+            properties.InputAdornmentEnd = (
+                <InfoTooltip
+                    text={t(
+                        "editors.spelTemplateEditor.infoText",
+                        `You are using a string-template-based approach, allowing text with embedded expressions. Text should not be quoted. \n 
+Embed expression with **#{ }**, e.g., Hello **#{ #input.name }**. For dynamic fields, use **#input['dynamicField'].toTargetType**. \n
+You can also use built-in helpers like **#UTILS** for additional functionality. \n
+Use autocompletion for available options. To read more see [Documentation](https://nussknacker.io/documentation/docs/scenarios_authoring/Spel)`,
+                    )}
+                />
+            );
         }
 
         return properties;


### PR DESCRIPTION
## Describe your changes
There is a problem with SpEL and SpEL Template editor field visibility because of i18n production file rendering when there is a text as variable provided
## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
