### PR TITLE
[NU-2077] Make dry run schemaless JSON validation possible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2114,6 +2114,7 @@ lazy val designer = (project in file("designer/server"))
     listenerApi,
     customHttpServiceApi,
     configLoaderApi,
+    flinkKafkaComponents              % Test,
     defaultHelpers                    % Test,
     testUtils                         % Test,
     flinkTestUtils                    % Test,

--- a/common-api/src/main/scala/pl/touk/nussknacker/engine/graph/expression/Expression.scala
+++ b/common-api/src/main/scala/pl/touk/nussknacker/engine/graph/expression/Expression.scala
@@ -6,6 +6,7 @@ import io.circe.syntax.EncoderOps
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language.{
   DictKeyWithLabel,
+  Json,
   Spel,
   SpelTemplate,
   TabularDataDefinition
@@ -23,6 +24,7 @@ object Expression {
       case SpelTemplate          => "spelTemplate"
       case DictKeyWithLabel      => "dictKeyWithLabel"
       case TabularDataDefinition => "tabularDataDefinition"
+      case Json                  => "json"
     }
 
   }
@@ -32,6 +34,7 @@ object Expression {
     object SpelTemplate          extends Language
     object DictKeyWithLabel      extends Language
     object TabularDataDefinition extends Language
+    object Json                  extends Language
 
     implicit val encoder: Encoder[Language] = Encoder.encodeString.contramap(_.toString)
 
@@ -40,6 +43,7 @@ object Expression {
       case "spelTemplate"          => Right(SpelTemplate)
       case "dictKeyWithLabel"      => Right(DictKeyWithLabel)
       case "tabularDataDefinition" => Right(TabularDataDefinition)
+      case "json"                  => Right(Json)
       case unknown                 => Left(s"Unknown language [$unknown]")
     }
 
@@ -55,4 +59,6 @@ object Expression {
   )
 
   def tabularDataDefinition(definition: String): Expression = Expression(Language.TabularDataDefinition, definition)
+
+  def json(jsonString: String): Expression = Expression(Language.Json, jsonString)
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/EventGeneratorSourceTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/EventGeneratorSourceTestingApiHttpServiceSpec.scala
@@ -1,13 +1,15 @@
 package pl.touk.nussknacker.ui.api.testing
 
 import com.typesafe.config.{Config, ConfigFactory}
+import io.circe.syntax.EncoderOps
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
 import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
-import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.TestSourceParameters
+import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.{AdhocTestParametersRequest, TestSourceParameters}
+import pl.touk.nussknacker.ui.process.marshall.CanonicalProcessConverter.toScenarioGraph
 
 trait EventGeneratorSourceTestingApiHttpServiceSpec extends TestingApiHttpServiceSpec {
 
@@ -34,7 +36,11 @@ trait EventGeneratorSourceTestingApiHttpServiceSpec extends TestingApiHttpServic
       )
       .emptySink("end", "dead-end")
 
-  override protected def parametersProvidedForDryRun: String = ""
+  override protected def parametersProvidedForDryRun: String =
+    AdhocTestParametersRequest(
+      sourceParameters = validParameters,
+      scenarioGraph = toScenarioGraph(exampleScenario)
+    ).asJson.toString()
 
   override protected def expectedSourceTestingParametersJson: String = ""
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/GenericSourceWithCustomVariablesTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/GenericSourceWithCustomVariablesTestingApiHttpServiceSpec.scala
@@ -1,10 +1,12 @@
 package pl.touk.nussknacker.ui.api.testing
 
+import io.circe.syntax.EncoderOps
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
-import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.TestSourceParameters
+import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.{AdhocTestParametersRequest, TestSourceParameters}
+import pl.touk.nussknacker.ui.process.marshall.CanonicalProcessConverter.toScenarioGraph
 
 class GenericSourceWithCustomVariablesTestingApiHttpServiceSpec extends TestingApiHttpServiceSpec {
 
@@ -17,12 +19,10 @@ class GenericSourceWithCustomVariablesTestingApiHttpServiceSpec extends TestingA
       .emptySink("end", "monitor")
 
   override protected def parametersProvidedForDryRun: String =
-    """
-      |"elements": {
-      |  "language": "spel",
-      |  "expression": "{'test'}"
-      |}
-      |""".stripMargin
+    AdhocTestParametersRequest(
+      sourceParameters = validParameters,
+      scenarioGraph = toScenarioGraph(exampleScenario)
+    ).asJson.toString()
 
   override protected def expectedSourceTestingParametersJson: String =
     """

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/JsonSchemalessAdHocTestsSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/JsonSchemalessAdHocTestsSpec.scala
@@ -1,0 +1,196 @@
+package pl.touk.nussknacker.ui.api.testing
+
+import com.dimafeng.testcontainers.{
+  Container,
+  ForAllTestContainer,
+  KafkaContainer,
+  MultipleContainers,
+  SchemaRegistryContainer
+}
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigValueFactory.fromMap
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.syntax.EncoderOps
+import org.apache.kafka.clients.admin.NewTopic
+import org.scalatest.freespec.AnyFreeSpecLike
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.validation.ValidationMode
+import pl.touk.nussknacker.engine.build.ScenarioBuilder
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.kafka.{KafkaConfig, KafkaUtils}
+import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
+import pl.touk.nussknacker.test.{PatientScalaFutures, RestAssuredVerboseLoggingIfValidationFails}
+import pl.touk.nussknacker.test.base.it.{NuItTest, WithSimplifiedConfigScenarioHelper}
+import pl.touk.nussknacker.test.config.WithSimplifiedDesignerConfig
+import pl.touk.nussknacker.test.containers.WithDockerContainers
+import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.{AdhocTestParametersRequest, TestSourceParameters}
+import pl.touk.nussknacker.ui.api.testing.JsonSchemalessAdHocTestsSpec.{
+  kafkaContainerAlias,
+  sinkTopicName,
+  sourceTopicName,
+  WithSchemalessAdHocTestParameters
+}
+import pl.touk.nussknacker.ui.process.marshall.CanonicalProcessConverter.toScenarioGraph
+
+import java.util.Arrays.asList
+import java.util.Collections
+import scala.jdk.CollectionConverters._
+
+class JsonSchemalessAdHocTestsSpec
+    extends AnyFreeSpecLike
+    with NuItTest
+    with WithSimplifiedDesignerConfig
+    with WithSimplifiedConfigScenarioHelper
+    with RestAssuredVerboseLoggingIfValidationFails
+    with PatientScalaFutures
+    with WithAdHocTestsLogic
+    with WithSchemalessAdHocTestParameters
+    with WithDockerContainers
+    with ForAllTestContainer
+    with StrictLogging {
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    createKafkaTopics()
+  }
+
+  "The endpoint for adhoc validate should" - {
+    "return no errors on valid parameters" in {
+      shouldValidateParametersProperly()
+    }
+    "return errors if passed parameter is not valid" in {
+      shouldReturnErrorsForInvalidParameters()
+    }
+  }
+
+  "The endpoint for adhoc test run should" - {
+    "run scenario and return result" in {
+      shouldProperlyRunAdHocTest()
+    }
+  }
+
+  protected val kafkaContainer: KafkaContainer =
+    KafkaContainer().configure { self =>
+      self.setNetwork(network)
+      self.setNetworkAliases(asList(kafkaContainerAlias))
+      self.setPortBindings(List("8070:9093").asJava)
+    }
+
+  private val schemaRegistryContainer: SchemaRegistryContainer =
+    SchemaRegistryContainer(network, kafkaContainerAlias).configure { self =>
+      self.setPortBindings(List("8069:8081").asJava)
+    }
+
+  override def container: Container = MultipleContainers(kafkaContainer, schemaRegistryContainer)
+
+  override def designerRawConfig: Config = super.designerRawConfig
+    .withoutPath("scenarioTypes.streaming.modelConfig.components.kafka.disabled")
+    .withValue(
+      "scenarioTypes.streaming.modelConfig.components.kafka.config.kafkaProperties",
+      fromMap(Map("bootstrap.servers" -> "localhost:8070", "schema.registry.url" -> "http://localhost:8069").asJava)
+    )
+
+  lazy val defaultKafkaConfig: KafkaConfig = KafkaConfig(
+    kafkaProperties = Some(Map("bootstrap.servers" -> kafkaContainer.bootstrapServers)),
+    kafkaEspProperties = None,
+  )
+
+  private def createKafkaTopics(): Unit = {
+    val sourceTopic = new NewTopic(sourceTopicName, Collections.emptyMap())
+    val sinkTopic   = new NewTopic(sinkTopicName, Collections.emptyMap())
+    KafkaUtils.usingAdminClient(defaultKafkaConfig) {
+      _.createTopics(List(sourceTopic, sinkTopic).asJava)
+    }
+  }
+
+}
+
+object JsonSchemalessAdHocTestsSpec {
+
+  private[JsonSchemalessAdHocTestsSpec] trait WithSchemalessAdHocTestParameters extends WithAdHocTestParameters {
+
+    protected def exampleScenarioSourceId: String = "start"
+
+    protected def exampleScenario: CanonicalProcess = {
+      ScenarioBuilder
+        .streaming("without-schema")
+        .parallelism(1)
+        .source(
+          exampleScenarioSourceId,
+          "kafka",
+          "Topic"        -> s"'$sourceTopicName'".spel,
+          "Content type" -> "'JSON'".spel
+        )
+        .emptySink(
+          "end",
+          "kafka",
+          "Key"                   -> "".spel,
+          "Raw editor"            -> "true".spel,
+          "Value"                 -> "#input".spel,
+          "Topic"                 -> s"'$sinkTopicName'".spel,
+          "Content type"          -> "'JSON'".spel,
+          "Value validation mode" -> s"'${ValidationMode.lax.name}'".spel
+        )
+    }
+
+    protected def validParameters: TestSourceParameters =
+      TestSourceParameters(exampleScenarioSourceId, Map(inputParameterName -> Expression.json(validJson)))
+
+    protected def invalidParameters: TestSourceParameters =
+      TestSourceParameters(exampleScenarioSourceId, Map(inputParameterName -> Expression.json(invalidJson)))
+
+    protected def parametersProvidedForDryRun: String = AdhocTestParametersRequest(
+      sourceParameters = validParameters,
+      scenarioGraph = toScenarioGraph(exampleScenario)
+    ).asJson.toString()
+
+    protected def expectedValidationErrorsOnInvalidParametersJson: String =
+      s"""
+         |[
+         |  {
+         |    "typ": "ExpressionParserCompilationError",
+         |    "message": "Failed to parse expression: expected } or , got 'a0.00}...' (line 3, column 45)",
+         |    "description": "There is problem with expression in field Some(Value) - it could not be parsed.",
+         |    "fieldName": "Value",
+         |    "errorType": "SaveAllowed",
+         |    "details": null
+         |  }
+         |]""".stripMargin
+
+    private val validJson = """|[
+                               |  {
+                               |    "products": [
+                               |      {"id": 1, "name": "Laptop", "price": 1200.00},
+                               |      {"id": 2, "name": "Smartphone", "price": 800.50},
+                               |      {"id": 3, "name": "Tablet", "price": 450.75}
+                               |    ]
+                               |  },
+                               |  {
+                               |    "someObject": {
+                               |      "someString": "some string value",
+                               |      "someBoolean": true,
+                               |      "someNumber": 21.37
+                               |    }
+                               |  }
+                               |]""".stripMargin
+
+    private val invalidJson = """|{
+                                 |  "products": [
+                                 |    {"id": 1, "name": "Laptop", "price": 120a0.00},
+                                 |    {"id": 2, "name": "Smartphone", "price": 800.50},
+                                 |    {"id": 3, "name": "Tablet", "price": 450.75}
+                                 |  ]
+                                 |}""".stripMargin
+
+    private val inputParameterName = ParameterName("Value")
+
+  }
+
+  private val sourceTopicName = "someInputTopic"
+
+  private val sinkTopicName = "someOutputTopic"
+
+  private val kafkaContainerAlias = "kafka"
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/TestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/TestingApiHttpServiceSpec.scala
@@ -1,11 +1,9 @@
 package pl.touk.nussknacker.ui.api.testing
 
 import io.circe.Encoder
-import io.circe.syntax.EncoderOps
 import io.restassured.RestAssured.given
 import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
 import org.apache.pekko.http.scaladsl.model.StatusCodes
-import org.hamcrest.Matchers.equalTo
 import org.scalatest.freespec.AnyFreeSpecLike
 import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
@@ -27,9 +25,7 @@ import pl.touk.nussknacker.test.config.{
   WithSimplifiedDesignerConfig
 }
 import pl.touk.nussknacker.test.utils.domain.TestProcessUtil.toJson
-import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.{AdhocTestParametersRequest, TestSourceParameters}
 import pl.touk.nussknacker.ui.process.marshall.CanonicalProcessConverter
-import pl.touk.nussknacker.ui.process.marshall.CanonicalProcessConverter.toScenarioGraph
 import pl.touk.nussknacker.ui.util.MultipartUtils.sttpPrepareMultiParts
 import sttp.client3.{quickRequest, UriContext}
 import sttp.model.{MediaType, StatusCode}
@@ -44,25 +40,15 @@ trait TestingApiHttpServiceSpec
     with WithBusinessCaseRestAssuredUsersExtensions
     with NuRestAssureMatchers
     with RestAssuredVerboseLoggingIfValidationFails
-    with PatientScalaFutures {
+    with PatientScalaFutures
+    with WithAdHocTestParameters
+    with WithAdHocTestsLogic {
 
   import pl.touk.nussknacker.engine.spel.SpelExtension._
-
-  protected def exampleScenarioSourceId: String
-
-  protected def exampleScenario: CanonicalProcess
-
-  protected def validParameters: TestSourceParameters
-
-  protected def invalidParameters: TestSourceParameters
-
-  protected def parametersProvidedForDryRun: String
 
   protected def expectedSourceTestingParametersJson: String
 
   protected def expectedTestDataJson: String
-
-  protected def expectedValidationErrorsOnInvalidParametersJson: String
 
   private val fragmentFixedParameter = FragmentParameter(
     ParameterName("paramFixedString"),
@@ -343,82 +329,19 @@ trait TestingApiHttpServiceSpec
 
   "The endpoint for adhoc validate should" - {
     "return no errors on valid parameters" in {
-      val request = AdhocTestParametersRequest(
-        validParameters,
-        exampleScenarioGraph
-      ).asJson.toString()
-
-      given()
-        .applicationState {
-          createSavedScenario(exampleScenario)
-        }
-        .when()
-        .basicAuthAllPermUser()
-        .jsonBody(request)
-        .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/adhoc/validate")
-        .Then()
-        .statusCode(200)
-        .equalsJsonBody(
-          s"""{
-             |    "validationErrors": [],
-             |    "validationPerformed": true
-             |}""".stripMargin
-        )
+      shouldValidateParametersProperly()
     }
     "return errors if passed parameter is not valid" in {
-      val request = AdhocTestParametersRequest(
-        invalidParameters,
-        exampleScenarioGraph
-      ).asJson.toString()
-
-      given()
-        .applicationState {
-          createSavedScenario(exampleScenario)
-        }
-        .when()
-        .basicAuthAllPermUser()
-        .jsonBody(request)
-        .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/adhoc/validate")
-        .Then()
-        .statusCode(200)
-        .equalsJsonBody(
-          s"""{
-             |    "validationErrors": $expectedValidationErrorsOnInvalidParametersJson,
-             |    "validationPerformed": true
-             |}
-             |""".stripMargin
-        )
+      shouldReturnErrorsForInvalidParameters()
     }
   }
 
   "The endpoint for adhoc test run should" - {
     "run scenario and return result" in {
-      given()
-        .applicationState {
-          createSavedScenario(exampleScenario)
-        }
-        .when()
-        .basicAuthAllPermUser()
-        .jsonBody(s"""{
-                     |  "sourceParameters": {
-                     |    "sourceId": "$exampleScenarioSourceId",
-                     |    "parameterExpressions": { $parametersProvidedForDryRun }
-                     |  },
-                     |  "scenarioGraph": ${toScenarioGraph(exampleScenario).asJson.spaces2}
-                     |}""".stripMargin)
-        .post(s"$nuDesignerHttpAddress/api/processManagement/testWithParameters/${exampleScenario.name}")
-        .Then()
-        .statusCode(200)
-        .body(
-          s"counts.$exampleScenarioSourceId.all",
-          equalTo(1),
-          "counts.end.all",
-          equalTo(1)
-        )
+      shouldProperlyRunAdHocTest()
     }
   }
 
-  private def exampleScenarioGraph    = CanonicalProcessConverter.toScenarioGraph(exampleScenario)
   private def exampleScenarioGraphStr = Encoder[ScenarioGraph].apply(exampleScenarioGraph).toString()
 
   private def canonicalGraphStr(canonical: CanonicalProcess) =

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/WithAdHocTestParameters.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/WithAdHocTestParameters.scala
@@ -1,0 +1,24 @@
+package pl.touk.nussknacker.ui.api.testing
+
+import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.TestSourceParameters
+import pl.touk.nussknacker.ui.process.marshall.CanonicalProcessConverter
+
+trait WithAdHocTestParameters {
+
+  protected def exampleScenarioSourceId: String
+
+  protected def exampleScenario: CanonicalProcess
+
+  protected def validParameters: TestSourceParameters
+
+  protected def invalidParameters: TestSourceParameters
+
+  protected def parametersProvidedForDryRun: String
+
+  protected def expectedValidationErrorsOnInvalidParametersJson: String
+
+  protected def exampleScenarioGraph: ScenarioGraph = CanonicalProcessConverter.toScenarioGraph(exampleScenario)
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/WithAdHocTestsLogic.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/WithAdHocTestsLogic.scala
@@ -1,0 +1,83 @@
+package pl.touk.nussknacker.ui.api.testing
+
+import io.circe.syntax.EncoderOps
+import io.restassured.RestAssured.`given`
+import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
+import org.hamcrest.Matchers.equalTo
+import pl.touk.nussknacker.test.NuRestAssureExtensions.{AppConfiguration, EqualsJsonBody, JsonBody}
+import pl.touk.nussknacker.test.base.it.{NuItTest, WithSimplifiedConfigScenarioHelper}
+import pl.touk.nussknacker.test.processes.WithScenarioActivitySpecAsserts.UsersBasicAuth
+import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.AdhocTestParametersRequest
+
+trait WithAdHocTestsLogic {
+  self: WithAdHocTestParameters with WithSimplifiedConfigScenarioHelper with NuItTest =>
+
+  def shouldValidateParametersProperly(): Unit = {
+    val request = AdhocTestParametersRequest(
+      validParameters,
+      exampleScenarioGraph
+    ).asJson.toString()
+
+    given()
+      .applicationState {
+        createSavedScenario(exampleScenario)
+      }
+      .when()
+      .basicAuthAllPermUser()
+      .jsonBody(request)
+      .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/adhoc/validate")
+      .Then()
+      .statusCode(200)
+      .equalsJsonBody(
+        s"""{
+           |    "validationErrors": [],
+           |    "validationPerformed": true
+           |}""".stripMargin
+      )
+  }
+
+  def shouldReturnErrorsForInvalidParameters(): Unit = {
+    val request = AdhocTestParametersRequest(
+      invalidParameters,
+      exampleScenarioGraph
+    ).asJson.toString()
+
+    given()
+      .applicationState {
+        createSavedScenario(exampleScenario)
+      }
+      .when()
+      .basicAuthAllPermUser()
+      .jsonBody(request)
+      .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/adhoc/validate")
+      .Then()
+      .statusCode(200)
+      .equalsJsonBody(
+        s"""{
+           |    "validationErrors": $expectedValidationErrorsOnInvalidParametersJson,
+           |    "validationPerformed": true
+           |}
+           |""".stripMargin
+      )
+  }
+
+  def shouldProperlyRunAdHocTest(): Unit = {
+    given()
+      .applicationState {
+        createSavedScenario(exampleScenario)
+      }
+      .when()
+      .basicAuthAllPermUser()
+      .jsonBody(parametersProvidedForDryRun)
+      .post(s"$nuDesignerHttpAddress/api/processManagement/testWithParameters/${exampleScenario.name}")
+      .Then()
+      .statusCode(200)
+      .body(
+        s"counts.$exampleScenarioSourceId.all",
+        equalTo(1),
+        "counts.end.all",
+        equalTo(1)
+      )
+  }
+
+}

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -133,6 +133,7 @@
   * For now on, default values are provided for dry run parameters.
 * [#7764](https://github.com/TouK/nussknacker/pull/7764) Fix SpEL template evaluation on runtime. For now on, there is
   no need to pass .toString on variable in SpEL template expression. 
+* [#7690](https://github.com/TouK/nussknacker/pull/7690) Add JSON validation for ad hoc tests with schemaless topics.
 
 ## 1.18
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
@@ -27,6 +27,7 @@ import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language.DictKeyWithLabel
 import pl.touk.nussknacker.engine.language.dictWithLabel.DictKeyWithLabelExpressionParser
+import pl.touk.nussknacker.engine.language.json.JsonParser
 import pl.touk.nussknacker.engine.language.tabularDataDefinition.TabularDataDefinitionParser
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser.Flavour
@@ -103,7 +104,8 @@ object ExpressionCompiler {
         spelParser(SpelExpressionParser.Standard),
         spelParser(SpelExpressionParser.Template),
         DictKeyWithLabelExpressionParser,
-        TabularDataDefinitionParser
+        TabularDataDefinitionParser,
+        JsonParser
       )
     val parsers = defaultParsers.map(p => p.languageId -> p).toMap
     new ExpressionCompiler(parsers, dictRegistry, expressionEvaluator)

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorBasedLanguageDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorBasedLanguageDeterminer.scala
@@ -14,10 +14,11 @@ object EditorBasedLanguageDeterminer {
     editor match {
       case SpelParameterEditor => Expression.Language.Spel
       case BoolParameterEditor | DateParameterEditor | TimeParameterEditor | DateTimeParameterEditor |
-          TextareaParameterEditor | JsonParameterEditor | DurationParameterEditor(_) | PeriodParameterEditor(_) |
-          CronParameterEditor | FixedValuesParameterEditor(_) | FixedValuesWithIconParameterEditor(_) |
+          TextareaParameterEditor | DurationParameterEditor(_) | PeriodParameterEditor(_) | CronParameterEditor |
+          FixedValuesParameterEditor(_) | FixedValuesWithIconParameterEditor(_) |
           FixedValuesWithRadioParameterEditor(_) =>
         Expression.Language.Spel
+      case JsonParameterEditor => Expression.Language.Json
       case SqlParameterEditor | SpelTemplateParameterEditor =>
         Expression.Language.SpelTemplate
       case DictParameterEditor(_) =>

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorPossibleValuesBasedDefaultValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/EditorPossibleValuesBasedDefaultValueDeterminer.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.definition.component.parameter.defaults
 import pl.touk.nussknacker.engine.api.definition.{
   DictParameterEditor,
   FixedValuesParameterEditor,
+  JsonParameterEditor,
   SpelTemplateParameterEditor,
   SqlParameterEditor,
   TabularTypedDataEditor
@@ -20,6 +21,7 @@ protected object EditorPossibleValuesBasedDefaultValueDeterminer extends Paramet
       case TabularTypedDataEditor :: Nil => Some(Expression.tabularDataDefinition(TabularTypedData.empty.stringify))
       case (SpelTemplateParameterEditor | SqlParameterEditor) :: Nil => Some(Expression.spelTemplate(""))
       case DictParameterEditor(_) :: Nil                             => Some(Expression(Language.DictKeyWithLabel, ""))
+      case JsonParameterEditor :: Nil                                => Some(Expression.json("{}"))
       case FixedValuesParameterEditor(firstValue :: _) :: _ :: Nil   => Some(Expression.spel(firstValue.expression))
       case _ :: FixedValuesParameterEditor(firstValue :: _) :: Nil   => Some(Expression.spel(firstValue.expression))
       case _                                                         => None

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/TypeRelatedParameterValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/TypeRelatedParameterValueDeterminer.scala
@@ -38,6 +38,7 @@ protected object TypeRelatedParameterValueDeterminer extends ParameterDefaultVal
   private def defaultStringExpression(editor: Option[ParameterEditor]): Expression =
     EditorBasedLanguageDeterminer.determineLanguageOf(editor) match {
       case Language.Spel => Expression.spel("''")
+      case Language.Json => Expression.spel("{}")
       case language @ (Language.SpelTemplate | Language.DictKeyWithLabel | Language.TabularDataDefinition) =>
         Expression(language, "")
     }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/TypeRelatedParameterValueDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/TypeRelatedParameterValueDeterminer.scala
@@ -38,7 +38,7 @@ protected object TypeRelatedParameterValueDeterminer extends ParameterDefaultVal
   private def defaultStringExpression(editor: Option[ParameterEditor]): Expression =
     EditorBasedLanguageDeterminer.determineLanguageOf(editor) match {
       case Language.Spel => Expression.spel("''")
-      case Language.Json => Expression.spel("{}")
+      case Language.Json => Expression.json("{}")
       case language @ (Language.SpelTemplate | Language.DictKeyWithLabel | Language.TabularDataDefinition) =>
         Expression(language, "")
     }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/json/JsonParser.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/json/JsonParser.scala
@@ -56,6 +56,6 @@ object JsonParser extends ExpressionParser {
 
 case object JsonExpressionTypingInfo extends ExpressionTypingInfo {
 
-  // TODO: Right now we just use Unknown but we should create appropriate typing in the future
+  // TODO: Right now we just use Unknown but we should create appropriate typing for Jsons in the future
   override def typingResult: TypingResult = Unknown
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/json/JsonParser.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/json/JsonParser.scala
@@ -1,0 +1,61 @@
+package pl.touk.nussknacker.engine.language.json
+
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.data.Validated.{invalidNel, Valid}
+import io.circe.{parser, Json}
+import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.context.ValidationContext
+import pl.touk.nussknacker.engine.api.expression.ExpressionTypingInfo
+import pl.touk.nussknacker.engine.api.generics.ExpressionParseError
+import pl.touk.nussknacker.engine.api.typed.typing.{TypingResult, Unknown}
+import pl.touk.nussknacker.engine.expression.parse.{CompiledExpression, ExpressionParser, TypedExpression}
+import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language
+import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.JsonParsingError
+
+object JsonParser extends ExpressionParser {
+
+  override def languageId: Language = Expression.Language.Json
+
+  override def parse(
+      jsonString: String,
+      ctx: ValidationContext,
+      expectedType: TypingResult
+  ): ValidatedNel[ExpressionParseError, TypedExpression] = {
+    parseJson(jsonString).map { json =>
+      TypedExpression(
+        CompiledJsonExpression(jsonString, json),
+        JsonExpressionTypingInfo
+      )
+    }
+  }
+
+  override def parseWithoutContextValidation(
+      jsonString: String,
+      expectedType: TypingResult
+  ): ValidatedNel[ExpressionParseError, CompiledExpression] = {
+    parseJson(jsonString).map(json => CompiledJsonExpression(jsonString, json))
+  }
+
+  private def parseJson(jsonString: String): Validated[NonEmptyList[JsonParsingError], Json] =
+    parser.parse(jsonString) match {
+      case Left(error) => invalidNel(JsonParsingError(error.message))
+      case Right(json) => Valid(json)
+    }
+
+  case class CompiledJsonExpression(originalJsonString: String, json: Json) extends CompiledExpression {
+
+    override def language: Language = languageId
+
+    override def original: String = originalJsonString
+
+    override def evaluate[T](ctx: Context, globals: Map[String, Any]): T = json.asInstanceOf[T]
+  }
+
+}
+
+case object JsonExpressionTypingInfo extends ExpressionTypingInfo {
+
+  // TODO: Right now we just use Unknown but we should create appropriate typing in the future
+  override def typingResult: TypingResult = Unknown
+}

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionParseError.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionParseError.scala
@@ -270,4 +270,6 @@ object SpelExpressionParseError {
 
   }
 
+  case class JsonParsingError(message: String) extends ExpressionParseError
+
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
@@ -445,7 +445,7 @@ private class NuSpelNodeParser(typer: Typer) extends LazyLogging {
     val rawExpression = language match {
       case Language.Spel         => Try(parser.parseExpression(input, null))
       case Language.SpelTemplate => Try(parser.parseExpression(input, new TemplateParserContext()))
-      case Language.DictKeyWithLabel | Language.TabularDataDefinition =>
+      case Language.DictKeyWithLabel | Language.TabularDataDefinition | Language.Json =>
         Failure(new IllegalArgumentException(s"Language $language is not supported"))
     }
     rawExpression

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/language/json/JsonParserTest.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/language/json/JsonParserTest.scala
@@ -30,6 +30,7 @@ class JsonParserTest extends AnyFunSuite with Matchers {
                        |]""".stripMargin
 
     val resultType = parser.parse(validJson, ValidationContext.empty, Unknown).validValue.typingInfo.typingResult
+    // TODO: Right now we just use Unknown but we should create appropriate typing for Jsons in the future
     resultType shouldBe Unknown
   }
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/language/json/JsonParserTest.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/language/json/JsonParserTest.scala
@@ -1,0 +1,50 @@
+package pl.touk.nussknacker.engine.language.json
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.context.ValidationContext
+import pl.touk.nussknacker.engine.api.typed.typing.Unknown
+import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.JsonParsingError
+import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage.convertValidatedToValuable
+
+class JsonParserTest extends AnyFunSuite with Matchers {
+
+  private val parser = JsonParser
+
+  test("should parse JSON expression") {
+    val validJson = """|[
+                       |  {
+                       |    "products": [
+                       |      {"id": 1, "name": "Laptop", "price": 1200.00},
+                       |      {"id": 2, "name": "Smartphone", "price": 800.50},
+                       |      {"id": 3, "name": "Tablet", "price": 450.75}
+                       |    ]
+                       |  },
+                       |  {
+                       |    "someObject": {
+                       |      "someString": "some string value",
+                       |      "someBoolean": true,
+                       |      "someNumber": 21.37
+                       |    }
+                       |  }
+                       |]""".stripMargin
+
+    val resultType = parser.parse(validJson, ValidationContext.empty, Unknown).validValue.typingInfo.typingResult
+    resultType shouldBe Unknown
+  }
+
+  test("should return error when JSON cannot be parsed") {
+    // Missing comma after Laptop object entry
+    val invalidJson = """|{
+                         |  "products": [
+                         |    {"id": 1, "name": "Laptop", "price": 1200.00}
+                         |    {"id": 2, "name": "Smartphone", "price": 800.50},
+                         |    {"id": 3, "name": "Tablet", "price": 450.75}
+                         |  ]
+                         |}""".stripMargin
+    val parsingErrors = parser.parse(invalidJson, ValidationContext.empty, Unknown).invalidValue
+    parsingErrors.size shouldBe 1
+    parsingErrors.head shouldBe JsonParsingError("expected ] or , got '{\"id\":...' (line 4, column 5)")
+  }
+
+}

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaBasedParameter.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaBasedParameter.scala
@@ -2,10 +2,10 @@ package pl.touk.nussknacker.engine.json
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.data.Validated.Valid
-import org.everit.json.schema.{EmptySchema, ObjectSchema, Schema}
+import org.everit.json.schema.{ObjectSchema, Schema}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
-import pl.touk.nussknacker.engine.api.definition.{JsonParameterEditor, Parameter, ParameterEditor}
+import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.graph.expression.Expression
@@ -38,22 +38,6 @@ object JsonSchemaBasedParameter {
       defaultValue = None,
       isRequired = None
     )
-
-  def emptySchemaBasedParameter(
-      defaultParamName: FieldName,
-      validationMode: ValidationMode
-  ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
-    val emptyJsonSchema = EmptySchema.INSTANCE
-    val typing          = SwaggerBasedJsonSchemaTypeDefinitionExtractor.swaggerType(emptyJsonSchema, None).typingResult
-    val parameter = Parameter(defaultParamName, typing)
-      .copy(isLazyParameter = true, editors = List(JsonParameterEditor))
-    Valid(
-      SingleSchemaBasedParameter(
-        parameter,
-        new JsonSchemaOutputValidator(validationMode).validate(_, emptyJsonSchema, None)
-      )
-    )
-  }
 
   private case class ParameterRetriever(
       rootSchema: Schema,

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaBasedParameter.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaBasedParameter.scala
@@ -2,10 +2,10 @@ package pl.touk.nussknacker.engine.json
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.data.Validated.Valid
-import org.everit.json.schema.{ObjectSchema, Schema}
+import org.everit.json.schema.{EmptySchema, ObjectSchema, Schema}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
-import pl.touk.nussknacker.engine.api.definition.Parameter
+import pl.touk.nussknacker.engine.api.definition.{JsonParameterEditor, Parameter, ParameterEditor}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.graph.expression.Expression
@@ -39,6 +39,16 @@ object JsonSchemaBasedParameter {
       isRequired = None
     )
 
+  def withEmptySchemaSupport(schema: Schema, defaultParamName: FieldName, validationMode: ValidationMode)(
+      implicit nodeId: NodeId
+  ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
+    ParameterRetriever(schema, defaultParamName, validationMode).toSchemaBasedParameterWithEmptySchemaSupport(
+      schema,
+      paramName = None,
+      defaultValue = None,
+      isRequired = None
+    )
+
   private case class ParameterRetriever(
       rootSchema: Schema,
       defaultParamName: FieldName,
@@ -65,18 +75,45 @@ object JsonSchemaBasedParameter {
       }
     }
 
+    def toSchemaBasedParameterWithEmptySchemaSupport(
+        schema: Schema,
+        paramName: Option[ParameterName],
+        defaultValue: Option[Expression],
+        isRequired: Option[Boolean]
+    ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
+      schema match {
+        case _: EmptySchema =>
+          // In a case of an empty JSON schema we want to present the user with Json editor and not standard SpEL one
+          Valid(
+            createJsonSinkSingleValueParameter(
+              schema,
+              paramName.getOrElse(defaultParamName),
+              defaultValue,
+              Some(true),
+              editor = Some(JsonParameterEditor)
+            )
+          )
+        case jsonSchema => toSchemaBasedParameter(jsonSchema, paramName, defaultValue, isRequired)
+      }
+    }
+
     private def createJsonSinkSingleValueParameter(
         schema: Schema,
         paramName: ParameterName,
         defaultValue: Option[Expression],
-        isRequired: Option[Boolean]
+        isRequired: Option[Boolean],
+        editor: Option[ParameterEditor] = None
     ): SingleSchemaBasedParameter = {
       val swaggerTyped = SwaggerBasedJsonSchemaTypeDefinitionExtractor.swaggerType(schema, Some(rootSchema))
       val typing       = swaggerTyped.typingResult
       // By default properties are not required: http://json-schema.org/understanding-json-schema/reference/object.html#required-properties
       val isOptional = !isRequired.getOrElse(false)
       val parameter = (if (isOptional) Parameter.optional(paramName, typing) else Parameter(paramName, typing))
-        .copy(isLazyParameter = true, defaultValue = defaultValue, editors = swaggerTyped.editorList)
+        .copy(
+          isLazyParameter = true,
+          defaultValue = defaultValue,
+          editors = editor.map(List(_)).getOrElse(swaggerTyped.editorList)
+        )
 
       SingleSchemaBasedParameter(
         parameter,

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaBasedParameter.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaBasedParameter.scala
@@ -39,10 +39,21 @@ object JsonSchemaBasedParameter {
       isRequired = None
     )
 
-  def emptySchemaBasedParameter(defaultParamName: FieldName, validationMode: ValidationMode)(
-      implicit nodeId: NodeId
-  ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
-    ParameterRetriever(EmptySchema.INSTANCE, defaultParamName, validationMode).getJsonEditorInputParameter
+  def emptySchemaBasedParameter(
+      defaultParamName: FieldName,
+      validationMode: ValidationMode
+  ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
+    val emptyJsonSchema = EmptySchema.INSTANCE
+    val typing          = SwaggerBasedJsonSchemaTypeDefinitionExtractor.swaggerType(emptyJsonSchema, None).typingResult
+    val parameter = Parameter(defaultParamName, typing)
+      .copy(isLazyParameter = true, editors = List(JsonParameterEditor))
+    Valid(
+      SingleSchemaBasedParameter(
+        parameter,
+        new JsonSchemaOutputValidator(validationMode).validate(_, emptyJsonSchema, None)
+      )
+    )
+  }
 
   private case class ParameterRetriever(
       rootSchema: Schema,
@@ -68,18 +79,6 @@ object JsonSchemaBasedParameter {
             createJsonSinkSingleValueParameter(schema, paramName.getOrElse(defaultParamName), defaultValue, isRequired)
           )
       }
-    }
-
-    def getJsonEditorInputParameter: ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
-      val typing = SwaggerBasedJsonSchemaTypeDefinitionExtractor.swaggerType(rootSchema, None).typingResult
-      val parameter = Parameter(defaultParamName, typing)
-        .copy(isLazyParameter = true, editors = List(JsonParameterEditor))
-      Valid(
-        SingleSchemaBasedParameter(
-          parameter,
-          new JsonSchemaOutputValidator(validationMode).validate(_, rootSchema, None)
-        )
-      )
     }
 
     private def createJsonSinkSingleValueParameter(

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaBasedParameter.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonSchemaBasedParameter.scala
@@ -39,15 +39,10 @@ object JsonSchemaBasedParameter {
       isRequired = None
     )
 
-  def withEmptySchemaSupport(schema: Schema, defaultParamName: FieldName, validationMode: ValidationMode)(
+  def emptySchemaBasedParameter(defaultParamName: FieldName, validationMode: ValidationMode)(
       implicit nodeId: NodeId
   ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
-    ParameterRetriever(schema, defaultParamName, validationMode).toSchemaBasedParameterWithEmptySchemaSupport(
-      schema,
-      paramName = None,
-      defaultValue = None,
-      isRequired = None
-    )
+    ParameterRetriever(EmptySchema.INSTANCE, defaultParamName, validationMode).getJsonEditorInputParameter
 
   private case class ParameterRetriever(
       rootSchema: Schema,
@@ -75,45 +70,30 @@ object JsonSchemaBasedParameter {
       }
     }
 
-    def toSchemaBasedParameterWithEmptySchemaSupport(
-        schema: Schema,
-        paramName: Option[ParameterName],
-        defaultValue: Option[Expression],
-        isRequired: Option[Boolean]
-    ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
-      schema match {
-        case _: EmptySchema =>
-          // In a case of an empty JSON schema we want to present the user with Json editor and not standard SpEL one
-          Valid(
-            createJsonSinkSingleValueParameter(
-              schema,
-              paramName.getOrElse(defaultParamName),
-              defaultValue,
-              Some(true),
-              editor = Some(JsonParameterEditor)
-            )
-          )
-        case jsonSchema => toSchemaBasedParameter(jsonSchema, paramName, defaultValue, isRequired)
-      }
+    def getJsonEditorInputParameter: ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
+      val typing = SwaggerBasedJsonSchemaTypeDefinitionExtractor.swaggerType(rootSchema, None).typingResult
+      val parameter = Parameter(defaultParamName, typing)
+        .copy(isLazyParameter = true, editors = List(JsonParameterEditor))
+      Valid(
+        SingleSchemaBasedParameter(
+          parameter,
+          new JsonSchemaOutputValidator(validationMode).validate(_, rootSchema, None)
+        )
+      )
     }
 
     private def createJsonSinkSingleValueParameter(
         schema: Schema,
         paramName: ParameterName,
         defaultValue: Option[Expression],
-        isRequired: Option[Boolean],
-        editor: Option[ParameterEditor] = None
+        isRequired: Option[Boolean]
     ): SingleSchemaBasedParameter = {
       val swaggerTyped = SwaggerBasedJsonSchemaTypeDefinitionExtractor.swaggerType(schema, Some(rootSchema))
       val typing       = swaggerTyped.typingResult
       // By default properties are not required: http://json-schema.org/understanding-json-schema/reference/object.html#required-properties
       val isOptional = !isRequired.getOrElse(false)
       val parameter = (if (isOptional) Parameter.optional(paramName, typing) else Parameter(paramName, typing))
-        .copy(
-          isLazyParameter = true,
-          defaultValue = defaultValue,
-          editors = editor.map(List(_)).getOrElse(swaggerTyped.editorList)
-        )
+        .copy(isLazyParameter = true, defaultValue = defaultValue, editors = swaggerTyped.editorList)
 
       SingleSchemaBasedParameter(
         parameter,

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -163,10 +163,30 @@ object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
     JsonPayloadRecordFormatterSupport
 }
 
-object NoSchemaJsonSupport {
+object NoSchemaJsonSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
 
-  def extractJsonInputParameter(
-  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, List[Parameter]] =
-    JsonSchemaBasedParameter.emptySchemaBasedParameter(sinkValueParamName, ValidationMode.lax).map(_.toParameters)
+  private final val jsonSupport = JsonSchemaSupport
+
+  override def payloadDeserializer: UniversalSchemaPayloadDeserializer = jsonSupport.payloadDeserializer
+
+  override def serializer(schemaOpt: Option[ParsedSchema], c: SchemaRegistryClient, isKey: Boolean): Serializer[Any] =
+    jsonSupport.serializer(schemaOpt, c, isKey)
+
+  override def typeDefinition(schema: ParsedSchema): TypingResult = jsonSupport.typeDefinition(schema)
+
+  override def formValueEncoder(schema: ParsedSchema, mode: ValidationMode): Any => AnyRef =
+    jsonSupport.formValueEncoder(schema, mode)
+
+  override def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport =
+    jsonSupport.recordFormatterSupport(schemaRegistryClient)
+
+  override def extractParameter(
+      schema: ParsedSchema,
+      rawMode: Boolean,
+      validationMode: ValidationMode,
+      rawParameter: Parameter,
+      restrictedParamNames: Set[ParameterName]
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
+    JsonSchemaBasedParameter.emptySchemaBasedParameter(sinkValueParamName, ValidationMode.lax)
 
 }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -121,7 +121,7 @@ class AvroSchemaSupport(kafkaConfig: KafkaConfig) extends ParsedSchemaSupport[Av
 
 }
 
-class JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
+object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
   override val payloadDeserializer: UniversalSchemaPayloadDeserializer = JsonSchemaPayloadDeserializer
 
   override def serializer(schemaOpt: Option[ParsedSchema], c: SchemaRegistryClient, isKey: Boolean): Serializer[Any] =
@@ -140,15 +140,17 @@ class JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
       rawParameter: Parameter,
       restrictedParamNames: Set[ParameterName]
   )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
-    extractSchemaBasedParameter(
-      schema,
-      rawMode,
-      validationMode,
-      rawParameter,
+    if (rawMode) {
+      Validated.Valid(
+        SingleSchemaBasedParameter(
+          rawParameter,
+          new JsonSchemaOutputValidator(validationMode).validate(_, schema.cast().rawSchema())
+        )
+      )
+    } else {
       // in editor mode we use lax validation mode, to be backward compatible
-      parameterForBasicMode =
-        JsonSchemaBasedParameter(schema.cast().rawSchema(), defaultParamName = sinkValueParamName, ValidationMode.lax)
-    )
+      JsonSchemaBasedParameter(schema.cast().rawSchema(), defaultParamName = sinkValueParamName, ValidationMode.lax)
+    }
   }
 
   override def formValueEncoder(schema: ParsedSchema, mode: ValidationMode): Any => AnyRef = {
@@ -159,49 +161,12 @@ class JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
 
   override def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport =
     JsonPayloadRecordFormatterSupport
-
-  protected def extractSchemaBasedParameter(
-      schema: ParsedSchema,
-      rawMode: Boolean,
-      validationMode: ValidationMode,
-      rawParameter: Parameter,
-      parameterForBasicMode: ValidatedNel[ProcessCompilationError, SchemaBasedParameter]
-  ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
-    if (rawMode) {
-      Validated.Valid(
-        SingleSchemaBasedParameter(
-          rawParameter,
-          new JsonSchemaOutputValidator(validationMode).validate(_, schema.cast().rawSchema())
-        )
-      )
-    } else {
-      parameterForBasicMode
-    }
-  }
-
 }
 
-object EmptySchemaJsonSupport extends JsonSchemaSupport {
+object NoSchemaJsonSupport {
 
-  override def extractParameter(
-      schema: ParsedSchema,
-      rawMode: Boolean,
-      validationMode: ValidationMode,
-      rawParameter: Parameter,
-      restrictedParamNames: Set[ParameterName]
-  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
-    extractSchemaBasedParameter(
-      schema,
-      rawMode,
-      validationMode,
-      rawParameter,
-      // in editor mode we use lax validation mode, to be backward compatible
-      parameterForBasicMode = JsonSchemaBasedParameter.withEmptySchemaSupport(
-        schema.cast().rawSchema(),
-        defaultParamName = sinkValueParamName,
-        ValidationMode.lax
-      )
-    )
-  }
+  def extractJsonInputParameter(
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, List[Parameter]] =
+    JsonSchemaBasedParameter.emptySchemaBasedParameter(sinkValueParamName, ValidationMode.lax).map(_.toParameters)
 
 }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -81,25 +81,6 @@ class AvroSchemaSupport(kafkaConfig: KafkaConfig) extends ParsedSchemaSupport[Av
   override def typeDefinition(schema: ParsedSchema): TypingResult =
     AvroSchemaTypeDefinitionExtractor.typeDefinition(schema.cast().rawSchema())
 
-  override def extractParameter(
-      schema: ParsedSchema,
-      rawMode: Boolean,
-      validationMode: ValidationMode,
-      rawParameter: Parameter,
-      restrictedParamNames: Set[ParameterName]
-  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
-    if (rawMode) {
-      Validated.Valid(
-        SingleSchemaBasedParameter(
-          rawParameter,
-          new AvroSchemaOutputValidator(validationMode).validate(_, schema.cast().rawSchema())
-        )
-      )
-    } else {
-      AvroSchemaBasedParameter(schema.cast().rawSchema(), restrictedParamNames)
-    }
-  }
-
   override def formValueEncoder(schema: ParsedSchema, validationMode: ValidationMode): Any => AnyRef = {
     val encoder = ToAvroSchemaBasedEncoder(validationMode)
     (value: Any) => encoder.encodeOrError(value, schema.cast().rawSchema())
@@ -121,6 +102,45 @@ class AvroSchemaSupport(kafkaConfig: KafkaConfig) extends ParsedSchemaSupport[Av
     }
   }
 
+  override def extractParameterForSink(
+      schema: ParsedSchema,
+      rawMode: Boolean,
+      validationMode: ValidationMode,
+      rawParameter: Parameter,
+      restrictedParamNames: Set[ParameterName]
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
+    extractParameter(schema, rawMode, validationMode, rawParameter, restrictedParamNames)
+
+  override def extractParameterForTests(schema: ParsedSchema)(
+      implicit nodeId: NodeId
+  ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
+    extractParameter(
+      schema,
+      rawMode = false,
+      validationMode = ValidationMode.lax,
+      rawParameter = Parameter[AnyRef](sinkValueParamName),
+      restrictedParamNames = Set.empty
+    )
+
+  private def extractParameter(
+      schema: ParsedSchema,
+      rawMode: Boolean,
+      validationMode: ValidationMode,
+      rawParameter: Parameter,
+      restrictedParamNames: Set[ParameterName]
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
+    if (rawMode) {
+      Validated.Valid(
+        SingleSchemaBasedParameter(
+          rawParameter,
+          new AvroSchemaOutputValidator(validationMode).validate(_, schema.cast().rawSchema())
+        )
+      )
+    } else {
+      AvroSchemaBasedParameter(schema.cast().rawSchema(), restrictedParamNames)
+    }
+  }
+
 }
 
 object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
@@ -135,7 +155,36 @@ object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
 
   override def typeDefinition(schema: ParsedSchema): TypingResult = schema.cast().returnType
 
-  override def extractParameter(
+  override def formValueEncoder(schema: ParsedSchema, mode: ValidationMode): Any => AnyRef = {
+    val encoder   = new ToJsonSchemaBasedEncoder(mode)
+    val rawSchema = schema.cast().rawSchema()
+    (value: Any) => encoder.encodeOrError(value, rawSchema)
+  }
+
+  override def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport =
+    JsonPayloadRecordFormatterSupport
+
+  override def extractParameterForSink(
+      schema: ParsedSchema,
+      rawMode: Boolean,
+      validationMode: ValidationMode,
+      rawParameter: Parameter,
+      restrictedParamNames: Set[ParameterName]
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
+    extractParameter(schema, rawMode, validationMode, rawParameter, restrictedParamNames)
+
+  override def extractParameterForTests(schema: ParsedSchema)(
+      implicit nodeId: NodeId
+  ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
+    extractParameter(
+      schema,
+      rawMode = false,
+      validationMode = ValidationMode.lax,
+      rawParameter = Parameter[AnyRef](sinkValueParamName),
+      restrictedParamNames = Set.empty
+    )
+
+  private def extractParameter(
       schema: ParsedSchema,
       rawMode: Boolean,
       validationMode: ValidationMode,
@@ -155,14 +204,6 @@ object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
     }
   }
 
-  override def formValueEncoder(schema: ParsedSchema, mode: ValidationMode): Any => AnyRef = {
-    val encoder   = new ToJsonSchemaBasedEncoder(mode)
-    val rawSchema = schema.cast().rawSchema()
-    (value: Any) => encoder.encodeOrError(value, rawSchema)
-  }
-
-  override def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport =
-    JsonPayloadRecordFormatterSupport
 }
 
 object NoSchemaJsonSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
@@ -182,14 +223,14 @@ object NoSchemaJsonSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
   override def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport =
     jsonSupport.recordFormatterSupport(schemaRegistryClient)
 
-  override def extractParameter(
+  override def extractParameterForSink(
       schema: ParsedSchema,
       rawMode: Boolean,
       validationMode: ValidationMode,
       rawParameter: Parameter,
       restrictedParamNames: Set[ParameterName]
   )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
-    jsonSupport.extractParameter(schema, rawMode, validationMode, rawParameter, restrictedParamNames)
+    jsonSupport.extractParameterForSink(schema, rawMode, validationMode, rawParameter, restrictedParamNames)
 
   override def extractParameterForTests(schema: ParsedSchema)(implicit nodeId: NodeId): Valid[SchemaBasedParameter] = {
     val parameter =

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -188,13 +188,16 @@ object NoSchemaJsonSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
       validationMode: ValidationMode,
       rawParameter: Parameter,
       restrictedParamNames: Set[ParameterName]
-  )(implicit nodeId: NodeId): Valid[SchemaBasedParameter] = {
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
+    jsonSupport.extractParameter(schema, rawMode, validationMode, rawParameter, restrictedParamNames)
+
+  override def extractParameterForTests(schema: ParsedSchema)(implicit nodeId: NodeId): Valid[SchemaBasedParameter] = {
     val parameter =
       Parameter(sinkValueParamName, Unknown).copy(isLazyParameter = true, editors = List(JsonParameterEditor))
     Valid(
       SingleSchemaBasedParameter(
         parameter,
-        new JsonSchemaOutputValidator(validationMode).validate(_, EmptySchema.INSTANCE, None)
+        new JsonSchemaOutputValidator(ValidationMode.lax).validate(_, EmptySchema.INSTANCE, None)
       )
     )
   }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -121,7 +121,7 @@ class AvroSchemaSupport(kafkaConfig: KafkaConfig) extends ParsedSchemaSupport[Av
 
 }
 
-object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
+class JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
   override val payloadDeserializer: UniversalSchemaPayloadDeserializer = JsonSchemaPayloadDeserializer
 
   override def serializer(schemaOpt: Option[ParsedSchema], c: SchemaRegistryClient, isKey: Boolean): Serializer[Any] =
@@ -140,17 +140,15 @@ object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
       rawParameter: Parameter,
       restrictedParamNames: Set[ParameterName]
   )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
-    if (rawMode) {
-      Validated.Valid(
-        SingleSchemaBasedParameter(
-          rawParameter,
-          new JsonSchemaOutputValidator(validationMode).validate(_, schema.cast().rawSchema())
-        )
-      )
-    } else {
+    extractSchemaBasedParameter(
+      schema,
+      rawMode,
+      validationMode,
+      rawParameter,
       // in editor mode we use lax validation mode, to be backward compatible
-      JsonSchemaBasedParameter(schema.cast().rawSchema(), defaultParamName = sinkValueParamName, ValidationMode.lax)
-    }
+      parameterForBasicMode =
+        JsonSchemaBasedParameter(schema.cast().rawSchema(), defaultParamName = sinkValueParamName, ValidationMode.lax)
+    )
   }
 
   override def formValueEncoder(schema: ParsedSchema, mode: ValidationMode): Any => AnyRef = {
@@ -161,4 +159,49 @@ object JsonSchemaSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
 
   override def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport =
     JsonPayloadRecordFormatterSupport
+
+  protected def extractSchemaBasedParameter(
+      schema: ParsedSchema,
+      rawMode: Boolean,
+      validationMode: ValidationMode,
+      rawParameter: Parameter,
+      parameterForBasicMode: ValidatedNel[ProcessCompilationError, SchemaBasedParameter]
+  ): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
+    if (rawMode) {
+      Validated.Valid(
+        SingleSchemaBasedParameter(
+          rawParameter,
+          new JsonSchemaOutputValidator(validationMode).validate(_, schema.cast().rawSchema())
+        )
+      )
+    } else {
+      parameterForBasicMode
+    }
+  }
+
+}
+
+object EmptySchemaJsonSupport extends JsonSchemaSupport {
+
+  override def extractParameter(
+      schema: ParsedSchema,
+      rawMode: Boolean,
+      validationMode: ValidationMode,
+      rawParameter: Parameter,
+      restrictedParamNames: Set[ParameterName]
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] = {
+    extractSchemaBasedParameter(
+      schema,
+      rawMode,
+      validationMode,
+      rawParameter,
+      // in editor mode we use lax validation mode, to be backward compatible
+      parameterForBasicMode = JsonSchemaBasedParameter.withEmptySchemaSupport(
+        schema.cast().rawSchema(),
+        defaultParamName = sinkValueParamName,
+        ValidationMode.lax
+      )
+    )
+  }
+
 }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -1,16 +1,18 @@
 package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal
 
 import cats.data.{Validated, ValidatedNel}
+import cats.data.Validated.Valid
 import io.circe.Json
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import org.apache.kafka.common.errors.SerializationException
 import org.apache.kafka.common.serialization.Serializer
+import org.everit.json.schema.EmptySchema
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
-import pl.touk.nussknacker.engine.api.definition.Parameter
+import pl.touk.nussknacker.engine.api.definition.{JsonParameterEditor, Parameter}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
-import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
+import pl.touk.nussknacker.engine.api.typed.typing.{TypingResult, Unknown}
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.json.JsonSchemaBasedParameter
 import pl.touk.nussknacker.engine.json.encode.{JsonSchemaOutputValidator, ToJsonSchemaBasedEncoder}
@@ -186,7 +188,15 @@ object NoSchemaJsonSupport extends ParsedSchemaSupport[OpenAPIJsonSchema] {
       validationMode: ValidationMode,
       rawParameter: Parameter,
       restrictedParamNames: Set[ParameterName]
-  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
-    JsonSchemaBasedParameter.emptySchemaBasedParameter(sinkValueParamName, ValidationMode.lax)
+  )(implicit nodeId: NodeId): Valid[SchemaBasedParameter] = {
+    val parameter =
+      Parameter(sinkValueParamName, Unknown).copy(isLazyParameter = true, editors = List(JsonParameterEditor))
+    Valid(
+      SingleSchemaBasedParameter(
+        parameter,
+        new JsonSchemaOutputValidator(validationMode).validate(_, EmptySchema.INSTANCE, None)
+      )
+    )
+  }
 
 }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
@@ -14,7 +14,7 @@ import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.kafka.KafkaConfig
 import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransformer.sinkValueParamName
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.SchemaRegistryClient
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{ContentTypesSchemas, SchemaRegistryClient}
 import pl.touk.nussknacker.engine.util.parameters.SchemaBasedParameter
 
 class UniversalSchemaSupportDispatcher private (kafkaConfig: KafkaConfig) {
@@ -24,6 +24,13 @@ class UniversalSchemaSupportDispatcher private (kafkaConfig: KafkaConfig) {
 
   def forSchemaType(schemaType: String): UniversalSchemaSupport =
     supportBySchemaType.getOrElse(schemaType, throw new UnsupportedSchemaType(schemaType))
+
+  def forParsedSchema(parsedSchema: ParsedSchema): UniversalSchemaSupport = parsedSchema match {
+    // For ad hoc tests we want to present the user with json editor when topic has no schema and content type Json was selected
+    case ContentTypesSchemas.schemaForJson => NoSchemaJsonSupport
+    case _                                 => forSchemaType(parsedSchema.schemaType())
+  }
+
 }
 
 object UniversalSchemaSupportDispatcher {

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
@@ -20,7 +20,7 @@ import pl.touk.nussknacker.engine.util.parameters.SchemaBasedParameter
 class UniversalSchemaSupportDispatcher private (kafkaConfig: KafkaConfig) {
 
   val supportBySchemaType: Map[String, UniversalSchemaSupport] =
-    Map(AvroSchema.TYPE -> new AvroSchemaSupport(kafkaConfig), JsonSchema.TYPE -> new JsonSchemaSupport)
+    Map(AvroSchema.TYPE -> new AvroSchemaSupport(kafkaConfig), JsonSchema.TYPE -> JsonSchemaSupport)
 
   def forSchemaType(schemaType: String): UniversalSchemaSupport =
     supportBySchemaType.getOrElse(schemaType, throw new UnsupportedSchemaType(schemaType))

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
@@ -48,7 +48,7 @@ trait UniversalSchemaSupport {
   def formValueEncoder(schema: ParsedSchema, mode: ValidationMode): Any => AnyRef
   def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport
 
-  def extractParameter(
+  protected def extractParameter(
       schema: ParsedSchema,
       rawMode: Boolean,
       validationMode: ValidationMode,
@@ -56,17 +56,31 @@ trait UniversalSchemaSupport {
       restrictedParamNames: Set[ParameterName]
   )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter]
 
-  final def extractParameters(
+  def extractParameterForSink(
+      schema: ParsedSchema,
+      rawMode: Boolean,
+      validationMode: ValidationMode,
+      rawParameter: Parameter,
+      restrictedParamNames: Set[ParameterName]
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
+    extractParameter(
+      schema: ParsedSchema,
+      rawMode: Boolean,
+      validationMode: ValidationMode,
+      rawParameter: Parameter,
+      restrictedParamNames: Set[ParameterName]
+    )
+
+  def extractParameterForTests(
       schema: ParsedSchema
-  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, List[Parameter]] = {
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
     extractParameter(
       schema,
       rawMode = false,
       validationMode = ValidationMode.lax,
       rawParameter = Parameter[AnyRef](sinkValueParamName),
       restrictedParamNames = Set.empty
-    ).map(_.toParameters)
-  }
+    )
 
   final def prepareMessageFormatter(schema: ParsedSchema, schemaRegistryClient: SchemaRegistryClient): Any => Json = {
     val recordFormatter = recordFormatterSupport(schemaRegistryClient)

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
@@ -20,7 +20,7 @@ import pl.touk.nussknacker.engine.util.parameters.SchemaBasedParameter
 class UniversalSchemaSupportDispatcher private (kafkaConfig: KafkaConfig) {
 
   val supportBySchemaType: Map[String, UniversalSchemaSupport] =
-    Map(AvroSchema.TYPE -> new AvroSchemaSupport(kafkaConfig), JsonSchema.TYPE -> JsonSchemaSupport)
+    Map(AvroSchema.TYPE -> new AvroSchemaSupport(kafkaConfig), JsonSchema.TYPE -> new JsonSchemaSupport)
 
   def forSchemaType(schemaType: String): UniversalSchemaSupport =
     supportBySchemaType.getOrElse(schemaType, throw new UnsupportedSchemaType(schemaType))

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaSupport.scala
@@ -13,7 +13,6 @@ import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.kafka.KafkaConfig
-import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransformer.sinkValueParamName
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{ContentTypesSchemas, SchemaRegistryClient}
 import pl.touk.nussknacker.engine.util.parameters.SchemaBasedParameter
 
@@ -48,7 +47,7 @@ trait UniversalSchemaSupport {
   def formValueEncoder(schema: ParsedSchema, mode: ValidationMode): Any => AnyRef
   def recordFormatterSupport(schemaRegistryClient: SchemaRegistryClient): RecordFormatterSupport
 
-  protected def extractParameter(
+  def extractParameterForSink(
       schema: ParsedSchema,
       rawMode: Boolean,
       validationMode: ValidationMode,
@@ -56,31 +55,9 @@ trait UniversalSchemaSupport {
       restrictedParamNames: Set[ParameterName]
   )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter]
 
-  def extractParameterForSink(
-      schema: ParsedSchema,
-      rawMode: Boolean,
-      validationMode: ValidationMode,
-      rawParameter: Parameter,
-      restrictedParamNames: Set[ParameterName]
-  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
-    extractParameter(
-      schema: ParsedSchema,
-      rawMode: Boolean,
-      validationMode: ValidationMode,
-      rawParameter: Parameter,
-      restrictedParamNames: Set[ParameterName]
-    )
-
   def extractParameterForTests(
       schema: ParsedSchema
-  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter] =
-    extractParameter(
-      schema,
-      rawMode = false,
-      validationMode = ValidationMode.lax,
-      rawParameter = Parameter[AnyRef](sinkValueParamName),
-      restrictedParamNames = Set.empty
-    )
+  )(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, SchemaBasedParameter]
 
   final def prepareMessageFormatter(schema: ParsedSchema, schemaRegistryClient: SchemaRegistryClient): Any => Json = {
     val recordFormatter = recordFormatterSupport(schemaRegistryClient)

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkFactory.scala
@@ -136,7 +136,7 @@ class UniversalKafkaSinkFactory(
         .andThen { runtimeSchemaData =>
           schemaSupportDispatcher
             .forSchemaType(runtimeSchemaData.schema.schemaType())
-            .extractParameter(
+            .extractParameterForSink(
               runtimeSchemaData.schema,
               rawMode = true,
               validationMode = extractValidationMode(mode),
@@ -171,7 +171,7 @@ class UniversalKafkaSinkFactory(
       val runtimeSchemaData = runtimeSchemaDataForContentType(contentType)
       schemaSupportDispatcher
         .forSchemaType(runtimeSchemaData.schema.schemaType())
-        .extractParameter(
+        .extractParameterForSink(
           runtimeSchemaData.schema,
           rawMode = true,
           validationMode = extractValidationMode(mode),
@@ -226,7 +226,7 @@ class UniversalKafkaSinkFactory(
         .andThen { schemaData =>
           schemaSupportDispatcher
             .forSchemaType(schemaData.schema.schemaType())
-            .extractParameter(
+            .extractParameterForSink(
               schemaData.schema,
               rawMode = false,
               validationMode = ValidationMode.lax,
@@ -257,7 +257,7 @@ class UniversalKafkaSinkFactory(
 
       schemaSupportDispatcher
         .forSchemaType(schemaData.schema.schemaType())
-        .extractParameter(
+        .extractParameterForSink(
           schemaData.schema,
           rawMode = false,
           validationMode = ValidationMode.lax,

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
@@ -25,7 +25,6 @@ import pl.touk.nussknacker.engine.api.process.{
 }
 import pl.touk.nussknacker.engine.api.test.TestRecord
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypingResult, Unknown}
-import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.kafka.PreparedKafkaTopic
 import pl.touk.nussknacker.engine.kafka.consumerrecord.SerializableConsumerRecord
 import pl.touk.nussknacker.engine.kafka.source._
@@ -37,7 +36,7 @@ import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransforme
 }
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry._
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.formatter.SchemaBasedSerializableConsumerRecord
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.{NoSchemaJsonSupport, UniversalSchemaSupport}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.UniversalSchemaSupport
 import pl.touk.nussknacker.engine.schemedkafka.source.UniversalKafkaSourceFactory._
 
 /**
@@ -256,7 +255,8 @@ class UniversalKafkaSourceFactory(
         val universalSchemaSupport: UniversalSchemaSupport = schemaSupportDispatcher.forParsedSchema(parsedSchema)
 
         universalSchemaSupport
-          .extractParameters(parsedSchema)
+          .extractParameterForTests(parsedSchema)
+          .map(_.toParameters)
           .map { params =>
             KafkaTestParametersInfo(params, prepareTestRecord(runtimeSchema, universalSchemaSupport, topic))
           }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
@@ -252,17 +252,11 @@ class UniversalKafkaSourceFactory(
         NonEmptyList.one(CustomNodeError(nodeId.id, "Cannot generate test parameters: no runtime schema found", None))
       )
       .andThen { runtimeSchema =>
-        val parsedSchema = runtimeSchema.schema
-        val universalSchemaSupport: UniversalSchemaSupport =
-          schemaSupportDispatcher.forSchemaType(runtimeSchema.schema.schemaType())
+        val parsedSchema                                   = runtimeSchema.schema
+        val universalSchemaSupport: UniversalSchemaSupport = schemaSupportDispatcher.forParsedSchema(parsedSchema)
 
-        val extractedParameters = parsedSchema match {
-          // For ad hoc tests we want to present the user with json editor when topic has no schema and content type Json was selected
-          case ContentTypesSchemas.schemaForJson => NoSchemaJsonSupport.extractJsonInputParameter()
-          case _                                 => universalSchemaSupport.extractParameters(parsedSchema)
-        }
-
-        extractedParameters
+        universalSchemaSupport
+          .extractParameters(parsedSchema)
           .map { params =>
             KafkaTestParametersInfo(params, prepareTestRecord(runtimeSchema, universalSchemaSupport, topic))
           }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
@@ -33,7 +33,7 @@ import pl.touk.nussknacker.engine.schemedkafka.{KafkaUniversalComponentTransform
 import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransformer.schemaVersionParamName
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry._
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.formatter.SchemaBasedSerializableConsumerRecord
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.UniversalSchemaSupport
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.{EmptySchemaJsonSupport, UniversalSchemaSupport}
 import pl.touk.nussknacker.engine.schemedkafka.source.UniversalKafkaSourceFactory._
 
 /**
@@ -248,8 +248,11 @@ class UniversalKafkaSourceFactory(
         NonEmptyList.one(CustomNodeError(nodeId.id, "Cannot generate test parameters: no runtime schema found", None))
       )
       .andThen { runtimeSchema =>
-        val universalSchemaSupport: UniversalSchemaSupport =
-          schemaSupportDispatcher.forSchemaType(runtimeSchema.schema.schemaType())
+        val universalSchemaSupport = runtimeSchema.schema match {
+          // For ad hoc tests we want to present the user with json editor when schemaless topic with Json content type was selected
+          case ContentTypesSchemas.schemaForJson => EmptySchemaJsonSupport
+          case _ => schemaSupportDispatcher.forSchemaType(runtimeSchema.schema.schemaType())
+        }
         universalSchemaSupport
           .extractParameters(runtimeSchema.schema)
           .map { params =>

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
@@ -25,15 +25,19 @@ import pl.touk.nussknacker.engine.api.process.{
 }
 import pl.touk.nussknacker.engine.api.test.TestRecord
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypingResult, Unknown}
+import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.kafka.PreparedKafkaTopic
 import pl.touk.nussknacker.engine.kafka.consumerrecord.SerializableConsumerRecord
 import pl.touk.nussknacker.engine.kafka.source._
 import pl.touk.nussknacker.engine.kafka.source.KafkaSourceFactory.{KafkaSourceImplFactory, KafkaTestParametersInfo}
 import pl.touk.nussknacker.engine.schemedkafka.{KafkaUniversalComponentTransformer, RuntimeSchemaData}
-import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransformer.schemaVersionParamName
+import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransformer.{
+  schemaVersionParamName,
+  sinkValueParamName
+}
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry._
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.formatter.SchemaBasedSerializableConsumerRecord
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.{EmptySchemaJsonSupport, UniversalSchemaSupport}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.{NoSchemaJsonSupport, UniversalSchemaSupport}
 import pl.touk.nussknacker.engine.schemedkafka.source.UniversalKafkaSourceFactory._
 
 /**
@@ -248,13 +252,17 @@ class UniversalKafkaSourceFactory(
         NonEmptyList.one(CustomNodeError(nodeId.id, "Cannot generate test parameters: no runtime schema found", None))
       )
       .andThen { runtimeSchema =>
-        val universalSchemaSupport = runtimeSchema.schema match {
-          // For ad hoc tests we want to present the user with json editor when schemaless topic with Json content type was selected
-          case ContentTypesSchemas.schemaForJson => EmptySchemaJsonSupport
-          case _ => schemaSupportDispatcher.forSchemaType(runtimeSchema.schema.schemaType())
+        val parsedSchema = runtimeSchema.schema
+        val universalSchemaSupport: UniversalSchemaSupport =
+          schemaSupportDispatcher.forSchemaType(runtimeSchema.schema.schemaType())
+
+        val extractedParameters = parsedSchema match {
+          // For ad hoc tests we want to present the user with json editor when topic has no schema and content type Json was selected
+          case ContentTypesSchemas.schemaForJson => NoSchemaJsonSupport.extractJsonInputParameter()
+          case _                                 => universalSchemaSupport.extractParameters(parsedSchema)
         }
-        universalSchemaSupport
-          .extractParameters(runtimeSchema.schema)
+
+        extractedParameters
           .map { params =>
             KafkaTestParametersInfo(params, prepareTestRecord(runtimeSchema, universalSchemaSupport, topic))
           }


### PR DESCRIPTION
## Describe your changes

Currently when we try to run ad hoc tests with schemaless JSON kafka topic source we aren't presented with a Json editor and the underlying language for the data is SpEL. Because of that the validation doesn't work properly treating JSONs as SpEL.

<img width="834" alt="Screenshot 2025-03-24 at 08 48 08" src="https://github.com/user-attachments/assets/eba254e3-cb03-454d-9268-a2237c98c1a3" />

In these changes I switched the underlying language to a new JSON one and use `JsonParameterEditor` for the ad hoc tests.

<img width="834" alt="Screenshot 2025-03-24 at 08 38 46" src="https://github.com/user-attachments/assets/9f3cd7c8-618e-42d1-a632-a8c9e789b76e" />

<img width="834" alt="Screenshot 2025-03-24 at 08 39 58" src="https://github.com/user-attachments/assets/b5ba46e8-63d8-42f4-8828-747f698aded6" />

In another PR I'll change the `Unknown` type to a `Json` one and also rename the `Value` to `Input` in ad hoc tests as that name would better suit it.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
