### PR TITLE
[Nu-7702] Warn user when scenario version is outdated before save or deploy

### DIFF
--- a/designer/client/src/components/modals/GenericConfirmDialog.tsx
+++ b/designer/client/src/components/modals/GenericConfirmDialog.tsx
@@ -1,9 +1,12 @@
 import { css, cx } from "@emotion/css";
-import { WindowButtonProps, WindowContentProps } from "@touk/window-manager";
-import React, { PropsWithChildren, useMemo } from "react";
-import { useTranslation } from "react-i18next";
-import { PromptContent, WindowKind } from "../../windowManager";
 import { Typography } from "@mui/material";
+import type { WindowButtonProps, WindowContentProps } from "@touk/window-manager";
+import type { PropsWithChildren} from "react";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { WindowKind } from "../../windowManager";
+import { PromptContent } from "../../windowManager";
 import { LoadingButtonTypes } from "../../windowManager/LoadingButton";
 
 export interface ConfirmDialogData {
@@ -12,6 +15,7 @@ export interface ConfirmDialogData {
     denyText?: string;
     //TODO: get rid of callbacks in store
     onConfirmCallback: (confirmed: boolean) => void;
+    width?: number;
 }
 
 export function GenericConfirmDialog({

--- a/designer/client/src/components/toolbars/process/buttons/SaveButton.tsx
+++ b/designer/client/src/components/toolbars/process/buttons/SaveButton.tsx
@@ -1,12 +1,21 @@
+import { defaults } from "lodash";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
+
 import Icon from "../../../../assets/img/toolbarButtons/save.svg";
-import { getProcessName, getProcessUnsavedNewName, isProcessRenamed, isSaveDisabled } from "../../../../reducers/selectors/graph";
+import HttpService from "../../../../http/HttpService";
+import {
+    getProcessName,
+    getProcessUnsavedNewName,
+    getProcessVersionId,
+    isProcessRenamed,
+    isSaveDisabled,
+} from "../../../../reducers/selectors/graph";
 import { getCapabilities } from "../../../../reducers/selectors/other";
 import { useWindows, WindowKind } from "../../../../windowManager";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
-import { ToolbarButtonProps } from "../../types";
+import type { ToolbarButtonProps } from "../../types";
 function SaveButton(props: ToolbarButtonProps): JSX.Element {
     const { t } = useTranslation();
     const { disabled, type } = props;
@@ -14,20 +23,47 @@ function SaveButton(props: ToolbarButtonProps): JSX.Element {
     const saveDisabled = useSelector(isSaveDisabled);
 
     const processName = useSelector(getProcessName);
+    const processVersionId = useSelector(getProcessVersionId);
     const unsavedNewName = useSelector(getProcessUnsavedNewName);
     const isRenamed = useSelector(isProcessRenamed);
     const title = isRenamed
         ? t("saveProcess.renameTitle", "Save scenario as {{name}}", { name: unsavedNewName })
         : t("saveProcess.title", "Save scenario {{name}}", { name: processName });
 
-    const { open } = useWindows();
-    const onClick = () =>
-        open({
-            title,
-            isModal: true,
-            shouldCloseOnEsc: true,
-            kind: WindowKind.saveProcess,
+    const { open, confirm } = useWindows();
+    const onClick = async () => {
+        await HttpService.validateProcessVersion(processName, processVersionId).then((res) => {
+            if (!res.data.isLatest) {
+                confirm({
+                    text: t(
+                        "panels.actions.confirm-unsafe-save.message",
+                        `Your local scenario version #${processVersionId} is outdated.
+                        There is newer version #${res.data.latestVersion} created by ${res.data.modifiedBy} available. Are you sure you want to override it?`,
+                    ),
+                    confirmText: t("panels.actions.confirm-unsafe-save.confirmButton", "Confirm"),
+                    denyText: t("panels.actions.confirm-unsafe-save.cancelButton", "Cancel"),
+                    onConfirmCallback: (confirmed) => {
+                        if (confirmed) {
+                            open({
+                                title,
+                                isModal: true,
+                                shouldCloseOnEsc: true,
+                                kind: WindowKind.saveProcess,
+                            });
+                        }
+                    },
+                    width: window.innerWidth / 3,
+                });
+            } else {
+                open({
+                    title,
+                    isModal: true,
+                    shouldCloseOnEsc: true,
+                    kind: WindowKind.saveProcess,
+                });
+            }
         });
+    };
 
     const available = !disabled && !saveDisabled && capabilities.write;
 

--- a/designer/client/src/components/toolbars/scenarioActions/buttons/DeployButton.tsx
+++ b/designer/client/src/components/toolbars/scenarioActions/buttons/DeployButton.tsx
@@ -1,24 +1,27 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+
 import { disableToolTipsHighlight, enableToolTipsHighlight, loadProcessState } from "../../../../actions/nk";
 import Icon from "../../../../assets/img/toolbarButtons/deploy.svg";
-import HttpService, { NodesDeploymentData } from "../../../../http/HttpService";
+import type { NodesDeploymentData } from "../../../../http/HttpService";
+import HttpService from "../../../../http/HttpService";
 import {
     getProcessName,
+    getProcessVersionId,
     hasError,
     isDeployPossible,
     isSaveDisabled,
     isValidationResultPresent,
 } from "../../../../reducers/selectors/graph";
 import { getCapabilities } from "../../../../reducers/selectors/other";
+import { ACTION_DIALOG_WIDTH } from "../../../../stylesheets/variables";
 import { useWindows } from "../../../../windowManager";
 import { WindowKind } from "../../../../windowManager";
-import { ToggleProcessActionModalData } from "../../../modals/DeployProcessDialog";
+import type { ToggleProcessActionModalData } from "../../../modals/DeployProcessDialog";
+import type { ProcessName, ProcessVersionId } from "../../../Process/types";
 import { ToolbarButton } from "../../../toolbarComponents/toolbarButtons";
-import { ToolbarButtonProps } from "../../types";
-import { ACTION_DIALOG_WIDTH } from "../../../../stylesheets/variables";
-import { ProcessName, ProcessVersionId } from "../../../Process/types";
+import type { ToolbarButtonProps } from "../../types";
 
 export default function DeployButton(props: ToolbarButtonProps) {
     const dispatch = useDispatch();
@@ -27,6 +30,7 @@ export default function DeployButton(props: ToolbarButtonProps) {
     const hasErrors = useSelector(hasError);
     const validationResultPresent = useSelector(isValidationResultPresent);
     const processName = useSelector(getProcessName);
+    const processVersionId = useSelector(getProcessVersionId);
     const capabilities = useSelector(getCapabilities);
     const { disabled, type } = props;
 
@@ -42,11 +46,46 @@ export default function DeployButton(props: ToolbarButtonProps) {
     const deployMouseOver = hasErrors ? () => dispatch(enableToolTipsHighlight()) : null;
     const deployMouseOut = hasErrors ? () => dispatch(disableToolTipsHighlight()) : null;
 
-    const { open } = useWindows();
+    const { open, confirm } = useWindows();
 
     const message = t("panels.actions.deploy.dialog", "Deploy scenario {{name}}", { name: processName });
     const action = (name: ProcessName, versionId: ProcessVersionId, comment: string, nodesDeploymentData?: NodesDeploymentData) =>
         HttpService.deploy(name, comment, nodesDeploymentData).finally(() => dispatch(loadProcessState(name, versionId)));
+
+    const handleOnClick = async () => {
+        await HttpService.validateProcessVersion(processName, processVersionId).then((res) => {
+            if (!res.data.isLatest) {
+                confirm({
+                    text: t(
+                        "panels.actions.confirm-unsafe-deployment.message",
+                        `There is newer version #${res.data.latestVersion} created by ${res.data.modifiedBy} available. Scenario will be deployed using the newest version.
+                         You're currently checked out on version #${res.data.localVersion}. 
+                         Are you sure you want to perform this action?`,
+                    ),
+                    confirmText: t("panels.actions.confirm-unsafe-deployment.confirmButton", "Confirm"),
+                    denyText: t("panels.actions.confirm-unsafe-deployment.cancelButton", "Cancel"),
+                    onConfirmCallback: (confirmed) => {
+                        if (confirmed) {
+                            open<ToggleProcessActionModalData>({
+                                title: message,
+                                kind: WindowKind.deployWithParameters,
+                                width: ACTION_DIALOG_WIDTH,
+                                meta: { action, displayWarnings: true },
+                            });
+                        }
+                    },
+                    width: window.innerWidth / 3,
+                });
+            } else {
+                open<ToggleProcessActionModalData>({
+                    title: message,
+                    kind: WindowKind.deployWithParameters,
+                    width: ACTION_DIALOG_WIDTH,
+                    meta: { action, displayWarnings: true },
+                });
+            }
+        });
+    };
 
     return (
         <ToolbarButton
@@ -54,14 +93,7 @@ export default function DeployButton(props: ToolbarButtonProps) {
             disabled={!available}
             icon={<Icon />}
             title={deployToolTip}
-            onClick={() =>
-                open<ToggleProcessActionModalData>({
-                    title: message,
-                    kind: WindowKind.deployWithParameters,
-                    width: ACTION_DIALOG_WIDTH,
-                    meta: { action, displayWarnings: true },
-                })
-            }
+            onClick={handleOnClick}
             onMouseOver={deployMouseOver}
             onMouseOut={deployMouseOut}
             type={type}

--- a/designer/client/src/components/versionControl/types.ts
+++ b/designer/client/src/components/versionControl/types.ts
@@ -1,0 +1,8 @@
+export type ProcessVersionValidationResponse = {
+    processName: string;
+    isLatest: boolean;
+    localVersion: number;
+    latestDeployedVersion: number | null;
+    latestVersion: number;
+    modifiedBy: string;
+};

--- a/designer/client/src/http/HttpService.ts
+++ b/designer/client/src/http/HttpService.ts
@@ -31,6 +31,7 @@ import { handleAxiosError } from "../devHelpers";
 import { Dimensions, StickyNote } from "../common/StickyNote";
 import { STICKY_NOTE_DEFAULT_COLOR } from "../components/graph/EspNode/stickyNote";
 import { ScenarioActionResult, ScenarioActionResultType } from "../components/toolbars/scenarioActions/buttons/types";
+import { ProcessVersionValidationResponse } from "../components/versionControl/types";
 
 type HealthCheckProcessDeploymentType = {
     status: string;
@@ -592,6 +593,17 @@ class HttpService {
             .catch((error) =>
                 Promise.reject(
                     this.#addError(i18next.t("notification.error.cannotValidateScenarioLabels", "Cannot validate scenario labels"), error),
+                ),
+            );
+    }
+
+    validateProcessVersion(processName: string, localVersion: number): Promise<AxiosResponse<ProcessVersionValidationResponse>> {
+        const data = { localVersion: localVersion };
+        return api
+            .post<ProcessVersionValidationResponse>(`/versionControl/${processName}/versionValidation`, data)
+            .catch((error) =>
+                Promise.reject(
+                    this.#addError(i18next.t("notification.error.cannotValidateProcessVersion", "Cannot validate process version"), error),
                 ),
             );
     }

--- a/designer/client/src/windowManager/useWindows.ts
+++ b/designer/client/src/windowManager/useWindows.ts
@@ -1,11 +1,13 @@
-import { useWindowManager, WindowId, WindowType } from "@touk/window-manager";
+import type { WindowId, WindowType } from "@touk/window-manager";
+import { useWindowManager } from "@touk/window-manager";
 import { defaults } from "lodash";
 import { useCallback, useEffect, useMemo } from "react";
+
 import { useUserSettings } from "../common/userSettings";
-import { ConfirmDialogData } from "../components/modals/GenericConfirmDialog";
-import { InfoDialogData } from "../components/modals/GenericInfoDialog";
-import { Scenario } from "../components/Process/types";
-import { NodeType } from "../types";
+import type { ConfirmDialogData } from "../components/modals/GenericConfirmDialog";
+import type { InfoDialogData } from "../components/modals/GenericInfoDialog";
+import type { Scenario } from "../components/Process/types";
+import type { NodeType } from "../types";
 import { WindowKind } from "./WindowKind";
 
 const useRemoveFocusOnEscKey = (isWindowOpen: boolean) => {
@@ -93,6 +95,7 @@ export function useWindows(parent?: WindowId) {
                 title: data.text,
                 kind: WindowKind.confirm,
                 meta: defaults(data, { confirmText: "Yes", denyText: "No" }),
+                ...(data.width != null && { layoutData: { width: data.width } }),
             });
         },
         [open],

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/VersionControlApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/VersionControlApiHttpService.scala
@@ -1,0 +1,63 @@
+package pl.touk.nussknacker.ui.api
+
+import cats.data.EitherT
+import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessIdWithName, ProcessName}
+import pl.touk.nussknacker.ui.api.description.VersionControlApiEndpoints
+import pl.touk.nussknacker.ui.api.description.VersionControlApiEndpoints.Dtos._
+import pl.touk.nussknacker.ui.api.description.VersionControlApiEndpoints.VersionControlError
+import pl.touk.nussknacker.ui.api.description.VersionControlApiEndpoints.VersionControlError.{
+  MissingProcessId,
+  MissingProcessVersion
+}
+import pl.touk.nussknacker.ui.process.{ProcessService, ScenarioQuery, ScenarioVersionQuery}
+import pl.touk.nussknacker.ui.process.ProcessService.{GetScenarioWithDetailsOptions, SkipScenarioGraph}
+import pl.touk.nussknacker.ui.process.repository.ScenarioVersionMetadata
+import pl.touk.nussknacker.ui.security.api.AuthManager
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class VersionControlApiHttpService(
+    authManager: AuthManager,
+    processService: ProcessService
+)(implicit executionContext: ExecutionContext)
+    extends BaseHttpService(authManager)
+    with LazyLogging {
+  private val securityInput = authManager.authenticationEndpointInput()
+
+  private val endpoints = new VersionControlApiEndpoints(securityInput)
+
+  expose {
+    endpoints.versionValidationEndpoint
+      .serverSecurityLogic(authorizeKnownUser[VersionControlError])
+      .serverLogicEitherT { implicit loggedUser =>
+        { case (scenarioName, processVersionValidationRequest) =>
+          for {
+            pid <- EitherT.fromOptionF(processService.getProcessId(scenarioName), MissingProcessId(scenarioName.value))
+
+            processWithDetails <- EitherT.right(
+              processService.getLatestProcessWithDetails(
+                ProcessIdWithName(pid, scenarioName),
+                GetScenarioWithDetailsOptions(SkipScenarioGraph, false)
+              )
+            )
+
+            localVersion          = processVersionValidationRequest.localVersion
+            latestDeployedVersion = processWithDetails.lastDeployedAction.map(_.processVersionId).map(_.value)
+            latestVersion         = processWithDetails.processVersionId.value
+            modifiedBy            = processWithDetails.modifiedBy
+
+            response = ProcessVersionValidationResponseDto(
+              processName = scenarioName.value,
+              isLatest = localVersion == latestVersion,
+              localVersion = localVersion,
+              latestDeployedVersion = latestDeployedVersion,
+              latestVersion = latestVersion,
+              modifiedBy = modifiedBy
+            )
+          } yield response
+        }
+      }
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/VersionControlApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/VersionControlApiEndpoints.scala
@@ -1,0 +1,126 @@
+package pl.touk.nussknacker.ui.api.description
+
+import derevo.circe.{decoder, encoder}
+import derevo.derive
+import pl.touk.nussknacker.engine.api.process.ProcessName
+import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions
+import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions.SecuredEndpoint
+import pl.touk.nussknacker.security.AuthCredentials
+import pl.touk.nussknacker.ui.api.TapirCodecs.ScenarioNameCodec._
+import pl.touk.nussknacker.ui.api.description.VersionControlApiEndpoints.VersionControlError
+import pl.touk.nussknacker.ui.api.description.VersionControlApiEndpoints.VersionControlError.{
+  MissingProcessId,
+  MissingProcessVersion
+}
+import sttp.model.StatusCode.BadRequest
+import sttp.tapir._
+import sttp.tapir.EndpointIO.Example
+import sttp.tapir.derevo.schema
+import sttp.tapir.json.circe._
+
+class VersionControlApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseEndpointDefinitions {
+
+  import VersionControlApiEndpoints.Dtos._
+
+  lazy val versionValidationEndpoint: SecuredEndpoint[
+    (ProcessName, ProcessVersionValidationRequestDto),
+    VersionControlError,
+    ProcessVersionValidationResponseDto,
+    Any
+  ] =
+    baseNuApiEndpoint
+      .summary("Checks if local scenario version is the newest one")
+      .tag("Version Control")
+      .post
+      .in("versionControl" / path[ProcessName]("scenarioName") / "versionValidation")
+      .in(
+        jsonBody[ProcessVersionValidationRequestDto]
+          .example(
+            ProcessVersionValidationRequestDto(
+              localVersion = 24
+            )
+          )
+      )
+      .out(
+        jsonBody[ProcessVersionValidationResponseDto]
+          .examples(
+            List(
+              Example.of(
+                name = Some("Newer process version is available"),
+                value = ProcessVersionValidationResponseDto(
+                  processName = "p1",
+                  isLatest = false,
+                  localVersion = 51,
+                  latestDeployedVersion = None,
+                  latestVersion = 52,
+                  modifiedBy = "nussknacker"
+                )
+              ),
+              Example.of(
+                name = Some("Process local version is the latest one"),
+                value = ProcessVersionValidationResponseDto(
+                  processName = "p2",
+                  isLatest = true,
+                  localVersion = 52,
+                  latestDeployedVersion = Some(48),
+                  latestVersion = 52,
+                  modifiedBy = "nussknacker"
+                )
+              )
+            )
+          )
+      )
+      .errorOut(
+        oneOf[VersionControlError](
+          oneOfVariant(
+            BadRequest,
+            plainBody[MissingProcessVersion]
+          ),
+          oneOfVariant(
+            BadRequest,
+            plainBody[MissingProcessId]
+          )
+        )
+      )
+      .withSecurity(auth)
+
+}
+
+object VersionControlApiEndpoints {
+
+  object Dtos {
+
+    @derive(schema, encoder, decoder)
+    final case class ProcessVersionValidationRequestDto(localVersion: Int)
+
+    @derive(schema, encoder, decoder)
+    final case class ProcessVersionValidationResponseDto(
+        processName: String,
+        isLatest: Boolean,
+        localVersion: Long,
+        latestDeployedVersion: Option[Long],
+        latestVersion: Long,
+        modifiedBy: String
+    )
+
+  }
+
+  sealed trait VersionControlError
+
+  object VersionControlError {
+    case class MissingProcessVersion(processName: String) extends VersionControlError
+    case class MissingProcessId(processName: String)      extends VersionControlError
+
+    implicit val missingProcessVersionCodec: Codec[String, MissingProcessVersion, CodecFormat.TextPlain] =
+      BaseEndpointDefinitions.toTextPlainCodecSerializationOnly[MissingProcessVersion](e =>
+        s"Missing scenario process version for process: ${e.processName}"
+      )
+
+    implicit val missingProcessIdCodec: Codec[String, MissingProcessId, CodecFormat.TextPlain] =
+      BaseEndpointDefinitions.toTextPlainCodecSerializationOnly[MissingProcessId](e =>
+        s"Missing process id for scenario with name: ${e.processName}"
+      )
+
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/TapirHttpServiceFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/TapirHttpServiceFactory.scala
@@ -71,6 +71,11 @@ object TapirHttpServiceFactory {
       categories = processingTypeServicesProvider.mapValues(_.category)
     )
 
+    val versionControlApiHttpService = new VersionControlApiHttpService(
+      authManager = authManager,
+      processService = processService
+    )
+
     val scenarioLabelsApiHttpService = new ScenarioLabelsApiHttpService(
       authManager = authManager,
       service = new ScenarioLabelsService(
@@ -239,6 +244,7 @@ object TapirHttpServiceFactory {
       scenarioParametersHttpService,
       stickyNotesApiHttpService,
       userApiHttpService,
+      versionControlApiHttpService,
       statisticsApiHttpService
     )
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/WithCategoryUsedMoreThanOnceConfigScenarioHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/WithCategoryUsedMoreThanOnceConfigScenarioHelper.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.test.base.it
 
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.test.base.db.WithTestDb
@@ -19,12 +20,19 @@ trait WithCategoryUsedMoreThanOnceConfigScenarioHelper {
     rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, isFragment = false)
   }
 
+  def prepareDeploy(scenarioId: ProcessId): Unit =
+    rawScenarioHelper.prepareDeploy(scenarioId).futureValue
+
   def createArchivedExampleScenario(scenarioName: ProcessName): ProcessId = {
     rawScenarioHelper.createArchivedExampleScenario(scenarioName, usedCategory.stringify, isFragment = false)
   }
 
   def createSavedFragment(scenario: CanonicalProcess): ProcessId = {
     rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, isFragment = true)
+  }
+
+  def updateScenario(scenarioName: ProcessName, scenario: CanonicalProcess): ProcessId = {
+    rawScenarioHelper.updateScenario(scenarioName, scenario).processId
   }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
@@ -151,7 +151,7 @@ private[test] class ScenarioHelper(dbRef: DbRef, clock: Clock, designerConfig: C
       )
     )
 
-  private def prepareDeploy(scenarioId: ProcessId): Future[_] = {
+  def prepareDeploy(scenarioId: ProcessId): Future[_] = {
     val actionName = ScenarioActionName.Deploy
     val comment    = Comment.from("Deploy comment")
     dbioRunner.run(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/VersionControlApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/VersionControlApiHttpServiceBusinessSpec.scala
@@ -1,0 +1,164 @@
+package pl.touk.nussknacker.ui.api
+
+import io.restassured.RestAssured.`given`
+import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
+import org.scalatest.concurrent.Eventually
+import org.scalatest.freespec.AnyFreeSpecLike
+import pl.touk.nussknacker.engine.api.process.ProcessName
+import pl.touk.nussknacker.engine.build.ScenarioBuilder
+import pl.touk.nussknacker.test.{
+  NuRestAssureExtensions,
+  NuRestAssureMatchers,
+  RestAssuredVerboseLoggingIfValidationFails,
+  StandardPatientScalaFutures
+}
+import pl.touk.nussknacker.test.base.it.{NuItTest, WithCategoryUsedMoreThanOnceConfigScenarioHelper}
+import pl.touk.nussknacker.test.config.WithCategoryUsedMoreThanOnceDesignerConfig
+import pl.touk.nussknacker.test.processes.WithScenarioActivitySpecAsserts
+
+class VersionControlApiHttpServiceBusinessSpec
+    extends AnyFreeSpecLike
+    with NuItTest
+    with WithCategoryUsedMoreThanOnceDesignerConfig
+    with WithScenarioActivitySpecAsserts
+    with WithCategoryUsedMoreThanOnceConfigScenarioHelper
+    with NuRestAssureExtensions
+    with NuRestAssureMatchers
+    with RestAssuredVerboseLoggingIfValidationFails
+    with Eventually
+    with StandardPatientScalaFutures {
+
+  "The endpoint for version control should" - {
+    "return the latest version when the scenario is unchanged" in {
+      given()
+        .applicationState(
+          createSavedScenario(exampleScenario)
+        )
+        .when()
+        .basicAuthAllPermUser()
+        .jsonBody(prepareRequestData(localVersion = 1))
+        .post(s"$nuDesignerHttpAddress/api/versionControl/test/versionValidation")
+        .Then()
+        .statusCode(200)
+        .equalsJsonBody(
+          prepareResponseData(
+            processName = processName.value,
+            isLatest = true,
+            localVersion = 1,
+            latestDeployedVersion = None,
+            latestVersion = 1,
+            modifiedBy = "admin"
+          )
+        )
+    }
+
+    "return an updated latest version when the scenario has changed" in {
+      given()
+        .applicationState(
+          {
+            createSavedScenario(exampleScenario)
+            updateScenario(processName, updatedScenario)
+          }
+        )
+        .when()
+        .basicAuthAllPermUser()
+        .jsonBody(prepareRequestData(localVersion = 1))
+        .post(s"$nuDesignerHttpAddress/api/versionControl/test/versionValidation")
+        .Then()
+        .statusCode(200)
+        .equalsJsonBody(
+          prepareResponseData(
+            processName = processName.value,
+            isLatest = false,
+            localVersion = 1,
+            latestDeployedVersion = None,
+            latestVersion = 2,
+            modifiedBy = "admin"
+          )
+        )
+    }
+
+    "return an updated latest deployed version" in {
+      given()
+        .applicationState(
+          {
+            val pid = createSavedScenario(exampleScenario)
+            prepareDeploy(pid)
+            updateScenario(processName, updatedScenario)
+          }
+        )
+        .when()
+        .basicAuthAllPermUser()
+        .jsonBody(prepareRequestData(localVersion = 1))
+        .post(s"$nuDesignerHttpAddress/api/versionControl/test/versionValidation")
+        .Then()
+        .statusCode(200)
+        .equalsJsonBody(
+          prepareResponseData(
+            processName = processName.value,
+            isLatest = false,
+            localVersion = 1,
+            latestDeployedVersion = Some(1),
+            latestVersion = 2,
+            modifiedBy = "admin"
+          )
+        )
+    }
+
+    "return an error when the scenario process ID is missing" in {
+      given()
+        .applicationState(
+          createSavedScenario(exampleScenario)
+        )
+        .when()
+        .basicAuthAllPermUser()
+        .jsonBody(prepareRequestData(localVersion = 2))
+        .post(s"$nuDesignerHttpAddress/api/versionControl/${missingProcessName.value}/versionValidation")
+        .Then()
+        .statusCode(400)
+        .equalsPlainBody(s"Missing process id for scenario with name: ${missingProcessName.value}")
+    }
+  }
+
+  private lazy val exampleScenario =
+    ScenarioBuilder
+      .withCustomMetaData("test", Map("environment" -> "test"))
+      .source("source", "csv-source-lite")
+      .emptySink("sink", "dead-end-lite")
+
+  private lazy val updatedScenario =
+    ScenarioBuilder
+      .withCustomMetaData("test", Map("environment" -> "test"))
+      .source("source", "csv-source-lite-v2")
+      .emptySink("sink", "dead-end-lite-v2")
+
+  private lazy val processName        = ProcessName("test")
+  private lazy val missingProcessName = ProcessName("missing-test")
+
+  private def prepareRequestData(localVersion: Int) =
+    s"""
+      |{
+      |  "localVersion": $localVersion
+      |}
+      |""".stripMargin
+
+  private def prepareResponseData(
+      processName: String,
+      isLatest: Boolean,
+      localVersion: Int,
+      latestDeployedVersion: Option[Long],
+      latestVersion: Int,
+      modifiedBy: String
+  ) =
+    s"""
+      |{
+      |  "processName": "$processName",
+      |  "isLatest": $isLatest,
+      |  "localVersion": $localVersion,
+      |  "latestDeployedVersion": ${latestDeployedVersion.getOrElse("null")},
+      |  "latestVersion": $latestVersion,
+      |  "modifiedBy": "$modifiedBy"
+      |}
+      |""".stripMargin
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/VersionControlApiHttpServiceSecuritySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/VersionControlApiHttpServiceSecuritySpec.scala
@@ -1,0 +1,84 @@
+package pl.touk.nussknacker.ui.api
+
+import io.restassured.RestAssured.`given`
+import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
+import org.hamcrest.Matchers.equalTo
+import org.scalatest.freespec.AnyFreeSpecLike
+import pl.touk.nussknacker.engine.api.process.ProcessName
+import pl.touk.nussknacker.engine.build.ScenarioBuilder
+import pl.touk.nussknacker.test.{NuRestAssureMatchers, RestAssuredVerboseLoggingIfValidationFails}
+import pl.touk.nussknacker.test.base.it.{NuItTest, WithSimplifiedConfigScenarioHelper}
+import pl.touk.nussknacker.test.config.{WithBusinessCaseRestAssuredUsersExtensions, WithSimplifiedDesignerConfig}
+
+class VersionControlApiHttpServiceSecuritySpec
+    extends AnyFreeSpecLike
+    with NuItTest
+    with WithSimplifiedDesignerConfig
+    with WithSimplifiedConfigScenarioHelper
+    with WithBusinessCaseRestAssuredUsersExtensions
+    with NuRestAssureMatchers
+    with RestAssuredVerboseLoggingIfValidationFails {
+
+  "The endpoint for version control should" - {
+    "authenticated should" - {
+      "return the latest version" in {
+        given()
+          .applicationState(
+            createSavedScenario(exampleScenario)
+          )
+          .when()
+          .basicAuthAllPermUser()
+          .jsonBody(requestDto)
+          .post(s"$nuDesignerHttpAddress/api/versionControl/${processName.value}/versionValidation")
+          .Then()
+          .statusCode(200)
+      }
+    }
+    "non authenticated should" - {
+      "forbid access" in {
+        given()
+          .applicationState(
+            createSavedScenario(exampleScenario)
+          )
+          .when()
+          .basicAuthUnknownUser()
+          .jsonBody(requestDto)
+          .post(s"$nuDesignerHttpAddress/api/versionControl/${processName.value}/versionValidation")
+          .Then()
+          .statusCode(401)
+          .body(equalTo("The supplied authentication is invalid"))
+      }
+    }
+    "no credentials were passed should" - {
+      "forbid access" in {
+        given()
+          .applicationState(
+            createSavedScenario(exampleScenario)
+          )
+          .when()
+          .noAuth()
+          .jsonBody(requestDto)
+          .post(s"$nuDesignerHttpAddress/api/versionControl/${processName.value}/versionValidation")
+          .Then()
+          .statusCode(401)
+          .body(equalTo("Invalid value (missing)"))
+      }
+    }
+  }
+
+  private lazy val processName = ProcessName("test")
+
+  private lazy val exampleScenario =
+    ScenarioBuilder
+      .withCustomMetaData("test", Map("environment" -> "test"))
+      .source("source", "csv-source-lite")
+      .emptySink("sink", "dead-end-lite")
+
+  private lazy val requestDto =
+    """
+      |{
+      |  "localVersion": 1
+      |}
+      |""".stripMargin
+
+}

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -3787,6 +3787,99 @@ paths:
       security:
       - {}
       - httpAuth: []
+  /api/versionControl/{scenarioName}/versionValidation:
+    post:
+      tags:
+      - Version Control
+      summary: Checks if local scenario version is the newest one
+      operationId: postApiVersioncontrolScenarionameVersionvalidation
+      parameters:
+      - name: Nu-Impersonate-User-Identity
+        in: header
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: scenarioName
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProcessVersionValidationRequestDto'
+            example:
+              localVersion: 24
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProcessVersionValidationResponseDto'
+              examples:
+                Newer process version is available:
+                  value:
+                    processName: p1
+                    isLatest: false
+                    localVersion: 51
+                    latestVersion: 52
+                    modifiedBy: nussknacker
+                Process local version is the latest one:
+                  value:
+                    processName: p2
+                    isLatest: true
+                    localVersion: 52
+                    latestDeployedVersion: 48
+                    latestVersion: 52
+                    modifiedBy: nussknacker
+        '400':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string
+        '401':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                CannotAuthenticateUser:
+                  value: The supplied authentication is invalid
+                ImpersonatedUserNotExistsError:
+                  value: No impersonated user data found for provided identity
+        '403':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                InsufficientPermission:
+                  value: The supplied authentication is not authorized to access this
+                    resource
+                ImpersonationMissingPermission:
+                  value: The supplied authentication is not authorized to impersonate
+        '501':
+          description: Impersonation is not supported for defined authentication mechanism
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                Example:
+                  summary: Cannot authenticate impersonated user as impersonation
+                    is not supported by the authentication mechanism
+                  value: Provided authentication method does not support impersonation
+      security:
+      - {}
+      - httpAuth: []
   /api/processes/{scenarioName}/{versionId}/activity/attachments:
     post:
       tags:
@@ -6939,6 +7032,42 @@ components:
       properties:
         additionalFields:
           $ref: '#/components/schemas/ProcessAdditionalFields'
+    ProcessVersionValidationRequestDto:
+      title: ProcessVersionValidationRequestDto
+      type: object
+      required:
+      - localVersion
+      properties:
+        localVersion:
+          type: integer
+          format: int32
+    ProcessVersionValidationResponseDto:
+      title: ProcessVersionValidationResponseDto
+      type: object
+      required:
+      - processName
+      - isLatest
+      - localVersion
+      - latestVersion
+      - modifiedBy
+      properties:
+        processName:
+          type: string
+        isLatest:
+          type: boolean
+        localVersion:
+          type: integer
+          format: int64
+        latestDeployedVersion:
+          type:
+          - integer
+          - 'null'
+          format: int64
+        latestVersion:
+          type: integer
+          format: int64
+        modifiedBy:
+          type: string
     PropertiesValidationRequestDto:
       title: PropertiesValidationRequestDto
       type: object


### PR DESCRIPTION
## Describe your changes

I implemented mechanism to warn user when tries to save version of scenario which is not the recent one (for example because someone else modified it in the meantime). 

![image](https://github.com/user-attachments/assets/fcac0070-8070-4c4d-ba04-7fa2df5879e2)

The analogous warning is added for deployment button

![image](https://github.com/user-attachments/assets/88657c25-f1db-480a-9e6a-701cb1797f2e)



## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
