### PR TITLE
Change the order of scenario properties in ProcessingTypeData

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeData.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeData.scala
@@ -71,11 +71,11 @@ object ProcessingTypeData {
       processingType: ProcessingType,
       componentDefinitionExtractionMode: ComponentDefinitionExtractionMode
   ) = {
-    val scenarioProperties = modelData.modelConfig
+    val scenarioProperties = deploymentScenarioPropertiesConfig ++ modelData.modelConfig
       .getOrElse[Map[ProcessingType, ScenarioPropertyConfig]](
         "scenarioPropertiesConfig",
         Map.empty
-      ) ++ deploymentScenarioPropertiesConfig
+      )
     val fragmentProperties = modelData.modelConfig
       .getOrElse[Map[ProcessingType, ScenarioPropertyConfig]]("fragmentPropertiesConfig", Map.empty)
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeData.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeData.scala
@@ -71,6 +71,7 @@ object ProcessingTypeData {
       processingType: ProcessingType,
       componentDefinitionExtractionMode: ComponentDefinitionExtractionMode
   ) = {
+    // TODO: consider using ParameterName for property names instead of String (for scenario and fragment properties)
     val scenarioProperties = deploymentScenarioPropertiesConfig ++ modelData.modelConfig
       .getOrElse[Map[String, ScenarioPropertyConfig]](
         "scenarioPropertiesConfig",

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeData.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeData.scala
@@ -72,12 +72,12 @@ object ProcessingTypeData {
       componentDefinitionExtractionMode: ComponentDefinitionExtractionMode
   ) = {
     val scenarioProperties = deploymentScenarioPropertiesConfig ++ modelData.modelConfig
-      .getOrElse[Map[ProcessingType, ScenarioPropertyConfig]](
+      .getOrElse[Map[String, ScenarioPropertyConfig]](
         "scenarioPropertiesConfig",
         Map.empty
       )
     val fragmentProperties = modelData.modelConfig
-      .getOrElse[Map[ProcessingType, ScenarioPropertyConfig]]("fragmentPropertiesConfig", Map.empty)
+      .getOrElse[Map[String, ScenarioPropertyConfig]]("fragmentPropertiesConfig", Map.empty)
 
     val staticDefinitionForDynamicComponents =
       createDynamicComponentsStaticDefinitions(modelData, metaDataInitializer, componentDefinitionExtractionMode)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeDataSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/processingtype/ProcessingTypeDataSpec.scala
@@ -1,0 +1,93 @@
+package pl.touk.nussknacker.ui.process.processingtype
+
+import cats.data.Validated.Valid
+import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.ConfigValueFactory.fromAnyRef
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.{JobsRecoverySettings, MetaDataInitializer}
+import pl.touk.nussknacker.engine.ProcessingTypeConfig.DeploymentManagerType
+import pl.touk.nussknacker.engine.api.component.{ComponentDefinition, ScenarioPropertyConfig}
+import pl.touk.nussknacker.engine.api.process.{Source, SourceFactory}
+import pl.touk.nussknacker.engine.deployment.EngineSetupName
+import pl.touk.nussknacker.engine.testing.LocalModelData
+import pl.touk.nussknacker.test.mock.MockDeploymentManager
+import pl.touk.nussknacker.test.utils.domain.TestFactory.modelDependencies
+
+class ProcessingTypeDataSpec extends AnyFunSuite with Matchers {
+
+  test("should combine config and deployment manager properties with priority of config properties") {
+
+    val propertyAFromConfig = ScenarioPropertyConfig.empty
+      .copy(
+        defaultValue = Some("default A config has higher priority"),
+        label = Some("label A config has higher priority"),
+      )
+    val propertyBFromConfig = ScenarioPropertyConfig.empty
+      .copy(
+        defaultValue = Some("default B config has higher priority"),
+        label = Some("label B config has higher priority")
+      )
+
+    val propertyBFromDeploymentData = ScenarioPropertyConfig.empty
+      .copy(
+        defaultValue = Some("default B"),
+        label = Some("label B"),
+      )
+
+    val propertyCFromDeploymentData = ScenarioPropertyConfig.empty
+      .copy(
+        defaultValue = Some("default C"),
+        label = Some("label C"),
+      )
+
+    val modelConfig = ConfigFactory
+      .empty()
+      .withValue("scenarioPropertiesConfig.property_A.defaultValue", fromAnyRef(propertyAFromConfig.defaultValue.get))
+      .withValue("scenarioPropertiesConfig.property_A.label", fromAnyRef(propertyAFromConfig.label.get))
+      .withValue("scenarioPropertiesConfig.property_B.defaultValue", fromAnyRef(propertyBFromConfig.defaultValue.get))
+      .withValue("scenarioPropertiesConfig.property_B.label", fromAnyRef(propertyBFromConfig.label.get))
+
+    val deploymentScenarioPropertiesConfig = Map(
+      "property_B" -> propertyBFromDeploymentData,
+      "property_C" -> propertyCFromDeploymentData
+    )
+
+    val processingTypeData = createProcessingTypeData(modelConfig, deploymentScenarioPropertiesConfig)
+
+    processingTypeData.designerModelData.scenarioPropertiesConfig shouldBe Map(
+      "property_A" -> propertyAFromConfig,
+      "property_B" -> propertyBFromConfig,
+      "property_C" -> propertyCFromDeploymentData
+    )
+
+  }
+
+  private def createProcessingTypeData(
+      modelConfig: Config,
+      deploymentScenarioPropertiesConfig: Map[String, ScenarioPropertyConfig]
+  ): ProcessingTypeData = {
+    val mockManager = MockDeploymentManager.create()
+    val deploymentData = new DeploymentData(
+      DeploymentManagerType("mock"),
+      Valid(mockManager),
+      MetaDataInitializer("streaming", Map.empty[String, String]),
+      deploymentScenarioPropertiesConfig,
+      List.empty,
+      JobsRecoverySettings.noRecovery,
+      EngineSetupName("mock")
+    )
+    ProcessingTypeData.createProcessingTypeData(
+      "dummy processingType",
+      LocalModelData(
+        modelConfig,
+        List(ComponentDefinition("source", SourceFactory.noParamUnboundedStreamFactory[Any](new Source {}))),
+        componentDefinitionExtractionMode = modelDependencies.componentDefinitionExtractionMode
+      ),
+      deploymentData,
+      category = "dummy category",
+      componentDefinitionExtractionMode = modelDependencies.componentDefinitionExtractionMode
+    )
+  }
+
+}


### PR DESCRIPTION
## Describe your changes

Model config should be able to alter/override fixed scenario parameters configuration provided by deployment manager. E.g. when I want to set additional validators for the parameter "Schedule" (aka "cron")  for PeriodicDeploymentManager.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
