### PR TITLE
Fix GeoUtils.distanceInKm, remove the Point class

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -150,6 +150,7 @@
 * [#7864](https://github.com/TouK/nussknacker/pull/7864) Add the forbidden IPs feature to the HTTP client configuration,
   if `followRedirect` is enabled then `Location` response header is also checked:
   * `forbiddenCidrs` - list of forbidden CIDR.
+* [#7961](https://github.com/TouK/nussknacker/pull/7961) Fix distance calculated by `GeoUtils.distanceInKm`
 
 ## 1.18
 

--- a/engine/flink/management/dev-model/src/test/resources/extractedTypes/devCreator.json
+++ b/engine/flink/management/dev-model/src/test/resources/extractedTypes/devCreator.json
@@ -18817,39 +18817,16 @@
     "methods": {
       "distanceInKm": [
         {
-          "description": "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm",
+          "description": "Calculate distance in kilometers between two points (with decimal coordinates), using the Haversine formula",
           "name": "distanceInKm",
           "signature": {
             "noVarArgs": [
-              {"name": "first point latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "first point longitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "second point latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "first point longitude", "refClazz": {"refClazzName": "java.lang.Number"}}
+              {"name": "First point - latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "First point - longitude", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "Second point - latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "Second point - longitude", "refClazz": {"refClazzName": "java.lang.Number"}}
             ],
             "result": {"refClazzName": "java.lang.Double"}
-          }
-        },
-        {
-          "description": "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm",
-          "name": "distanceInKm",
-          "signature": {
-            "noVarArgs": [
-              {"name": "first point", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}},
-              {"name": "second point", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}}
-            ],
-            "result": {"refClazzName": "java.lang.Double"}
-          }
-        }
-      ],
-      "toPoint": [
-        {
-          "name": "toPoint",
-          "signature": {
-            "noVarArgs": [
-              {"name": "lat", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "lon", "refClazz": {"refClazzName": "java.lang.Number"}}
-            ],
-            "result": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}
           }
         }
       ]
@@ -19580,52 +19557,6 @@
           "signature": {
             "noVarArgs": [],
             "result": {"refClazzName": "java.time.format.DecimalStyle"}
-          }
-        }
-      ]
-    }
-  },
-  {
-    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"},
-    "methods": {
-      "lat": [
-        {
-          "name": "lat",
-          "signature": {
-            "noVarArgs": [],
-            "result": {"refClazzName": "java.lang.Double"}
-          }
-        }
-      ],
-      "lon": [
-        {
-          "name": "lon",
-          "signature": {
-            "noVarArgs": [],
-            "result": {"refClazzName": "java.lang.Double"}
-          }
-        }
-      ],
-      "toString": [
-        {
-          "name": "toString",
-          "signature": {
-            "noVarArgs": [],
-            "result": {"refClazzName": "java.lang.String"}
-          }
-        }
-      ]
-    },
-    "staticMethods": {
-      "apply": [
-        {
-          "name": "apply",
-          "signature": {
-            "noVarArgs": [
-              {"name": "lat", "refClazz": {"refClazzName": "java.lang.Double"}},
-              {"name": "lon", "refClazz": {"refClazzName": "java.lang.Double"}}
-            ],
-            "result": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}
           }
         }
       ]

--- a/engine/flink/management/dev-model/src/test/resources/extractedTypes/devCreator.json
+++ b/engine/flink/management/dev-model/src/test/resources/extractedTypes/devCreator.json
@@ -18821,10 +18821,10 @@
           "name": "distanceInKm",
           "signature": {
             "noVarArgs": [
-              {"name": "First point - latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "First point - longitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "Second point - latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "Second point - longitude", "refClazz": {"refClazzName": "java.lang.Number"}}
+              {"name": "latitude1", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "longitude1", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "latitude2", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "longitude2", "refClazz": {"refClazzName": "java.lang.Number"}}
             ],
             "result": {"refClazzName": "java.lang.Double"}
           }

--- a/engine/flink/tests/src/test/resources/extractedTypes/defaultModel.json
+++ b/engine/flink/tests/src/test/resources/extractedTypes/defaultModel.json
@@ -17426,10 +17426,10 @@
           "name": "distanceInKm",
           "signature": {
             "noVarArgs": [
-              {"name": "First point - latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "First point - longitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "Second point - latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "Second point - longitude", "refClazz": {"refClazzName": "java.lang.Number"}}
+              {"name": "latitude1", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "longitude1", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "latitude2", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "longitude2", "refClazz": {"refClazzName": "java.lang.Number"}}
             ],
             "result": {"refClazzName": "java.lang.Double"}
           }

--- a/engine/flink/tests/src/test/resources/extractedTypes/defaultModel.json
+++ b/engine/flink/tests/src/test/resources/extractedTypes/defaultModel.json
@@ -15714,52 +15714,6 @@
     }
   },
   {
-    "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"},
-    "methods": {
-      "lat": [
-        {
-          "name": "lat",
-          "signature": {
-            "noVarArgs": [],
-            "result": {"refClazzName": "java.lang.Double"}
-          }
-        }
-      ],
-      "lon": [
-        {
-          "name": "lon",
-          "signature": {
-            "noVarArgs": [],
-            "result": {"refClazzName": "java.lang.Double"}
-          }
-        }
-      ],
-      "toString": [
-        {
-          "name": "toString",
-          "signature": {
-            "noVarArgs": [],
-            "result": {"refClazzName": "java.lang.String"}
-          }
-        }
-      ]
-    },
-    "staticMethods": {
-      "apply": [
-        {
-          "name": "apply",
-          "signature": {
-            "noVarArgs": [
-              {"name": "lat", "refClazz": {"refClazzName": "java.lang.Double"}},
-              {"name": "lon", "refClazz": {"refClazzName": "java.lang.Double"}}
-            ],
-            "result": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}
-          }
-        }
-      ]
-    }
-  },
-  {
     "clazzName": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.base64$"},
     "methods": {
       "decode": [
@@ -17468,39 +17422,16 @@
     "methods": {
       "distanceInKm": [
         {
-          "description": "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm",
+          "description": "Calculate distance in kilometers between two points (with decimal coordinates), using the Haversine formula",
           "name": "distanceInKm",
           "signature": {
             "noVarArgs": [
-              {"name": "first point latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "first point longitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "second point latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "first point longitude", "refClazz": {"refClazzName": "java.lang.Number"}}
+              {"name": "First point - latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "First point - longitude", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "Second point - latitude", "refClazz": {"refClazzName": "java.lang.Number"}},
+              {"name": "Second point - longitude", "refClazz": {"refClazzName": "java.lang.Number"}}
             ],
             "result": {"refClazzName": "java.lang.Double"}
-          }
-        },
-        {
-          "description": "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm",
-          "name": "distanceInKm",
-          "signature": {
-            "noVarArgs": [
-              {"name": "first point", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}},
-              {"name": "second point", "refClazz": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}}
-            ],
-            "result": {"refClazzName": "java.lang.Double"}
-          }
-        }
-      ],
-      "toPoint": [
-        {
-          "name": "toPoint",
-          "signature": {
-            "noVarArgs": [
-              {"name": "lat", "refClazz": {"refClazzName": "java.lang.Number"}},
-              {"name": "lon", "refClazz": {"refClazzName": "java.lang.Number"}}
-            ],
-            "result": {"refClazzName": "pl.touk.nussknacker.engine.util.functions.Point"}
           }
         }
       ]

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/geo.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/geo.scala
@@ -27,13 +27,13 @@ trait GeoUtils extends HideToString {
       latitude2.doubleValue().toRadians
     )
     val c = 2 * asin(sqrt(a))
-    c * EARTH_MEAN_RADIUS
+    c * EarthMeanRadius
   }
 
 }
 
-object GeoUtils {
+private object GeoUtils {
   // 6371 is recommended by the International Union of Geodesy and Geophysics,
   // it minimizes the RMS relative error between the great circle and geodesic distance
-  val EARTH_MEAN_RADIUS: Long = 6371
+  private val EarthMeanRadius: Long = 6371
 }

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/geo.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/geo.scala
@@ -7,34 +7,28 @@ object geo extends GeoUtils
 trait GeoUtils extends HideToString {
 
   @Documentation(description =
-    "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm"
+    "Calculate distance in kilometers between two points (with decimal coordinates), using the Haversine formula"
   )
   def distanceInKm(
-      @ParamName("first point latitude") currentLat: Number,
-      @ParamName("first point longitude") currentLon: Number,
-      @ParamName("second point latitude") otherLat: Number,
-      @ParamName("first point longitude") otherLon: Number
-  ): Double =
-    distanceInKm(toPoint(currentLat, currentLon), toPoint(otherLat, otherLon))
-
-  @Documentation(description =
-    "Calculate distance in km between two points (with decimal coordinates), using haversine algorithm"
-  )
-  // https://rosettacode.org/wiki/Haversine_formula#Scala
-  def distanceInKm(@ParamName("first point") current: Point, @ParamName("second point") other: Point): Double = {
-    val dLat = (current.lat - other.lat).toRadians
-    val dLon = (current.lon - other.lon).toRadians
-
+      @ParamName("First point - latitude") lat1: Number,
+      @ParamName("First point - longitude") lon1: Number,
+      @ParamName("Second point - latitude") lat2: Number,
+      @ParamName("Second point - longitude") lon2: Number
+  ): Double = {
+    // https://rosettacode.org/wiki/Haversine_formula#Scala
     import scala.math._
 
-    val a = pow(sin(dLat / 2), 2) + pow(sin(dLon / 2), 2) * cos(current.lon.toRadians) * cos(other.lat.toRadians)
+    val dLat = (lat1.doubleValue() - lat2.doubleValue()).toRadians
+    val dLon = (lon1.doubleValue() - lon2.doubleValue()).toRadians
+
+    val a = pow(sin(dLat / 2), 2) + pow(sin(dLon / 2), 2) * cos(lat1.doubleValue().toRadians) * cos(
+      lat2.doubleValue().toRadians
+    )
     val c = 2 * asin(sqrt(a))
-    val R = 6372.8
+    // 6371 is recommended by the International Union of Geodesy and Geophysics,
+    // it minimizes the RMS relative error between the great circle and geodesic distance
+    val R = 6371
     c * R
   }
 
-  def toPoint(lat: Number, lon: Number): Point = Point(lat.doubleValue(), lon.doubleValue())
-
 }
-
-case class Point(lat: Double, lon: Double)

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/geo.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/geo.scala
@@ -12,19 +12,19 @@ trait GeoUtils extends HideToString {
     "Calculate distance in kilometers between two points (with decimal coordinates), using the Haversine formula"
   )
   def distanceInKm(
-      @ParamName("First point - latitude") lat1: Number,
-      @ParamName("First point - longitude") lon1: Number,
-      @ParamName("Second point - latitude") lat2: Number,
-      @ParamName("Second point - longitude") lon2: Number
+      @ParamName("latitude1") latitude1: Number,
+      @ParamName("longitude1") longitude1: Number,
+      @ParamName("latitude2") latitude2: Number,
+      @ParamName("longitude2") longitude2: Number
   ): Double = {
     // https://rosettacode.org/wiki/Haversine_formula#Scala
     import scala.math._
 
-    val dLat = (lat1.doubleValue() - lat2.doubleValue()).toRadians
-    val dLon = (lon1.doubleValue() - lon2.doubleValue()).toRadians
+    val dLat = (latitude1.doubleValue() - latitude2.doubleValue()).toRadians
+    val dLon = (longitude1.doubleValue() - longitude2.doubleValue()).toRadians
 
-    val a = pow(sin(dLat / 2), 2) + pow(sin(dLon / 2), 2) * cos(lat1.doubleValue().toRadians) * cos(
-      lat2.doubleValue().toRadians
+    val a = pow(sin(dLat / 2), 2) + pow(sin(dLon / 2), 2) * cos(latitude1.doubleValue().toRadians) * cos(
+      latitude2.doubleValue().toRadians
     )
     val c = 2 * asin(sqrt(a))
     c * EARTH_MEAN_RADIUS

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/geo.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/geo.scala
@@ -6,6 +6,8 @@ object geo extends GeoUtils
 
 trait GeoUtils extends HideToString {
 
+  import GeoUtils._
+
   @Documentation(description =
     "Calculate distance in kilometers between two points (with decimal coordinates), using the Haversine formula"
   )
@@ -25,10 +27,13 @@ trait GeoUtils extends HideToString {
       lat2.doubleValue().toRadians
     )
     val c = 2 * asin(sqrt(a))
-    // 6371 is recommended by the International Union of Geodesy and Geophysics,
-    // it minimizes the RMS relative error between the great circle and geodesic distance
-    val R = 6371
-    c * R
+    c * EARTH_MEAN_RADIUS
   }
 
+}
+
+object GeoUtils {
+  // 6371 is recommended by the International Union of Geodesy and Geophysics,
+  // it minimizes the RMS relative error between the great circle and geodesic distance
+  val EARTH_MEAN_RADIUS: Long = 6371
 }

--- a/utils/default-helpers/src/test/scala/pl/touk/nussknacker/engine/util/functions/GeoUtilsSpec.scala
+++ b/utils/default-helpers/src/test/scala/pl/touk/nussknacker/engine/util/functions/GeoUtilsSpec.scala
@@ -1,0 +1,23 @@
+package pl.touk.nussknacker.engine.util.functions
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class GeoUtilsSpec extends AnyFunSuite with Matchers {
+
+  test("accepts Null Island") {
+    geo.distanceInKm(0, 0, 0, 0) shouldBe 0
+  }
+
+  test("calculates distance between the White House and the Eiffel Tower") {
+    val whiteHouse  = (38.898, -77.037)
+    val eiffelTower = (48.858, 2.294)
+
+    val distanceOnWGS84Ellipsoid = 6177.45
+    // we assume up to 0.5% error
+    geo.distanceInKm(whiteHouse._1, whiteHouse._2, eiffelTower._1, eiffelTower._2) should ===(
+      distanceOnWGS84Ellipsoid +- distanceOnWGS84Ellipsoid * 0.005
+    )
+  }
+
+}


### PR DESCRIPTION
## Describe your changes

* fixes a case of copy-paste gone wrong
* removes the `Point` class - we don't want Scala types in Flink state, and seeing as the algorithm was wrong nobody was using it anyway (I hope)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
