### PR TITLE
Method doing conversion but without conversion (`TypingResult.canBeConvertedWithoutConversionTo`) removal.

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminer.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminer.scala
@@ -30,7 +30,7 @@ private[typed] object AssignabilityDeterminer {
       case (_, Unknown(_))    => ().validNel
       case (Unknown(_), _)    => ().validNel
       case (TypedNull, other) => isNullAssignableTo(other)
-      case (_, TypedNull)     => s"No type can be assigned to ${TypedNull.display}".invalidNel
+      case (_, TypedNull)     => s"${from.display} cannot be assigned to ${TypedNull.display}".invalidNel
       case (given: SingleTypingResult, target: TypedUnion) =>
         isAnyOfAssignableToAnyOf(NonEmptyList.one(given), target.possibleTypes)
       case (given: TypedUnion, targe: SingleTypingResult) =>
@@ -83,10 +83,10 @@ private[typed] object AssignabilityDeterminer {
           condNel(
             given.dictId == target.dictId,
             (),
-            "The type and target type are Dicts with unequal IDs"
+            "Given type and target type are Dicts with unequal IDs"
           )
         case (_: TypedDict, _) =>
-          "The type is a Dict but the target type not".invalidNel
+          "Given type is a Dict but the target type not".invalidNel
         case (_, _: TypedDict) =>
           "The target type is a Dict but given type not".invalidNel
         case _ =>
@@ -103,7 +103,7 @@ private[typed] object AssignabilityDeterminer {
           )
         case (_: TypedTaggedValue, _) => ().validNel
         case (_, _: TypedTaggedValue) =>
-          s"The type is not a tagged value".invalidNel
+          s"Given type is not a tagged value but target type is".invalidNel
         case _ => ().validNel
       }
     }
@@ -159,7 +159,8 @@ private[typed] object AssignabilityDeterminer {
               canBeAssignedToOrAssignedFrom(givenClassParam, targetParam).isValid
             },
             (),
-            s"Wrong type parameters"
+            s"Generic type parameters (${givenClass.params.map(_.display).mkString(", ")}) don't match " +
+              s"expected parameters: ${targetCandidate.params.map(_.display).mkString(", ")}"
           )
       }
     }
@@ -169,7 +170,7 @@ private[typed] object AssignabilityDeterminer {
       condNel(
         givenClass == to,
         (),
-        f"${givenClass.display} and ${to.display} are not the same"
+        f"${givenClass.display} cannot be assigned to ${to.display}"
       ) orElse
         isAssignable(givenClass.klass, to.klass)
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminer.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminer.scala
@@ -1,85 +1,73 @@
 package pl.touk.nussknacker.engine.api.typed
 
-import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.data.{NonEmptyList, ValidatedNel}
 import cats.data.Validated._
 import cats.implicits.{catsSyntaxValidatedId, _}
 import org.apache.commons.lang3.ClassUtils
+import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.NoConversion
 import pl.touk.nussknacker.engine.api.typed.typing._
 
 /**
-  * This class determine whether we can assign one type to another type - that is if its the same class, a subclass or can be converted to another type. We provide two modes of conversion -
+ * This class determine whether we can assign one type to another type - that is if its the same class, a subclass or can be converted to another type.
+ * We provide two conversion strategies:
  * 1. Loose conversion is based on the fact that TypingResults are
  * sets of possible supertypes with some additional restrictions (like TypedObjectTypingResult). It is basically how SpEL
  * can convert things. Like CommonSupertypeFinder it's in the spirit of "Be type safe as much as possible, but also provide some helpful
  * conversion for types not in the same jvm class hierarchy like boxed Integer to boxed Long and so on".
  * 2. Strict conversion checks whether we can convert to a wider type. Eg only widening numerical types
  * are allowed ( Int -> Long). For other types it should work the same as a loose conversion.
- *
-  */
-object AssignabilityDeterminer {
+ */
+private[typed] object AssignabilityDeterminer {
 
   private val javaMapClass       = classOf[java.util.Map[_, _]]
   private val javaListClass      = classOf[java.util.List[_]]
   private val arrayOfAnyRefClass = classOf[Array[AnyRef]]
 
-  /**
-   * This method checks if `givenType` can by subclass of `superclassCandidate`
-   * It will return true if `givenType` is equals to `superclassCandidate` or `givenType` "extends" `superclassCandidate`
-   */
-  def isAssignableLoose(from: TypingResult, to: TypingResult): ValidatedNel[String, Unit] =
-    isAssignable(from, to, LooseConversionChecker)
-
-  def isAssignableStrict(from: TypingResult, to: TypingResult): ValidatedNel[String, Unit] =
-    isAssignable(from, to, StrictConversionChecker)
-
-  def isAssignableWithoutConversion(from: TypingResult, to: TypingResult): ValidatedNel[String, Unit] =
-    isAssignable(from, to, WithoutConversionChecker)
-
-  private def isAssignable(from: TypingResult, to: TypingResult, conversionChecker: ConversionChecker) = {
+  def isAssignable(from: TypingResult, to: TypingResult)(
+      implicit conversionStrategy: ConversionStrategy
+  ): ValidatedNel[String, Unit] = {
     (from, to) match {
       case (_, Unknown(_))    => ().validNel
       case (Unknown(_), _)    => ().validNel
-      case (TypedNull, other) => isNullAsignableTo(other)
-      case (_, TypedNull)     => s"No type can be subclass of ${TypedNull.display}".invalidNel
-      case (given: SingleTypingResult, superclass: TypedUnion) =>
-        isAnyOfAssignableToAnyOf(NonEmptyList.one(given), superclass.possibleTypes, conversionChecker)
-      case (given: TypedUnion, superclass: SingleTypingResult) =>
-        isAnyOfAssignableToAnyOf(given.possibleTypes, NonEmptyList.one(superclass), conversionChecker)
-      case (given: SingleTypingResult, superclass: SingleTypingResult) =>
-        isSingleAssignableToSingle(given, superclass, conversionChecker)
-      case (given: TypedUnion, superclass: TypedUnion) =>
-        isAnyOfAssignableToAnyOf(given.possibleTypes, superclass.possibleTypes, conversionChecker)
+      case (TypedNull, other) => isNullAssignableTo(other)
+      case (_, TypedNull)     => s"No type can be assigned to ${TypedNull.display}".invalidNel
+      case (given: SingleTypingResult, target: TypedUnion) =>
+        isAnyOfAssignableToAnyOf(NonEmptyList.one(given), target.possibleTypes)
+      case (given: TypedUnion, targe: SingleTypingResult) =>
+        isAnyOfAssignableToAnyOf(given.possibleTypes, NonEmptyList.one(targe))
+      case (given: SingleTypingResult, target: SingleTypingResult) =>
+        isSingleAssignableToSingle(given, target)
+      case (given: TypedUnion, target: TypedUnion) =>
+        isAnyOfAssignableToAnyOf(given.possibleTypes, target.possibleTypes)
     }
   }
 
-  private def isNullAsignableTo(to: TypingResult): ValidatedNel[String, Unit] = to match {
+  private def isNullAssignableTo(to: TypingResult): ValidatedNel[String, Unit] = to match {
     // TODO: Null should not be subclass of typed map that has all values assigned.
-    case TypedObjectWithValue(_, _) => s"${TypedNull.display} cannot be subclass of type with value".invalidNel
+    case TypedObjectWithValue(_, _) => s"${TypedNull.display} cannot be assigned to type with value".invalidNel
     case _                          => ().validNel
   }
 
-  private def isSingleAssignableToSingle(
-      from: SingleTypingResult,
-      to: SingleTypingResult,
-      conversionChecker: ConversionChecker
+  private def isSingleAssignableToSingle(from: SingleTypingResult, to: SingleTypingResult)(
+      implicit conversionStrategy: ConversionStrategy
   ): ValidatedNel[String, Unit] = {
-    val objTypeRestriction = isSingleAssignableToTypedClass(from, to.runtimeObjType, conversionChecker)
+    val objTypeRestriction = isSingleAssignableToTypedClass(from, to.runtimeObjType)
     val typedObjectRestrictions = (_: Unit) =>
       to match {
-        case superclass: TypedObjectTypingResult =>
+        case target: TypedObjectTypingResult =>
           val givenTypeFields = from match {
             case given: TypedObjectTypingResult => given.fields
             case _                              => Map.empty[String, TypingResult]
           }
 
-          superclass.fields.toList
+          target.fields.toList
             .map { case (name, typ) =>
               givenTypeFields.get(name) match {
                 case None =>
                   s"Field '$name' is lacking".invalidNel
                 case Some(givenFieldType) =>
                   condNel(
-                    isAssignable(givenFieldType, typ, conversionChecker).isValid,
+                    isAssignable(givenFieldType, typ).isValid,
                     (),
                     s"Field '$name' is of the wrong type. Expected: ${givenFieldType.display}, actual: ${typ.display}"
                   )
@@ -91,27 +79,27 @@ object AssignabilityDeterminer {
       }
     val dictRestriction = (_: Unit) => {
       (from, to) match {
-        case (given: TypedDict, superclass: TypedDict) =>
+        case (given: TypedDict, target: TypedDict) =>
           condNel(
-            given.dictId == superclass.dictId,
+            given.dictId == target.dictId,
             (),
-            "The type and the superclass candidate are Dicts with unequal IDs"
+            "The type and target type are Dicts with unequal IDs"
           )
         case (_: TypedDict, _) =>
-          "The type is a Dict but the superclass candidate not".invalidNel
+          "The type is a Dict but the target type not".invalidNel
         case (_, _: TypedDict) =>
-          "The superclass candidate is a Dict but the type not".invalidNel
+          "The target type is a Dict but given type not".invalidNel
         case _ =>
           ().validNel
       }
     }
     val taggedValueRestriction = (_: Unit) => {
       (from, to) match {
-        case (givenTaggedValue: TypedTaggedValue, superclassTaggedValue: TypedTaggedValue) =>
+        case (givenTaggedValue: TypedTaggedValue, targetTaggedValue: TypedTaggedValue) =>
           condNel(
-            givenTaggedValue.tag == superclassTaggedValue.tag,
+            givenTaggedValue.tag == targetTaggedValue.tag,
             (),
-            s"Tagged values have unequal tags: ${givenTaggedValue.tag} and ${superclassTaggedValue.tag}"
+            s"Tagged values have unequal tags: ${givenTaggedValue.tag} and ${targetTaggedValue.tag}"
           )
         case (_: TypedTaggedValue, _) => ().validNel
         case (_, _: TypedTaggedValue) =>
@@ -119,10 +107,8 @@ object AssignabilityDeterminer {
         case _ => ().validNel
       }
     }
-    // Type like Integer can be subclass of Integer{5}, because Integer could
-    // possibly have value of 5, that would make it subclass of Integer{5}.
-    // This allows us to supply unknown Integer to function that requires
-    // Integer{5}.
+    // Type like Integer{5} can be assigned to Integer, because Integer could possibly have value of 5 which was erased
+    // This allows us to supply unknown Integer to function that requires Integer{5}.
     val dataValueRestriction = (_: Unit) => {
       (from, to) match {
         case (TypedObjectWithValue(_, givenValue), TypedObjectWithValue(_, candidateValue))
@@ -137,42 +123,40 @@ object AssignabilityDeterminer {
       (typedObjectRestrictions combine dictRestriction combine taggedValueRestriction combine dataValueRestriction)
   }
 
-  private def isSingleAssignableToTypedClass(
-      from: SingleTypingResult,
-      to: TypedClass,
-      conversionChecker: ConversionChecker
+  private def isSingleAssignableToTypedClass(from: SingleTypingResult, to: TypedClass)(
+      implicit conversionStrategy: ConversionStrategy
   ): ValidatedNel[String, Unit] = {
-    def typeParametersMatches(givenClass: TypedClass, superclassCandidate: TypedClass) = {
-      def canBeSubOrSuperclass(givenClassParam: TypingResult, superclassParam: TypingResult) =
+    def typeParametersMatches(givenClass: TypedClass, targetCandidate: TypedClass) = {
+      def canBeAssignedToOrAssignedFrom(givenClassParam: TypingResult, targetParam: TypingResult) =
         condNel(
-          isAssignable(givenClassParam, superclassParam, conversionChecker).isValid ||
-            isAssignable(superclassParam, givenClassParam, conversionChecker).isValid,
+          isAssignable(givenClassParam, targetParam).isValid ||
+            isAssignable(targetParam, givenClassParam).isValid,
           (),
-          f"None of ${givenClassParam.display} and ${superclassParam.display} is a subclass of another"
+          f"None of ${givenClassParam.display} and ${targetParam.display} can be assigned to another"
         )
 
-      (givenClass, superclassCandidate) match {
-        case (TypedClass(_, givenElementParam :: Nil), TypedClass(superclass, superclassParam :: Nil))
-            // Array are invariant but we have built-in conversion between array types - this check should be moved outside this class when we move away canBeConvertedTo as well
-            if javaListClass.isAssignableFrom(superclass) || arrayOfAnyRefClass.isAssignableFrom(superclass) =>
-          isAssignable(givenElementParam, superclassParam, conversionChecker)
+      (givenClass, targetCandidate, conversionStrategy) match {
+        case (TypedClass(_, givenElementParam :: Nil), TypedClass(targetClass, targetParam :: Nil), _)
+            if javaListClass.isAssignableFrom(targetClass) || arrayOfAnyRefClass.isAssignableFrom(targetClass) =>
+          isAssignable(givenElementParam, targetParam)
         case (
               TypedClass(_, givenKeyParam :: givenValueParam :: Nil),
-              TypedClass(superclass, superclassKeyParam :: superclassValueParam :: Nil)
-            ) if javaMapClass.isAssignableFrom(superclass) =>
-          // Map's key generic param is invariant. We can't just check givenKeyParam == superclassKeyParam because of Unknown type which is a kind of wildcard
+              TypedClass(targetClass, targetKeyParam :: targetValueParam :: Nil),
+              _
+            ) if javaMapClass.isAssignableFrom(targetClass) =>
+          // Map's key generic param is invariant. We can't just check givenKeyParam == targetKeyParam because of Unknown type which is a kind of wildcard
           condNel(
-            isAssignable(givenKeyParam, superclassKeyParam, conversionChecker).isValid &&
-              isAssignable(superclassKeyParam, givenKeyParam, conversionChecker).isValid,
+            isAssignable(givenKeyParam, targetKeyParam).isValid &&
+              isAssignable(targetKeyParam, givenKeyParam).isValid,
             (),
-            s"Key types of Maps ${givenKeyParam.display} and ${superclassKeyParam.display} are not equals"
-          ) andThen (_ => isAssignable(givenValueParam, superclassValueParam, conversionChecker))
+            s"Key types of Maps ${givenKeyParam.display} and ${targetKeyParam.display} are not equals"
+          ) andThen (_ => isAssignable(givenValueParam, targetValueParam))
         case _ =>
           // for unknown types we are lax - the generic type may be co- contra- or in-variant - and we don't want to
           // return validation errors in this case. It's better to accept to much than too little
           condNel(
-            superclassCandidate.params.zip(givenClass.params).forall { case (superclassParam, givenClassParam) =>
-              canBeSubOrSuperclass(givenClassParam, superclassParam).isValid
+            targetCandidate.params.zip(givenClass.params).forall { case (targetParam, givenClassParam) =>
+              canBeAssignedToOrAssignedFrom(givenClassParam, targetParam).isValid
             },
             (),
             s"Wrong type parameters"
@@ -190,78 +174,35 @@ object AssignabilityDeterminer {
         isAssignable(givenClass.klass, to.klass)
 
     val canBeSubclass = equalClassesOrCanAssign andThen (_ => typeParametersMatches(givenClass, to))
-    canBeSubclass orElse conversionChecker.isConvertable(from, to)
+    conversionStrategy match {
+      case NoConversion => canBeSubclass
+      case nonEmptyStrategy: NonEmptyConversionStrategy =>
+        canBeSubclass.recover {
+          case _ if TypeConversionHandler.canBeConverted(from, to)(nonEmptyStrategy) => ()
+        }
+    }
+
   }
 
-  private def isAnyOfAssignableToAnyOf(
-      from: NonEmptyList[SingleTypingResult],
-      to: NonEmptyList[SingleTypingResult],
-      conversionChecker: ConversionChecker
+  private def isAnyOfAssignableToAnyOf(from: NonEmptyList[SingleTypingResult], to: NonEmptyList[SingleTypingResult])(
+      implicit conversionStrategy: ConversionStrategy
   ): ValidatedNel[String, Unit] = {
-    // Would be more safety to do givenTypes.forAll(... superclassCandidates.exists ...) - we wil protect against
+    // Would be more safety to do givenTypes.forAll(... targetCandidates.exists ...) - we will protect against
     // e.g. (String | Int).isAnyOfAssignableToAnyOf(String) which can fail in runtime for Int, but on the other hand we can't block user's intended action.
     // He/she could be sure that in this type, only String will appear. He/she also can't easily downcast (String | Int) to String so leaving here
     // "double exists" looks like a good tradeoff
     condNel(
-      from.exists(given => to.exists(isSingleAssignableToSingle(given, _, conversionChecker).isValid)),
+      from.exists(given => to.exists(isSingleAssignableToSingle(given, _).isValid)),
       (),
       s"""None of the following types:
          |${from.map(" - " + _.display).toList.mkString(",\n")}
-         |can be a subclass of any of:
+         |can be a assigned to any of:
          |${to.map(" - " + _.display).toList.mkString(",\n")}""".stripMargin
     )
   }
 
   // we use explicit autoboxing = true flag, as ClassUtils in commons-lang3:3.3 (used in Flink) cannot handle JDK 11...
   private def isAssignable(from: Class[_], to: Class[_]): ValidatedNel[String, Unit] =
-    condNel(ClassUtils.isAssignable(from, to, true), (), s"$to is not assignable from $from")
-
-  // TODO: Conversions should be checked during typing, not during generic usage of TypingResult.canBeSubclassOf(...)
-  private sealed trait ConversionChecker {
-
-    def isConvertable(
-        from: SingleTypingResult,
-        to: TypedClass
-    ): ValidatedNel[String, Unit]
-
-  }
-
-  private object WithoutConversionChecker extends ConversionChecker {
-
-    override def isConvertable(
-        from: SingleTypingResult,
-        to: TypedClass
-    ): ValidatedNel[String, Unit] = {
-      val errMsgPrefix =
-        s"${from.runtimeObjType.display} is not the same as ${to.display}"
-      condNel(from.withoutValue == to.withoutValue, (), errMsgPrefix)
-    }
-
-  }
-
-  private object StrictConversionChecker extends ConversionChecker {
-
-    override def isConvertable(
-        from: SingleTypingResult,
-        to: TypedClass
-    ): ValidatedNel[String, Unit] = {
-      val errMsgPrefix =
-        s"${from.runtimeObjType.display} cannot be strictly converted to ${to.display}"
-      condNel(TypeConversionHandler.canBeStrictlyConvertedTo(from, to), (), errMsgPrefix)
-    }
-
-  }
-
-  private object LooseConversionChecker extends ConversionChecker {
-
-    override def isConvertable(
-        from: SingleTypingResult,
-        to: TypedClass
-    ): ValidatedNel[String, Unit] = {
-      val errMsgPrefix = s"${from.runtimeObjType.display} cannot be converted to ${to.display}"
-      condNel(TypeConversionHandler.canBeLooselyConvertedTo(from, to), (), errMsgPrefix)
-    }
-
-  }
+    condNel(ClassUtils.isAssignable(from, to, true), (), s"$from is not assignable to $to")
 
 }

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/NumberTypeUtils.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/NumberTypeUtils.scala
@@ -15,9 +15,9 @@ object NumberTypeUtils {
     else if (typ == Typed[java.lang.Double]) java.lang.Double.valueOf(0)
     else if (typ == Typed[java.math.BigDecimal]) java.math.BigDecimal.ZERO
     // in case of some unions
-    else if (typ.canBeConvertedTo(Typed[java.lang.Integer])) java.lang.Integer.valueOf(0)
+    else if (typ.canBeLooselyAssignedTo(Typed[java.lang.Integer])) java.lang.Integer.valueOf(0)
     // double is quite safe - it can be converted to any Number
-    else if (typ.canBeConvertedTo(Typed[Number])) java.lang.Double.valueOf(0)
+    else if (typ.canBeLooselyAssignedTo(Typed[Number])) java.lang.Double.valueOf(0)
     else throw new IllegalArgumentException(s"Not expected type: ${typ.display}, should be Number")
   }
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/TypeConversionHandler.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/TypeConversionHandler.scala
@@ -2,11 +2,10 @@ package pl.touk.nussknacker.engine.api.typed
 
 import org.apache.commons.lang3.{ClassUtils, LocaleUtils}
 import org.springframework.util.StringUtils
+import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.{Loose, Strict}
 import pl.touk.nussknacker.engine.api.typed.supertype.NumberTypesPromotionStrategy
-import pl.touk.nussknacker.engine.api.typed.supertype.NumberTypesPromotionStrategy.AllNumbers
 import pl.touk.nussknacker.engine.api.typed.typing.{SingleTypingResult, TypedClass, TypedObjectWithValue}
 
-import java.math.BigInteger
 import java.nio.charset.Charset
 import java.time._
 import java.time.chrono.{ChronoLocalDate, ChronoLocalDateTime}
@@ -18,7 +17,10 @@ import scala.util.Try
   * This class handle conversion logic which is done in SpEL's org.springframework.expression.TypeConverter.
   * See pl.touk.nussknacker.engine.spel.internal.DefaultSpelConversionsProvider for full conversion list
   */
-object TypeConversionHandler {
+private[engine] object TypeConversionHandler {
+
+  private val javaListClass      = classOf[java.util.List[_]]
+  private val arrayOfAnyRefClass = classOf[Array[AnyRef]]
 
   /**
     * java.math.BigDecimal is quite often returned as a wrapper for all kind of numbers (floating and without floating point).
@@ -65,32 +67,28 @@ object TypeConversionHandler {
     StringConversion[ChronoLocalDateTime[_]](LocalDateTime.parse)
   )
 
-  def canBeLooselyConvertedTo(from: SingleTypingResult, to: TypedClass): Boolean =
-    canBeConvertedToAux(from, to)
-
-  def canBeStrictlyConvertedTo(from: SingleTypingResult, to: TypedClass): Boolean =
-    canBeConvertedToAux(from, to, strict = true)
-
-  private def canBeConvertedToAux(from: SingleTypingResult, to: TypedClass, strict: Boolean = false) = {
+  def canBeConverted(from: SingleTypingResult, to: TypedClass)(
+      implicit conversionStrategy: NonEmptyConversionStrategy
+  ): Boolean = {
     handleStringToValueClassConversions(from, to) ||
-    handleNumberConversion(from.runtimeObjType, to, strict)
+    handleArrayToListConversions(from.runtimeObjType, to) ||
+    handleNumberConversion(from.runtimeObjType, to)
   }
 
-  private def handleNumberConversion(from: SingleTypingResult, to: TypedClass, strict: Boolean) = {
-    val boxedGivenClass          = ClassUtils.primitiveToWrapper(from.runtimeObjType.klass)
-    val boxedSuperclassCandidate = ClassUtils.primitiveToWrapper(to.klass)
-
-    if (strict)
-      handleStrictNumberConversions(boxedGivenClass, boxedSuperclassCandidate)
-    else
-      handleLooseNumberConversion(boxedGivenClass, boxedSuperclassCandidate)
+  private def handleNumberConversion(from: SingleTypingResult, to: TypedClass)(
+      implicit conversionStrategy: NonEmptyConversionStrategy
+  ) = {
+    conversionStrategy match {
+      case Strict => handleStrictNumberConversions(from.runtimeObjType.klass, to.klass)
+      case Loose  => handleLooseNumberConversion(from.runtimeObjType.klass, to.klass)
+    }
   }
 
   // See org.springframework.core.convert.support.NumberToNumberConverterFactory
-  private def handleLooseNumberConversion(
-      boxedGivenClass: Class[_],
-      boxedSuperclassCandidate: Class[_]
-  ): Boolean = {
+  private def handleLooseNumberConversion(from: Class[_], to: Class[_]): Boolean = {
+    val boxedGivenClass          = ClassUtils.primitiveToWrapper(from)
+    val boxedSuperclassCandidate = ClassUtils.primitiveToWrapper(to)
+
     // We can't check precision here so we need to be loose here
     if (NumberTypesPromotionStrategy
         .isFloatingNumber(boxedSuperclassCandidate) || boxedSuperclassCandidate == classOf[java.math.BigDecimal]) {
@@ -103,25 +101,47 @@ object TypeConversionHandler {
   }
 
   private def handleStrictNumberConversions(givenClass: Class[_], to: Class[_]): Boolean = {
-    (givenClass, to) match {
-      case (bigInteger, t)
-          if (bigInteger == classOf[BigInteger] && (t == classOf[BigDecimal] || t == classOf[BigInteger])) =>
-        true
-      case (f, t) if (AllNumbers.contains(f) && AllNumbers.contains(t)) =>
-        AllNumbers.indexOf(f) >= AllNumbers.indexOf(t)
-      case _ => false
-
+    (Option(ClassUtils.wrapperToPrimitive(givenClass)), Option(ClassUtils.wrapperToPrimitive(to))) match {
+      case (Some(givenPrimitive), Some(toPrimitive)) => ClassUtils.isAssignable(givenPrimitive, toPrimitive)
+      case (_, _)                                    => false
     }
   }
 
   private def handleStringToValueClassConversions(
       from: SingleTypingResult,
       to: TypedClass
-  ): Boolean =
+  )(implicit conversionStrategy: NonEmptyConversionStrategy): Boolean =
     from match {
-      case TypedObjectWithValue(_, str: String) =>
+      case TypedObjectWithValue(_, str: String) if conversionStrategy == ConversionStrategy.Loose =>
         stringConversions.exists(_.canConvert(str, to))
       case _ => false
     }
+
+  // See pl.touk.nussknacker.engine.spel.internal.ArrayToListConverter
+  private def handleArrayToListConversions(from: TypedClass, to: TypedClass)(
+      implicit conversionStrategy: NonEmptyConversionStrategy
+  ): Boolean = {
+    (from, to) match {
+      case (TypedClass(`arrayOfAnyRefClass`, _), TypedClass(`javaListClass`, _))
+          if conversionStrategy == ConversionStrategy.Loose =>
+        true
+      case _ =>
+        false
+    }
+  }
+
+}
+
+private[engine] sealed trait ConversionStrategy
+
+private[engine] sealed trait NonEmptyConversionStrategy extends ConversionStrategy
+
+private[engine] object ConversionStrategy {
+
+  object NoConversion extends ConversionStrategy
+
+  object Strict extends NonEmptyConversionStrategy
+
+  object Loose extends NonEmptyConversionStrategy
 
 }

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/TypeConversionHandler.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/TypeConversionHandler.scala
@@ -70,9 +70,20 @@ private[engine] object TypeConversionHandler {
   def canBeConverted(from: SingleTypingResult, to: TypedClass)(
       implicit conversionStrategy: NonEmptyConversionStrategy
   ): Boolean = {
-    handleStringToValueClassConversions(from, to) ||
-    handleArrayToListConversions(from.runtimeObjType, to) ||
+    handleImplicitConversion(from, to) ||
     handleNumberConversion(from.runtimeObjType, to)
+  }
+
+  private def handleImplicitConversion(from: SingleTypingResult, to: TypedClass)(
+      implicit conversionStrategy: NonEmptyConversionStrategy
+  ) = {
+    conversionStrategy match {
+      // Implicit conversions are not allowed in strict conversion strategy. We want to behave as plain java, without magical tricks.
+      case Strict => false
+      case Loose =>
+        handleStringToValueClassConversions(from, to) ||
+        handleArrayToListConversions(from.runtimeObjType, to)
+    }
   }
 
   private def handleNumberConversion(from: SingleTypingResult, to: TypedClass)(
@@ -110,20 +121,18 @@ private[engine] object TypeConversionHandler {
   private def handleStringToValueClassConversions(
       from: SingleTypingResult,
       to: TypedClass
-  )(implicit conversionStrategy: NonEmptyConversionStrategy): Boolean =
+  ): Boolean =
     from match {
-      case TypedObjectWithValue(_, str: String) if conversionStrategy == ConversionStrategy.Loose =>
+      case TypedObjectWithValue(_, str: String) =>
         stringConversions.exists(_.canConvert(str, to))
       case _ => false
     }
 
   // See pl.touk.nussknacker.engine.spel.internal.ArrayToListConverter
-  private def handleArrayToListConversions(from: TypedClass, to: TypedClass)(
-      implicit conversionStrategy: NonEmptyConversionStrategy
-  ): Boolean = {
+  private def handleArrayToListConversions(from: TypedClass, to: TypedClass): Boolean = {
     (from, to) match {
-      case (TypedClass(`arrayOfAnyRefClass`, _), TypedClass(`javaListClass`, _))
-          if conversionStrategy == ConversionStrategy.Loose =>
+      // Generic type parameters are checked in AssignabilityDeterminer
+      case (TypedClass(`arrayOfAnyRefClass`, _), TypedClass(`javaListClass`, _)) =>
         true
       case _ =>
         false

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/NumberTypesPromotionStrategy.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/NumberTypesPromotionStrategy.scala
@@ -85,7 +85,7 @@ object NumberTypesPromotionStrategy {
     classOf[java.lang.Byte]
   )
 
-  val AllNumbers: Seq[Class[_]] = FloatingNumbers ++ DecimalNumbers
+  private val AllNumbers: Seq[Class[_]] = FloatingNumbers ++ DecimalNumbers
 
   def isDecimalNumber(clazz: Class[_]): Boolean = DecimalNumbers.contains(clazz)
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
@@ -33,7 +33,7 @@ object typing {
 
     /**
      * Checks if given type is a target type or given type can be converted to target type without loss of precision
-     * e.g. int to long
+     * e.g. int to long conversion is acceptable but long to int is not
      */
     final def canBeStrictlyAssignedTo(typingResult: TypingResult): Boolean =
       AssignabilityDeterminer.isAssignable(this, typingResult)(Strict).isValid
@@ -44,7 +44,8 @@ object typing {
     //       canBeStrictlyAssignedTo was probly the better choice
     /**
      * Checks if given type is a target type or there exists a conversion to target type, with possible
-     * loss of precision, e.g. long to int. If you need to retain conversion precision, use canBeStrictlyAssignedTo
+     * loss of precision, e.g. both int to long and long to int conversions are acceptable.
+     * If you need to retain conversion precision, use canBeStrictlyAssignedTo
      */
     final def canBeLooselyAssignedTo(typingResult: TypingResult): Boolean =
       AssignabilityDeterminer.isAssignable(this, typingResult)(Loose).isValid

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
@@ -7,6 +7,7 @@ import enumeratum._
 import io.circe.{Decoder, Encoder}
 import org.apache.commons.lang3.ClassUtils
 import pl.touk.nussknacker.engine.api.json.encoders.{ToJsonEncoderWithFallback, TypeEncoders}
+import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.{Loose, Strict}
 import pl.touk.nussknacker.engine.api.typed.supertype.CommonSupertypeFinder
 import pl.touk.nussknacker.engine.api.typed.typing.DisplayStrategy.{DefaultDisplayStrategy, JsonDisplayStrategy}
 import pl.touk.nussknacker.engine.api.typed.typing.Typed.fromInstance
@@ -31,23 +32,31 @@ object typing {
   sealed trait TypingResult {
 
     /**
-     * Checks if there exists a conversion to a given typingResult, with possible loss of precision, e.g. long to int.
-     * If you need to retain conversion precision, use canBeStrictlyConvertedTo
+     * Checks if given type is a target type or given type can be converted to target type without loss of precision
+     * e.g. int to long
      */
-    final def canBeConvertedTo(typingResult: TypingResult): Boolean =
-      AssignabilityDeterminer.isAssignableLoose(this, typingResult).isValid
+    final def canBeStrictlyAssignedTo(typingResult: TypingResult): Boolean =
+      AssignabilityDeterminer.isAssignable(this, typingResult)(Strict).isValid
+
+    // TODO: We should remove this method and instead, use variant with ConversionStrategy parameter
+    //       Thanks to that we can have one, simple method using Strict ConversionStrategy in components API
+    //       Before we do this, we should verify if canBeLooselyAssignedTo was correctly used - in some places
+    //       canBeStrictlyAssignedTo was probly the better choice
+    /**
+     * Checks if given type is a target type or there exists a conversion to target type, with possible
+     * loss of precision, e.g. long to int. If you need to retain conversion precision, use canBeStrictlyAssignedTo
+     */
+    final def canBeLooselyAssignedTo(typingResult: TypingResult): Boolean =
+      AssignabilityDeterminer.isAssignable(this, typingResult)(Loose).isValid
 
     /**
-     * Checks if the conversion to a given typingResult can be made without loss of precision
+     * Checks if the given type is a target type or can be converted to target type with custom conversion strategy.
+     * This method is package protected, because it is designed for internal, Nussknacker usage.
      */
-    final def canBeStrictlyConvertedTo(typingResult: TypingResult): Boolean =
-      AssignabilityDeterminer.isAssignableStrict(this, typingResult).isValid
-
-    /**
-     * Checks if the conversion to a given typingResult can be made without any conversion.
-     */
-    final def canBeConvertedWithoutConversionTo(typingResult: TypingResult): Boolean =
-      AssignabilityDeterminer.isAssignableWithoutConversion(this, typingResult).isValid
+    private[engine] final def canBeAssignedTo(typingResult: TypingResult)(
+        implicit conversionStrategy: ConversionStrategy
+    ): Boolean =
+      AssignabilityDeterminer.isAssignable(this, typingResult)(conversionStrategy).isValid
 
     def valueOpt: Option[Any]
 
@@ -506,7 +515,7 @@ object typing {
 
     def unapply(typingResult: TypingResult): Option[TypingResultTypedValue[T]] = {
       Option(typingResult)
-        .filter(_.canBeConvertedTo(Typed.fromDetailedType[T]))
+        .filter(_.canBeLooselyAssignedTo(Typed.fromDetailedType[T]))
         .map(new TypingResultTypedValue(_))
     }
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
@@ -56,7 +56,7 @@ object typing {
     private[engine] final def canBeAssignedTo(typingResult: TypingResult)(
         implicit conversionStrategy: ConversionStrategy
     ): Boolean =
-      AssignabilityDeterminer.isAssignable(this, typingResult)(conversionStrategy).isValid
+      AssignabilityDeterminer.isAssignable(this, typingResult).isValid
 
     def valueOpt: Option[Any]
 

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminerSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminerSpec.scala
@@ -6,7 +6,10 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables.Table
+import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.{Loose, Strict}
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
+
+import java.time.ZoneId
 
 class AssignabilityDeterminerSpec extends AnyFunSuite with Matchers {
 
@@ -20,16 +23,16 @@ class AssignabilityDeterminerSpec extends AnyFunSuite with Matchers {
     (Typed[Map[String, Int]], Typed[Map[Any, Any]], Valid(()), Valid(()))
   )
 
-  test("isAssignableStrict should pass for widening cases") {
+  test("isAssignable with Strict ConversionStrategy should pass for widening cases") {
     forAll(wideningConversionCases) { (sourceType, targetType, expectedStrict, _) =>
-      val result = AssignabilityDeterminer.isAssignableStrict(sourceType, targetType)
+      val result = AssignabilityDeterminer.isAssignable(sourceType, targetType)(Strict)
       result shouldBe expectedStrict
     }
   }
 
-  test("isAssignableLoose should pass for widening cases") {
+  test("isAssignable with Loose ConversionStrategy should pass for widening cases") {
     forAll(wideningConversionCases) { (sourceType, targetType, _, expectedLoose) =>
-      val result = AssignabilityDeterminer.isAssignableLoose(sourceType, targetType)
+      val result = AssignabilityDeterminer.isAssignable(sourceType, targetType)(Loose)
       result shouldBe expectedLoose
     }
   }
@@ -42,9 +45,9 @@ class AssignabilityDeterminerSpec extends AnyFunSuite with Matchers {
     (Typed[BigDecimal], Typed[Double], Invalid(NonEmptyList.of("")), Valid(()))
   )
 
-  test("isAssignableStrict should fail for narrowing numerical cases") {
+  test("isAssignable with Strict ConversionStrategy should fail for narrowing numerical cases") {
     forAll(narrowingConversionCases) { (sourceType, targetType, expectedStrict, _) =>
-      val result = AssignabilityDeterminer.isAssignableStrict(sourceType, targetType)
+      val result = AssignabilityDeterminer.isAssignable(sourceType, targetType)(Strict)
       result match {
         case Valid(_) if expectedStrict.isValid     => succeed
         case Invalid(_) if expectedStrict.isInvalid => succeed
@@ -53,14 +56,37 @@ class AssignabilityDeterminerSpec extends AnyFunSuite with Matchers {
     }
   }
 
-  test("isAssignableLoose should pass for narrowing cases") {
+  test("isAssignable with Loose ConversionStrategy should pass for narrowing cases") {
     forAll(narrowingConversionCases) { (sourceType, targetType, _, expectedLoose) =>
-      val result = AssignabilityDeterminer.isAssignableLoose(sourceType, targetType)
+      val result = AssignabilityDeterminer.isAssignable(sourceType, targetType)(Loose)
       result match {
         case Valid(_) if expectedLoose.isValid     => succeed
         case Invalid(_) if expectedLoose.isInvalid => succeed
         case _ => fail(s"Unexpected result: $result for types $sourceType -> $targetType")
       }
+    }
+  }
+
+  val implicitConversionCases = Table(
+    ("sourceType", "targetType"),
+    (Typed.fromInstance("UTC"), Typed[ZoneId]),
+    (Typed.fromInstance(Array(1, 2, 3)), Typed.fromDetailedType[java.util.List[Int]]),
+    (Typed.fromInstance(java.math.BigInteger.ONE), Typed[java.math.BigDecimal]),
+    (Typed.fromInstance(123), Typed[java.math.BigDecimal]),
+    (Typed.fromInstance(123), Typed[java.math.BigInteger]),
+  )
+
+  test("isAssignable with Strict ConversionStrategy should fail for implicit conversions") {
+    forAll(implicitConversionCases) { (sourceType, targetType) =>
+      val result = AssignabilityDeterminer.isAssignable(sourceType, targetType)(Strict)
+      result shouldBe 'invalid
+    }
+  }
+
+  test("isAssignable with Loose ConversionStrategy should pass for implicit conversions") {
+    forAll(implicitConversionCases) { (sourceType, targetType) =>
+      val result = AssignabilityDeterminer.isAssignable(sourceType, targetType)(Loose)
+      result shouldBe 'valid
     }
   }
 

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminerSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminerSpec.scala
@@ -79,14 +79,14 @@ class AssignabilityDeterminerSpec extends AnyFunSuite with Matchers {
   test("isAssignable with Strict ConversionStrategy should fail for implicit conversions") {
     forAll(implicitConversionCases) { (sourceType, targetType) =>
       val result = AssignabilityDeterminer.isAssignable(sourceType, targetType)(Strict)
-      result shouldBe 'invalid
+      result shouldBe Symbol("invalid")
     }
   }
 
   test("isAssignable with Loose ConversionStrategy should pass for implicit conversions") {
     forAll(implicitConversionCases) { (sourceType, targetType) =>
       val result = AssignabilityDeterminer.isAssignable(sourceType, targetType)(Loose)
-      result shouldBe 'valid
+      result shouldBe Symbol("valid")
     }
   }
 

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypedFromInstanceTest.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypedFromInstanceTest.scala
@@ -60,20 +60,20 @@ class TypedFromInstanceTest extends AnyFunSuite with Matchers with LoneElement w
   }
 
   test("should type empty list") {
-    Typed.fromInstance(Nil).canBeConvertedTo(Typed(classOf[List[_]])) shouldBe true
-    Typed.fromInstance(Nil.asJava).canBeConvertedTo(Typed(classOf[java.util.List[_]])) shouldBe true
+    Typed.fromInstance(Nil).canBeLooselyAssignedTo(Typed(classOf[List[_]])) shouldBe true
+    Typed.fromInstance(Nil.asJava).canBeLooselyAssignedTo(Typed(classOf[java.util.List[_]])) shouldBe true
   }
 
   test("should type lists and return union of types coming from all elements") {
     def checkTypingResult(obj: Any, klass: Class[_], paramTypingResult: TypingResult): Unit = {
       val typingResult = Typed.fromInstance(obj)
 
-      typingResult.canBeConvertedTo(Typed(klass)) shouldBe true
+      typingResult.canBeLooselyAssignedTo(Typed(klass)) shouldBe true
       typingResult.withoutValue
         .asInstanceOf[TypedClass]
         .params
         .loneElement
-        .canBeConvertedTo(paramTypingResult) shouldBe true
+        .canBeLooselyAssignedTo(paramTypingResult) shouldBe true
     }
 
     def checkNotASubclassOfOtherParamTypingResult(obj: Any, otherParamTypingResult: TypingResult): Unit = {
@@ -82,7 +82,7 @@ class TypedFromInstanceTest extends AnyFunSuite with Matchers with LoneElement w
         .asInstanceOf[TypedClass]
         .params
         .loneElement
-        .canBeConvertedTo(otherParamTypingResult) shouldBe false
+        .canBeLooselyAssignedTo(otherParamTypingResult) shouldBe false
     }
 
     val listOfSimpleObjects = List[Any](1.1, 2)

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultErrorMessagesSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultErrorMessagesSpec.scala
@@ -16,7 +16,7 @@ class TypingResultErrorMessagesSpec extends AnyFunSuite with Matchers with Optio
 
   import AssignabilityDeterminer.isAssignable
 
-  test("determine if can be subclass for simple typed objects") {
+  test("determine if can be assigned for simple typed objects") {
 
     isAssignable(
       typeMap(
@@ -40,23 +40,23 @@ class TypingResultErrorMessagesSpec extends AnyFunSuite with Matchers with Optio
       .invalid
   }
 
-  test("determine if can be subclass for map of typed objects") {
+  test("determine if can be assigned for map of typed objects") {
     isAssignable(
       typeMap("field1" -> list(typeMap("field2a" -> Typed[String], "field3" -> Typed[Int]))),
       typeMap("field1" -> list(typeMap("field2" -> Typed[String])))
     )(Loose) shouldBe NonEmptyList
       .of(
-        "Map[String,List[Record{field2a: String, field3: Integer}]] cannot be converted to Map[String,List[Record{field2: String}]]"
+        "Field 'field2' is lacking"
       )
       .invalid
   }
 
-  test("determine if can be subclass for class") {
+  test("determine if can be assigned for class") {
     isAssignable(Typed.fromDetailedType[Set[BigDecimal]], Typed.fromDetailedType[Set[String]])(Loose) shouldBe
-      "Set[BigDecimal] cannot be converted to Set[String]".invalidNel
+      "Generic type parameters (BigDecimal) don't match expected parameters: String".invalidNel
   }
 
-  test("determine if can be subclass for tagged value") {
+  test("determine if can be assigned for tagged value") {
     isAssignable(
       Typed.tagged(Typed.typedClass[String], "tag1"),
       Typed.tagged(Typed.typedClass[String], "tag2")
@@ -64,19 +64,19 @@ class TypingResultErrorMessagesSpec extends AnyFunSuite with Matchers with Optio
       "Tagged values have unequal tags: tag1 and tag2".invalidNel
 
     isAssignable(Typed.typedClass[String], Typed.tagged(Typed.typedClass[String], "tag1"))(Loose) shouldBe
-      "The type is not a tagged value".invalidNel
+      "Given type is not a tagged value but target type is".invalidNel
   }
 
-  test("determine if can be subclass for object with value") {
+  test("determine if can be assigned for object with value") {
     isAssignable(Typed.fromInstance(2), Typed.fromInstance(3))(Loose) shouldBe
       "Types with value have different values: 2 and 3".invalidNel
   }
 
-  test("determine if can be subclass for null") {
+  test("determine if can be assigned for null") {
     isAssignable(Typed[String], TypedNull)(Loose) shouldBe
-      "No type can be subclass of Null".invalidNel
+      "String cannot be assigned to Null".invalidNel
     isAssignable(TypedNull, Typed.fromInstance(1))(Loose) shouldBe
-      "Null cannot be subclass of type with value".invalidNel
+      "Null cannot be assigned to type with value".invalidNel
   }
 
 }

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultErrorMessagesSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultErrorMessagesSpec.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import org.scalatest.{Inside, OptionValues}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.typed.AssignabilityDeterminer.isAssignableLoose
+import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.Loose
 import pl.touk.nussknacker.engine.api.typed.typing._
 
 class TypingResultErrorMessagesSpec extends AnyFunSuite with Matchers with OptionValues with Inside {
@@ -18,7 +18,7 @@ class TypingResultErrorMessagesSpec extends AnyFunSuite with Matchers with Optio
 
   test("determine if can be subclass for simple typed objects") {
 
-    isAssignableLoose(
+    isAssignable(
       typeMap(
         "field1" -> Typed[String],
         "field2" -> Typed[Int],
@@ -31,7 +31,7 @@ class TypingResultErrorMessagesSpec extends AnyFunSuite with Matchers with Optio
         "field4" -> Typed[String],
         "field5" -> list(typeMap("field2" -> Typed[String]))
       )
-    ) shouldBe NonEmptyList
+    )(Loose) shouldBe NonEmptyList
       .of(
         "Field 'field2' is of the wrong type. Expected: Integer, actual: String",
         "Field 'field3' is of the wrong type. Expected: List[Record{field2a: String, field3: Integer}], actual: String",
@@ -41,10 +41,10 @@ class TypingResultErrorMessagesSpec extends AnyFunSuite with Matchers with Optio
   }
 
   test("determine if can be subclass for map of typed objects") {
-    isAssignableLoose(
+    isAssignable(
       typeMap("field1" -> list(typeMap("field2a" -> Typed[String], "field3" -> Typed[Int]))),
       typeMap("field1" -> list(typeMap("field2" -> Typed[String])))
-    ) shouldBe NonEmptyList
+    )(Loose) shouldBe NonEmptyList
       .of(
         "Map[String,List[Record{field2a: String, field3: Integer}]] cannot be converted to Map[String,List[Record{field2: String}]]"
       )
@@ -52,30 +52,30 @@ class TypingResultErrorMessagesSpec extends AnyFunSuite with Matchers with Optio
   }
 
   test("determine if can be subclass for class") {
-    isAssignableLoose(Typed.fromDetailedType[Set[BigDecimal]], Typed.fromDetailedType[Set[String]]) shouldBe
+    isAssignable(Typed.fromDetailedType[Set[BigDecimal]], Typed.fromDetailedType[Set[String]])(Loose) shouldBe
       "Set[BigDecimal] cannot be converted to Set[String]".invalidNel
   }
 
   test("determine if can be subclass for tagged value") {
-    isAssignableLoose(
+    isAssignable(
       Typed.tagged(Typed.typedClass[String], "tag1"),
       Typed.tagged(Typed.typedClass[String], "tag2")
-    ) shouldBe
+    )(Loose) shouldBe
       "Tagged values have unequal tags: tag1 and tag2".invalidNel
 
-    isAssignableLoose(Typed.typedClass[String], Typed.tagged(Typed.typedClass[String], "tag1")) shouldBe
+    isAssignable(Typed.typedClass[String], Typed.tagged(Typed.typedClass[String], "tag1"))(Loose) shouldBe
       "The type is not a tagged value".invalidNel
   }
 
   test("determine if can be subclass for object with value") {
-    isAssignableLoose(Typed.fromInstance(2), Typed.fromInstance(3)) shouldBe
+    isAssignable(Typed.fromInstance(2), Typed.fromInstance(3))(Loose) shouldBe
       "Types with value have different values: 2 and 3".invalidNel
   }
 
   test("determine if can be subclass for null") {
-    isAssignableLoose(Typed[String], TypedNull) shouldBe
+    isAssignable(Typed[String], TypedNull)(Loose) shouldBe
       "No type can be subclass of Null".invalidNel
-    isAssignableLoose(TypedNull, Typed.fromInstance(1)) shouldBe
+    isAssignable(TypedNull, Typed.fromInstance(1))(Loose) shouldBe
       "Null cannot be subclass of type with value".invalidNel
   }
 

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
@@ -30,35 +30,35 @@ class TypingResultSpec
 
   private def list(arg: TypingResult) = Typed.genericTypeClass[java.util.List[_]](List(arg))
 
-  test("determine if can be subclass for typed object") {
+  test("determine if can be assigned for typed object") {
 
-    typeMap("field1" -> Typed[String], "field2" -> Typed[Int]).canBeConvertedTo(
+    typeMap("field1" -> Typed[String], "field2" -> Typed[Int]).canBeLooselyAssignedTo(
       typeMap("field1" -> Typed[String])
     ) shouldBe true
 
-    typeMap("field1" -> Typed[String]).canBeConvertedTo(
+    typeMap("field1" -> Typed[String]).canBeLooselyAssignedTo(
       typeMap("field1" -> Typed[String], "field2" -> Typed[Int])
     ) shouldBe false
 
-    typeMap("field1" -> Typed[Int]).canBeConvertedTo(
+    typeMap("field1" -> Typed[Int]).canBeLooselyAssignedTo(
       typeMap("field1" -> Typed[String])
     ) shouldBe false
 
-    typeMap("field1" -> Typed[Int]).canBeConvertedTo(
+    typeMap("field1" -> Typed[Int]).canBeLooselyAssignedTo(
       typeMap("field1" -> Typed[Number])
     ) shouldBe true
 
-    typeMap("field1" -> list(typeMap("field2" -> Typed[String], "field3" -> Typed[Int]))).canBeConvertedTo(
+    typeMap("field1" -> list(typeMap("field2" -> Typed[String], "field3" -> Typed[Int]))).canBeLooselyAssignedTo(
       typeMap("field1" -> list(typeMap("field2" -> Typed[String])))
     ) shouldBe true
 
-    typeMap("field1" -> list(typeMap("field2a" -> Typed[String], "field3" -> Typed[Int]))).canBeConvertedTo(
+    typeMap("field1" -> list(typeMap("field2a" -> Typed[String], "field3" -> Typed[Int]))).canBeLooselyAssignedTo(
       typeMap("field1" -> list(typeMap("field2" -> Typed[String])))
     ) shouldBe false
 
-    typeMap("field1" -> Typed[String]).canBeConvertedTo(Typed[java.util.Map[_, _]]) shouldBe true
+    typeMap("field1" -> Typed[String]).canBeLooselyAssignedTo(Typed[java.util.Map[_, _]]) shouldBe true
 
-    Typed[java.util.Map[_, _]].canBeConvertedTo(typeMap("field1" -> Typed[String])) shouldBe false
+    Typed[java.util.Map[_, _]].canBeLooselyAssignedTo(typeMap("field1" -> Typed[String])) shouldBe false
   }
 
   test("extract Unknown value type when no super matching supertype found among all fields of Record") {
@@ -75,79 +75,79 @@ class TypingResultSpec
     Typed.record(Map.empty[String, TypingResult]).runtimeObjType.params(1) shouldEqual Unknown
   }
 
-  test("determine if can be subclass for typed unions") {
-    Typed(Typed[String], Typed[Int]).canBeConvertedTo(Typed[Int]) shouldBe true
-    Typed[Int].canBeConvertedTo(Typed(Typed[String], Typed[Int])) shouldBe true
+  test("determine if can be assigned for typed unions") {
+    Typed(Typed[String], Typed[Int]).canBeLooselyAssignedTo(Typed[Int]) shouldBe true
+    Typed[Int].canBeLooselyAssignedTo(Typed(Typed[String], Typed[Int])) shouldBe true
 
-    Typed(Typed[String], Typed[Int]).canBeConvertedTo(Typed(Typed[Long], Typed[Int])) shouldBe true
+    Typed(Typed[String], Typed[Int]).canBeLooselyAssignedTo(Typed(Typed[Long], Typed[Int])) shouldBe true
   }
 
-  test("determine if can be subclass for unknown") {
-    Unknown.canBeConvertedTo(Typed[Int]) shouldBe true
-    Typed[Int].canBeConvertedTo(Unknown) shouldBe true
+  test("determine if can be assigned for unknown") {
+    Unknown.canBeLooselyAssignedTo(Typed[Int]) shouldBe true
+    Typed[Int].canBeLooselyAssignedTo(Unknown) shouldBe true
 
-    Unknown.canBeConvertedTo(Typed(Typed[String], Typed[Int])) shouldBe true
-    Typed(Typed[String], Typed[Int]).canBeConvertedTo(Unknown) shouldBe true
+    Unknown.canBeLooselyAssignedTo(Typed(Typed[String], Typed[Int])) shouldBe true
+    Typed(Typed[String], Typed[Int]).canBeLooselyAssignedTo(Unknown) shouldBe true
 
-    Unknown.canBeConvertedTo(typeMap("field1" -> Typed[String])) shouldBe true
-    typeMap("field1" -> Typed[String]).canBeConvertedTo(Unknown) shouldBe true
+    Unknown.canBeLooselyAssignedTo(typeMap("field1" -> Typed[String])) shouldBe true
+    typeMap("field1" -> Typed[String]).canBeLooselyAssignedTo(Unknown) shouldBe true
   }
 
-  test("determine if can be subclass for class") {
+  test("determine if can be assigned for class") {
     Typed
       .fromDetailedType[java.util.List[BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.List[BigDecimal]]) shouldBe true
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.List[BigDecimal]]) shouldBe true
     Typed
       .fromDetailedType[java.util.List[BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.List[Number]]) shouldBe true
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.List[Number]]) shouldBe true
     Typed
       .fromDetailedType[java.util.List[Number]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.List[BigDecimal]]) shouldBe false
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.List[BigDecimal]]) shouldBe false
 
     Typed
       .fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe true
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe true
     Typed
       .fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, Number]]) shouldBe true
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, Number]]) shouldBe true
     Typed
       .fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.Map[Number, Number]]) shouldBe false
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.Map[Number, Number]]) shouldBe false
     Typed
       .fromDetailedType[java.util.Map[Number, Number]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe false
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe false
     Typed
       .fromDetailedType[java.util.Map[Number, BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe false
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe false
     Typed
       .fromDetailedType[java.util.Map[BigDecimal, Number]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe false
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe false
     Typed
       .fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.Map[_, BigDecimal]]) shouldBe true
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.Map[_, BigDecimal]]) shouldBe true
     Typed
       .fromDetailedType[java.util.Map[_, BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe true
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[java.util.Map[BigDecimal, BigDecimal]]) shouldBe true
 
     // For arrays it might be tricky
     Typed
       .fromDetailedType[Array[BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[Array[BigDecimal]]) shouldBe true
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[Array[BigDecimal]]) shouldBe true
     Typed
       .fromDetailedType[Array[BigDecimal]]
-      .canBeConvertedTo(Typed.fromDetailedType[Array[Number]]) shouldBe true
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[Array[Number]]) shouldBe true
     Typed
       .fromDetailedType[Array[Number]]
-      .canBeConvertedTo(Typed.fromDetailedType[Array[BigDecimal]]) shouldBe false
+      .canBeLooselyAssignedTo(Typed.fromDetailedType[Array[BigDecimal]]) shouldBe false
   }
 
   test("determine if numbers can be converted") {
-    Typed[Int].canBeConvertedTo(Typed[Long]) shouldBe true
-    Typed[Long].canBeConvertedTo(Typed[Int]) shouldBe true
-    Typed[Long].canBeConvertedTo(Typed[Double]) shouldBe true
-    Typed[Double].canBeConvertedTo(Typed[Long]) shouldBe false
-    Typed[java.math.BigDecimal].canBeConvertedTo(Typed[Long]) shouldBe true
-    Typed[Long].canBeConvertedTo(Typed[java.math.BigDecimal]) shouldBe true
+    Typed[Int].canBeLooselyAssignedTo(Typed[Long]) shouldBe true
+    Typed[Long].canBeLooselyAssignedTo(Typed[Int]) shouldBe true
+    Typed[Long].canBeLooselyAssignedTo(Typed[Double]) shouldBe true
+    Typed[Double].canBeLooselyAssignedTo(Typed[Long]) shouldBe false
+    Typed[java.math.BigDecimal].canBeLooselyAssignedTo(Typed[Long]) shouldBe true
+    Typed[Long].canBeLooselyAssignedTo(Typed[java.math.BigDecimal]) shouldBe true
   }
 
   test("find common supertype for simple types") {
@@ -300,25 +300,25 @@ class TypingResultSpec
     ) shouldBe empty
   }
 
-  test("determine if can be subclass for tagged value") {
+  test("determine if can be assigned for tagged value") {
     Typed
       .tagged(Typed.typedClass[String], "tag1")
-      .canBeConvertedTo(Typed.tagged(Typed.typedClass[String], "tag1")) shouldBe true
+      .canBeLooselyAssignedTo(Typed.tagged(Typed.typedClass[String], "tag1")) shouldBe true
     Typed
       .tagged(Typed.typedClass[String], "tag1")
-      .canBeConvertedTo(Typed.tagged(Typed.typedClass[String], "tag2")) shouldBe false
+      .canBeLooselyAssignedTo(Typed.tagged(Typed.typedClass[String], "tag2")) shouldBe false
     Typed
       .tagged(Typed.typedClass[String], "tag1")
-      .canBeConvertedTo(Typed.tagged(Typed.typedClass[Integer], "tag1")) shouldBe false
-    Typed.tagged(Typed.typedClass[String], "tag1").canBeConvertedTo(Typed.typedClass[String]) shouldBe true
-    Typed.typedClass[String].canBeConvertedTo(Typed.tagged(Typed.typedClass[String], "tag1")) shouldBe false
+      .canBeLooselyAssignedTo(Typed.tagged(Typed.typedClass[Integer], "tag1")) shouldBe false
+    Typed.tagged(Typed.typedClass[String], "tag1").canBeLooselyAssignedTo(Typed.typedClass[String]) shouldBe true
+    Typed.typedClass[String].canBeLooselyAssignedTo(Typed.tagged(Typed.typedClass[String], "tag1")) shouldBe false
   }
 
-  test("determine if can be subclass for null") {
-    TypedNull.canBeConvertedTo(Typed[Int]) shouldBe true
-    TypedNull.canBeConvertedTo(Typed.fromInstance(4)) shouldBe false
-    TypedNull.canBeConvertedTo(TypedNull) shouldBe true
-    Typed[String].canBeConvertedTo(TypedNull) shouldBe false
+  test("determine if can be assigned for null") {
+    TypedNull.canBeLooselyAssignedTo(Typed[Int]) shouldBe true
+    TypedNull.canBeLooselyAssignedTo(Typed.fromInstance(4)) shouldBe false
+    TypedNull.canBeLooselyAssignedTo(TypedNull) shouldBe true
+    Typed[String].canBeLooselyAssignedTo(TypedNull) shouldBe false
   }
 
   test("should deeply extract typ parameters") {
@@ -336,24 +336,24 @@ class TypingResultSpec
     }
   }
 
-  test("determine if can be subclass for object with value") {
-    Typed.fromInstance(45).canBeConvertedTo(Typed.typedClass[Long]) shouldBe true
-    Typed.fromInstance(29).canBeConvertedTo(Typed.typedClass[String]) shouldBe false
-    Typed.fromInstance(78).canBeConvertedTo(Typed.fromInstance(78)) shouldBe true
-    Typed.fromInstance(12).canBeConvertedTo(Typed.fromInstance(15)) shouldBe false
-    Typed.fromInstance(41).canBeConvertedTo(Typed.fromInstance("t")) shouldBe false
-    Typed.typedClass[String].canBeConvertedTo(Typed.fromInstance("t")) shouldBe true
+  test("determine if can be assigned for object with value") {
+    Typed.fromInstance(45).canBeLooselyAssignedTo(Typed.typedClass[Long]) shouldBe true
+    Typed.fromInstance(29).canBeLooselyAssignedTo(Typed.typedClass[String]) shouldBe false
+    Typed.fromInstance(78).canBeLooselyAssignedTo(Typed.fromInstance(78)) shouldBe true
+    Typed.fromInstance(12).canBeLooselyAssignedTo(Typed.fromInstance(15)) shouldBe false
+    Typed.fromInstance(41).canBeLooselyAssignedTo(Typed.fromInstance("t")) shouldBe false
+    Typed.typedClass[String].canBeLooselyAssignedTo(Typed.fromInstance("t")) shouldBe true
   }
 
-  test("determine if can be subclass for object with value - use conversion") {
-    Typed.fromInstance("2007-12-03").canBeConvertedTo(Typed.typedClass[LocalDate]) shouldBe true
-    Typed.fromInstance("2007-12-03T10:15:30").canBeConvertedTo(Typed.typedClass[LocalDateTime]) shouldBe true
+  test("determine if can be assigned for object with value - use conversion") {
+    Typed.fromInstance("2007-12-03").canBeLooselyAssignedTo(Typed.typedClass[LocalDate]) shouldBe true
+    Typed.fromInstance("2007-12-03T10:15:30").canBeLooselyAssignedTo(Typed.typedClass[LocalDateTime]) shouldBe true
 
-    Typed.fromInstance("2007-12-03-qwerty").canBeConvertedTo(Typed.typedClass[LocalDate]) shouldBe false
-    Typed.fromInstance("2007-12-03").canBeConvertedTo(Typed.typedClass[Currency]) shouldBe false
+    Typed.fromInstance("2007-12-03-qwerty").canBeLooselyAssignedTo(Typed.typedClass[LocalDate]) shouldBe false
+    Typed.fromInstance("2007-12-03").canBeLooselyAssignedTo(Typed.typedClass[Currency]) shouldBe false
   }
 
-  test("determinate if can be superclass for objects with value") {
+  test("determinate if can be supertype for objects with value") {
     intersectionSuperTypeFinder.commonSupertypeOpt(Typed.fromInstance(65), Typed.fromInstance(65)).value shouldBe Typed
       .fromInstance(65)
     intersectionSuperTypeFinder.commonSupertypeOpt(Typed.fromInstance(91), Typed.fromInstance(35)).value shouldBe Typed
@@ -449,7 +449,7 @@ class TypingResultSpec
       logger.trace(s"Checking: ${input.display}")
       withClue(s"Input: ${input.display};") {
 
-        input.canBeConvertedTo(input) shouldBe true
+        input.canBeLooselyAssignedTo(input) shouldBe true
         val superType = CommonSupertypeFinder.Default.commonSupertype(input, input)
         withClue(s"Supertype: ${superType.display};") {
           superType shouldEqual input
@@ -463,11 +463,11 @@ class TypingResultSpec
       logger.trace(s"Checking: ${input.display}")
       withClue(s"Input: ${input.display};") {
 
-        input.canBeConvertedTo(input) shouldBe true
+        input.canBeLooselyAssignedTo(input) shouldBe true
         val superType = CommonSupertypeFinder.Default.commonSupertype(input, input)
         withClue(s"Supertype: ${superType.display};") {
           // We generate combinations of types co we can only check if input type is a subclass of super type
-          input.canBeConvertedTo(superType)
+          input.canBeLooselyAssignedTo(superType)
         }
       }
     }
@@ -483,12 +483,12 @@ class TypingResultSpec
       logger.trace(s"Checking supertype of: ${first.display} and ${second.display}")
       withClue(s"Input: ${first.display}; ${second.display};") {
 
-        first.canBeConvertedTo(first) shouldBe true
-        second.canBeConvertedTo(second) shouldBe true
+        first.canBeLooselyAssignedTo(first) shouldBe true
+        second.canBeLooselyAssignedTo(second) shouldBe true
         val superType = CommonSupertypeFinder.Default.commonSupertype(first, second)
         withClue(s"Supertype: ${superType.display};") {
-          first.canBeConvertedTo(superType)
-          second.canBeConvertedTo(superType)
+          first.canBeLooselyAssignedTo(superType)
+          second.canBeLooselyAssignedTo(superType)
         }
       }
     }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/DictApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/DictApiHttpService.scala
@@ -86,7 +86,7 @@ class DictApiHttpService(
                   success(
                     dictionaries
                       .filter { case (id, definition) =>
-                        definition.valueType(id).canBeStrictlyConvertedTo(expectedType)
+                        definition.valueType(id).canBeStrictlyAssignedTo(expectedType)
                       }
                       .map { case (id, _) => DictDto(id, id) }
                       .toList

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DictApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DictApiHttpServiceSpec.scala
@@ -101,35 +101,6 @@ class DictApiHttpServiceSpec
         )
     }
 
-    "return proper list for expected type BigInteger" in {
-      given()
-        .when()
-        .basicAuthAllPermUser()
-        .jsonBody("""{
-                    |  "expectedType" : {
-                    |      "type" : "TypedClass",
-                    |      "refClazzName" : "java.math.BigInteger",
-                    |      "params" : []
-                    |  }
-                    |}""".stripMargin)
-        .post(s"$nuDesignerHttpAddress/api/processDefinitionData/${Streaming.stringify}/dicts")
-        .Then()
-        .statusCode(200)
-        .equalsJsonBody(
-          s"""[
-             |
-             |  {
-             |    "id": "integer_dict",
-             |    "label": "integer_dict"
-             |  },
-             |  {
-             |    "id" : "long_dict",
-             |    "label" : "long_dict"
-             |  }
-             |]""".stripMargin
-        )
-    }
-
     "fail for bad request" in {
       given()
         .when()

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -116,8 +116,10 @@ To see the biggest differences please consult the [changelog](Changelog.md).
     * Renamed a `SimpleEditor` to the `Editor` in components API.
     * For now on, you can add multiple editors on a single param. The first editor annotation is treated as a default
       editor.
-* [#7711](https://github.com/TouK/nussknacker/pull/7711)
-  * `TypingResult` API changes - `TypedNull.wihoutValue` returns `Unknown` type instead of `TypedNull`
+* [#7711](https://github.com/TouK/nussknacker/pull/7711) [#7984](https://github.com/TouK/nussknacker/pull/7984) `TypingResult` API changes:
+  * `TypedNull.wihoutValue` returns `Unknown` type instead of `TypedNull`
+  * `canBeConvertedTo` renamed to `canBeLooselyAssignedTo`
+  * `canBeStrictlyConvertedTo` renamed to `canBeStrictlyAssignedTo`
 * [#7768](https://github.com/TouK/nussknacker/pull/7768)
   * `ModelData.withThisAsContextClassLoader` was renamed to `withModelClassloaderAsContextClassLoader`
   * New, `DeploymentManager.scenarioCompilationDependenciesResource` method was added. For flink-based DMs it should be

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/AggregatesSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/AggregatesSpec.scala
@@ -92,8 +92,8 @@ class AggregatesSpec extends AnyFunSuite with TableDrivenPropertyChecks with Mat
 
   private def shouldBeInstanceOf(obj: Any, typ: TypingResult): Unit = {
     val typeFromInstance  = Typed.fromInstance(obj)
-    val canBeSubclassCase = typeFromInstance.canBeConvertedTo(typ)
-    val typedObjectCase = typ.isInstanceOf[TypedObjectTypingResult] && typeFromInstance.canBeConvertedTo(
+    val canBeSubclassCase = typeFromInstance.canBeLooselyAssignedTo(typ)
+    val typedObjectCase = typ.isInstanceOf[TypedObjectTypingResult] && typeFromInstance.canBeLooselyAssignedTo(
       typ.asInstanceOf[TypedObjectTypingResult].runtimeObjType
     )
     (canBeSubclassCase || typedObjectCase) shouldBe true

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/aggregates.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/aggregates.scala
@@ -223,7 +223,7 @@ object aggregates {
     override def result(finalAggregate: Aggregate): AnyRef = finalAggregate
 
     override def computeOutputType(input: typing.TypingResult): Validated[String, typing.TypingResult] = {
-      if (input.canBeConvertedTo(Typed[Boolean])) {
+      if (input.canBeLooselyAssignedTo(Typed[Boolean])) {
         Valid(Typed[Long])
       } else {
         Invalid(s"Invalid aggregate type: ${input.display}, should be: ${Typed[Boolean].display}")
@@ -483,7 +483,7 @@ object aggregates {
     ): Validated[String, TypedObjectTypingResult] = {
       input match {
         case TypedObjectTypingResult(inputFields, klass, _)
-            if inputFields.keySet == scalaFields.keySet && klass.canBeConvertedTo(
+            if inputFields.keySet == scalaFields.keySet && klass.canBeLooselyAssignedTo(
               Typed[java.util.Map[String, _]]
             ) =>
           val validationRes = scalaFields
@@ -569,7 +569,7 @@ object aggregates {
   trait MathAggregator { self: ReducingAggregator =>
 
     override def computeOutputType(input: typing.TypingResult): Validated[String, typing.TypingResult] = {
-      if (input.canBeConvertedTo(Typed[Number])) {
+      if (input.canBeLooselyAssignedTo(Typed[Number])) {
         // In some cases type can be promoted to other class e.g. Byte is promoted to Int for sum
         Valid(promotionStrategy.promoteSingle(input))
       } else {
@@ -597,7 +597,7 @@ object aggregates {
 
     override def computeOutputType(input: typing.TypingResult): Validated[String, typing.TypingResult] = {
 
-      if (!input.canBeConvertedTo(Typed[Number])) {
+      if (!input.canBeLooselyAssignedTo(Typed[Number])) {
         Invalid(s"Invalid aggregate type: ${input.display}, should be: ${Typed[Number].display}")
       } else {
         Valid(ForLargeFloatingNumbersOperation.promoteSingle(input))

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
@@ -45,7 +45,7 @@ object ForEachTransformer extends CustomStreamTransformer with Serializable {
   private def returnType(elements: LazyParameter[util.Collection[AnyRef]]): typing.TypingResult =
     elements.returnType match {
       case tc: SingleTypingResult
-          if tc.runtimeObjType.canBeConvertedTo(
+          if tc.runtimeObjType.canBeLooselyAssignedTo(
             Typed[util.Collection[_]]
           ) && tc.runtimeObjType.params.nonEmpty =>
         tc.runtimeObjType.params.head

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableTypeOutputValidator.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableTypeOutputValidator.scala
@@ -14,7 +14,7 @@ object TableTypeOutputValidator {
     val aligned              = ToTableTypeSchemaBasedEncoder.alignTypingResult(actualType, expectedType)
     val expectedTypingResult = expectedType.toTypingResult
 
-    if (aligned.canBeConvertedTo(expectedTypingResult)) {
+    if (aligned.canBeLooselyAssignedTo(expectedTypingResult)) {
       Valid(())
     } else {
       invalidNel(

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/ToTableTypeSchemaBasedEncoder.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/ToTableTypeSchemaBasedEncoder.scala
@@ -26,7 +26,7 @@ object ToTableTypeSchemaBasedEncoder {
       case (null, _) =>
         null
       // We don't know what is the precise of decimal so we have to assume that it will fit the target type to not block the user
-      case (number: Number, _) if Typed.typedClass(number.getClass).canBeConvertedTo(targetType.toTypingResult) =>
+      case (number: Number, _) if Typed.typedClass(number.getClass).canBeLooselyAssignedTo(targetType.toTypingResult) =>
         NumberUtils
           .convertNumberToTargetClass[Number](number, targetType.getDefaultConversion.asInstanceOf[Class[Number]])
       case (_, rowType: RowType) =>
@@ -83,7 +83,7 @@ object ToTableTypeSchemaBasedEncoder {
       // We don't know what is the precision of decimal so we have to assume that it will fit the target type to not block the user
       case (typ: SingleTypingResult, _)
           if typ
-            .canBeConvertedTo(Typed[Number]) && typ.canBeConvertedTo(targetType.toTypingResult) =>
+            .canBeLooselyAssignedTo(Typed[Number]) && typ.canBeLooselyAssignedTo(targetType.toTypingResult) =>
         targetType.toTypingResult
       case (recordType: TypedObjectTypingResult, rowType: RowType)
           if Set[Class[_]](javaMapClass, rowClass).contains(recordType.runtimeObjType.klass) =>
@@ -105,10 +105,10 @@ object ToTableTypeSchemaBasedEncoder {
       case (
             TypedObjectTypingResult(_, TypedClass(`javaMapClass`, keyType :: valueType :: Nil), _),
             multisetType: MultisetType
-          ) if valueType.canBeConvertedTo(Typed[Int]) =>
+          ) if valueType.canBeLooselyAssignedTo(Typed[Int]) =>
         alignMultisetType(keyType, multisetType)
       case (TypedClass(`javaMapClass`, keyType :: valueType :: Nil), multisetType: MultisetType)
-          if valueType.canBeConvertedTo(Typed[Int]) =>
+          if valueType.canBeLooselyAssignedTo(Typed[Int]) =>
         alignMultisetType(keyType, multisetType)
       case (TypedClass(`arrayClass`, elementType :: Nil), arrayType: ArrayType) =>
         Typed.genericTypeClass(arrayClass, List(alignTypingResult(elementType, arrayType.getElementType)))

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/global/DocumentationFunctions.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/global/DocumentationFunctions.scala
@@ -62,7 +62,7 @@ object DocumentationFunctions {
         (left.withoutValue, right.withoutValue) match {
           case (`intType`, `intType`)       => intType.validNel
           case (`doubleType`, `doubleType`) => doubleType.validNel
-          case (l, r) if List(l, r).forall(_.canBeConvertedTo(numberType)) =>
+          case (l, r) if List(l, r).forall(_.canBeLooselyAssignedTo(numberType)) =>
             OtherError(s"Addition of ${l.display} and ${r.display} is not supported").invalidNel
           case (`stringType`, `stringType`) => stringType.validNel
           case _                            => ArgumentTypeError.invalidNel
@@ -110,7 +110,7 @@ object DocumentationFunctions {
           case Some(v) => v.validNel
           case None    => OtherError("No field with given name").invalidNel
         }
-      case TypedObjectTypingResult(_, _, _) :: x :: Nil if x.canBeConvertedTo(stringType) =>
+      case TypedObjectTypingResult(_, _, _) :: x :: Nil if x.canBeLooselyAssignedTo(stringType) =>
         OtherError("Expected string with known value").invalidNel
       case _ =>
         ArgumentTypeError.invalidNel

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/global/ExampleFunctions.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/global/ExampleFunctions.scala
@@ -147,7 +147,7 @@ object ExampleFunctions {
     override def computeResultType(
         arguments: List[TypingResult]
     ): ValidatedNel[GenericFunctionTypingError, TypingResult] = {
-      if (arguments.exists(!_.canBeConvertedTo(Typed[Number]))) return ArgumentTypeError.invalidNel
+      if (arguments.exists(!_.canBeLooselyAssignedTo(Typed[Number]))) return ArgumentTypeError.invalidNel
       arguments match {
         case t :: Nil           => t.validNel
         case l :: r :: Nil      => Typed.record(Map("left" -> l, "right" -> r)).validNel

--- a/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/ForEachTransformer.scala
+++ b/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/ForEachTransformer.scala
@@ -42,7 +42,7 @@ class ForEachTransformerComponent(elements: LazyParameter[java.util.Collection[A
   override def returnType: typing.TypingResult = {
     elements.returnType match {
       case tc: SingleTypingResult
-          if tc.runtimeObjType.canBeConvertedTo(
+          if tc.runtimeObjType.canBeLooselyAssignedTo(
             Typed[java.util.Collection[_]]
           ) && tc.runtimeObjType.params.nonEmpty =>
         tc.runtimeObjType.params.head

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/FragmentParameterValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/FragmentParameterValidator.scala
@@ -171,7 +171,7 @@ case class FragmentParameterValidator(classDefinitions: ClassDefinitionSet) {
 
               val dictValueType = dictDefinition.valueType(dictId)
 
-              if (dictValueType.canBeConvertedTo(fragmentParameterTypingResult)) {
+              if (dictValueType.canBeLooselyAssignedTo(fragmentParameterTypingResult)) {
                 Valid(())
               } else {
                 invalidNel(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/ClassDefinitionExtractor.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/ClassDefinitionExtractor.scala
@@ -141,7 +141,7 @@ class ClassDefinitionExtractor(settings: ClassExtractionSettings) extends LazyLo
 
         methodsForParams
           .find { case (_, method) =>
-            methodsForParams.forall(mi => method.signature.result.canBeConvertedTo(mi._2.signature.result))
+            methodsForParams.forall(mi => method.signature.result.canBeLooselyAssignedTo(mi._2.signature.result))
           }
           .getOrElse(methodsForParams.minBy(_._2.signature.result.display))
       }
@@ -273,7 +273,7 @@ class ClassDefinitionExtractor(settings: ClassExtractionSettings) extends LazyLo
               )
               reflectionBasedDefinition.result
             }
-            if (returnedResultType.canBeConvertedTo(returnedResultType)) {
+            if (returnedResultType.canBeLooselyAssignedTo(returnedResultType)) {
               returnedResultType
             } else {
               logger.warn(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/MethodDefinition.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/MethodDefinition.scala
@@ -9,8 +9,7 @@ import pl.touk.nussknacker.engine.api.generics.{
   Parameter
 }
 import pl.touk.nussknacker.engine.api.generics.GenericFunctionTypingError.ArgumentTypeError
-import pl.touk.nussknacker.engine.api.typed.typing
-import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, TypingResult}
+import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.spel.SpelExpressionParseErrorConverter
 
 sealed trait MethodDefinition {
@@ -31,19 +30,13 @@ sealed trait MethodDefinition {
 
   protected def isValidMethodInfo(arguments: List[TypingResult], methodTypeInfo: MethodTypeInfo): Boolean = {
     val checkNoVarArgs = arguments.length >= methodTypeInfo.noVarArgs.length &&
-      arguments.zip(methodTypeInfo.noVarArgs).forall {
-        // Allow pass array as List argument because of array to list auto conversion:
-        // pl.touk.nussknacker.engine.spel.internal.ArrayToListConverter
-        case (tc @ TypedClass(klass, _), Parameter(_, y)) if klass.isArray =>
-          tc.canBeConvertedTo(y) || Typed
-            .genericTypeClass[java.util.List[_]](tc.params)
-            .canBeConvertedTo(y)
-        case (x, Parameter(_, y)) => x.canBeConvertedTo(y)
+      arguments.zip(methodTypeInfo.noVarArgs).forall { case (x, Parameter(_, y)) =>
+        x.canBeLooselyAssignedTo(y)
       }
 
     val checkVarArgs = methodTypeInfo.varArg match {
       case Some(Parameter(_, t)) =>
-        arguments.drop(methodTypeInfo.noVarArgs.length).forall(_.canBeConvertedTo(t))
+        arguments.drop(methodTypeInfo.noVarArgs.length).forall(_.canBeLooselyAssignedTo(t))
       case None =>
         arguments.length == methodTypeInfo.noVarArgs.length
     }
@@ -96,7 +89,7 @@ case class FunctionalMethodDefinition(
 
     val typeCalculated = typeFunction(methodInvocationTarget, arguments).leftMap(_.map(errorConverter.convert))
     typeCalculated.map { calculated =>
-      if (!typesFromStaticMethodInfo.exists(calculated.canBeConvertedTo)) {
+      if (!typesFromStaticMethodInfo.exists(calculated.canBeLooselyAssignedTo)) {
         val expectedTypesString = typesFromStaticMethodInfo.map(_.display).mkString("(", ", ", ")")
         val argumentsString     = arguments.map(_.display).mkString("(", ", ", ")")
         throw new AssertionError(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/MethodTypeInfoSubclassChecker.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/clazz/MethodTypeInfoSubclassChecker.scala
@@ -12,7 +12,7 @@ object MethodTypeInfoSubclassChecker {
     val MethodTypeInfo(superclassNoVarArg, superclassVarArgOption, superclassResult) = superclassInfo
 
     val validatedVarArgs = (subclassVarArgOption, superclassVarArgOption) match {
-      case (Some(sub), Some(sup)) if sub.refClazz.canBeConvertedTo(sup.refClazz) => ().validNel
+      case (Some(sub), Some(sup)) if sub.refClazz.canBeLooselyAssignedTo(sup.refClazz) => ().validNel
       case (Some(sub), Some(sup)) => NotSubclassVarArgument(sub.refClazz, sup.refClazz).invalidNel
       case (Some(_), None)        => BadVarArg.invalidNel
       case (None, Some(_))        => ().validNel
@@ -38,7 +38,7 @@ object MethodTypeInfoSubclassChecker {
     )
     val validatedNoVarArgs = zippedParameters.zipWithIndex
       .map {
-        case ((sub, sup), _) if sub.refClazz.canBeConvertedTo(sup.refClazz) => ().validNel
+        case ((sub, sup), _) if sub.refClazz.canBeLooselyAssignedTo(sup.refClazz) => ().validNel
         case ((sub, sup), i) => NotSubclassArgument(i + 1, sub.refClazz, sup.refClazz).invalidNel
       }
       .sequence
@@ -46,7 +46,7 @@ object MethodTypeInfoSubclassChecker {
 
     val validatedResult =
       Validated.condNel(
-        subclassResult.canBeConvertedTo(superclassResult),
+        subclassResult.canBeLooselyAssignedTo(superclassResult),
         (),
         NotSubclassResult(subclassResult, superclassResult)
       )

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/dictWithLabel/DictKeyWithLabelExpressionParser.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/dictWithLabel/DictKeyWithLabelExpressionParser.scala
@@ -24,11 +24,11 @@ case class DictKeyWithLabelExpressionTypingInfo(key: String, label: Option[Strin
 
   // We should support at least types defined in FragmentParameterValidator#permittedTypesForEditors
   override def typingResult: TypingResult = expectedType match {
-    case clazz: TypedClass if clazz.canBeConvertedTo(Typed[Long]) && Try(key.toLong).toOption.isDefined =>
+    case clazz: TypedClass if clazz.canBeLooselyAssignedTo(Typed[Long]) && Try(key.toLong).toOption.isDefined =>
       TypedObjectWithValue(clazz.runtimeObjType, key.toLong)
-    case clazz: TypedClass if clazz.canBeConvertedTo(Typed[Boolean]) && Try(key.toBoolean).toOption.isDefined =>
+    case clazz: TypedClass if clazz.canBeLooselyAssignedTo(Typed[Boolean]) && Try(key.toBoolean).toOption.isDefined =>
       TypedObjectWithValue(clazz.runtimeObjType, key.toBoolean)
-    case clazz: TypedClass if clazz.canBeConvertedTo(Typed[String]) =>
+    case clazz: TypedClass if clazz.canBeLooselyAssignedTo(Typed[String]) =>
       TypedObjectWithValue(clazz.runtimeObjType, key)
     case _ => expectedType
   }
@@ -85,11 +85,11 @@ object DictKeyWithLabelExpressionParser extends ExpressionParser {
     override def language: Language = languageId
 
     override def evaluate[T](ctx: Context, globals: Map[String, Any]): T = {
-      if (expectedType.canBeConvertedTo(Typed[Long])) {
+      if (expectedType.canBeLooselyAssignedTo(Typed[Long])) {
         key.toLong.asInstanceOf[T]
-      } else if (expectedType.canBeConvertedTo(Typed[Boolean])) {
+      } else if (expectedType.canBeLooselyAssignedTo(Typed[Boolean])) {
         key.toBoolean.asInstanceOf[T]
-      } else if (expectedType.canBeConvertedTo(Typed[String])) {
+      } else if (expectedType.canBeLooselyAssignedTo(Typed[String])) {
         key.asInstanceOf[T]
       } else {
         throw new IllegalStateException(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpression.scala
@@ -130,7 +130,7 @@ class SpelExpression(
         val evaluationResult = TemplateEvaluationResult(parts)
         if (expectedReturnType == Typed[TemplateEvaluationResult]) {
           evaluationResult.asInstanceOf[T]
-        } else if (expectedReturnType.canBeStrictlyConvertedTo(Typed[CharSequence])) {
+        } else if (expectedReturnType.canBeStrictlyAssignedTo(Typed[CharSequence])) {
           evaluationResult.renderedTemplate.asInstanceOf[T]
         } else {
           throw new IllegalStateException(s"Expression parsed with unexpected type: $expectedReturnType")

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
@@ -427,9 +427,9 @@ class SpelExpressionSuggester(
 
   private def determineIterableElementTypingResult(parent: TypingResult): TypingResult = {
     parent match {
-      case tc: SingleTypingResult if tc.runtimeObjType.canBeConvertedTo(Typed[java.util.Collection[_]]) =>
+      case tc: SingleTypingResult if tc.runtimeObjType.canBeLooselyAssignedTo(Typed[java.util.Collection[_]]) =>
         tc.runtimeObjType.params.headOption.getOrElse(Unknown)
-      case tc: SingleTypingResult if tc.runtimeObjType.canBeConvertedTo(Typed[java.util.Map[_, _]]) =>
+      case tc: SingleTypingResult if tc.runtimeObjType.canBeLooselyAssignedTo(Typed[java.util.Map[_, _]]) =>
         Typed.record(
           Map(
             "key"   -> tc.runtimeObjType.params.headOption.getOrElse(Unknown),

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionValidator.scala
@@ -23,7 +23,7 @@ class SpelExpressionValidator(typer: Typer) {
           Valid(collected)
         case a if a == Typed[String] && expectedType == Typed[TemplateEvaluationResult] =>
           Valid(collected)
-        case a if a.canBeConvertedTo(expectedType) =>
+        case a if a.canBeLooselyAssignedTo(expectedType) =>
           Valid(collected)
         case a =>
           Invalid(NonEmptyList.of(ExpressionTypeError(expectedType, a)))

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/Typer.scala
@@ -15,6 +15,7 @@ import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.expression._
 import pl.touk.nussknacker.engine.api.generics.ExpressionParseError
+import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.NoConversion
 import pl.touk.nussknacker.engine.api.typed.supertype.{CommonSupertypeFinder, NumberTypesPromotionStrategy}
 import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.api.typed.typing.Typed.typedListWithElementValues
@@ -24,13 +25,7 @@ import pl.touk.nussknacker.engine.dict.SpelDictTyper
 import pl.touk.nussknacker.engine.expression.NullExpression
 import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.{ArgumentTypeError, PartTypeError}
 import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.IllegalOperationError._
-import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.MissingObjectError.{
-  ConstructionOfUnknown,
-  NonReferenceError,
-  NoPropertyError,
-  NoPropertyTypeError,
-  UnresolvedReferenceError
-}
+import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.MissingObjectError._
 import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.OperatorError._
 import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.SelectionProjectionError.{
   IllegalProjectionError,
@@ -148,8 +143,8 @@ private[spel] class Typer(
     def withChildrenOfType[Parts: universe.TypeTag](result: TypingResult) = {
       val w = valid(result)
       withTypedChildren {
-        case list if list.forall(_.canBeConvertedTo(Typed.fromDetailedType[Parts])) => w
-        case _                                                                      => w.tell(List(PartTypeError))
+        case list if list.forall(_.canBeLooselyAssignedTo(Typed.fromDetailedType[Parts])) => w
+        case _                                                                            => w.tell(List(PartTypeError))
       }
     }
 
@@ -200,7 +195,7 @@ private[spel] class Typer(
             case (ref: PropertyOrFieldReference) :: Nil => typeFieldNameReferenceOnRecord(ref.getName, record)
             case _                                      => typeFieldNameReferenceOnRecord(indexString, record)
           }
-        case indexKey :: Nil if indexKey.canBeConvertedTo(Typed[String]) =>
+        case indexKey :: Nil if indexKey.canBeLooselyAssignedTo(Typed[String]) =>
           if (dynamicPropertyAccessAllowed) valid(Unknown)
           else
             record.runtimeObjType.params match {
@@ -233,7 +228,7 @@ private[spel] class Typer(
             // It would be hard to change implementation of .asMap extension so we partially turn off this feature of indexer conversion
             // by allowing in typing only situations when map key type and indexer type are the same (though we have to allow
             // indexing with unknown type)
-            case indexKey :: Nil if indexKey.canBeConvertedWithoutConversionTo(keyParam) => valid(valueParam)
+            case indexKey :: Nil if indexKey.canBeAssignedTo(keyParam)(NoConversion) => valid(valueParam)
             case _ => invalid(IllegalIndexingOperation)
           }
         case d: TypedDict                    => dictTyper.typeDictValue(d, e).map(toNodeResult)
@@ -373,7 +368,8 @@ private[spel] class Typer(
 
       case e: OpMinus =>
         withTypedChildren {
-          case left :: right :: Nil if left.canBeConvertedTo(Typed[Number]) && right.canBeConvertedTo(Typed[Number]) =>
+          case left :: right :: Nil
+              if left.canBeLooselyAssignedTo(Typed[Number]) && right.canBeLooselyAssignedTo(Typed[Number]) =>
             val fallback = NumberTypesPromotionStrategy.ForMathOperation.promote(left, right)
             operationOnTypesValue[Number, Number, Number](left, right, fallback)((n1, n2) =>
               Valid(MathUtils.minus(n1, n2))
@@ -382,7 +378,7 @@ private[spel] class Typer(
             invalid(OperatorNonNumericError(e.getOperatorName, left))
           case left :: right :: Nil =>
             invalid(OperatorMismatchTypeError(e.getOperatorName, left, right))
-          case left :: Nil if left.canBeConvertedTo(Typed[Number]) =>
+          case left :: Nil if left.canBeLooselyAssignedTo(Typed[Number]) =>
             val resultType = left.withoutValue
             val result     = operationOnTypesValue[Number, Number](left)(MathUtils.negate).getOrElse(resultType)
             valid(result)
@@ -412,18 +408,20 @@ private[spel] class Typer(
         withTypedChildren {
           case left :: right :: Nil if left == Unknown || right == Unknown =>
             valid(Unknown)
-          case left :: right :: Nil if left.canBeConvertedTo(Typed[String]) || right.canBeConvertedTo(Typed[String]) =>
+          case left :: right :: Nil
+              if left.canBeLooselyAssignedTo(Typed[String]) || right.canBeLooselyAssignedTo(Typed[String]) =>
             operationOnTypesValue[Any, Any, String](left, right, Typed[String])((l, r) =>
               Valid(l.toString + r.toString)
             )
-          case left :: right :: Nil if left.canBeConvertedTo(Typed[Number]) && right.canBeConvertedTo(Typed[Number]) =>
+          case left :: right :: Nil
+              if left.canBeLooselyAssignedTo(Typed[Number]) && right.canBeLooselyAssignedTo(Typed[Number]) =>
             val fallback = NumberTypesPromotionStrategy.ForMathOperation.promote(left, right)
             operationOnTypesValue[Number, Number, Number](left, right, fallback)((n1, n2) =>
               Valid(MathUtils.plus(n1, n2))
             )
           case left :: right :: Nil =>
             invalid(OperatorMismatchTypeError(e.getOperatorName, left, right))
-          case left :: Nil if left.canBeConvertedTo(Typed[Number]) =>
+          case left :: Nil if left.canBeLooselyAssignedTo(Typed[Number]) =>
             valid(left)
           case left :: Nil =>
             invalid(OperatorNonNumericError(e.getOperatorName, left))
@@ -465,7 +463,7 @@ private[spel] class Typer(
           elementType <- extractIterativeType(iterateType)
           selectionType = resolveSelectionTypingResult(e, iterateType, elementType)
           result <- typeChildren(validationContext, node, current.pushOnStack(elementType)) {
-            case result :: Nil if result.canBeConvertedTo(Typed[Boolean]) =>
+            case result :: Nil if result.canBeLooselyAssignedTo(Typed[Boolean]) =>
               valid(selectionType)
             case other =>
               invalid(IllegalSelectionTypeError(other), selectionType)
@@ -476,7 +474,7 @@ private[spel] class Typer(
           case condition :: onTrue :: onFalse :: Nil =>
             for {
               _ <- Option(condition)
-                .filter(_.canBeConvertedTo(Typed[Boolean]))
+                .filter(_.canBeLooselyAssignedTo(Typed[Boolean]))
                 .map(valid)
                 .getOrElse(invalid(TernaryOperatorNotBooleanError(condition)))
             } yield CommonSupertypeFinder.Default.commonSupertype(onTrue, onFalse)
@@ -537,10 +535,10 @@ private[spel] class Typer(
       // as properly determining it would require evaluating the selection expression for each element (likely working on the AST)
       parentType match {
         case tc: SingleTypingResult
-            if tc.runtimeObjType.canBeConvertedTo(Typed[java.util.Collection[_]]) ||
+            if tc.runtimeObjType.canBeLooselyAssignedTo(Typed[java.util.Collection[_]]) ||
               tc.runtimeObjType.klass.isArray =>
           tc.withoutValue
-        case tc: SingleTypingResult if tc.runtimeObjType.canBeConvertedTo(Typed[java.util.Map[_, _]]) =>
+        case tc: SingleTypingResult if tc.runtimeObjType.canBeLooselyAssignedTo(Typed[java.util.Map[_, _]]) =>
           Typed.record(Map.empty)
         case _ =>
           parentType
@@ -592,7 +590,8 @@ private[spel] class Typer(
       op: Option[(Number, Number) => Validated[ExpressionParseError, Any]]
   )(implicit numberPromotionStrategy: NumberTypesPromotionStrategy): TypingR[CollectedTypingResult] = {
     typeChildren(validationContext, node, current) {
-      case left :: right :: Nil if left.canBeConvertedTo(Typed[Number]) && right.canBeConvertedTo(Typed[Number]) =>
+      case left :: right :: Nil
+          if left.canBeLooselyAssignedTo(Typed[Number]) && right.canBeLooselyAssignedTo(Typed[Number]) =>
         val fallback = numberPromotionStrategy.promote(left, right)
         op
           .map(operationOnTypesValue[Number, Number, Any](left, right, fallback)(_))
@@ -611,7 +610,7 @@ private[spel] class Typer(
       current: TypingContext
   )(op: Number => Any): TypingR[CollectedTypingResult] = {
     typeChildren(validationContext, node, current) {
-      case left :: Nil if left.canBeConvertedTo(Typed[Number]) =>
+      case left :: Nil if left.canBeLooselyAssignedTo(Typed[Number]) =>
         val result = operationOnTypesValue[Number, Any](left)(op).getOrElse(left.withoutValue)
         valid(result)
       case left :: Nil =>
@@ -707,10 +706,10 @@ private[spel] class Typer(
 
   private def extractIterativeType(parent: TypingResult): TypingR[TypingResult] = parent match {
     case tc: SingleTypingResult
-        if tc.runtimeObjType.canBeConvertedTo(Typed[java.util.Collection[_]]) ||
+        if tc.runtimeObjType.canBeLooselyAssignedTo(Typed[java.util.Collection[_]]) ||
           tc.runtimeObjType.klass.isArray =>
       valid(tc.runtimeObjType.params.headOption.getOrElse(Unknown))
-    case tc: SingleTypingResult if tc.runtimeObjType.canBeConvertedTo(Typed[java.util.Map[_, _]]) =>
+    case tc: SingleTypingResult if tc.runtimeObjType.canBeLooselyAssignedTo(Typed[java.util.Map[_, _]]) =>
       valid(
         Typed.record(
           Map(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/typer/MethodReferenceTyper.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/typer/MethodReferenceTyper.scala
@@ -62,7 +62,7 @@ class MethodReferenceTyper(classDefinitionSet: ClassDefinitionSet, methodExecuti
   )(implicit reference: MethodReference): Either[Option[ExpressionParseError], NonEmptyList[MethodDefinition]] = {
     def displayableType = clazzDefinitions.map(k => k.clazzName).map(_.display).toList.mkString(", ")
 
-    def isClass = clazzDefinitions.map(k => k.clazzName).exists(_.canBeConvertedTo(Typed[Class[_]]))
+    def isClass = clazzDefinitions.map(k => k.clazzName).exists(_.canBeLooselyAssignedTo(Typed[Class[_]]))
 
     val clazzMethods =
       if (reference.isStatic) clazzDefinitions.toList.flatMap(_.staticMethods.get(reference.methodName).toList.flatten)

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -1511,7 +1511,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   }
 
   test("should convert array to list when passing arg which type should be list") {
-    evaluate[Any]("T(java.lang.String).join(',', #array)") shouldBe "a,b"
+    evaluate[Any]("#processHelper.stringList(#array)", ctxWithGlobal) shouldBe 2
   }
 
   test("should calculate correct type of list after projection on list") {
@@ -2231,7 +2231,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
       val parsedRoundTripExpression = parse[Any](mapExpression + ".toList.toMap", customCtx).validValue
       parsedRoundTripExpression.evaluateSync[Any](customCtx) shouldBe givenMap
       val roundTripTypeIsAGeneralizationOfGivenType =
-        givenMapExpression.returnType canBeConvertedTo parsedRoundTripExpression.returnType
+        givenMapExpression.returnType canBeLooselyAssignedTo parsedRoundTripExpression.returnType
       roundTripTypeIsAGeneralizationOfGivenType shouldBe true
     }
 

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/collection.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/collection.scala
@@ -363,8 +363,8 @@ object CollectionUtils {
           case _ if firstComponentType.withoutValue == secondComponentType.withoutValue =>
             listType.copy(params = firstComponentType.withoutValue :: Nil)
           case _
-              if firstComponentType.canBeConvertedTo(numberType) && secondComponentType
-                .canBeConvertedTo(numberType) =>
+              if firstComponentType.canBeLooselyAssignedTo(numberType) && secondComponentType
+                .canBeLooselyAssignedTo(numberType) =>
             Typed.genericTypeClass(fClass, List(numberType))
           case _ => listType.copy(params = Unknown :: Nil)
         }

--- a/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/numeric.scala
+++ b/utils/default-helpers/src/main/scala/pl/touk/nussknacker/engine/util/functions/numeric.scala
@@ -130,7 +130,7 @@ object NumericUtils {
     override def computeResultType(
         arguments: List[typing.TypingResult]
     ): ValidatedNel[GenericFunctionTypingError, typing.TypingResult] = {
-      if (arguments.head.canBeConvertedTo(Typed[Number])) arguments.head.withoutValue.validNel
+      if (arguments.head.canBeLooselyAssignedTo(Typed[Number])) arguments.head.withoutValue.validNel
       else Typed[Number].validNel
     }
 

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/encode/JsonSchemaOutputValidator.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/encode/JsonSchemaOutputValidator.scala
@@ -370,7 +370,7 @@ class JsonSchemaOutputValidator(validationMode: ValidationMode) extends LazyLogg
       case (TypedClass(_, Nil), TypedClass(_, Nil)) => invalid(typingResult, schema, rootSchema, path)
       case _ =>
         condNel(
-          typingResult.canBeConvertedTo(schemaAsTypedResult),
+          typingResult.canBeLooselyAssignedTo(schemaAsTypedResult),
           (),
           OutputValidatorTypeError(path, typingResult, JsonSchemaExpected(schema, rootSchema))
         )

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroSchemaOutputValidator.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/encode/AvroSchemaOutputValidator.scala
@@ -157,7 +157,7 @@ class AvroSchemaOutputValidator(validationMode: ValidationMode) extends LazyLogg
       case _ @TypedClass(klass, key :: value :: Nil) if isMap(klass) =>
         // Map keys are assumed to be strings: https://avro.apache.org/docs/current/spec.html#Maps
         condNel(
-          key.canBeConvertedTo(Typed.apply[java.lang.String]),
+          key.canBeLooselyAssignedTo(Typed.apply[java.lang.String]),
           (),
           typeError(typingResult, schema, path)
         ).andThen(_ => validateTypingResult(value, schema.getValueType, buildPath("*", path, useIndexer = true)))


### PR DESCRIPTION
Some additional changes:
- All implicit conversion checks are now done in one place (`TypeConversionHandler`), before the change array to list conversion was checked in `MethodDefinition`
- Implicit conversions are now not valid for strict conversion checking
- Strict conversion check doesn't allow implicit conversions such as Int to BigDecimal or String to ZoneId
- Better method names in the `TypingResult` API: `canBeAssignedTo` instead of `canBeConvertedTo`

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
