### PR TITLE
Fix for broken node details modal after using fragment with not compatible parameters

### DIFF
--- a/designer/client/src/components/graph/node-modal/NodeTypeDetailsContent.tsx
+++ b/designer/client/src/components/graph/node-modal/NodeTypeDetailsContent.tsx
@@ -48,15 +48,14 @@ export type NodeTypeDetailsContentProps = {
 
 export function useNodeAdjust() {
     const getParameterDefinitions = useSelector(getDynamicParameterDefinitions);
-    const adjustNode = useCallback(
+    return useCallback(
         (node: NodeType) => {
             const parameterDefinitions = getParameterDefinitions(node);
-            const { adjustedNode } = adjustParameters(node, parameterDefinitions);
+            const adjustedNode = adjustParameters(node, parameterDefinitions);
             return generateUUIDs(adjustedNode, ["fields", "parameters"]);
         },
         [getParameterDefinitions],
     );
-    return adjustNode;
 }
 
 export function useNodeTypeDetailsContentLogic(props: Pick<NodeTypeDetailsContentProps, "onChange" | "node" | "edges" | "showValidation">) {

--- a/designer/client/src/components/graph/node-modal/ParametersUtils.ts
+++ b/designer/client/src/components/graph/node-modal/ParametersUtils.ts
@@ -1,15 +1,6 @@
-import { NodeType, Parameter, UIParameter } from "../../../types";
 import { cloneDeep, get, set } from "lodash";
 
-export type AdjustReturn = {
-    adjustedNode: NodeType;
-    //currently not used, but maybe we can e.g. display them somewhere?
-    unusedParameters: Parameter[];
-};
-
-const findUnusedParameters = (parameters: Array<Parameter>, definitions: UIParameter[] = []) => {
-    return parameters.filter((param) => !definitions.find((def) => def.name == param.name));
-};
+import type { NodeType, UIParameter } from "../../../types";
 
 const parametersPath = (node) => {
     switch (node.type) {
@@ -19,6 +10,7 @@ const parametersPath = (node) => {
             return `parameters`;
         case "Source":
         case "Sink":
+        case "FragmentInput":
             return `ref.parameters`;
         case "Enricher":
             return `service.parameters`;
@@ -30,12 +22,12 @@ const parametersPath = (node) => {
 };
 
 //We want to change parameters in node based on current node definition. This function can be used in
-//two cases: dynamic parameters handling and automatic node migrations (e.g. in fragments). Currently we use it only for dynamic parameters
-export function adjustParameters(node: NodeType, parameterDefinitions: UIParameter[]): AdjustReturn {
+//two cases: dynamic parameters handling and automatic node migrations (e.g. in fragments)
+export function adjustParameters(node: NodeType, parameterDefinitions: UIParameter[]): NodeType {
     const path = parametersPath(node);
 
     if (!path || !parameterDefinitions) {
-        return { adjustedNode: node, unusedParameters: [] };
+        return node;
     }
 
     const currentNode = cloneDeep(node);
@@ -51,7 +43,5 @@ export function adjustParameters(node: NodeType, parameterDefinitions: UIParamet
             };
             return currentParam || parameterFromDefinition;
         });
-    const adjustedNode = set(currentNode, path, adjustedParameters);
-    const unusedParameters = findUnusedParameters(currentParameters, parameterDefinitions);
-    return { adjustedNode, unusedParameters };
+    return set(currentNode, path, adjustedParameters);
 }


### PR DESCRIPTION
Steps to reproduce:
- create fragment
- use fragment in scenario
- change fragment, adding parameters, changing outputs
- get back to scenario
Result:
![image](https://github.com/user-attachments/assets/910ad3a5-dfe4-4ec8-a2f3-a486227fffd2)

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
