### PR TITLE
Improved ProcessListener behavior and test results when there is no sink

### DIFF
--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/FlinkMiniClusterTestRunner.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/FlinkMiniClusterTestRunner.scala
@@ -10,6 +10,7 @@ import pl.touk.nussknacker.engine.flink.util.source.EmitWatermarkAfterEachElemen
 import pl.touk.nussknacker.engine.flink.util.transformer.FlinkBaseComponentProvider
 import pl.touk.nussknacker.engine.flink.util.transformer.aggregate.AggregateWindowsConfig
 import pl.touk.nussknacker.engine.process.helpers.ConfigCreatorWithCollectingListener
+import pl.touk.nussknacker.engine.process.helpers.SampleNodes.LogService
 import pl.touk.nussknacker.engine.process.runner.FlinkScenarioUnitTestJob
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.testmode.{ResultsCollectingListener, ResultsCollectingListenerHolder}
@@ -57,13 +58,19 @@ trait FlinkMiniClusterTestRunner { _: FlinkSpec =>
       }
     LocalModelData(
       config,
-      sourcesWithMockedData.toList.map { case (name, data) =>
-        ComponentDefinition(name, sourceComponent(data))
-      } :::
+      List(
+        sourcesWithMockedData.toList.map { case (name, data) =>
+          ComponentDefinition(name, sourceComponent(data))
+        },
         FlinkBaseUnboundedComponentProvider.create(
           DocsConfig.Default,
           aggregateWindowsConfig
-        ) ::: FlinkBaseComponentProvider.Components,
+        ),
+        FlinkBaseComponentProvider.Components,
+        List(
+          ComponentDefinition("loggerService", LogService)
+        ),
+      ).flatten,
       configCreator = new ConfigCreatorWithCollectingListener(collectingListener),
     )
   }

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ScenarioWithoutSinksSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ScenarioWithoutSinksSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.compile.FragmentResolver
 import pl.touk.nussknacker.engine.flink.test.FlinkSpec
+import pl.touk.nussknacker.engine.graph.node.Case
 import pl.touk.nussknacker.test.VeryPatientScalaFutures
 
 class ScenarioWithoutSinksSpec
@@ -180,6 +181,101 @@ class ScenarioWithoutSinksSpec
           Map("input" -> 20, "timesFour" -> 80),
           Map("input" -> 30, "timesFour" -> 120),
           Map("input" -> 40, "timesFour" -> 160),
+        )
+      },
+      allowEndingScenarioWithoutSink = true,
+    )
+  }
+
+  test("ending without sink is allowed - there is a split with no continuations") {
+    val scenario =
+      ScenarioBuilder
+        .streaming("sample-split")
+        .source("start-foo", "start1")
+        .split(
+          "split",
+          GraphBuilder.endWithoutSink,
+          GraphBuilder.endWithoutSink
+        )
+
+    withCollectingTestResults(
+      scenario,
+      testResults => {
+        assertNumberOfSamplesThatFinishedInNode(testResults, "split", 4)
+        transitionVariables(testResults, "start-foo", Some("split")) shouldBe Set(
+          Map("input" -> 10),
+          Map("input" -> 20),
+          Map("input" -> 30),
+          Map("input" -> 40),
+        )
+        transitionVariables(testResults, "split", None) shouldBe Set(
+          Map("input" -> 10),
+          Map("input" -> 20),
+          Map("input" -> 30),
+          Map("input" -> 40),
+        )
+      },
+      allowEndingScenarioWithoutSink = true,
+    )
+  }
+
+  test("ending without sink is allowed - there is a switch with no continuations") {
+    val scenario =
+      ScenarioBuilder
+        .streaming("sample-split")
+        .source("start-foo", "start1")
+        .switch(
+          "switch",
+          "''".spel,
+          "var",
+          Case("'1'".spel, GraphBuilder.endWithoutSink),
+          Case("'2'".spel, GraphBuilder.endWithoutSink)
+        )
+
+    withCollectingTestResults(
+      scenario,
+      testResults => {
+        assertNumberOfSamplesThatFinishedInNode(testResults, "switch", 4)
+        transitionVariables(testResults, "start-foo", Some("switch")) shouldBe Set(
+          Map("input" -> 10),
+          Map("input" -> 20),
+          Map("input" -> 30),
+          Map("input" -> 40),
+        )
+        transitionVariables(testResults, "switch", None) shouldBe Set(
+          Map("input" -> 10, "var" -> ""),
+          Map("input" -> 20, "var" -> ""),
+          Map("input" -> 30, "var" -> ""),
+          Map("input" -> 40, "var" -> ""),
+        )
+      },
+      allowEndingScenarioWithoutSink = true,
+    )
+  }
+
+  test("ending without sink is allowed - there is a logging processor with no continuations") {
+    val scenario =
+      ScenarioBuilder
+        .streaming("sample-split")
+        .source("start-foo", "start1")
+        .processor("processor", "loggerService", "all" -> "'abrakadabra'".spel)
+        .endWithoutSink
+
+    withCollectingTestResults(
+      scenario,
+      testResults => {
+        assertNumberOfSamplesThatFinishedInNode(testResults, "processor", 4)
+        transitionVariables(testResults, "start-foo", Some("processor")) shouldBe Set(
+          Map("input" -> 10),
+          Map("input" -> 20),
+          Map("input" -> 30),
+          Map("input" -> 40),
+        )
+        transitionVariables(testResults, "processor", None) shouldBe Set(
+          Map("input" -> 10),
+          Map("input" -> 20),
+          Map("input" -> 30),
+          Map("input" -> 40),
         )
       },
       allowEndingScenarioWithoutSink = true,

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/MissingSinkHandler.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/MissingSinkHandler.scala
@@ -6,7 +6,12 @@ import pl.touk.nussknacker.engine.graph.node
 //  - older behavior is that error is returned for missing sinks
 //  - new behavior, which we intend to become the default and only one in the future, allows ending scenario without sink
 sealed trait MissingSinkHandler {
-  def handleMissingSink(previousNodeId: String): MaybeArtificial[Option[node.SubsequentNode]]
+
+  def handleMissingSink(
+      previousNodeId: String,
+      nodeOnMissingSink: Option[node.SubsequentNode],
+  ): MaybeArtificial[Option[node.SubsequentNode]]
+
 }
 
 object MissingSinkHandler {
@@ -14,18 +19,20 @@ object MissingSinkHandler {
   object AllowMissingSinkHandler extends MissingSinkHandler {
 
     override def handleMissingSink(
-        previousNodeId: String
+        previousNodeId: String,
+        nodeOnMissingSink: Option[node.SubsequentNode],
     ): MaybeArtificial[Option[node.SubsequentNode]] =
-      new MaybeArtificial(None, Nil)
+      new MaybeArtificial(nodeOnMissingSink, Nil)
 
   }
 
   object DoNotAllowMissingSinkHandler extends MissingSinkHandler {
 
     override def handleMissingSink(
-        previousNodeId: String
+        previousNodeId: String,
+        nodeOnMissingSink: Option[node.SubsequentNode],
     ): MaybeArtificial[Option[node.SubsequentNode]] =
-      new MaybeArtificial(None, InvalidTailOfBranch(previousNodeId) :: Nil)
+      new MaybeArtificial(nodeOnMissingSink, InvalidTailOfBranch(previousNodeId) :: Nil)
 
   }
 

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/ProcessCanonizer.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/ProcessCanonizer.scala
@@ -96,7 +96,7 @@ object ProcessCanonizer {
         }
 
       case canonicalnode.SplitNode(bare, Nil) :: Nil =>
-        missingSinkHandler.handleMissingSink(bare.id)
+        missingSinkHandler.handleMissingSink(bare.id, Some(node.SplitNode(bare, List.empty)))
 
       case (a @ canonicalnode.SplitNode(bare, nexts)) :: Nil =>
         nexts
@@ -110,7 +110,7 @@ object ProcessCanonizer {
         MaybeArtificial.missingSinkError(InvalidTailOfBranch(invalidHead.id))
 
       case Nil =>
-        missingSinkHandler.handleMissingSink(previous.id)
+        missingSinkHandler.handleMissingSink(previous.id, None)
     }
 
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine
 
-import cats.Monad
+import cats.{Applicative, Id, Monad}
 import cats.effect.IO
 import cats.syntax.all._
 import com.github.ghik.silencer.silent
@@ -117,7 +117,7 @@ private class InterpreterInternal[F[_]: Monad](
         invokeWrappedInInterpreterShape(ref, ctx).map {
           // for Processor the result is null/BoxedUnit/Void etc. so we ignore it
           case Left(ValueWithContext(_, newCtx)) =>
-            List(Left(InterpretationResult(EndReference(id), newCtx)))
+            interpretationResult[Id](node, EndReference(id), newCtx)
           case Right(exInfo) => List(Right(exInfo))
         }
       case EndingProcessor(id, _, true) =>
@@ -194,19 +194,22 @@ private class InterpreterInternal[F[_]: Monad](
       case EndingCustomNode(id, ref) =>
         listeners.foreach(_.endEncountered(id, ref, ctx, jobData.metaData))
         interpretationResult(node, EndReference(id), ctx)
+      case SplitNode(_, Nil) =>
+        onProcessingFinishedInNode(node, ctx)
+        Applicative[F].pure(List.empty)
       case SplitNode(_, nexts) =>
         import cats.implicits._
         nexts.map(interpretNext(node, _, ctx)).sequence.map(_.flatten)
     }
   }
 
-  private def interpretationResult(
+  private def interpretationResult[FF[_]: Applicative](
       node: Node,
       reference: PartReference,
       ctx: Context
-  ): F[List[Result[InterpretationResult]]] = {
+  ): FF[List[Result[InterpretationResult]]] = {
     onProcessingFinishedInNode(node, ctx)
-    Monad[F].pure(List(Left(InterpretationResult(reference, ctx))))
+    Applicative[FF].pure(List(Left(InterpretationResult(reference, ctx))))
   }
 
   private def interpretOptionalNext(


### PR DESCRIPTION
## Describe your changes

Added missing invocations of ProcessListener from Interpreter. It fixed the issue of incomplete test results (missing transition from last node) and counts for scenarios that end with a switch, split and processor.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
