### PR TITLE
fix cancel problems when cancelling scenario in restarting state

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicProcessService.scala
@@ -296,7 +296,7 @@ class PeriodicProcessService(
         case (_, _, deployment, Some(status))
             if SimpleStateStatus.DefaultFollowingDeployStatuses.contains(status.status) =>
           deployment.id
-        // Without restarting, we silently succeed the restarting scenario cancel without sending anything to flink
+        // Without considering the `restarting` scenario status, we silently succeed cancelling of the scenario in Restarting status, without sending anything to Flink
         case (_, _, deployment, Some(status)) if status.status == SimpleStateStatus.Restarting =>
           deployment.id
       }.toSet

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicProcessService.scala
@@ -296,6 +296,9 @@ class PeriodicProcessService(
         case (_, _, deployment, Some(status))
             if SimpleStateStatus.DefaultFollowingDeployStatuses.contains(status.status) =>
           deployment.id
+        // Without restarting, we silently succeed the restarting scenario cancel without sending anything to flink
+        case (_, _, deployment, Some(status)) if status.status == SimpleStateStatus.Restarting =>
+          deployment.id
       }.toSet
     } yield (followingDeployDeploymentsForSchedules, needRescheduleDeployments)
 


### PR DESCRIPTION
## Describe your changes
Currently if a periodic (others unchecked) scenario is in state restarting, clicking cancel by the user makes the action succeed in nussknacker. But on flink nothing happens. 
This is caised by a missing state check in `PeriodicProcessService.synchronizeDeploymentsStates` - it silently succeeds on restarting, without actually doing anything. That passess an empty list to the cancel command which succeeds. 

I fix the issue by adding an extra case to the `synchronizeDeploymentStates` method.

 Perhaps some other guard could be investigated to avoid silently failing on other statuses or after logic reuse. 

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
