### PR TITLE
[NU-2232] Handle chat stream errors in assistant

### DIFF
--- a/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
+++ b/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
@@ -1,5 +1,5 @@
 import type { ChatModelRunOptions, TextContentPart } from "@assistant-ui/react";
-import { AssistantRuntimeProvider, useLocalRuntime, type ChatModelAdapter } from "@assistant-ui/react";
+import { AssistantRuntimeProvider, type ChatModelAdapter, useLocalRuntime } from "@assistant-ui/react";
 import { createParser } from "eventsource-parser";
 import type { ReactNode } from "react";
 import React from "react";
@@ -19,12 +19,25 @@ const ThreadIdManager = {
     },
 };
 
+enum StreamStatus {
+    STREAMING = "streaming",
+    ABORTED = "aborted",
+    FINISHED = "finished",
+    ERROR = "error",
+}
+
+type StreamState =
+    | { status: StreamStatus.STREAMING }
+    | { status: StreamStatus.ABORTED }
+    | { status: StreamStatus.FINISHED }
+    | { status: StreamStatus.ERROR; error?: string };
+
 async function initializeChatStream(
     messages: ChatModelRunOptions["messages"],
     abortSignal?: AbortSignal,
 ): Promise<{
     responseParts: string[];
-    state: { isAborted: boolean; isFinished: boolean };
+    stateRef: { value: StreamState };
 }> {
     const response = await httpService.sendChatMessage(
         messages[messages.length - 1].content[0] as TextContentPart,
@@ -32,15 +45,17 @@ async function initializeChatStream(
         ThreadIdManager.THREAD_ID,
     );
     const responseParts: string[] = [];
-    const state = { isAborted: false, isFinished: false };
+    const stateRef: { value: StreamState } = { value: { status: StreamStatus.STREAMING } };
 
     const parser = createParser({
         onEvent({ event, data }) {
             if (event === "delta") {
+                console.log("Received delta event:", data);
                 responseParts.push(JSON.parse(data).text);
             }
             if (event === "stop") {
-                state.isFinished = true;
+                console.log("Received stop event:", data);
+                stateRef.value = { status: StreamStatus.FINISHED };
                 ThreadIdManager.THREAD_ID = JSON.parse(data).threadId;
             }
         },
@@ -55,22 +70,24 @@ async function initializeChatStream(
             parser.feed(value);
         }
     };
-    readStream();
+    readStream().catch((error) => {
+        stateRef.value = { status: StreamStatus.ERROR, error: "An error occurred, please try again" };
+    });
 
     if (abortSignal) {
         abortSignal.addEventListener("abort", () => {
             console.log("Message aborted");
-            state.isAborted = true;
+            stateRef.value = { status: StreamStatus.ABORTED };
             reader.cancel();
         });
     }
 
-    return { responseParts, state };
+    return { responseParts, stateRef };
 }
 
 const ModelAdapter: ChatModelAdapter = {
     async *run(chatModelOptions) {
-        const { responseParts, state } = await initializeChatStream(chatModelOptions.messages, chatModelOptions.abortSignal);
+        const { responseParts, stateRef } = await initializeChatStream(chatModelOptions.messages, chatModelOptions.abortSignal);
 
         yield {
             content: [],
@@ -79,28 +96,40 @@ const ModelAdapter: ChatModelAdapter = {
 
         let text = "";
         while (true) {
-            if (state.isAborted) {
-                yield {
-                    content: [{ type: "text", text }],
-                    status: { type: "incomplete", reason: "cancelled" },
-                };
-                return;
-            }
-            if (responseParts.length > 0) {
-                const part = responseParts.shift();
-                text += part;
-                yield {
-                    content: [{ type: "text", text }],
-                    status: { type: "running" },
-                };
-            } else if (state.isFinished && responseParts.length === 0) {
-                yield {
-                    content: [{ type: "text", text }],
-                    status: { type: "complete", reason: "stop" },
-                };
-                return;
-            } else {
-                await new Promise((resolve) => setTimeout(resolve, 100));
+            const state = stateRef.value;
+            switch (state.status) {
+                case StreamStatus.ABORTED:
+                    yield {
+                        content: [{ type: "text", text }],
+                        status: { type: "incomplete", reason: "cancelled" },
+                    };
+                    return;
+                case StreamStatus.STREAMING:
+                    if (responseParts.length > 0) {
+                        console.log("Streaming response parts:", responseParts.length);
+                        const part = responseParts.shift();
+                        text += part;
+                        yield {
+                            content: [{ type: "text", text }],
+                            status: { type: "running" },
+                        };
+                    } else {
+                        // Await for new tokens to arrive.
+                        await new Promise((resolve) => setTimeout(resolve, 100));
+                    }
+                    break;
+                case StreamStatus.FINISHED:
+                    yield {
+                        content: [{ type: "text", text }],
+                        status: { type: "complete", reason: "stop" },
+                    };
+                    return;
+                case StreamStatus.ERROR:
+                    yield {
+                        content: [{ type: "text", text }],
+                        status: { type: "incomplete", reason: "error", error: state.error },
+                    };
+                    return;
             }
         }
     },

--- a/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
+++ b/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
@@ -1,6 +1,7 @@
 import type { ChatModelRunOptions, TextContentPart } from "@assistant-ui/react";
 import { AssistantRuntimeProvider, type ChatModelAdapter, useLocalRuntime } from "@assistant-ui/react";
-import { createParser } from "eventsource-parser";
+import type { EventSourceMessage } from "eventsource-parser";
+import { EventSourceParserStream } from "eventsource-parser/stream";
 import type { ReactNode } from "react";
 import React from "react";
 
@@ -19,75 +20,44 @@ const ThreadIdManager = {
     },
 };
 
-enum StreamStatus {
-    STREAMING = "streaming",
-    ABORTED = "aborted",
-    FINISHED = "finished",
-    ERROR = "error",
-}
+type ChatStreamEvent = { type: "delta"; responsePart: string } | { type: "stop" };
 
-type StreamState =
-    | { status: StreamStatus.STREAMING }
-    | { status: StreamStatus.ABORTED }
-    | { status: StreamStatus.FINISHED }
-    | { status: StreamStatus.ERROR; error?: string };
+const parseEvent: (eventSourceMessage: EventSourceMessage) => ChatStreamEvent = (eventSourceMessage) => {
+    if (eventSourceMessage.event === "delta") {
+        return { type: "delta", responsePart: JSON.parse(eventSourceMessage.data).text };
+    } else if (eventSourceMessage.event === "stop") {
+        ThreadIdManager.THREAD_ID = JSON.parse(eventSourceMessage.data).threadId;
+        return { type: "stop" };
+    }
+    return;
+};
 
-async function initializeChatStream(
+async function* initializeChatStream(
     messages: ChatModelRunOptions["messages"],
     abortSignal?: AbortSignal,
-): Promise<{
-    responseParts: string[];
-    stateRef: { value: StreamState };
-}> {
+): AsyncGenerator<ChatStreamEvent> {
     const response = await httpService.sendChatMessage(
         messages[messages.length - 1].content[0] as TextContentPart,
         abortSignal,
         ThreadIdManager.THREAD_ID,
     );
-    const responseParts: string[] = [];
-    const stateRef: { value: StreamState } = { value: { status: StreamStatus.STREAMING } };
 
-    const parser = createParser({
-        onEvent({ event, data }) {
-            if (event === "delta") {
-                console.log("Received delta event:", data);
-                responseParts.push(JSON.parse(data).text);
-            }
-            if (event === "stop") {
-                console.log("Received stop event:", data);
-                stateRef.value = { status: StreamStatus.FINISHED };
-                ThreadIdManager.THREAD_ID = JSON.parse(data).threadId;
-            }
-        },
-    });
+    const reader = response.body.pipeThrough(new TextDecoderStream()).pipeThrough(new EventSourceParserStream()).getReader();
 
-    const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
-    const readStream = async () => {
-        // eslint-disable-next-line no-constant-condition
+    try {
         while (true) {
-            const { value, done } = await reader.read();
+            const { done, value } = await reader.read();
             if (done) break;
-            parser.feed(value);
+            yield parseEvent(value);
         }
-    };
-    readStream().catch((error) => {
-        stateRef.value = { status: StreamStatus.ERROR, error: "An error occurred, please try again" };
-    });
-
-    if (abortSignal) {
-        abortSignal.addEventListener("abort", () => {
-            console.log("Message aborted");
-            stateRef.value = { status: StreamStatus.ABORTED };
-            reader.cancel();
-        });
+    } finally {
+        reader.releaseLock();
     }
-
-    return { responseParts, stateRef };
 }
 
 const ModelAdapter: ChatModelAdapter = {
     async *run(chatModelOptions) {
-        const { responseParts, stateRef } = await initializeChatStream(chatModelOptions.messages, chatModelOptions.abortSignal);
+        const chatStream = initializeChatStream(chatModelOptions.messages, chatModelOptions.abortSignal);
 
         yield {
             content: [],
@@ -95,41 +65,19 @@ const ModelAdapter: ChatModelAdapter = {
         };
 
         let text = "";
-        while (true) {
-            const state = stateRef.value;
-            switch (state.status) {
-                case StreamStatus.ABORTED:
-                    yield {
-                        content: [{ type: "text", text }],
-                        status: { type: "incomplete", reason: "cancelled" },
-                    };
-                    return;
-                case StreamStatus.STREAMING:
-                    if (responseParts.length > 0) {
-                        console.log("Streaming response parts:", responseParts.length);
-                        const part = responseParts.shift();
-                        text += part;
-                        yield {
-                            content: [{ type: "text", text }],
-                            status: { type: "running" },
-                        };
-                    } else {
-                        // Await for new tokens to arrive.
-                        await new Promise((resolve) => setTimeout(resolve, 100));
-                    }
-                    break;
-                case StreamStatus.FINISHED:
-                    yield {
-                        content: [{ type: "text", text }],
-                        status: { type: "complete", reason: "stop" },
-                    };
-                    return;
-                case StreamStatus.ERROR:
-                    yield {
-                        content: [{ type: "text", text }],
-                        status: { type: "incomplete", reason: "error", error: state.error },
-                    };
-                    return;
+        for await (const event of chatStream) {
+            if (event.type === "delta") {
+                text += event.responsePart;
+                yield {
+                    content: [{ type: "text", text }],
+                    status: { type: "running" },
+                };
+            } else if (event.type === "stop") {
+                yield {
+                    content: [{ type: "text", text }],
+                    status: { type: "complete", reason: "stop" },
+                };
+                return;
             }
         }
     },

--- a/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
+++ b/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
@@ -47,13 +47,19 @@ async function* initializeChatStream(
         ThreadIdManager.THREAD_ID,
     );
 
+    if (!response.ok) {
+        console.error("Failed to fetch chat stream: ", response.statusText);
+        yield { type: "error" };
+        return;
+    }
+
     const reader = response.body.pipeThrough(new TextDecoderStream()).pipeThrough(new EventSourceParserStream()).getReader();
 
     const abortHandler = () => {
         try {
             reader.cancel("Operation aborted");
         } catch (error) {
-            console.warn("Error canceling reader:", error);
+            console.warn("Error canceling reader: ", error);
         }
     };
 
@@ -72,7 +78,7 @@ async function* initializeChatStream(
                     yield { type: "aborted" };
                     break;
                 }
-                console.error("Error reading from chat stream: ", error);
+                console.error("Error while reading from chat stream: ", error);
                 yield { type: "error" };
             }
         }
@@ -116,7 +122,7 @@ const ModelAdapter: ChatModelAdapter = {
             } else if (event.type === "error") {
                 yield {
                     content: [{ type: "text", text }],
-                    status: { type: "incomplete", reason: "error", error: "Unexpected error, please try again." },
+                    status: { type: "incomplete", reason: "error", error: "An unexpected error occurred. Please try again." },
                 };
                 return;
             } else if (event.type === "unknown") {

--- a/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
+++ b/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
@@ -114,7 +114,6 @@ const ModelAdapter: ChatModelAdapter = {
                     status: { type: "incomplete", reason: "cancelled" },
                 };
             } else if (event.type === "error") {
-                console.log("Error in chat stream, yielding error message");
                 yield {
                     content: [{ type: "text", text }],
                     status: { type: "incomplete", reason: "error", error: "Unexpected error, please try again." },

--- a/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
+++ b/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
@@ -72,7 +72,6 @@ async function* initializeChatStream(
                     yield { type: "aborted" };
                     break;
                 }
-
                 console.error("Error reading from chat stream: ", error);
                 yield { type: "error" };
             }

--- a/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
+++ b/designer/client/src/components/aiAssistant/AiAssistantProvider.tsx
@@ -20,16 +20,21 @@ const ThreadIdManager = {
     },
 };
 
-type ChatStreamEvent = { type: "delta"; responsePart: string } | { type: "stop" };
+type ChatStreamEvent =
+    | { type: "delta"; responsePart: string }
+    | { type: "stop"; threadId: string }
+    | { type: "aborted" }
+    | { type: "error" }
+    | { type: "unknown"; originalType?: string; data: string };
 
 const parseEvent: (eventSourceMessage: EventSourceMessage) => ChatStreamEvent = (eventSourceMessage) => {
     if (eventSourceMessage.event === "delta") {
         return { type: "delta", responsePart: JSON.parse(eventSourceMessage.data).text };
     } else if (eventSourceMessage.event === "stop") {
-        ThreadIdManager.THREAD_ID = JSON.parse(eventSourceMessage.data).threadId;
-        return { type: "stop" };
+        return { type: "stop", threadId: JSON.parse(eventSourceMessage.data).threadId };
+    } else {
+        return { type: "unknown", originalType: eventSourceMessage.event, data: eventSourceMessage.data };
     }
-    return;
 };
 
 async function* initializeChatStream(
@@ -44,13 +49,38 @@ async function* initializeChatStream(
 
     const reader = response.body.pipeThrough(new TextDecoderStream()).pipeThrough(new EventSourceParserStream()).getReader();
 
+    const abortHandler = () => {
+        try {
+            reader.cancel("Operation aborted");
+        } catch (error) {
+            console.warn("Error canceling reader:", error);
+        }
+    };
+
+    if (abortSignal) {
+        abortSignal.addEventListener("abort", abortHandler);
+    }
+
     try {
         while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            yield parseEvent(value);
+            try {
+                const { done, value } = await reader.read();
+                if (done) break;
+                yield parseEvent(value);
+            } catch (error) {
+                if (abortSignal?.aborted) {
+                    yield { type: "aborted" };
+                    break;
+                }
+
+                console.error("Error reading from chat stream: ", error);
+                yield { type: "error" };
+            }
         }
     } finally {
+        if (abortSignal) {
+            abortSignal.removeEventListener("abort", abortHandler);
+        }
         reader.releaseLock();
     }
 }
@@ -73,10 +103,26 @@ const ModelAdapter: ChatModelAdapter = {
                     status: { type: "running" },
                 };
             } else if (event.type === "stop") {
+                ThreadIdManager.THREAD_ID = event.threadId;
                 yield {
                     content: [{ type: "text", text }],
                     status: { type: "complete", reason: "stop" },
                 };
+                return;
+            } else if (event.type === "aborted") {
+                yield {
+                    content: [{ type: "text", text }],
+                    status: { type: "incomplete", reason: "cancelled" },
+                };
+            } else if (event.type === "error") {
+                console.log("Error in chat stream, yielding error message");
+                yield {
+                    content: [{ type: "text", text }],
+                    status: { type: "incomplete", reason: "error", error: "Unexpected error, please try again." },
+                };
+                return;
+            } else if (event.type === "unknown") {
+                console.warn("Received unknown event type: ", event.originalType, " with data: ", event.data);
                 return;
             }
         }

--- a/designer/client/src/components/aiAssistant/components/AssistantMessage.tsx
+++ b/designer/client/src/components/aiAssistant/components/AssistantMessage.tsx
@@ -22,19 +22,34 @@ export const AssistantMessage = () => {
         );
     }
 
-    if ((messageText.length === 0 && status.type === "complete") || status.type === "incomplete") {
+    if ((status.type === "complete" && messageText.length === 0) || (status.type === "incomplete" && status.reason === "cancelled")) {
         return null;
     }
 
-    return (
-        <Box position={"relative"} onMouseEnter={handleShowActions} onMouseLeave={handleHideActions}>
-            <Box position={"relative"} pb={0.5}>
-                <MarkdownStyled>{messageText}</MarkdownStyled>
-                <ActionsContainer show={showActions} placement={"left"}>
-                    <CopyContent text={messageText} />
-                    <RefreshAssistantAnswer />
-                </ActionsContainer>
+    if (status.type === "complete") {
+        return (
+            <Box position={"relative"} onMouseEnter={handleShowActions} onMouseLeave={handleHideActions}>
+                <Box position={"relative"} pb={0.5}>
+                    <MarkdownStyled>{messageText}</MarkdownStyled>
+                    <ActionsContainer show={showActions} placement={"left"}>
+                        <CopyContent text={messageText} />
+                        <RefreshAssistantAnswer />
+                    </ActionsContainer>
+                </Box>
             </Box>
-        </Box>
-    );
+        );
+    }
+
+    if (status.type == "incomplete" && status.reason === "error") {
+        return (
+            <Box position={"relative"} onMouseEnter={handleShowActions} onMouseLeave={handleHideActions}>
+                <Box position={"relative"} pb={0.5}>
+                    <MarkdownStyled sx={{ color: "error.main" }}>{status.error?.toString()}</MarkdownStyled>
+                    <ActionsContainer show={showActions} placement={"left"}>
+                        <RefreshAssistantAnswer />
+                    </ActionsContainer>
+                </Box>
+            </Box>
+        );
+    }
 };

--- a/designer/client/src/components/aiAssistant/components/AssistantMessage.tsx
+++ b/designer/client/src/components/aiAssistant/components/AssistantMessage.tsx
@@ -26,7 +26,7 @@ export const AssistantMessage = () => {
         return null;
     }
 
-    if (status.type === "complete") {
+    if (status.type === "running" || status.type === "complete") {
         return (
             <Box position={"relative"} onMouseEnter={handleShowActions} onMouseLeave={handleHideActions}>
                 <Box position={"relative"} pb={0.5}>


### PR DESCRIPTION
* `initializeChatStream` returns a generator of chat stream events instead of a promise with mutable response parts array and stream state.
* An error that occurs in the chat stream is displayed in the assistant window, and the last question can be retried.

![Screenshot 2025-06-04 at 11-42-25 Nussknacker](https://github.com/user-attachments/assets/7687316a-f92c-4acc-aa1b-76720ecd71fa)
