### PR TITLE
Rename parameters in the filter and previous-value components

### DIFF
--- a/defaultModel/src/main/scala/pl/touk/nussknacker/defaultmodel/DefaultModelMigrations.scala
+++ b/defaultModel/src/main/scala/pl/touk/nussknacker/defaultmodel/DefaultModelMigrations.scala
@@ -15,7 +15,8 @@ class DefaultModelMigrations extends ProcessMigrations {
     // 100 -> NewMigration,
     // Newly added migrations should be in the hundreds: 100, 200, 300 and so on. We do this because
     // many ProcessMigrations can be loaded using SPI, and we want to avoid overlapping numbers when merging.
-    100 -> SampleGeneratorToEventGeneratorAndPeriodToScheduleParameter
+    100 -> SampleGeneratorToEventGeneratorAndPeriodToScheduleParameter,
+    200 -> PreviousValueParameterNamesMigration,
   )
 
 }

--- a/defaultModel/src/main/scala/pl/touk/nussknacker/defaultmodel/migrations/PreviousValueParameterNamesMigration.scala
+++ b/defaultModel/src/main/scala/pl/touk/nussknacker/defaultmodel/migrations/PreviousValueParameterNamesMigration.scala
@@ -1,0 +1,29 @@
+package pl.touk.nussknacker.defaultmodel.migrations
+
+import pl.touk.nussknacker.engine.api.MetaData
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
+import pl.touk.nussknacker.engine.graph.node
+import pl.touk.nussknacker.engine.graph.node.CustomNode
+import pl.touk.nussknacker.engine.migration.NodeMigration
+
+object PreviousValueParameterNamesMigration extends NodeMigration {
+
+  override val description: String = "Rename Previous Value component parameters"
+
+  override def migrateNode(metaData: MetaData): PartialFunction[node.NodeData, node.NodeData] = {
+    case customNode @ CustomNode(_, _, "previousValue", parameters, _) =>
+      customNode.copy(parameters = renameParameters(parameters))
+  }
+
+  private def renameParameters(parameters: List[Parameter]) = {
+    parameters.map {
+      case param @ Parameter(ParameterName("groupBy"), _) =>
+        param.copy(name = ParameterName("Key"))
+      case param @ Parameter(ParameterName("value"), _) =>
+        param.copy(name = ParameterName("Value"))
+      case param => param
+    }
+  }
+
+}

--- a/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/DecisionTableParameterNamesMigrationSpec.scala
+++ b/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/DecisionTableParameterNamesMigrationSpec.scala
@@ -1,8 +1,7 @@
-package pl.touk.nussknacker.defaultModel.migrations
+package pl.touk.nussknacker.defaultmodel.migrations
 
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.defaultmodel.migrations.DecisionTableParameterNamesMigration
 import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter

--- a/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/PeriodicToSampleGeneratorSpec.scala
+++ b/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/PeriodicToSampleGeneratorSpec.scala
@@ -1,8 +1,7 @@
-package pl.touk.nussknacker.defaultModel.migrations
+package pl.touk.nussknacker.defaultmodel.migrations
 
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.defaultmodel.migrations.SampleGeneratorToEventGeneratorAndPeriodToScheduleParameter
 import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
@@ -10,12 +9,23 @@ import pl.touk.nussknacker.engine.graph.node.Source
 import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 
-class SampleGeneratorToEventGeneratorAndPeriodicToScheduleSpec extends AnyFreeSpecLike with Matchers {
+class PeriodicToSampleGeneratorSpec extends AnyFreeSpecLike with Matchers {
 
-  "SampleGeneratorToEventGeneratorAndPeriodicToScheduleSpec should be applied" in {
+  "PeriodicToSampleGeneratorMigration should be applied" in {
     val metaData = MetaData("test", StreamMetaData(Some(1)))
     val beforeMigration = Source(
-      id = "sample-generator",
+      id = "periodic",
+      ref = SourceRef(
+        typ = "periodic",
+        parameters = List(
+          Parameter(ParameterName("period"), "T(java.time.Duration).parse('PT1M')".spel),
+          Parameter(ParameterName("count"), "1".spel),
+          Parameter(ParameterName("value"), "1".spel),
+        )
+      )
+    )
+    val expectedAfterMigration = Source(
+      id = "periodic",
       ref = SourceRef(
         typ = "sample-generator",
         parameters = List(
@@ -25,19 +35,8 @@ class SampleGeneratorToEventGeneratorAndPeriodicToScheduleSpec extends AnyFreeSp
         )
       )
     )
-    val expectedAfterMigration = Source(
-      id = "sample-generator",
-      ref = SourceRef(
-        typ = "event-generator",
-        parameters = List(
-          Parameter(ParameterName("schedule"), "T(java.time.Duration).parse('PT1M')".spel),
-          Parameter(ParameterName("count"), "1".spel),
-          Parameter(ParameterName("value"), "1".spel),
-        )
-      )
-    )
 
-    val migrated = SampleGeneratorToEventGeneratorAndPeriodToScheduleParameter.migrateNode(metaData)(beforeMigration)
+    val migrated = PeriodicToSampleGeneratorMigration.migrateNode(metaData)(beforeMigration)
 
     migrated shouldBe expectedAfterMigration
   }

--- a/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/PreviousValueParameterNamesMigrationTest.scala
+++ b/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/PreviousValueParameterNamesMigrationTest.scala
@@ -1,0 +1,39 @@
+package pl.touk.nussknacker.defaultmodel.migrations
+
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
+import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
+import pl.touk.nussknacker.engine.graph.node.CustomNode
+import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
+
+class PreviousValueParameterNamesMigrationTest extends AnyFreeSpecLike with Matchers {
+
+  "PreviousValueParameterNamesMigration should be applied" in {
+    val metaData = MetaData("test", StreamMetaData(Some(1)))
+    val beforeMigration = CustomNode(
+      id = "Customer Previous Value",
+      outputVar = Some("previousInput"),
+      nodeType = "previousValue",
+      parameters = List(
+        Parameter(ParameterName("groupBy"), "#input.customerId".spel),
+        Parameter(ParameterName("value"), "#input".spel),
+      ),
+    )
+    val expectedAfterMigration = CustomNode(
+      id = "Customer Previous Value",
+      outputVar = Some("previousInput"),
+      nodeType = "previousValue",
+      parameters = List(
+        Parameter(ParameterName("Key"), "#input.customerId".spel),
+        Parameter(ParameterName("Value"), "#input".spel),
+      ),
+    )
+
+    val migrated = PreviousValueParameterNamesMigration.migrateNode(metaData)(beforeMigration)
+
+    migrated shouldBe expectedAfterMigration
+  }
+
+}

--- a/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/SampleGeneratorToEventGeneratorAndPeriodicToScheduleSpec.scala
+++ b/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/SampleGeneratorToEventGeneratorAndPeriodicToScheduleSpec.scala
@@ -1,8 +1,7 @@
-package pl.touk.nussknacker.defaultModel.migrations
+package pl.touk.nussknacker.defaultmodel.migrations
 
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.defaultmodel.migrations.PeriodicToSampleGeneratorMigration
 import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
@@ -10,23 +9,12 @@ import pl.touk.nussknacker.engine.graph.node.Source
 import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 
-class PeriodicToSampleGeneratorSpec extends AnyFreeSpecLike with Matchers {
+class SampleGeneratorToEventGeneratorAndPeriodicToScheduleSpec extends AnyFreeSpecLike with Matchers {
 
-  "PeriodicToSampleGeneratorMigration should be applied" in {
+  "SampleGeneratorToEventGeneratorAndPeriodicToScheduleSpec should be applied" in {
     val metaData = MetaData("test", StreamMetaData(Some(1)))
     val beforeMigration = Source(
-      id = "periodic",
-      ref = SourceRef(
-        typ = "periodic",
-        parameters = List(
-          Parameter(ParameterName("period"), "T(java.time.Duration).parse('PT1M')".spel),
-          Parameter(ParameterName("count"), "1".spel),
-          Parameter(ParameterName("value"), "1".spel),
-        )
-      )
-    )
-    val expectedAfterMigration = Source(
-      id = "periodic",
+      id = "sample-generator",
       ref = SourceRef(
         typ = "sample-generator",
         parameters = List(
@@ -36,8 +24,19 @@ class PeriodicToSampleGeneratorSpec extends AnyFreeSpecLike with Matchers {
         )
       )
     )
+    val expectedAfterMigration = Source(
+      id = "sample-generator",
+      ref = SourceRef(
+        typ = "event-generator",
+        parameters = List(
+          Parameter(ParameterName("schedule"), "T(java.time.Duration).parse('PT1M')".spel),
+          Parameter(ParameterName("count"), "1".spel),
+          Parameter(ParameterName("value"), "1".spel),
+        )
+      )
+    )
 
-    val migrated = PeriodicToSampleGeneratorMigration.migrateNode(metaData)(beforeMigration)
+    val migrated = SampleGeneratorToEventGeneratorAndPeriodToScheduleParameter.migrateNode(metaData)(beforeMigration)
 
     migrated shouldBe expectedAfterMigration
   }

--- a/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/SpelToSpelTemplateNodeMigrationSpec.scala
+++ b/defaultModel/src/test/scala/pl/touk/nussknacker/defaultmodel/migrations/SpelToSpelTemplateNodeMigrationSpec.scala
@@ -1,8 +1,7 @@
-package pl.touk.nussknacker.defaultModel.migrations
+package pl.touk.nussknacker.defaultmodel.migrations
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.defaultmodel.migrations.SpelToSpelTemplateNodeMigration
 import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.graph.evaluatedparam.{BranchParameters, Parameter}

--- a/designer/client/src/components/graph/node-modal/filter.tsx
+++ b/designer/client/src/components/graph/node-modal/filter.tsx
@@ -49,7 +49,7 @@ export function Filter({
             <StaticExpressionField
                 renderFieldLabel={renderFieldLabel}
                 setProperty={setProperty}
-                fieldLabel={"Expression"}
+                fieldLabel={"Condition"}
                 parameterDefinitions={parameterDefinitions}
                 showSwitch={showSwitch}
                 variableTypes={variableTypes}

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/ModelUtilExceptionHandlingSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/ModelUtilExceptionHandlingSpec.scala
@@ -29,9 +29,7 @@ import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage
 
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
-import scala.compat.java8.FutureConverters._
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
 
 class ModelUtilExceptionHandlingSpec
     extends AnyFunSuite
@@ -56,8 +54,8 @@ class ModelUtilExceptionHandlingSpec
               "previousValue",
               "out1",
               "previousValue",
-              "groupBy" -> generator.throwFromString().spel,
-              "value"   -> generator.throwFromString().spel
+              "Key"   -> generator.throwFromString().spel,
+              "Value" -> generator.throwFromString().spel
             )
             .customNode(
               "aggregate-sliding",

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
@@ -18,15 +18,15 @@ case object PreviousValueTransformer extends CustomStreamTransformer with Explic
 
   @MethodToInvoke(returnType = classOf[Value])
   def execute(
-      @ParamName("groupBy") groupBy: LazyParameter[CharSequence],
-      @ParamName("value") value: LazyParameter[Value]
+      @ParamName("Key") key: LazyParameter[CharSequence],
+      @ParamName("Value") value: LazyParameter[Value]
   ): FlinkCustomStreamTransformation with ReturningType = FlinkCustomStreamTransformation(
     (start: DataStream[Context], ctx: FlinkCustomNodeContext) => {
       val valueTypeInfo = TypeInformationDetection.instance.forType[AnyRef](value.returnType)
       setUidToNodeIdIfNeed(
         ctx,
         start
-          .groupBy(groupBy)(ctx)
+          .groupBy(key)(ctx)
           .flatMap(
             new PreviousValueFunction(value, ctx.lazyParameterHelper, valueTypeInfo),
             ctx.valueWithContextInfo.forType(valueTypeInfo)

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/StateCompatibilityTest.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/StateCompatibilityTest.scala
@@ -81,8 +81,8 @@ class StateCompatibilityTest extends FlinkWithKafkaSuite with PatientScalaFuture
       "previousValue",
       "previousValue",
       "previousValue",
-      "groupBy" -> "'constant'".spel,
-      "value"   -> "#input".spel
+      "Key"   -> "'constant'".spel,
+      "Value" -> "#input".spel
     )
     .emptySink(
       "sink",


### PR DESCRIPTION
* filter: Expression -> Condition
* previous-value: groupBy -> Key, value -> Value 

![Screenshot 2025-06-05 at 09-51-39 Nussknacker](https://github.com/user-attachments/assets/a1501c4f-a547-4730-b594-f935f0573413)
![Screenshot 2025-06-05 at 11-17-03 Nussknacker](https://github.com/user-attachments/assets/43228bc7-ccd7-4ac7-869c-e6d05c2a7624)