### PR TITLE
Fix sorting by status in component usages view

### DIFF
--- a/designer/submodules/packages/components/src/components/usages/usagesTable.tsx
+++ b/designer/submodules/packages/components/src/components/usages/usagesTable.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@mui/material";
+import type { ProcessStateType } from "nussknackerUi/components/Process/types";
 import { formatDateTime } from "nussknackerUi/DateUtils";
 import { EventTrackingSelector, getEventTrackingProps } from "nussknackerUi/eventTracking";
 import type { ComponentUsageType, NodeUsageData } from "nussknackerUi/HttpService";
@@ -60,6 +61,7 @@ export function UsagesTable(props: TableViewData<UsageWithStatus>): JSX.Element 
                 headerName: t("table.usages.title.STATUS", "Status"),
                 display: "flex",
                 minWidth: 130,
+                sortComparator: (s1: ProcessStateType, s2: ProcessStateType) => s1.status.name.localeCompare(s2.status.name),
                 renderCell: (props) => {
                     if (!props.value) {
                         return (

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -191,6 +191,7 @@ description: Stay informed with detailed changelogs covering new features, impro
 * [#7982](https://github.com/TouK/nussknacker/pull/7982) Mock expression added to enrichers (except decision-table) which can be used to hardcode enricher output in tests without calling external services.
 * [#8116](https://github.com/TouK/nussknacker/pull/8116) Improved Kafka metadata caching: common cache and caching topics when schemaless topics are enabled
 * [#8123](https://github.com/TouK/nussknacker/pull/8123) For now on, it is possible to deploy and save a scenario at the same time.
+* [#8228](https://github.com/TouK/nussknacker/pull/8228) Fixed sorting by scenario status name in component usages view.
 
 ## 1.18
 


### PR DESCRIPTION
## Describe your changes

Currently when we are in the component usages view sorting by scenario status does not work properly.

![bad](https://github.com/user-attachments/assets/0036890e-975a-4a7a-bc9a-68de235edbee)

The column contains custom objects with icons and it lacked a comparator. After adding that we sort the column by the status name.

![ok](https://github.com/user-attachments/assets/4356623f-2794-49b1-869a-c52bf8bdad38)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
