### PR TITLE
Fix component usages status sorting with fragments

### DIFF
--- a/designer/submodules/packages/components/src/components/usages/usagesTable.tsx
+++ b/designer/submodules/packages/components/src/components/usages/usagesTable.tsx
@@ -61,7 +61,14 @@ export function UsagesTable(props: TableViewData<UsageWithStatus>): JSX.Element 
                 headerName: t("table.usages.title.STATUS", "Status"),
                 display: "flex",
                 minWidth: 130,
-                sortComparator: (s1: ProcessStateType, s2: ProcessStateType) => s1.status.name.localeCompare(s2.status.name),
+                sortComparator: (s1: ProcessStateType, s2: ProcessStateType) => {
+                    // Fragments don't have state so s1 or s2 can be undefined
+                    if (!s1 && !s2) return 0;
+                    if (!s1) return 1;
+                    if (!s2) return -1;
+
+                    return s1.status.name.localeCompare(s2.status.name);
+                },
                 renderCell: (props) => {
                     if (!props.value) {
                         return (


### PR DESCRIPTION
## Describe your changes

In [this PR](https://github.com/TouK/nussknacker/pull/8228) i introduced a possibility to sort senarios by status in component usages. Unfortunately it didn't work when a component was used in a fragment as they don't have a state and compared values could be undefined resulting in an error:

![bad](https://github.com/user-attachments/assets/7cae8d8c-d6c7-475c-bbd0-1142d812b6b1)

Now fragments without the state will be listed as the last ones in order:

![ok](https://github.com/user-attachments/assets/1f649d8b-cf99-4576-a0ac-04d10a4b0c6e)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
