### PR TITLE
[NU-2245] JSON editor snippet fixes

### DIFF
--- a/designer/client/src/components/graph/node-modal/editors/expression/AceEditorJsonBasedSnippets.ts
+++ b/designer/client/src/components/graph/node-modal/editors/expression/AceEditorJsonBasedSnippets.ts
@@ -111,10 +111,10 @@ const getEditorContext = (session: Ace.EditSession, pos: Ace.Position, beforeCur
     const hasEmptyObjectAcrossLines = previousFirstChar === "{" && nextFirstChar === "}";
 
     // Just an opening brace (need to add closing brace)
-    const hasOpeningBraceOnly = beforeCursor.trimRight().endsWith("{") && !(nextFirstChar === "}" || afterCursor.includes("}"));
+    const hasOpeningBraceOnly = beforeCursor.trim() === "{" && afterCursor.trim() === "" && session.getLength() === 1;
 
     // Between properties (line ends with comma)
-    const isAfterComma = session.getLine(pos.row).trim().endsWith(",");
+    const isAfterComma = session.getLine(pos.row).trimRight().endsWith(",") && afterCursor.trim() === "";
 
     return {
         hasEmptyObject: hasEmptyObjectOnSameLine || hasEmptyObjectAcrossLines,


### PR DESCRIPTION
## Describe your changes
- Fix issue when entering clicks after opening brace { character when content is provided. No snippet provided
- Fix issue when JSON is inline and an enter key is clicked after a comma character. No snippet provided


https://github.com/user-attachments/assets/a0f54b80-ed6c-4d50-a1da-58122bfdf827



## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
