### PR TITLE
Set default Kafka serializer/deserializer in `KafkaUtils` as class names to be compatible with Flink's `KafkaSource`

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -214,6 +214,7 @@ description: Stay informed with detailed changelogs covering new features, impro
     * currently supported for Kafka Sinks only.
 * [#8209](https://github.com/TouK/nussknacker/pull/8209) Support for jdk 1.17. Scala 2.12.10 -> 2.12.20 and 2.13.15 -> 2.13.16 migration. Using the own flink-scala library also for 2.12 builds.  
 * [8304](https://github.com/TouK/nussknacker/pull/8304) Added functionality of setting component group in ComponentDefinition using `withComponentGroup`.
+* [#8319](https://github.com/TouK/nussknacker/pull/8319) Set default Kafka serializer/deserializer in `KafkaUtils` as class names to be compatible with Flink's `KafkaSource`
 
 ## 1.18
 

--- a/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/LoopUntilClosed.scala
+++ b/engine/lite/kafka/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/kafka/LoopUntilClosed.scala
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.concurrent.BasicThreadFactory
 import org.apache.kafka.common.errors.InterruptException
 import pl.touk.nussknacker.engine.lite.TaskStatus
 import pl.touk.nussknacker.engine.lite.TaskStatus.{DuringDeploy, Restarting, Running, TaskStatus}
+import pl.touk.nussknacker.engine.util.ThreadUtils
 import pl.touk.nussknacker.engine.util.metrics.{Gauge, MetricIdentifier, MetricsProviderForScenario}
 
 import java.util.concurrent.{Executors, TimeUnit}
@@ -58,7 +59,9 @@ class TaskRunner(
     val ecForRunningTasks = ExecutionContext.fromExecutor(threadPool)
     tasks.map { task =>
       Future {
-        task.run()
+        ThreadUtils.withContextClassLoader(getClass.getClassLoader) {
+          task.run()
+        }
       }(ecForRunningTasks)
     }
   }

--- a/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
+++ b/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
@@ -204,9 +204,11 @@ trait KafkaUtils extends LazyLogging {
   def sendToKafkaWithTempProducer(
       record: ProducerRecord[Array[Byte], Array[Byte]]
   )(kafkaProducerCreator: KafkaProducerCreator[Array[Byte], Array[Byte]]): Future[RecordMetadata] = {
-    // returned future is completed, as this method flushes producer cache
-    Using.resource(kafkaProducerCreator.createProducer("temp-" + record.topic())) { producer =>
-      sendToKafka(record)(producer)
+    ThreadUtils.withContextClassLoader(classOf[KafkaClient].getClassLoader) {
+      // returned future is completed, as this method flushes producer cache
+      Using.resource(kafkaProducerCreator.createProducer("temp-" + record.topic())) { producer =>
+        sendToKafka(record)(producer)
+      }
     }
   }
 

--- a/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
+++ b/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
@@ -1,10 +1,10 @@
 package pl.touk.nussknacker.engine.kafka
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.kafka.clients.KafkaClient
+import org.apache.kafka.clients.{CommonClientConfigs, KafkaClient}
 import org.apache.kafka.clients.admin.{Admin, AdminClient}
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, KafkaConsumer}
-import org.apache.kafka.clients.producer.{Callback, Producer, ProducerRecord, RecordMetadata}
+import org.apache.kafka.clients.producer.{Callback, Producer, ProducerConfig, ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
 import pl.touk.nussknacker.engine.api.process.TopicName
@@ -30,7 +30,7 @@ trait KafkaUtils extends LazyLogging {
   val defaultTimeoutMillis = 10000
 
   def setClientId(props: Properties, id: String): Unit = {
-    props.setProperty("client.id", sanitizeClientId(id))
+    props.setProperty(CommonClientConfigs.CLIENT_ID_CONFIG, sanitizeClientId(id))
   }
 
   def createKafkaAdminClient(kafkaConfig: KafkaConfig): Admin = {
@@ -82,8 +82,8 @@ trait KafkaUtils extends LazyLogging {
 
   def toProducerProperties(config: KafkaConfig, clientId: String): Properties = {
     val props: Properties = new Properties
-    props.put("key.serializer", classOf[ByteArraySerializer].getName)
-    props.put("value.serializer", classOf[ByteArraySerializer].getName)
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
     setClientId(props, clientId)
     withPropertiesFromConfig(props, config)
   }
@@ -102,8 +102,8 @@ trait KafkaUtils extends LazyLogging {
 
   def toConsumerProperties(config: KafkaConfig, groupId: Option[String]): Properties = {
     val props = new Properties()
-    props.put("value.deserializer", classOf[ByteArrayDeserializer].getName)
-    props.put("key.deserializer", classOf[ByteArrayDeserializer].getName)
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
     groupId.foreach(props.setProperty("group.id", _))
     withPropertiesFromConfig(props, config)
   }

--- a/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
+++ b/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
@@ -82,8 +82,8 @@ trait KafkaUtils extends LazyLogging {
 
   def toProducerProperties(config: KafkaConfig, clientId: String): Properties = {
     val props: Properties = new Properties
-    props.put("key.serializer", classOf[ByteArraySerializer])
-    props.put("value.serializer", classOf[ByteArraySerializer])
+    props.put("key.serializer", classOf[ByteArraySerializer].getName)
+    props.put("value.serializer", classOf[ByteArraySerializer].getName)
     setClientId(props, clientId)
     withPropertiesFromConfig(props, config)
   }
@@ -102,8 +102,8 @@ trait KafkaUtils extends LazyLogging {
 
   def toConsumerProperties(config: KafkaConfig, groupId: Option[String]): Properties = {
     val props = new Properties()
-    props.put("value.deserializer", classOf[ByteArrayDeserializer])
-    props.put("key.deserializer", classOf[ByteArrayDeserializer])
+    props.put("value.deserializer", classOf[ByteArrayDeserializer].getName)
+    props.put("key.deserializer", classOf[ByteArrayDeserializer].getName)
     groupId.foreach(props.setProperty("group.id", _))
     withPropertiesFromConfig(props, config)
   }


### PR DESCRIPTION
## Describe your changes

Pass default Kafka serializer/deserializer as strings. Using class instances worked with old Kafka client, but KafkaSource actually requires them to conform to specification, i.e. to be passed as class names.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
