### PR TITLE
[NU-2293] add SpEL template snippets to sql editor

### DIFF
--- a/designer/client/cypress/e2e/sqlEditor.cy.ts
+++ b/designer/client/cypress/e2e/sqlEditor.cy.ts
@@ -34,4 +34,22 @@ describe("Sql editor", () => {
                 .click();
         });
     });
+
+    it("should insert '#{ # }' snippet when '#{' provided", () => {
+        cy.visitNewProcess(seed, "withSqlEditor");
+        cy.get("[model-id=sql-source]").should("be.visible").trigger("dblclick");
+        cy.get("[title='sql']").next().find(".ace_editor").should("be.visible").parent().as("editor");
+
+        cy.get("@editor").click();
+        cy.realPress([Cypress.platform === "darwin" ? "Meta" : "Control", "a"]); // Select all (Cmd+A)
+        cy.realPress("Backspace"); // Delete selection
+        cy.realType("#{");
+
+        cy.get("@editor").within(() => {
+            cy.window().then((win) => {
+                const aceEditor = (win as any).ace.edit(Cypress.$(".ace_editor")[0]);
+                expect(aceEditor.getValue()).to.eq("#{ # }");
+            });
+        });
+    });
 });

--- a/designer/client/src/components/graph/node-modal/editors/expression/AceEditorJsonBasedSnippets.ts
+++ b/designer/client/src/components/graph/node-modal/editors/expression/AceEditorJsonBasedSnippets.ts
@@ -13,12 +13,13 @@ export const setupAceEditorSnippets = (editor: Ace.Editor): void => {
     const isJsonEditor = editorMode.includes("json");
     const isJsonTemplateEditor = editorMode.includes("jsonTemplate");
     const isSpelTemplateEditor = editorMode.includes("spelTemplate");
+    const isSqlEditor = editorMode.includes("sql");
 
     if (isJsonEditor || isJsonTemplateEditor) {
         setupJsonBasedSnippets(editor);
     }
 
-    if (isJsonTemplateEditor || isSpelTemplateEditor) {
+    if (isJsonTemplateEditor || isSpelTemplateEditor || isSqlEditor) {
         setupSpelTemplateBasedSnippets(editor);
     }
 };

--- a/designer/client/src/containers/theme/styles.ts
+++ b/designer/client/src/containers/theme/styles.ts
@@ -119,7 +119,7 @@ const aceEditorStyles = (theme: Theme) => ({
     ".ace-nussknacker .ace_comment": {
         color: "#75715E",
     },
-    ".ace-nussknacker .ace_spel": {
+    ".ace-nussknacker .ace_spel, .ace-nussknacker .ace_jsonTemplate, .ace-nussknacker .ace_spelTemplate": {
         color: "#337AB7",
     },
     ".ace-nussknacker .ace_paren": {
@@ -167,9 +167,6 @@ const aceEditorStyles = (theme: Theme) => ({
                 marginBottom: "5px",
             },
         },
-    },
-    ".ace-nussknacker .ace_jsonTemplate, .ace-nussknacker .ace_spelTemplate": {
-        color: "#00BFA5",
     },
 
     ".ace-nussknacker .ace_static_highlight": {

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -235,6 +235,7 @@ description: Stay informed with detailed changelogs covering new features, impro
 * [#8209](https://github.com/TouK/nussknacker/pull/8209) Support for jdk 1.17. Scala 2.12.10 -> 2.12.20 and 2.13.15 -> 2.13.16 migration. Using the own flink-scala library also for 2.12 builds.  
 * [8304](https://github.com/TouK/nussknacker/pull/8304) Added functionality of setting component group in ComponentDefinition using `withComponentGroup`.
 * [#8319](https://github.com/TouK/nussknacker/pull/8319) Set default Kafka serializer/deserializer in `KafkaUtils` as class names to be compatible with Flink's `KafkaSource`
+* [#8266](https://github.com/TouK/nussknacker/pull/8266)[8337](https://github.com/TouK/nussknacker/pull/8337) Add snippet to the SpEL Template expression in String Template, JSON Template and Sql Editors
 
 ## 1.18
 


### PR DESCRIPTION
## Describe your changes
- Adjust SpEL template braces color

<img width="1289" height="718" alt="image" src="https://github.com/user-attachments/assets/0d1a0e6a-7ee3-45b4-97f7-9ce3d597798e" />

<img width="1268" height="698" alt="image" src="https://github.com/user-attachments/assets/06587ec4-9ab3-462b-b873-6b13a6b42a7c" />

- Provide SpEL Template snippet to the SQL editor

https://github.com/user-attachments/assets/addb2f30-ed5b-4895-8bf3-872dd8c3ee2b




## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
