### PR TITLE
[NU-2299] fix no error message visible in live data

### DIFF
--- a/designer/client/src/common/TestResultUtils.ts
+++ b/designer/client/src/common/TestResultUtils.ts
@@ -89,7 +89,7 @@ class TestResultUtils {
     };
 
     private _nodeResults(results: TestResultsDto, nodeId: NodeId): ResultContextJson[] {
-        return results?.nodeResults?.[nodeId] || [];
+        return results?.nodeTransitionResults?.find((nodeTransitionResult) => nodeTransitionResult.sourceNodeId === nodeId)?.results || [];
     }
 
     private _invocationResults(results: TestResultsDto, nodeId: NodeId): ExpressionInvocationResultJson[] {

--- a/designer/client/src/common/TestResultUtils.ts
+++ b/designer/client/src/common/TestResultUtils.ts
@@ -101,7 +101,7 @@ class TestResultUtils {
     }
 
     private _errors(results: TestResultsDto, nodeId: NodeId): ExceptionResultJson[] {
-        return results?.exceptions?.filter((ex) => ex.nodeId === nodeId);
+        return results?.exceptionsByNodeId[nodeId] ?? [];
     }
 
     private _contextDisplay = (context: ResultContextJson): string => {

--- a/designer/client/src/components/graph/node-modal/tests/ExpressionTestResults.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/ExpressionTestResults.tsx
@@ -5,6 +5,7 @@ import React, { useRef, useState } from "react";
 import type { PropsWithChildren } from "react";
 
 import type { NodeResultsForContext } from "../../../../common/TestResultUtils";
+import { useUserSettings } from "../../../../common/userSettings";
 import { InfoTooltip } from "../editors/InfoTooltip";
 import { HIDDEN_TEXTAREA_PIXEL_HEIGHT } from "../NodeDetailsContent/NodeTableStyled";
 import TestValue from "./TestValue";
@@ -21,13 +22,15 @@ export default function ExpressionTestResults(props: PropsWithChildren<Expressio
     const [collapsedTestResults, setCollapsedTestResults] = useState(true);
     const testValue = fieldName ? resultsToShow && resultsToShow.expressionResults[fieldName] : null;
     const PrettyIconComponent = collapsedTestResults ? VisibilityOff : Visibility;
+    const [userSettings] = useUserSettings();
+    const showInputsAndOutputs = userSettings["node.showInputsAndOutputs"];
 
-    return testValue ? (
+    return testValue && !showInputsAndOutputs ? (
         <div>
             {props.children}
             <FormControl>
                 <FormLabel>
-                    <InfoTooltip title={"Value evaluated in test case"} variant={"hover"}>
+                    <InfoTooltip title={"Expression evaluation result"} variant={"hover"}>
                         <InfoIcon sx={() => ({ alignSelf: "center" })} />
                     </InfoTooltip>
                     {testValue.pretty && !fitsMaxHeight ? (

--- a/designer/client/src/components/graph/node-modal/tests/ExpressionTestResults.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/ExpressionTestResults.tsx
@@ -5,7 +5,6 @@ import React, { useRef, useState } from "react";
 import type { PropsWithChildren } from "react";
 
 import type { NodeResultsForContext } from "../../../../common/TestResultUtils";
-import { useUserSettings } from "../../../../common/userSettings";
 import { InfoTooltip } from "../editors/InfoTooltip";
 import { HIDDEN_TEXTAREA_PIXEL_HEIGHT } from "../NodeDetailsContent/NodeTableStyled";
 import TestValue from "./TestValue";
@@ -22,10 +21,8 @@ export default function ExpressionTestResults(props: PropsWithChildren<Expressio
     const [collapsedTestResults, setCollapsedTestResults] = useState(true);
     const testValue = fieldName ? resultsToShow && resultsToShow.expressionResults[fieldName] : null;
     const PrettyIconComponent = collapsedTestResults ? VisibilityOff : Visibility;
-    const [userSettings] = useUserSettings();
-    const showInputsAndOutputs = userSettings["node.showInputsAndOutputs"];
 
-    return testValue && !showInputsAndOutputs ? (
+    return testValue ? (
         <div>
             {props.children}
             <FormControl>

--- a/designer/client/src/components/graph/node-modal/tests/TestErrors.tsx
+++ b/designer/client/src/components/graph/node-modal/tests/TestErrors.tsx
@@ -16,7 +16,7 @@ export default function TestErrors(): JSX.Element {
     return (
         <FormControl>
             <FormLabel>
-                <InfoTooltip title={"Test case error"} variant={"hover"}>
+                <InfoTooltip title={"Error during evaluation"} variant={"hover"}>
                     <WarningIcon sx={(theme) => ({ color: theme.palette.warning.main })} />
                 </InfoTooltip>
             </FormLabel>

--- a/designer/client/src/http/resultsWithCountsDto.ts
+++ b/designer/client/src/http/resultsWithCountsDto.ts
@@ -36,11 +36,14 @@ export type NodeTransitionResult = {
 };
 
 export interface TestResultsDto {
+    /** @deprecated Use nodeTransitionResults instead */
     nodeResults?: Record<NodeId, ResultContextJson[]> | null;
     nodeTransitionResults?: NodeTransitionResult[] | null;
     invocationResults: Record<NodeId, ExpressionInvocationResultJson[]>;
     externalInvocationResults: Record<NodeId, ExternalInvocationResultJson[]>;
+    /** @deprecated Use exceptionsByNodeId instead */
     exceptions: ExceptionResultJson[];
+    exceptionsByNodeId: Record<NodeId, ExceptionResultJson[]>;
 }
 
 export interface NodeCounts {


### PR DESCRIPTION
## Describe your changes

1. showInputsAndOutputs: enabled for live data
<img width="1303" height="702" alt="image" src="https://github.com/user-attachments/assets/7bc28447-68ae-4140-8047-ceddc7ecf208" />

<img width="1311" height="700" alt="image" src="https://github.com/user-attachments/assets/c647ae22-cc2b-44d2-a2eb-9c120b64aaef" />

2. showInputsAndOutputs: disabled for live data

<img width="1303" height="705" alt="image" src="https://github.com/user-attachments/assets/8c643b14-98f2-4cf2-8648-5814864f9a10" />

3. showInputsAndOutputs: enabled for test data
<img width="1291" height="717" alt="image" src="https://github.com/user-attachments/assets/1fdae3c7-dee2-448f-826c-90db20bd0f38" />

4. showInputsAndOutputs: disabled for test data
<img width="891" height="716" alt="image" src="https://github.com/user-attachments/assets/02ede6a6-c024-4201-8c90-a63baa29edb9" />

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
