### PR TITLE
[NU-2189] ScenarioTestingApiHttpServiceSpec simpler

### DIFF
--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/EventGeneratorSourceTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/EventGeneratorSourceTestingApiHttpServiceSpec.scala
@@ -4,7 +4,6 @@ import com.typesafe.config.{Config, ConfigFactory}
 import io.circe.syntax.EncoderOps
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.graph.expression.Expression
@@ -53,8 +52,6 @@ trait EventGeneratorSourceTestingApiHttpServiceSpec
       testData = ScenarioTestData.WithParameters(validParameters),
       scenarioGraph = exampleScenario.toScenarioGraph
     ).asJson.toString()
-
-  override protected def expectedSourceTestingParametersJson: String = ""
 
   override protected def validParameters: TestSourceParameters =
     TestSourceParameters(exampleScenarioSourceId, Map.empty)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/FragmentScenarioTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/FragmentScenarioTestingApiHttpServiceSpec.scala
@@ -1,0 +1,237 @@
+package pl.touk.nussknacker.ui.api.testing
+
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.Encoder
+import io.restassured.RestAssured.`given`
+import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
+import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
+import pl.touk.nussknacker.engine.api.parameter.{ParameterName, ValueInputWithFixedValuesProvided}
+import pl.touk.nussknacker.engine.build.ScenarioBuilder
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.graph.node.FragmentInputDefinition.{FragmentClazzRef, FragmentParameter}
+import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
+import pl.touk.nussknacker.test.{
+  NuRestAssureMatchers,
+  PatientScalaFutures,
+  RestAssuredVerboseLoggingIfValidationFails,
+  WithTestHttpClient
+}
+import pl.touk.nussknacker.test.base.it.{NuItTest, WithSimplifiedConfigScenarioHelper}
+import pl.touk.nussknacker.test.config.{
+  WithBusinessCaseRestAssuredUsersExtensions,
+  WithMockableDeploymentManager,
+  WithSimplifiedDesignerConfig
+}
+
+class FragmentScenarioTestingApiHttpServiceSpec
+    extends AnyFreeSpecLike
+    with NuItTest
+    with WithTestHttpClient
+    with WithSimplifiedDesignerConfig
+    with WithSimplifiedConfigScenarioHelper
+    with WithMockableDeploymentManager
+    with WithBusinessCaseRestAssuredUsersExtensions
+    with NuRestAssureMatchers
+    with RestAssuredVerboseLoggingIfValidationFails
+    with PatientScalaFutures
+    with Matchers
+    with LazyLogging {
+
+  private val fragmentFixedParameter = FragmentParameter(
+    ParameterName("paramFixedString"),
+    FragmentClazzRef[java.lang.String],
+    initialValue = Some(FixedExpressionValue("'uno'", "uno")),
+    hintText = None,
+    valueEditor = Some(
+      ValueInputWithFixedValuesProvided(
+        fixedValuesList = List(
+          FixedExpressionValue("'uno'", "uno"),
+          FixedExpressionValue("'due'", "due"),
+        ),
+        allowOtherValue = false
+      )
+    ),
+    valueCompileTimeValidation = None
+  )
+
+  private val fragmentRawStringParameter = FragmentParameter(
+    ParameterName("paramRawString"),
+    FragmentClazzRef[java.lang.String],
+    initialValue = None,
+    hintText = None,
+    valueEditor = None,
+    valueCompileTimeValidation = None
+  )
+
+  "The endpoint for generating test parameters should" - {
+    "generate parameters for fragment with fixed list parameter" in {
+      val fragment = exampleFragment(fragmentFixedParameter)
+      val expectedTestParameters =
+        s"""[
+           |    {
+           |        "sourceId": "fragment",
+           |        "parameters": [
+           |            {
+           |                "name": "paramFixedString",
+           |                "typ": {
+           |                    "display": "String",
+           |                    "type": "TypedClass",
+           |                    "refClazzName": "java.lang.String",
+           |                    "params": [
+           |
+           |                    ]
+           |                },
+           |                "editors": [{
+           |                    "possibleValues": [
+           |                        {
+           |                            "expression": "",
+           |                            "label": ""
+           |                        },
+           |                        {
+           |                            "expression": "'uno'",
+           |                            "label": "uno"
+           |                        },
+           |                        {
+           |                            "expression": "'due'",
+           |                            "label": "due"
+           |                        }
+           |                    ],
+           |                    "type": "FixedValuesParameterEditor"
+           |                }],
+           |                "defaultValue": {
+           |                    "language": "spel",
+           |                    "expression": "'uno'"
+           |                },
+           |                "additionalVariables": {
+           |
+           |                },
+           |                "variablesToHide": [
+           |
+           |                ],
+           |                "branchParam": false,
+           |                "hintText": null,
+           |                "label": "paramFixedString",
+           |                "requiredParam": false,
+           |                "category": "Standard",
+           |                "changesCanReloadParameters": false,
+           |                "nonImportantForExecution": false
+           |            }
+           |        ]
+           |    }
+           |]
+           |""".stripMargin
+      given()
+        .applicationState {
+          createSavedScenario(fragment)
+        }
+        .when()
+        .basicAuthAllPermUser()
+        .jsonBody(canonicalGraphStr(fragment))
+        .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${fragment.name}/capabilities")
+        .Then()
+        .statusCode(200)
+        .equalsJsonBody(
+          s"""{
+             |    "testWithParameters": {
+             |      "status": "AVAILABLE",
+             |      "sourceParameters": $expectedTestParameters
+             |    },
+             |    "testWithGeneratedData": {
+             |      "status": "NOT_AVAILABLE",
+             |      "reason":"NOT_SUPPORTED_BY_SOURCES"
+             |    },
+             |    "testWithLiveData": {
+             |      "status": "NOT_AVAILABLE",
+             |      "reason":"NOT_SUPPORTED_BY_SOURCES"
+             |    }
+             |}""".stripMargin
+        )
+    }
+
+    "Generate parameters with simplified (single) editor for fragment with raw string parameter" in {
+      val fragment = exampleFragment(fragmentRawStringParameter)
+      val expectedTestParameters =
+        s"""[
+           |    {
+           |        "sourceId": "fragment",
+           |        "parameters": [
+           |            {
+           |                "name": "paramRawString",
+           |                "typ": {
+           |                    "display": "String",
+           |                    "type": "TypedClass",
+           |                    "refClazzName": "java.lang.String",
+           |                    "params": [
+           |
+           |                    ]
+           |                },
+           |                "editors": [
+           |                    {
+           |                        "type": "SpelTemplateParameterEditor"
+           |                    },
+           |                    {
+           |                        "type": "SpelParameterEditor"
+           |                    }
+           |                ],
+           |                "defaultValue": {
+           |                    "language": "spelTemplate",
+           |                    "expression": ""
+           |                },
+           |                "additionalVariables": {
+           |
+           |                },
+           |                "variablesToHide": [
+           |
+           |                ],
+           |                "branchParam": false,
+           |                "hintText": null,
+           |                "label": "paramRawString",
+           |                "requiredParam": false,
+           |                "category": "Standard",
+           |                "changesCanReloadParameters": false,
+           |                "nonImportantForExecution": false
+           |            }
+           |        ]
+           |    }
+           |]
+           |""".stripMargin
+      given()
+        .applicationState {
+          createSavedScenario(fragment)
+        }
+        .when()
+        .basicAuthAllPermUser()
+        .jsonBody(canonicalGraphStr(fragment))
+        .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${fragment.name}/capabilities")
+        .Then()
+        .statusCode(200)
+        .equalsJsonBody(
+          s"""{
+             |    "testWithParameters": {
+             |      "status": "AVAILABLE",
+             |      "sourceParameters": $expectedTestParameters
+             |    },
+             |    "testWithGeneratedData": {
+             |      "status": "NOT_AVAILABLE",
+             |      "reason":"NOT_SUPPORTED_BY_SOURCES"
+             |    },
+             |    "testWithLiveData": {
+             |      "status": "NOT_AVAILABLE",
+             |      "reason":"NOT_SUPPORTED_BY_SOURCES"
+             |    }
+             |}""".stripMargin
+        )
+    }
+  }
+
+  private def exampleFragment(parameter: FragmentParameter) = ScenarioBuilder
+    .fragmentWithRawParameters("fragment", parameter)
+    .fragmentOutput("fragmentEnd", "output", "out" -> "'hola'".spel)
+
+  private def canonicalGraphStr(canonical: CanonicalProcess) =
+    Encoder[ScenarioGraph].apply(canonical.toScenarioGraph).toString()
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/GenericSourceWithCustomTestingSupportTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/GenericSourceWithCustomTestingSupportTestingApiHttpServiceSpec.scala
@@ -36,47 +36,6 @@ class GenericSourceWithCustomTestingSupportTestingApiHttpServiceSpec
       scenarioGraph = exampleScenario.toScenarioGraph
     ).asJson.toString()
 
-  override protected def expectedSourceTestingParametersJson: String =
-    """
-      |  {
-      |    "name": "elements",
-      |    "typ": {
-      |      "display": "List[String]",
-      |      "type": "TypedClass",
-      |      "refClazzName": "java.util.List",
-      |      "params": [
-      |        {
-      |          "display": "String",
-      |          "type": "TypedClass",
-      |          "refClazzName": "java.lang.String",
-      |          "params": [
-      |          ]
-      |        }
-      |      ]
-      |    },
-      |    "editors": [
-      |      {
-      |        "type": "SpelParameterEditor"
-      |      }
-      |    ],
-      |    "defaultValue": {
-      |      "language": "spel",
-      |      "expression": "{}"
-      |    },
-      |    "additionalVariables": {
-      |    },
-      |    "variablesToHide": [
-      |    ],
-      |    "branchParam": false,
-      |    "requiredParam": true,
-      |    "hintText": null,
-      |    "label": "elements",
-      |    "category": "Standard",
-      |    "changesCanReloadParameters": false,
-      |    "nonImportantForExecution": false
-      |  }
-      |""".stripMargin
-
   override protected def expectedTestDataJson: String =
     s"""[
        |  {"sourceId":"sourceId","variables":{"input": "test-0"},"timestamp":123},

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/GenericSourceWithCustomTestingSupportTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/GenericSourceWithCustomTestingSupportTestingApiHttpServiceSpec.scala
@@ -4,7 +4,6 @@ import io.circe.syntax.EncoderOps
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
-import pl.touk.nussknacker.engine.api.typed.typing
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/ScenarioTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/ScenarioTestingApiHttpServiceSpec.scala
@@ -9,13 +9,11 @@ import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.scalatest.Assertion
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
-import pl.touk.nussknacker.engine.api.parameter.{ParameterName, ValueInputWithFixedValuesProvided}
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.graph.node.FragmentInputDefinition.{FragmentClazzRef, FragmentParameter}
 import pl.touk.nussknacker.test.{
   NuRestAssureMatchers,
   PatientScalaFutures,
@@ -60,36 +58,6 @@ trait ScenarioTestingApiHttpServiceSpec
   protected def expectedTestDataJson: String
 
   protected val inputValueNotMatchingExpectedType = "false"
-
-  private val fragmentFixedParameter = FragmentParameter(
-    ParameterName("paramFixedString"),
-    FragmentClazzRef[java.lang.String],
-    initialValue = Some(FixedExpressionValue("'uno'", "uno")),
-    hintText = None,
-    valueEditor = Some(
-      ValueInputWithFixedValuesProvided(
-        fixedValuesList = List(
-          FixedExpressionValue("'uno'", "uno"),
-          FixedExpressionValue("'due'", "due"),
-        ),
-        allowOtherValue = false
-      )
-    ),
-    valueCompileTimeValidation = None
-  )
-
-  private val fragmentRawStringParameter = FragmentParameter(
-    ParameterName("paramRawString"),
-    FragmentClazzRef[java.lang.String],
-    initialValue = None,
-    hintText = None,
-    valueEditor = None,
-    valueCompileTimeValidation = None
-  )
-
-  private def exampleFragment(parameter: FragmentParameter) = ScenarioBuilder
-    .fragmentWithRawParameters("fragment", parameter)
-    .fragmentOutput("fragmentEnd", "output", "out" -> "'hola'".spel)
 
   "The endpoint for capabilities should" - {
     "return valid capabilities for scenario with all capabilities" in {
@@ -215,163 +183,6 @@ trait ScenarioTestingApiHttpServiceSpec
              |]
              |""".stripMargin
           )
-        )
-    }
-    "generate parameters for fragment with fixed list parameter" in {
-      val fragment = exampleFragment(fragmentFixedParameter)
-      val expectedTestParameters =
-        s"""[
-             |    {
-             |        "sourceId": "fragment",
-             |        "parameters": [
-             |            {
-             |                "name": "paramFixedString",
-             |                "typ": {
-             |                    "display": "String",
-             |                    "type": "TypedClass",
-             |                    "refClazzName": "java.lang.String",
-             |                    "params": [
-             |
-             |                    ]
-             |                },
-             |                "editors": [{
-             |                    "possibleValues": [
-             |                        {
-             |                            "expression": "",
-             |                            "label": ""
-             |                        },
-             |                        {
-             |                            "expression": "'uno'",
-             |                            "label": "uno"
-             |                        },
-             |                        {
-             |                            "expression": "'due'",
-             |                            "label": "due"
-             |                        }
-             |                    ],
-             |                    "type": "FixedValuesParameterEditor"
-             |                }],
-             |                "defaultValue": {
-             |                    "language": "spel",
-             |                    "expression": "'uno'"
-             |                },
-             |                "additionalVariables": {
-             |
-             |                },
-             |                "variablesToHide": [
-             |
-             |                ],
-             |                "branchParam": false,
-             |                "hintText": null,
-             |                "label": "paramFixedString",
-             |                "requiredParam": false,
-             |                "category": "Standard",
-             |                "changesCanReloadParameters": false,
-             |                "nonImportantForExecution": false
-             |            }
-             |        ]
-             |    }
-             |]
-             |""".stripMargin
-      given()
-        .applicationState {
-          createSavedScenario(fragment)
-        }
-        .when()
-        .basicAuthAllPermUser()
-        .jsonBody(canonicalGraphStr(fragment))
-        .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${fragment.name}/capabilities")
-        .Then()
-        .statusCode(200)
-        .equalsJsonBody(
-          s"""{
-             |    "testWithParameters": {
-             |      "status": "AVAILABLE",
-             |      "sourceParameters": $expectedTestParameters
-             |    },
-             |    "testWithGeneratedData": {
-             |      "status": "NOT_AVAILABLE",
-             |      "reason":"NOT_SUPPORTED_BY_SOURCES"
-             |    },
-             |    "testWithLiveData": {
-             |      "status": "NOT_AVAILABLE",
-             |      "reason":"NOT_SUPPORTED_BY_SOURCES"
-             |    }
-             |}""".stripMargin
-        )
-    }
-    "Generate parameters with simplified (single) editor for fragment with raw string parameter" in {
-      val fragment = exampleFragment(fragmentRawStringParameter)
-      val expectedTestParameters =
-        s"""[
-           |    {
-           |        "sourceId": "fragment",
-           |        "parameters": [
-           |            {
-           |                "name": "paramRawString",
-           |                "typ": {
-           |                    "display": "String",
-           |                    "type": "TypedClass",
-           |                    "refClazzName": "java.lang.String",
-           |                    "params": [
-           |
-           |                    ]
-           |                },
-           |                "editors": [
-           |                    {
-           |                        "type": "SpelTemplateParameterEditor"
-           |                    },
-           |                    {
-           |                        "type": "SpelParameterEditor"
-           |                    }
-           |                ],
-           |                "defaultValue": {
-           |                    "language": "spelTemplate",
-           |                    "expression": ""
-           |                },
-           |                "additionalVariables": {
-           |
-           |                },
-           |                "variablesToHide": [
-           |
-           |                ],
-           |                "branchParam": false,
-           |                "hintText": null,
-           |                "label": "paramRawString",
-           |                "requiredParam": false,
-           |                "category": "Standard",
-           |                "changesCanReloadParameters": false,
-           |                "nonImportantForExecution": false
-           |            }
-           |        ]
-           |    }
-           |]
-           |""".stripMargin
-      given()
-        .applicationState {
-          createSavedScenario(fragment)
-        }
-        .when()
-        .basicAuthAllPermUser()
-        .jsonBody(canonicalGraphStr(fragment))
-        .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${fragment.name}/capabilities")
-        .Then()
-        .statusCode(200)
-        .equalsJsonBody(
-          s"""{
-             |    "testWithParameters": {
-             |      "status": "AVAILABLE",
-             |      "sourceParameters": $expectedTestParameters
-             |    },
-             |    "testWithGeneratedData": {
-             |      "status": "NOT_AVAILABLE",
-             |      "reason":"NOT_SUPPORTED_BY_SOURCES"
-             |    },
-             |    "testWithLiveData": {
-             |      "status": "NOT_AVAILABLE",
-             |      "reason":"NOT_SUPPORTED_BY_SOURCES"
-             |    }
-             |}""".stripMargin
         )
     }
     "return error if scenario does not exists" in {
@@ -540,9 +351,6 @@ trait ScenarioTestingApiHttpServiceSpec
        |  "scenarioGraph": $scenarioGraphStr,
        |  "numberOfSamples": $numberOfSamples
        |}""".stripMargin
-
-  private def canonicalGraphStr(canonical: CanonicalProcess) =
-    Encoder[ScenarioGraph].apply(canonical.toScenarioGraph).toString()
 
   protected def exampleScenarioInputVariableType: TypingResult
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/ScenarioTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/ScenarioTestingApiHttpServiceSpec.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.ui.api.testing
 
 import com.typesafe.scalalogging.LazyLogging
-import io.circe.Encoder
 import io.circe.syntax._
 import io.restassured.RestAssured.given
 import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
@@ -9,7 +8,6 @@ import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.scalatest.Assertion
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
@@ -53,8 +51,6 @@ trait ScenarioTestingApiHttpServiceSpec
 
   protected val generatedSamplesCount = 3
 
-  protected def expectedSourceTestingParametersJson: String
-
   protected def expectedTestDataJson: String
 
   protected val inputValueNotMatchingExpectedType = "false"
@@ -67,7 +63,7 @@ trait ScenarioTestingApiHttpServiceSpec
         }
         .when()
         .basicAuthAllPermUser()
-        .jsonBody(exampleScenarioGraphStr)
+        .jsonBody(exampleScenarioGraph.asJson.spaces2)
         .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/capabilities")
         .Then()
         .statusCode(200)
@@ -93,7 +89,7 @@ trait ScenarioTestingApiHttpServiceSpec
         }
         .when()
         .basicAuthWriter()
-        .jsonBody(exampleScenarioGraphStr)
+        .jsonBody(exampleScenarioGraph.asJson.spaces2)
         .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/capabilities")
         .Then()
         .statusCode(200)
@@ -123,7 +119,7 @@ trait ScenarioTestingApiHttpServiceSpec
         }
         .when()
         .basicAuthNoPermUser()
-        .jsonBody(exampleScenarioGraphStr)
+        .jsonBody(exampleScenarioGraph.asJson.spaces2)
         .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/capabilities")
         .Then()
         .statusCode(403)
@@ -138,7 +134,7 @@ trait ScenarioTestingApiHttpServiceSpec
         }
         .when()
         .basicAuthAllPermUser()
-        .jsonBody(testDataGenerationRequest(exampleScenarioGraphStr, generatedSamplesCount))
+        .jsonBody(testDataGenerationRequest(exampleScenarioGraph.asJson.spaces2, generatedSamplesCount))
         .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/generatedTestData")
         .Then()
         .statusCode(200)
@@ -151,7 +147,7 @@ trait ScenarioTestingApiHttpServiceSpec
         }
         .when()
         .basicAuthAllPermUser()
-        .jsonBody(testDataGenerationRequest(exampleScenarioGraphStr, 100))
+        .jsonBody(testDataGenerationRequest(exampleScenarioGraph.asJson.spaces2, 100))
         .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/generatedTestData")
         .Then()
         .statusCode(StatusCodes.BadRequest.intValue)
@@ -163,27 +159,7 @@ trait ScenarioTestingApiHttpServiceSpec
 
   "The endpoint for generating test parameters should" - {
     "properly generate parameters for source with support of testParametersDefinition" in {
-      given()
-        .applicationState {
-          createSavedScenario(exampleScenario)
-        }
-        .when()
-        .basicAuthAllPermUser()
-        .jsonBody(exampleScenarioGraphStr)
-        .post(s"$nuDesignerHttpAddress/api/scenarioTesting/${exampleScenario.name}/capabilities")
-        .Then()
-        .statusCode(200)
-        .equalsJsonBody(
-          responseWithParameters(
-            s"""[
-             |    {
-             |        "sourceId": "$exampleScenarioSourceId",
-             |        "parameters": [$expectedSourceTestingParametersJson]
-             |    }
-             |]
-             |""".stripMargin
-          )
-        )
+      shouldProperlyGetTestParameters()
     }
     "return error if scenario does not exists" in {
       val notExistingScenarioName = exampleScenario.name.value + "_2"
@@ -194,7 +170,7 @@ trait ScenarioTestingApiHttpServiceSpec
         .when()
         .basicAuthAllPermUser()
         .jsonBody(s"""{
-              |  "scenarioGraph": $exampleScenarioGraphStr,
+              |  "scenarioGraph": ${exampleScenarioGraph.asJson.spaces2},
               |  "numberOfSamples": 100
               |}""".stripMargin)
         .post(s"$nuDesignerHttpAddress/api/scenarioTesting/$notExistingScenarioName/generatedTestData")
@@ -310,12 +286,6 @@ trait ScenarioTestingApiHttpServiceSpec
     }
   }
 
-  "The endpoint for adhoc test parameters should" - {
-    "return test parameters" in {
-      shouldProperlyGetTestParameters()
-    }
-  }
-
   "The endpoint for test with live data should" - {
     "return error if trying to test with 0 samples" in {
       given()
@@ -340,8 +310,6 @@ trait ScenarioTestingApiHttpServiceSpec
   }
 
   protected def verifyTestFromFileWithCorrectTestDataResponse(response: Response[String]): Assertion
-
-  private def exampleScenarioGraphStr = Encoder[ScenarioGraph].apply(exampleScenarioGraph).toString()
 
   private def testDataGenerationRequest(
       scenarioGraphStr: String,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/SchemalessKafkaJsonTypeTests.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/SchemalessKafkaJsonTypeTests.scala
@@ -39,7 +39,6 @@ import pl.touk.nussknacker.ui.api.ScenarioValidationRequest
 import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.TestSourceParameters
 import pl.touk.nussknacker.ui.api.description.scenarioTesting.Dtos.ScenarioTestData
 import pl.touk.nussknacker.ui.api.description.scenarioTesting.Dtos.Validate.ScenarioTestValidationRequest
-import pl.touk.nussknacker.ui.api.testing.SchemalessKafkaJsonTypeTests._
 
 import java.util.{Collections, UUID}
 import java.util.Arrays.asList
@@ -53,12 +52,144 @@ class SchemalessKafkaJsonTypeTests
     with RestAssuredVerboseLoggingIfValidationFails
     with PatientScalaFutures
     with WithAdHocTestsLogic
-    with WithSchemalessAdHocTestsLogic
     with WithAdHocInvalidParametersTestsLogic
     with WithDockerContainers
     with ForAllTestContainer
     with StrictLogging
     with NuRestAssureExtensions {
+
+  private val kafkaContainerAlias = "kafka"
+
+  protected val kafkaContainer: KafkaContainer =
+    KafkaContainer().configure { self =>
+      self.setNetwork(network)
+      self.setNetworkAliases(asList(kafkaContainerAlias))
+      self.setPortBindings(List("8070:9093").asJava)
+    }
+
+  private val schemaRegistryContainer: SchemaRegistryContainer =
+    SchemaRegistryContainer(network, kafkaContainerAlias).configure { self =>
+      self.setPortBindings(List("8069:8081").asJava)
+    }
+
+  private lazy val defaultKafkaConfig: KafkaConfig = KafkaConfig(
+    kafkaProperties = Some(Map("bootstrap.servers" -> kafkaContainer.bootstrapServers)),
+    kafkaEspProperties = None,
+  )
+
+  override val container: Container = MultipleContainers(kafkaContainer, schemaRegistryContainer)
+
+  private val validJson = """|{
+                             |  "name": "FooBar"
+                             |}""".stripMargin
+
+  private val invalidJson = """|{
+                               |  "products": [
+                               |    {"id": 1, "name": "Laptop", "price": 120a0.00},
+                               |    {"id": 2, "name": "Smartphone", "price": 800.50},
+                               |    {"id": 3, "name": "Tablet", "price": 450.75}
+                               |  ]
+                               |}""".stripMargin
+
+  private val sourceTopicName = "someInputTopic"
+
+  private val sinkTopicName = "someOutputTopic"
+
+  private val variablesNodeName = "vars"
+  private val nameVariable      = "name"
+  private val ageVariable       = "age"
+  private val isAdultVariable   = "isAdult"
+
+  override protected val exampleScenarioSourceId: String = "start"
+
+  override protected val exampleScenario: CanonicalProcess = {
+    ScenarioBuilder
+      .streaming("without-schema")
+      .parallelism(1)
+      .source(
+        exampleScenarioSourceId,
+        "kafka",
+        "Topic"        -> s"'$sourceTopicName'".spel,
+        "Content type" -> "'JSON'".spel,
+        "Data sample"  -> Expression.json("{\"name\": \"Tom\"}")
+      )
+      // We add filtering logic to ensure that types are correctly verified during testing
+      .filter("filter", "#input.name != 'asdf'".spel)
+      .emptySink(
+        "end",
+        "kafka",
+        "Key"                   -> "".spel,
+        "Raw editor"            -> "true".spel,
+        "Value"                 -> "#input".spel,
+        "Topic"                 -> s"'$sinkTopicName'".spel,
+        "Content type"          -> "'JSON'".spel,
+        "Value validation mode" -> s"'${ValidationMode.lax.name}'".spel
+      )
+  }
+
+  override protected val validParameters: TestSourceParameters =
+    TestSourceParameters(exampleScenarioSourceId, Map(inputParamName -> Expression.json(validJson)))
+
+  override protected val invalidParameters: TestSourceParameters =
+    TestSourceParameters(exampleScenarioSourceId, Map(inputParamName -> Expression.json(invalidJson)))
+
+  override protected val parametersProvidedForDryRun: String =
+    ScenarioTestValidationRequest(
+      testData = ScenarioTestData.WithParameters(validParameters),
+      scenarioGraph = exampleScenario.toScenarioGraph
+    ).asJson.toString()
+
+  override protected val expectedValidationErrorsOnInvalidParametersJson: String =
+    s"""
+       |[
+       |  {
+       |    "typ": "ExpressionParserCompilationError",
+       |    "message": "expected } or , got 'a0.00}...'",
+       |    "description": "There is problem with expression in field Some(Input) - it could not be parsed.",
+       |    "fieldName": "Input",
+       |    "errorType": "SaveAllowed",
+       |    "details": {"start":{"column":44,"row":2},"end":{"column":45,"row":2},"type":"CoordinatesBasedTextRange"}
+       |  }
+       |]""".stripMargin
+
+  override protected def expectedTestParametersJson: String = {
+    s"""
+       |[
+       |  {
+       |    "sourceId": "$exampleScenarioSourceId",
+       |    "parameters": [
+       |      {
+       |        "name": "Input",
+       |        "typ": {
+       |          "display": "Json",
+       |          "type": "Unknown",
+       |          "refClazzName": "java.lang.Object",
+       |          "params": []
+       |        },
+       |        "editors": [
+       |          {
+       |            "type": "JsonParameterEditor"
+       |          }
+       |        ],
+       |        "defaultValue": {
+       |          "language": "json",
+       |          "expression": "{\\n  \\"name\\" : \\"Tom\\"\\n}"
+       |        },
+       |        "additionalVariables": {},
+       |        "variablesToHide": [],
+       |        "branchParam": false,
+       |        "hintText": null,
+       |        "label": "Input",
+       |        "requiredParam": true,
+       |        "category": "Standard",
+       |        "changesCanReloadParameters": false,
+       |        "nonImportantForExecution": false
+       |      }
+       |    ]
+       |  }
+       |]
+       |""".stripMargin
+  }
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -198,20 +329,6 @@ class SchemalessKafkaJsonTypeTests
     }
   }
 
-  protected val kafkaContainer: KafkaContainer =
-    KafkaContainer().configure { self =>
-      self.setNetwork(network)
-      self.setNetworkAliases(asList(kafkaContainerAlias))
-      self.setPortBindings(List("8070:9093").asJava)
-    }
-
-  private val schemaRegistryContainer: SchemaRegistryContainer =
-    SchemaRegistryContainer(network, kafkaContainerAlias).configure { self =>
-      self.setPortBindings(List("8069:8081").asJava)
-    }
-
-  override def container: Container = MultipleContainers(kafkaContainer, schemaRegistryContainer)
-
   override def designerRawConfig: Config = super.designerRawConfig
     .withoutPath("scenarioTypes.streaming.modelConfig.components.kafka.disabled")
     .withValue(
@@ -222,11 +339,6 @@ class SchemalessKafkaJsonTypeTests
       "scenarioTypes.streaming.modelConfig.components.kafka.config.useDataSampleParamForSchemalessJsonTopicBasedKafkaSource",
       ConfigValueFactory.fromAnyRef(true)
     )
-
-  lazy val defaultKafkaConfig: KafkaConfig = KafkaConfig(
-    kafkaProperties = Some(Map("bootstrap.servers" -> kafkaContainer.bootstrapServers)),
-    kafkaEspProperties = None,
-  )
 
   private def createKafkaTopics(): Unit = {
     val sourceTopic = new NewTopic(sourceTopicName, Collections.emptyMap())
@@ -270,131 +382,6 @@ class SchemalessKafkaJsonTypeTests
        |  "scenarioGraph": $scenarioGraphStr,
        |  "numberOfSamples": $numberOfSamples
        |}""".stripMargin
-
-}
-
-object SchemalessKafkaJsonTypeTests {
-
-  private[SchemalessKafkaJsonTypeTests] trait WithSchemalessAdHocTestsLogic
-      extends WithAdHocTestsLogic
-      with WithAdHocInvalidParametersTestsLogic {
-    self: WithSimplifiedConfigScenarioHelper with NuItTest =>
-
-    override protected def exampleScenarioSourceId: String = "start"
-
-    override protected def exampleScenario: CanonicalProcess = {
-      ScenarioBuilder
-        .streaming("without-schema")
-        .parallelism(1)
-        .source(
-          exampleScenarioSourceId,
-          "kafka",
-          "Topic"        -> s"'$sourceTopicName'".spel,
-          "Content type" -> "'JSON'".spel,
-          "Data sample"  -> Expression.json("{\"name\": \"Tom\"}")
-        )
-        // We add filtering logic to ensure that types are correctly verified during testing
-        .filter("filter", "#input.name != 'asdf'".spel)
-        .emptySink(
-          "end",
-          "kafka",
-          "Key"                   -> "".spel,
-          "Raw editor"            -> "true".spel,
-          "Value"                 -> "#input".spel,
-          "Topic"                 -> s"'$sinkTopicName'".spel,
-          "Content type"          -> "'JSON'".spel,
-          "Value validation mode" -> s"'${ValidationMode.lax.name}'".spel
-        )
-    }
-
-    override protected def validParameters: TestSourceParameters =
-      TestSourceParameters(exampleScenarioSourceId, Map(inputParamName -> Expression.json(validJson)))
-
-    override protected def invalidParameters: TestSourceParameters =
-      TestSourceParameters(exampleScenarioSourceId, Map(inputParamName -> Expression.json(invalidJson)))
-
-    override protected def parametersProvidedForDryRun: String =
-      ScenarioTestValidationRequest(
-        testData = ScenarioTestData.WithParameters(validParameters),
-        scenarioGraph = exampleScenario.toScenarioGraph
-      ).asJson.toString()
-
-    override protected def expectedValidationErrorsOnInvalidParametersJson: String =
-      s"""
-         |[
-         |  {
-         |    "typ": "ExpressionParserCompilationError",
-         |    "message": "expected } or , got 'a0.00}...'",
-         |    "description": "There is problem with expression in field Some(Input) - it could not be parsed.",
-         |    "fieldName": "Input",
-         |    "errorType": "SaveAllowed",
-         |    "details": {"start":{"column":44,"row":2},"end":{"column":45,"row":2},"type":"CoordinatesBasedTextRange"}
-         |  }
-         |]""".stripMargin
-
-    override protected def expectedTestParametersJson: String = {
-      s"""
-         |[
-         |  {
-         |    "sourceId": "$exampleScenarioSourceId",
-         |    "parameters": [
-         |      {
-         |        "name": "Input",
-         |        "typ": {
-         |          "display": "Json",
-         |          "type": "Unknown",
-         |          "refClazzName": "java.lang.Object",
-         |          "params": []
-         |        },
-         |        "editors": [
-         |          {
-         |            "type": "JsonParameterEditor"
-         |          }
-         |        ],
-         |        "defaultValue": {
-         |          "language": "json",
-         |          "expression": "{\\n  \\"name\\" : \\"Tom\\"\\n}"
-         |        },
-         |        "additionalVariables": {},
-         |        "variablesToHide": [],
-         |        "branchParam": false,
-         |        "hintText": null,
-         |        "label": "Input",
-         |        "requiredParam": true,
-         |        "category": "Standard",
-         |        "changesCanReloadParameters": false,
-         |        "nonImportantForExecution": false
-         |      }
-         |    ]
-         |  }
-         |]
-         |""".stripMargin
-    }
-
-    private val validJson = """|{
-                               |  "name": "FooBar"
-                               |}""".stripMargin
-
-    private val invalidJson = """|{
-                                 |  "products": [
-                                 |    {"id": 1, "name": "Laptop", "price": 120a0.00},
-                                 |    {"id": 2, "name": "Smartphone", "price": 800.50},
-                                 |    {"id": 3, "name": "Tablet", "price": 450.75}
-                                 |  ]
-                                 |}""".stripMargin
-
-  }
-
-  private val sourceTopicName = "someInputTopic"
-
-  private val sinkTopicName = "someOutputTopic"
-
-  private val kafkaContainerAlias = "kafka"
-
-  private val variablesNodeName = "vars"
-  private val nameVariable      = "name"
-  private val ageVariable       = "age"
-  private val isAdultVariable   = "isAdult"
 
   private def getScenarioWithDataSample(dataSample: String) =
     ScenarioBuilder


### PR DESCRIPTION
## Describe your changes

* extracted a separate `FragmentScenarioTestingApiHttpServiceSpec` class instead of running fragments test for `event-generator` (in 4 variants) and for `GenericSourceWithCustomTestingSupport` 
* `SchemalessKafkaJsonTypeTests`: removed `WithSchemalessAdHocTestsLogic` abstraction layer, which was used only by `SchemalessKafkaJsonTypeTests`
* Removed duplicated test parameters definition checking

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
