### PR TITLE
Fix: changesCanReloadParameters for last parameter was true when some unhandled by component, validation error happen

### DIFF
--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/DynamicNodeValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/DynamicNodeValidator.scala
@@ -120,6 +120,10 @@ class DynamicNodeValidator(
         )
       }
 
+      // We assume that the last parameter in the last step can't reload parameters so we revert original value of this property
+      def revertChangesCanReloadParametersForLastParameter(parameters: List[Parameter]) =
+        parameters.transformLast(_.copy(changesCanReloadParameters = false))
+
       Try(definition.lift.apply(transformationStep)) match {
         case Success(None) =>
           returnUnmatchedFallback
@@ -129,9 +133,9 @@ class DynamicNodeValidator(
             case component.FinalResults(finalContext, errors, state) =>
               // we add distinct here, as multi-step, partial validation of parameters can cause duplicate errors if implementation is not v. careful
               val allErrors = (errorsCombined ++ errors).distinct
-              // We assume that the last parameter in the last step can't reload parameters so we revert original value of this property
-              val finalParametersDefinition =
-                evaluatedNodeParametersSoFar.map(_._1).transformLast(_.copy(changesCanReloadParameters = false))
+              val finalParametersDefinition = revertChangesCanReloadParametersForLastParameter(
+                evaluatedNodeParametersSoFar.map(_._1)
+              )
               Valid(
                 TransformationResult(
                   allErrors,
@@ -188,7 +192,7 @@ class DynamicNodeValidator(
           Valid(
             TransformationResult(
               errors ++ fallbackResult.errors,
-              evaluatedNodeParametersSoFar.map(_._1),
+              revertChangesCanReloadParametersForLastParameter(evaluatedNodeParametersSoFar.map(_._1)),
               fallbackResult.finalContext,
               fallbackResult.state,
               nodeParameters

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/GenericTransformationValidationSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/GenericTransformationValidationSpec.scala
@@ -94,10 +94,7 @@ class GenericTransformationValidationSpec
     validator.validate(process, isFragment = false)
   }
 
-  private val expectedGenericParameters =
-    prepareExpectedGenericParameters(lastParameterChangesCanReloadParameters = false)
-
-  private def prepareExpectedGenericParameters(lastParameterChangesCanReloadParameters: Boolean) = List(
+  private val expectedGenericParameters = List(
     Parameter[String](ParameterName("par1"))
       .copy(
         editors = List(
@@ -117,12 +114,7 @@ class GenericTransformationValidationSpec
       ),
     Parameter(ParameterName("val1"), Unknown).copy(editors = List(SpelParameterEditor), defaultValue = Some("".spel)),
     Parameter(ParameterName("val2"), Unknown).copy(editors = List(SpelParameterEditor), defaultValue = Some("".spel)),
-    Parameter(ParameterName("val3"), Unknown)
-      .copy(
-        editors = List(SpelParameterEditor),
-        defaultValue = Some("".spel),
-        changesCanReloadParameters = lastParameterChangesCanReloadParameters
-      )
+    Parameter(ParameterName("val3"), Unknown).copy(editors = List(SpelParameterEditor), defaultValue = Some("".spel))
   )
 
   test("should validate happy path") {
@@ -245,11 +237,7 @@ class GenericTransformationValidationSpec
         .emptySink("end", "dummySink")
     )
 
-    // For the failure case, we don't know if parameters returned during the last step before the failure,
-    // was the last one, so we can't clear lastParameterChangesCanReloadParameters value
-    val expectedGenericParametersForExceptionDuringValidation =
-      prepareExpectedGenericParameters(lastParameterChangesCanReloadParameters = true)
-    result.parametersInNodes("genericProcessor") shouldBe expectedGenericParametersForExceptionDuringValidation
+    result.parametersInNodes("genericProcessor") shouldBe expectedGenericParameters
   }
 
   test("should dependent parameter in sink") {


### PR DESCRIPTION


## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
