### PR TITLE
Fix periodic-dev processing mode config in dev configuration

### DIFF
--- a/.run/RunEnvForLocalDesigner.run.xml
+++ b/.run/RunEnvForLocalDesigner.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="RunEnvForLocalDesigner" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="pl.touk.nussknacker.dev.RunEnvForLocalDesigner" />
-    <module name="nussknacker-designer" />
+    <module name="nussknacker.nussknacker-designer.test" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="pl.touk.nussknacker.dev.*" />

--- a/examples/dev/local-testing.docker-compose.yml
+++ b/examples/dev/local-testing.docker-compose.yml
@@ -148,6 +148,9 @@ services:
       - 3031:8081
     environment:
       JOB_MANAGER_RPC_ADDRESS: "flink-jobmanager"
+      KAFKA_ADDRESS: "kafka:9092"
+      SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      INFLUXDB_URL: "http://influxdb:8086"
     healthcheck:
       test: [ "CMD-SHELL", "curl -f http://localhost:8081/jobs/overview" ]
       interval: 10s

--- a/nussknacker-dist/src/universal/conf/dev-application.conf
+++ b/nussknacker-dist/src/universal/conf/dev-application.conf
@@ -263,12 +263,6 @@ scenarioTypes {
       restUrl: "http://jobmanager:8081"
       restUrl: ${?FLINK_REST_URL}
       useMiniClusterForDeployment: false
-      useMiniClusterForDeployment: ${?FLINK_USE_MINICLUSTER_FOR_DEPLOY}
-      miniCluster {
-        config: {
-          "metrics.reporter.prometheus_reporter.port":  "9250"
-        } ${flinkMiniClusterConfig}
-      }
       scenarioStateVerification {
         enabled: ${?FLINK_SHOULD_VERIFY_BEFORE_DEPLOY}
       }


### PR DESCRIPTION
## Describe your changes

The periodic-dev processing mode stopped working in local test environment and on our development environment, fixed. It was configured to use minicluster, but scheduling mechanism on Flink does not support minicluster (it is not needed outside of tests and not trivial to add).

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
