### PR TITLE
[NU-2189] java enum usages in json context fixes

### DIFF
--- a/common-api/src/main/scala/pl/touk/nussknacker/engine/api/util/ReflectUtils.scala
+++ b/common-api/src/main/scala/pl/touk/nussknacker/engine/api/util/ReflectUtils.scala
@@ -38,11 +38,14 @@ object ReflectUtils {
     }
   }
 
-  def javaEnumNames(clazz: Class[_]): Array[String] = {
-    if (!clazz.isEnum)
-      throw new IllegalArgumentException(s"Class ${clazz.getName} is not an Enum")
+  object JavaEnumConstants {
 
-    clazz.asInstanceOf[Class[Enum[_]]].getEnumConstants.map(_.name())
+    def unapply(clazz: Class[_]): Option[List[Enum[_]]] =
+      Option(clazz)
+        .filter(_.isEnum)
+        .map(_.asInstanceOf[Class[Enum[_]]])
+        .map(_.getEnumConstants.toList)
+
   }
 
 }

--- a/common-api/src/main/scala/pl/touk/nussknacker/engine/api/util/ReflectUtils.scala
+++ b/common-api/src/main/scala/pl/touk/nussknacker/engine/api/util/ReflectUtils.scala
@@ -38,4 +38,11 @@ object ReflectUtils {
     }
   }
 
+  def javaEnumNames(clazz: Class[_]): Array[String] = {
+    if (!clazz.isEnum)
+      throw new IllegalArgumentException(s"Class ${clazz.getName} is not an Enum")
+
+    clazz.asInstanceOf[Class[Enum[_]]].getEnumConstants.map(_.name())
+  }
+
 }

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/json/encoders/ToJsonEncoderWithFallback.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/json/encoders/ToJsonEncoderWithFallback.scala
@@ -88,7 +88,7 @@ private[encoders] trait ToJsonEncoderWithFallback {
     case vals: Iterable[_] =>
       encodeIterable(vals)
     case value: Enum[_] =>
-      fromString(value.toString).validNel
+      fromString(value.name()).validNel
     case value: DisplayJson =>
       value.asJson.validNel
     case value =>

--- a/components-api/src/test/java/pl/touk/nussknacker/engine/util/json/SampleEnumWithToStringOverridden.java
+++ b/components-api/src/test/java/pl/touk/nussknacker/engine/util/json/SampleEnumWithToStringOverridden.java
@@ -1,0 +1,16 @@
+package pl.touk.nussknacker.engine.util.json;
+
+public enum SampleEnumWithToStringOverridden {
+    LOREM("lorem"), IPSUM("ipsum"), DOLOR("dolor");
+
+    public final String name;
+
+    SampleEnumWithToStringOverridden(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/FromJsonTypingResultBasedDecoderSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/FromJsonTypingResultBasedDecoderSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.prop.Tables.Table
 import pl.touk.nussknacker.engine.api.json.decoders.FromJsonTypingResultBasedDecoder
 import pl.touk.nussknacker.engine.api.json.encoders.ToJsonEncoder
 import pl.touk.nussknacker.engine.api.typed.typing._
-import pl.touk.nussknacker.engine.util.json.SampleEnum
+import pl.touk.nussknacker.engine.util.json.{SampleEnum, SampleEnumWithToStringOverridden}
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
 
 import scala.jdk.CollectionConverters._
@@ -135,6 +135,17 @@ class FromJsonTypingResultBasedDecoderSpec
     val encodedJson = ToJsonEncoder.default.encodeUnsafe(givenValue)
     encodedJson shouldEqual Json.fromString("DOLOR")
     val decodedValue = FromJsonTypingResultBasedDecoder.decodeValue(Typed[SampleEnum], encodedJson.hcursor).rightValue
+    decodedValue shouldBe givenValue
+  }
+
+  // This test demonstrates how kafka TimestampType is handled
+  test("should decode enum class with toString overridden") {
+    val givenValue  = SampleEnumWithToStringOverridden.DOLOR
+    val encodedJson = ToJsonEncoder.default.encodeUnsafe(givenValue)
+    encodedJson shouldEqual Json.fromString("DOLOR")
+    val decodedValue = FromJsonTypingResultBasedDecoder
+      .decodeValue(Typed[SampleEnumWithToStringOverridden], encodedJson.hcursor)
+      .rightValue
     decodedValue shouldBe givenValue
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/SchemalessKafkaJsonTypeTests.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/SchemalessKafkaJsonTypeTests.scala
@@ -374,7 +374,7 @@ class SchemalessKafkaJsonTypeTests
        |        ],
        |        "defaultValue": {
        |          "language": "json",
-       |          "expression": "{\\n  \\"input\\" : {\\n    \\"name\\" : \\"\\"\\n  },\\n  \\"inputMeta\\" : {\\n    \\"key\\" : \\"\\",\\n    \\"topic\\" : \\"\\",\\n    \\"partition\\" : 0,\\n    \\"offset\\" : 0,\\n    \\"timestamp\\" : 0,\\n    \\"timestampType\\" : {\\n      \\n    },\\n    \\"headers\\" : {\\n      \\"field\\" : \\"\\"\\n    },\\n    \\"leaderEpoch\\" : 0\\n  }\\n}"
+       |          "expression": "{\\n  \\"input\\" : {\\n    \\"name\\" : \\"\\"\\n  },\\n  \\"inputMeta\\" : {\\n    \\"key\\" : \\"\\",\\n    \\"topic\\" : \\"\\",\\n    \\"partition\\" : 0,\\n    \\"offset\\" : 0,\\n    \\"timestamp\\" : 0,\\n    \\"timestampType\\" : \\"NO_TIMESTAMP_TYPE\\",\\n    \\"headers\\" : {\\n      \\"field\\" : \\"\\"\\n    },\\n    \\"leaderEpoch\\" : 0\\n  }\\n}"
        |        },
        |        "additionalVariables": {},
        |        "variablesToHide": [],

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -221,6 +221,7 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 * [#8198](https://github.com/TouK/nussknacker/pull/8198) Support for test data without `sourceId` specified is removed - now, you always have to specify it
 * [#7137](https://github.com/TouK/nussknacker/pull/7137)[#8317](https://github.com/TouK/nussknacker/pull/8317) Updated Flink 1.19.2 -> 1.20.2.
 * [#8209](https://github.com/TouK/nussknacker/pull/8209) Nussknacker now requires flink to be run with replaced `lib/flink-scala_2.12-x.x.x.jar` by `pl.touk:flink-scala` lib for the same scala version as used Nussknacker distribution. We provide prebuild flink docker images on [Docker Hub](https://hub.docker.com/r/touk/flink)    
+* [#8478](https://github.com/TouK/nussknacker/pull/8478) The behavior of `enum` to json encoding has been changed - now it uses `.name()` instead of `.toString()` 
 
 ## In version 1.18.0
 

--- a/e2e-tests/src/test/scala/pl/touk/nussknacker/DetectLargeTransactionSpec.scala
+++ b/e2e-tests/src/test/scala/pl/touk/nussknacker/DetectLargeTransactionSpec.scala
@@ -77,7 +77,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 0,
              |                  "leaderEpoch": 0,
@@ -108,7 +108,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 1,
              |                  "leaderEpoch": 0,
@@ -139,7 +139,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 2,
              |                  "leaderEpoch": 0,
@@ -178,7 +178,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 3,
              |                  "leaderEpoch": 0,
@@ -209,7 +209,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 4,
              |                  "leaderEpoch": 0,
@@ -240,7 +240,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 5,
              |                  "leaderEpoch": 0,
@@ -279,7 +279,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 0,
              |                  "leaderEpoch": 0,
@@ -310,7 +310,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 1,
              |                  "leaderEpoch": 0,
@@ -341,7 +341,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 2,
              |                  "leaderEpoch": 0,
@@ -372,7 +372,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 3,
              |                  "leaderEpoch": 0,
@@ -403,7 +403,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 4,
              |                  "leaderEpoch": 0,
@@ -434,7 +434,7 @@ class DetectLargeTransactionSpec
              |                "pretty": {
              |                  "timestamp": "${regexes.decimalRegex}",
              |                  "partition": 0,
-             |                  "timestampType": "CreateTime",
+             |                  "timestampType": "CREATE_TIME",
              |                  "key": "",
              |                  "offset": 5,
              |                  "leaderEpoch": 0,

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
@@ -101,31 +101,9 @@ class SchemedKafkaScenarioTestingSpec
   }
 
   test("Should pass correct timestamp from test data") {
-    val topic             = UnspecializedTopicName("address")
-    val expectedTimestamp = System.currentTimeMillis()
-    val inputMeta = InputMeta(
-      key = null,
-      topic = topic.name,
-      partition = 0,
-      offset = 1,
-      timestamp = expectedTimestamp,
-      timestampType = TimestampType.CREATE_TIME,
-      headers = Collections.emptyMap(),
-      leaderEpoch = 0
-    )
-    val inputMetaAsJson = Json.fromFields(
-      Map(
-        "key"           -> Json.Null,
-        "topic"         -> Json.fromString(topic.name),
-        "partition"     -> Json.fromInt(0),
-        "offset"        -> Json.fromInt(1),
-        "timestamp"     -> Json.fromLong(expectedTimestamp),
-        "timestampType" -> Json.fromString("CreateTime"),
-        "headers"       -> Json.fromFields(List.empty),
-        "leaderEpoch"   -> Json.fromInt(0)
-      )
-    )
-    val id: Int = registerSchema(topic, Address.schema)
+    val topic          = UnspecializedTopicName("address")
+    val givenTimestamp = System.currentTimeMillis()
+    val id             = registerSchema(topic, Address.schema)
 
     val process = ScenarioBuilder
       .streaming("test")
@@ -138,19 +116,42 @@ class SchemedKafkaScenarioTestingSpec
       .customNode("transform", "extractedTimestamp", "extractAndTransformTimestamp", "timestampToSet" -> "0L".spel)
       .emptySink("end", "sinkForInputMeta", SingleValueParamName -> "#inputMeta".spel)
 
-    val consumerRecord = ToJsonEncoder.default
-      .encodeUnsafe(inputMeta)
-      .mapObject(
-        _.add("value", obj("city" -> fromString("Lublin"), "street" -> fromString("Lipowa")))
+    val consumerRecordJson =
+      Json.fromFields(
+        Map(
+          "key"           -> Json.Null,
+          "topic"         -> Json.fromString(topic.name),
+          "partition"     -> Json.fromInt(0),
+          "offset"        -> Json.fromInt(1),
+          "timestamp"     -> Json.fromLong(givenTimestamp),
+          "timestampType" -> Json.fromString("CreateTime"),
+          "headers"       -> Json.fromFields(List.empty),
+          "leaderEpoch"   -> Json.fromInt(0),
+          "value"         -> obj("city" -> fromString("Lublin"), "street" -> fromString("Lipowa"))
+        )
       )
-    val testRecordJson = obj("keySchemaId" -> Null, "valueSchemaId" -> fromInt(id), "consumerRecord" -> consumerRecord)
-    val scenarioTestData = ScenarioTestData(ScenarioTestSourceSpecificFormatJsonRecord("start", testRecordJson, timestamp = None) :: Nil)
+    val testRecordJson =
+      obj("keySchemaId" -> Null, "valueSchemaId" -> fromInt(id), "consumerRecord" -> consumerRecordJson)
+    val scenarioTestData =
+      ScenarioTestData(ScenarioTestSourceSpecificFormatJsonRecord("start", testRecordJson, timestamp = None) :: Nil)
 
     val results = testRunner.runTests(process, scenarioTestData).futureValue
 
     val testResultVars = results.nodeResults("end").head.variables
-    testResultVars("extractedTimestamp").hcursor.downField("pretty").as[Long].rightValue shouldBe expectedTimestamp
-    testResultVars("inputMeta").hcursor.downField("pretty").focus.value shouldBe inputMetaAsJson
+    testResultVars("extractedTimestamp").hcursor.downField("pretty").as[Long].rightValue shouldBe givenTimestamp
+    val expectedInputMetaInTestResults = Json.fromFields(
+      Map(
+        "key"           -> Json.Null,
+        "topic"         -> Json.fromString(topic.name),
+        "partition"     -> Json.fromInt(0),
+        "offset"        -> Json.fromInt(1),
+        "timestamp"     -> Json.fromLong(givenTimestamp),
+        "timestampType" -> Json.fromString("CREATE_TIME"),
+        "headers"       -> Json.fromFields(List.empty),
+        "leaderEpoch"   -> Json.fromInt(0)
+      )
+    )
+    testResultVars("inputMeta").hcursor.downField("pretty").focus.value shouldBe expectedInputMetaInTestResults
   }
 
   test("Should pass parameters correctly and use them in scenario test") {

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/InitialJsonFromTypingResultDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/InitialJsonFromTypingResultDeterminer.scala
@@ -5,6 +5,7 @@ import pl.touk.nussknacker.engine.api.json.encoders.ToJsonEncoder
 import pl.touk.nussknacker.engine.api.typed.StandardTypesClasses
 import pl.touk.nussknacker.engine.api.typed.StandardTypesClasses._
 import pl.touk.nussknacker.engine.api.typed.typing._
+import pl.touk.nussknacker.engine.api.util.ReflectUtils
 import pl.touk.nussknacker.engine.util.Implicits.{RichScalaListMap, RichTupleList}
 
 object InitialJsonFromTypingResultDeterminer {
@@ -64,8 +65,8 @@ object InitialJsonFromTypingResultDeterminer {
       defaultJsonForDecimalNumber
     case TypedClass(clazz, _) if StandardTypesClasses.isFloatingPointNumber(clazz) =>
       defaultJsonForFloatingPointNumber
-    case TypedClass(clazz, _) if StandardTypesClasses.isFloatingPointNumber(clazz) =>
-      defaultJsonForFloatingPointNumber
+    case TypedClass(clazz, _) if clazz.isEnum && ReflectUtils.javaEnumNames(clazz).nonEmpty =>
+      Json.fromString(ReflectUtils.javaEnumNames(clazz).head)
     case TypedClass(StandardClass(defaultJson), _) => defaultJson
   }
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/InitialJsonFromTypingResultDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/defaults/InitialJsonFromTypingResultDeterminer.scala
@@ -6,6 +6,7 @@ import pl.touk.nussknacker.engine.api.typed.StandardTypesClasses
 import pl.touk.nussknacker.engine.api.typed.StandardTypesClasses._
 import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.api.util.ReflectUtils
+import pl.touk.nussknacker.engine.api.util.ReflectUtils.JavaEnumConstants
 import pl.touk.nussknacker.engine.util.Implicits.{RichScalaListMap, RichTupleList}
 
 object InitialJsonFromTypingResultDeterminer {
@@ -65,8 +66,8 @@ object InitialJsonFromTypingResultDeterminer {
       defaultJsonForDecimalNumber
     case TypedClass(clazz, _) if StandardTypesClasses.isFloatingPointNumber(clazz) =>
       defaultJsonForFloatingPointNumber
-    case TypedClass(clazz, _) if clazz.isEnum && ReflectUtils.javaEnumNames(clazz).nonEmpty =>
-      Json.fromString(ReflectUtils.javaEnumNames(clazz).head)
+    case TypedClass(JavaEnumConstants(firstEnumConstant :: _), _) =>
+      Json.fromString(firstEnumConstant.name())
     case TypedClass(StandardClass(defaultJson), _) => defaultJson
   }
 

--- a/utils/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/InputMetaToJsonSpec.scala
+++ b/utils/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/source/InputMetaToJsonSpec.scala
@@ -33,7 +33,7 @@ class InputMetaToJsonSpec extends AnyFunSuite with Matchers with TableDrivenProp
         "partition"     -> fromInt(1),
         "offset"        -> fromLong(10),
         "timestamp"     -> fromLong(1000),
-        "timestampType" -> fromString("CreateTime"),
+        "timestampType" -> fromString("CREATE_TIME"),
         "headers"       -> obj("A" -> fromString("B")),
         "leaderEpoch"   -> fromInt(10)
       )


### PR DESCRIPTION
- first value as initial value
- `.name()` instead `.toString()` used in encoding

## Describe your changes

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
