### PR TITLE
[NU-2314] Spel parser naming refactor

### DIFF
--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/AvroSchemaSpelExpressionSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/AvroSchemaSpelExpressionSpec.scala
@@ -18,7 +18,7 @@ import pl.touk.nussknacker.engine.expression.parse.TypedExpression
 import pl.touk.nussknacker.engine.schemedkafka.schema.PaymentV1
 import pl.touk.nussknacker.engine.schemedkafka.typed.AvroSchemaTypeDefinitionExtractor
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser.Standard
+import pl.touk.nussknacker.engine.spel.SpelFlavour
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 
 import java.time.{Instant, LocalDate, LocalTime}
@@ -238,7 +238,7 @@ class AvroSchemaSpelExpressionSpec extends AnyFunSpec with Matchers {
         ModelDefinitionBuilder.emptyExpressionConfig,
         new SimpleDictRegistry(Map(dictId -> EmbeddedDictDefinition(Map("key1" -> "value1")))),
         enableSpelForceCompile = true,
-        Standard,
+        SpelFlavour.Standard,
         ClassDefinitionTestUtils.createDefinitionForClasses(classOf[EnumSymbol])
       )
       .parse(expr, validationCtx, Typed.fromDetailedType[T])

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
@@ -35,7 +35,7 @@ import pl.touk.nussknacker.engine.language.dictWithLabel.DictKeyWithLabelExpress
 import pl.touk.nussknacker.engine.language.json.{JsonParser, JsonTemplateParser}
 import pl.touk.nussknacker.engine.language.tabularDataDefinition.TabularDataDefinitionParser
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser.Flavour
+import pl.touk.nussknacker.engine.spel.SpelFlavour
 import pl.touk.nussknacker.engine.util.Implicits._
 import pl.touk.nussknacker.engine.util.validated.ValidatedSyntax._
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
@@ -94,7 +94,7 @@ object ExpressionCompiler {
       classDefinitionSet: ClassDefinitionSet,
       expressionEvaluator: ExpressionEvaluator
   ): ExpressionCompiler = {
-    def spelParser(flavour: Flavour) =
+    def spelParser(flavour: SpelFlavour) =
       SpelExpressionParser.default(
         classLoader,
         expressionConfig,
@@ -104,8 +104,8 @@ object ExpressionCompiler {
         classDefinitionSet
       )
 
-    val spelStandardParser = spelParser(SpelExpressionParser.Standard)
-    val spelTemplateParser = spelParser(SpelExpressionParser.Template)
+    val spelStandardParser = spelParser(SpelFlavour.Standard)
+    val spelTemplateParser = spelParser(SpelFlavour.Template)
     val defaultParsers =
       Seq(
         spelStandardParser,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/json/JsonTemplateTypeDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/json/JsonTemplateTypeDeterminer.scala
@@ -18,7 +18,7 @@ import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.expression.parse.CompiledExpression
 import pl.touk.nussknacker.engine.language.json.JsonParsingFailureToExpressionParseErrorConverter.ParsingFailureExt
 import pl.touk.nussknacker.engine.language.json.JsonTemplateTypeDeterminer._
-import pl.touk.nussknacker.engine.spel.{SpelExpression, SpelExpressionParser, SpelExpressionRepr}
+import pl.touk.nussknacker.engine.spel.{CompiledSpelExpression, SpelExpressionParser, SpelExpressionRepr}
 import pl.touk.nussknacker.engine.util.Implicits._
 
 import java.math.{BigDecimal => JBigDecimal}
@@ -54,11 +54,11 @@ private[json] class JsonTemplateTypeDeterminer(spelParser: SpelExpressionParser)
       compiledExpression: CompiledExpression
   )(handle: SpringExpression => T): T =
     compiledExpression match {
-      case expression: SpelExpression =>
+      case expression: CompiledSpelExpression =>
         handle(expression.parsedSpringExpression)
       case _ =>
         throw new IllegalStateException(
-          s"Invalid compiled expression: ${compiledExpression.getClass.getName}. Expected: ${classOf[SpelExpression].getName}"
+          s"Invalid compiled expression: ${compiledExpression.getClass.getName}. Expected: ${classOf[CompiledSpelExpression].getName}"
         )
     }
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/CompiledSpelExpression.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/CompiledSpelExpression.scala
@@ -1,7 +1,6 @@
 package pl.touk.nussknacker.engine.spel
 
-import cats.data.{NonEmptyList, Validated, ValidatedNel}
-import cats.data.Validated.Valid
+import cats.data.ValidatedNel
 import com.typesafe.scalalogging.LazyLogging
 import org.springframework.expression._
 import org.springframework.expression.common.{CompositeStringExpression, LiteralExpression}
@@ -9,26 +8,13 @@ import org.springframework.expression.spel._
 import org.springframework.expression.spel.ast.SpelNodeImpl
 import pl.touk.nussknacker.engine.api.{Context, TemplateEvaluationResult, TemplateRenderedPart}
 import pl.touk.nussknacker.engine.api.TemplateRenderedPart.{RenderedLiteral, RenderedSubExpression}
-import pl.touk.nussknacker.engine.api.context.ValidationContext
-import pl.touk.nussknacker.engine.api.dict.DictRegistry
 import pl.touk.nussknacker.engine.api.exception.NonTransientException
-import pl.touk.nussknacker.engine.api.generics.ExpressionParseError
 import pl.touk.nussknacker.engine.api.typed.typing.{SingleTypingResult, Typed, TypingResult}
-import pl.touk.nussknacker.engine.definition.clazz.ClassDefinitionSet
-import pl.touk.nussknacker.engine.definition.globalvariables.ExpressionConfigDefinition
-import pl.touk.nussknacker.engine.dict.{KeysDictTyper, LabelsDictTyper}
-import pl.touk.nussknacker.engine.expression.{IndexBasedTextRange, NullExpression}
-import pl.touk.nussknacker.engine.expression.parse.{CompiledExpression, ExpressionParser, TypedExpression}
-import pl.touk.nussknacker.engine.graph.expression.{Expression => GraphExpression}
+import pl.touk.nussknacker.engine.expression.NullExpression
+import pl.touk.nussknacker.engine.expression.parse.CompiledExpression
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language
-import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.SpelExpressionUnderlyingParserError
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser.Flavour
 import pl.touk.nussknacker.engine.spel.internal.EvaluationContextPreparer
-import pl.touk.nussknacker.engine.spel.parser.{
-  ExceptionWithExpressionTextRange,
-  ExpressionWithTextRange,
-  NuSpelExpressionParser
-}
+import pl.touk.nussknacker.engine.spel.parser.ExpressionWithTextRange
 
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.control.NonFatal
@@ -47,12 +33,12 @@ import scala.util.control.NonFatal
  * - unless Expression is marked @volatile multiple threads might parse it on their own,
  * - performance problem might occur if the ClassCastException is thrown often (e. g. for consecutive calls to getValue)
  */
-class SpelExpression(
+class CompiledSpelExpression(
     override val original: String,
     reparseFunction: () => ValidatedNel[SpelExpressionParseError, ExpressionWithTextRange],
     initiallyParsedExpression: ExpressionWithTextRange,
     expectedReturnType: TypingResult,
-    flavour: Flavour,
+    flavour: SpelFlavour,
     evaluationContextPreparer: EvaluationContextPreparer
 ) extends CompiledExpression
     with LazyLogging {
@@ -150,9 +136,9 @@ class SpelExpression(
 
   private def getValueDependingOnFlavourAndResultType[T](context: EvaluationContext): T = {
     flavour match {
-      case SpelExpressionParser.Standard =>
+      case SpelFlavour.Standard =>
         parsed.getExpression.getValue(context, expectedClass).asInstanceOf[T]
-      case SpelExpressionParser.Template =>
+      case SpelFlavour.Template =>
         val parts            = renderTemplateExpressionParts(context)
         val evaluationResult = TemplateEvaluationResult(parts)
         if (expectedReturnType == Typed[TemplateEvaluationResult]) {
@@ -213,199 +199,3 @@ class SpelExpressionEvaluationException(val expression: String, cause: Throwable
       s"Expression [$expression] evaluation failed, message: ${cause.getMessage}",
       cause = cause
     )
-
-class SpelExpressionParser(
-    immediateCompileParser: NuSpelExpressionParser,
-    typer: Typer,
-    dictRegistry: DictRegistry,
-    enableSpelForceCompile: Boolean,
-    flavour: Flavour,
-    prepareEvaluationContext: EvaluationContextPreparer
-) extends ExpressionParser {
-
-  import pl.touk.nussknacker.engine.spel.SpelExpressionParser._
-
-  override final val languageId: Language = flavour.languageId
-
-  override def parse(
-      original: String,
-      ctx: ValidationContext,
-      expectedType: TypingResult
-  ): ValidatedNel[ExpressionParseError, TypedExpression] = {
-    val optionalNullExpression = if (flavour != Template) handleBlankExpressionAsNullExpression(original) else None
-    optionalNullExpression.getOrElse {
-      parseSpelExpressionUsingImmediateCompileConfiguration(original)
-        .andThen { parsed =>
-          typer
-            .typeExpression(parsed, ctx, flavour)
-            .map((parsed, _))
-            .leftMap(_.map(_.toParseError(original)))
-        }
-        .andThen { case (parsed, collectedTypingResult) =>
-          validateResultTypeIfNeeded(collectedTypingResult, expectedType)
-            .map(_ => (parsed, collectedTypingResult))
-        }
-        .map { case (parsed, collectedTypingResult) =>
-          TypedExpression(
-            createExpression(
-              original = original,
-              initiallyParsedExpression = parsed,
-              expectedType = expectedType
-            ),
-            collectedTypingResult.typingInfo
-          )
-        }
-    }
-  }
-
-  private def parseSpelExpressionUsingImmediateCompileConfiguration(
-      original: String
-  ): ValidatedNel[SpelExpressionParseError, ExpressionWithTextRange] = {
-    Validated
-      .catchNonFatal(immediateCompileParser.parseExpression(original, flavour.parserContext.orNull))
-      .leftMap { ex =>
-        val textRangeOpt = Option(ex)
-          .collect {
-            case ex: ExceptionWithExpressionTextRange =>
-              ex.getExpressionTextRange
-            case ex: ParseException =>
-              IndexBasedTextRange(ex.getPosition, ex.getPosition + 1)
-          }
-          .map(_.toCoordinatesBasedTextRange(original))
-        val message = Option(ex)
-          .collect {
-            case ex: SpelParseException =>
-              ex.getMessageCode match {
-                case SpelMessage.MORE_INPUT =>
-                  // This message sounds better than "After parsing a valid expression, there is still more data in the expression: ''{0}''"
-                  "Unexpected text"
-                case _ => messageWithoutExpressionAndErrorCodeIndicator(ex)
-              }
-            case ex: ParseException =>
-              ex.getSimpleMessage
-          }
-          .getOrElse(ex.getMessage)
-        NonEmptyList.of(
-          SpelExpressionUnderlyingParserError(message, textRangeOpt)
-        )
-      }
-  }
-
-  private def validateResultTypeIfNeeded(
-      collected: CollectedTypingResult,
-      expectedType: TypingResult,
-  ): ValidatedNel[ExpressionParseError, Unit] = {
-    if (expectedType == Typed[SpelExpressionRepr] || expectedType == Typed[TemplateEvaluationResult]) {
-      Valid(())
-    } else {
-      ExpressionParser.validateResultTypeMatchExpectedType(collected.finalResult.typingResult, expectedType)
-    }
-  }
-
-  // SpEL adds:
-  // - Expression [<expression>]: prefix - see ExpressionException.toDetailedString
-  // - EL1001E: prefix - (error code indicator), see SpelMessage.formatMessage
-  // We remove both things to make messages more human-readable
-  // To avoid first prefix we call getSimpleMessage instead of getMessage.
-  private def messageWithoutExpressionAndErrorCodeIndicator(ex: SpelParseException) =
-    ex.getSimpleMessage.replaceFirst("^EL\\d{4}E?: ", "")
-
-  private def createExpression(
-      original: String,
-      initiallyParsedExpression: ExpressionWithTextRange,
-      expectedType: TypingResult
-  ) = {
-    val expr =
-      new SpelExpression(
-        original = original,
-        // We should consider using parser with compilation off for reparse
-        reparseFunction = () => parseSpelExpressionUsingImmediateCompileConfiguration(original),
-        initiallyParsedExpression = initiallyParsedExpression,
-        expectedReturnType = expectedType,
-        flavour = flavour,
-        evaluationContextPreparer = prepareEvaluationContext
-      )
-    if (enableSpelForceCompile) {
-      expr.forceCompile()
-    }
-    expr
-  }
-
-  def typingDictLabels =
-    new SpelExpressionParser(
-      immediateCompileParser,
-      typer.withDictTyper(new LabelsDictTyper(dictRegistry)),
-      dictRegistry,
-      enableSpelForceCompile,
-      flavour,
-      prepareEvaluationContext
-    )
-
-  def withTyper(modify: Typer => Typer): SpelExpressionParser = {
-    new SpelExpressionParser(
-      immediateCompileParser,
-      modify(typer),
-      dictRegistry,
-      enableSpelForceCompile,
-      flavour,
-      prepareEvaluationContext
-    )
-  }
-
-}
-
-object SpelExpressionParser extends LazyLogging {
-
-  sealed abstract class Flavour(val languageId: Language, val parserContext: Option[ParserContext])
-  object Standard extends Flavour(GraphExpression.Language.Spel, None)
-  // TODO: should we enable other prefixes/suffixes?
-  object Template extends Flavour(GraphExpression.Language.SpelTemplate, Some(ParserContext.TEMPLATE_EXPRESSION))
-
-  def default(
-      classLoader: ClassLoader,
-      expressionConfig: ExpressionConfigDefinition,
-      dictRegistry: DictRegistry,
-      enableSpelForceCompile: Boolean,
-      flavour: Flavour,
-      classDefinitionSet: ClassDefinitionSet,
-  ): SpelExpressionParser = {
-
-    // we have to pass classloader, because default contextClassLoader can be sth different than we expect...
-    val immediateCompileParser = new NuSpelExpressionParser(
-      createSpelParserConfiguration(classLoader)
-    )
-    val evaluationContextPreparer = EvaluationContextPreparer.default(classLoader, expressionConfig, classDefinitionSet)
-    val typer = Typer.default(
-      classLoader,
-      expressionConfig,
-      new KeysDictTyper(dictRegistry),
-      classDefinitionSet,
-      absentVariableReferenceAllowed = false
-    )
-    new SpelExpressionParser(
-      immediateCompileParser,
-      typer,
-      dictRegistry,
-      enableSpelForceCompile,
-      flavour,
-      evaluationContextPreparer
-    )
-  }
-
-  private def createSpelParserConfiguration(classLoader: ClassLoader) = {
-    val autoGrowNullReferences = false
-    val autoGrowCollections    = false
-    val maximumAutoGrowSize    = Integer.MAX_VALUE
-    val maximumExpressionLength =
-      Integer.MAX_VALUE // By default, it is limited to 10_000 (DEFAULT_MAX_EXPRESSION_LENGTH)
-    new SpelParserConfiguration(
-      SpelCompilerMode.IMMEDIATE,
-      classLoader,
-      autoGrowNullReferences,
-      autoGrowCollections,
-      maximumAutoGrowSize,
-      maximumExpressionLength
-    )
-  }
-
-}

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionParser.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionParser.scala
@@ -1,0 +1,215 @@
+package pl.touk.nussknacker.engine.spel
+
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.data.Validated.Valid
+import com.typesafe.scalalogging.LazyLogging
+import org.springframework.expression.ParseException
+import org.springframework.expression.spel.{SpelCompilerMode, SpelMessage, SpelParseException, SpelParserConfiguration}
+import pl.touk.nussknacker.engine.api.TemplateEvaluationResult
+import pl.touk.nussknacker.engine.api.context.ValidationContext
+import pl.touk.nussknacker.engine.api.dict.DictRegistry
+import pl.touk.nussknacker.engine.api.generics.ExpressionParseError
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
+import pl.touk.nussknacker.engine.definition.clazz.ClassDefinitionSet
+import pl.touk.nussknacker.engine.definition.globalvariables.ExpressionConfigDefinition
+import pl.touk.nussknacker.engine.dict.{KeysDictTyper, LabelsDictTyper}
+import pl.touk.nussknacker.engine.expression.IndexBasedTextRange
+import pl.touk.nussknacker.engine.expression.parse.{ExpressionParser, TypedExpression}
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language
+import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.SpelExpressionUnderlyingParserError
+import pl.touk.nussknacker.engine.spel.internal.EvaluationContextPreparer
+import pl.touk.nussknacker.engine.spel.parser.{
+  ExceptionWithExpressionTextRange,
+  ExpressionWithTextRange,
+  NuSpelExpressionParser
+}
+
+class SpelExpressionParser(
+    immediateCompileParser: NuSpelExpressionParser,
+    typer: SpelTyper,
+    dictRegistry: DictRegistry,
+    enableSpelForceCompile: Boolean,
+    flavour: SpelFlavour,
+    prepareEvaluationContext: EvaluationContextPreparer
+) extends ExpressionParser {
+
+  override final val languageId: Language = flavour.languageId
+
+  override def parse(
+      original: String,
+      ctx: ValidationContext,
+      expectedType: TypingResult
+  ): ValidatedNel[ExpressionParseError, TypedExpression] = {
+    val optionalNullExpression =
+      if (flavour != SpelFlavour.Template) handleBlankExpressionAsNullExpression(original) else None
+    optionalNullExpression.getOrElse {
+      parseSpelExpressionUsingImmediateCompileConfiguration(original)
+        .andThen { parsed =>
+          typer
+            .typeExpression(parsed, ctx, flavour)
+            .map((parsed, _))
+            .leftMap(_.map(_.toParseError(original)))
+        }
+        .andThen { case (parsed, collectedTypingResult) =>
+          validateResultTypeIfNeeded(collectedTypingResult, expectedType)
+            .map(_ => (parsed, collectedTypingResult))
+        }
+        .map { case (parsed, collectedTypingResult) =>
+          TypedExpression(
+            createExpression(
+              original = original,
+              initiallyParsedExpression = parsed,
+              expectedType = expectedType
+            ),
+            collectedTypingResult.typingInfo
+          )
+        }
+    }
+  }
+
+  private def parseSpelExpressionUsingImmediateCompileConfiguration(
+      original: String
+  ): ValidatedNel[SpelExpressionParseError, ExpressionWithTextRange] = {
+    Validated
+      .catchNonFatal(immediateCompileParser.parseExpression(original, flavour.parserContext.orNull))
+      .leftMap { ex =>
+        val textRangeOpt = Option(ex)
+          .collect {
+            case ex: ExceptionWithExpressionTextRange =>
+              ex.getExpressionTextRange
+            case ex: ParseException =>
+              IndexBasedTextRange(ex.getPosition, ex.getPosition + 1)
+          }
+          .map(_.toCoordinatesBasedTextRange(original))
+        val message = Option(ex)
+          .collect {
+            case ex: SpelParseException =>
+              ex.getMessageCode match {
+                case SpelMessage.MORE_INPUT =>
+                  // This message sounds better than "After parsing a valid expression, there is still more data in the expression: ''{0}''"
+                  "Unexpected text"
+                case _ => messageWithoutExpressionAndErrorCodeIndicator(ex)
+              }
+            case ex: ParseException =>
+              ex.getSimpleMessage
+          }
+          .getOrElse(ex.getMessage)
+        NonEmptyList.of(
+          SpelExpressionUnderlyingParserError(message, textRangeOpt)
+        )
+      }
+  }
+
+  private def validateResultTypeIfNeeded(
+      collected: CollectedTypingResult,
+      expectedType: TypingResult,
+  ): ValidatedNel[ExpressionParseError, Unit] = {
+    if (expectedType == Typed[SpelExpressionRepr] || expectedType == Typed[TemplateEvaluationResult]) {
+      Valid(())
+    } else {
+      ExpressionParser.validateResultTypeMatchExpectedType(collected.finalResult.typingResult, expectedType)
+    }
+  }
+
+  // SpEL adds:
+  // - Expression [<expression>]: prefix - see ExpressionException.toDetailedString
+  // - EL1001E: prefix - (error code indicator), see SpelMessage.formatMessage
+  // We remove both things to make messages more human-readable
+  // To avoid first prefix we call getSimpleMessage instead of getMessage.
+  private def messageWithoutExpressionAndErrorCodeIndicator(ex: SpelParseException) =
+    ex.getSimpleMessage.replaceFirst("^EL\\d{4}E?: ", "")
+
+  private def createExpression(
+      original: String,
+      initiallyParsedExpression: ExpressionWithTextRange,
+      expectedType: TypingResult
+  ) = {
+    val expr =
+      new CompiledSpelExpression(
+        original = original,
+        // We should consider using parser with compilation off for reparse
+        reparseFunction = () => parseSpelExpressionUsingImmediateCompileConfiguration(original),
+        initiallyParsedExpression = initiallyParsedExpression,
+        expectedReturnType = expectedType,
+        flavour = flavour,
+        evaluationContextPreparer = prepareEvaluationContext
+      )
+    if (enableSpelForceCompile) {
+      expr.forceCompile()
+    }
+    expr
+  }
+
+  def typingDictLabels =
+    new SpelExpressionParser(
+      immediateCompileParser,
+      typer.withDictTyper(new LabelsDictTyper(dictRegistry)),
+      dictRegistry,
+      enableSpelForceCompile,
+      flavour,
+      prepareEvaluationContext
+    )
+
+  def withTyper(modify: SpelTyper => SpelTyper): SpelExpressionParser = {
+    new SpelExpressionParser(
+      immediateCompileParser,
+      modify(typer),
+      dictRegistry,
+      enableSpelForceCompile,
+      flavour,
+      prepareEvaluationContext
+    )
+  }
+
+}
+
+object SpelExpressionParser extends LazyLogging {
+
+  def default(
+      classLoader: ClassLoader,
+      expressionConfig: ExpressionConfigDefinition,
+      dictRegistry: DictRegistry,
+      enableSpelForceCompile: Boolean,
+      flavour: SpelFlavour,
+      classDefinitionSet: ClassDefinitionSet,
+  ): SpelExpressionParser = {
+
+    // we have to pass classloader, because default contextClassLoader can be sth different than we expect...
+    val immediateCompileParser = new NuSpelExpressionParser(
+      createSpelParserConfiguration(classLoader)
+    )
+    val evaluationContextPreparer = EvaluationContextPreparer.default(classLoader, expressionConfig, classDefinitionSet)
+    val typer = SpelTyper.default(
+      classLoader,
+      expressionConfig,
+      new KeysDictTyper(dictRegistry),
+      classDefinitionSet,
+      absentVariableReferenceAllowed = false
+    )
+    new SpelExpressionParser(
+      immediateCompileParser,
+      typer,
+      dictRegistry,
+      enableSpelForceCompile,
+      flavour,
+      evaluationContextPreparer
+    )
+  }
+
+  private def createSpelParserConfiguration(classLoader: ClassLoader) = {
+    val autoGrowNullReferences = false
+    val autoGrowCollections    = false
+    val maximumAutoGrowSize    = Integer.MAX_VALUE
+    val maximumExpressionLength =
+      Integer.MAX_VALUE // By default, it is limited to 10_000 (DEFAULT_MAX_EXPRESSION_LENGTH)
+    new SpelParserConfiguration(
+      SpelCompilerMode.IMMEDIATE,
+      classLoader,
+      autoGrowNullReferences,
+      autoGrowCollections,
+      maximumAutoGrowSize,
+      maximumExpressionLength
+    )
+  }
+
+}

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
@@ -3,7 +3,6 @@ package pl.touk.nussknacker.engine.spel
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.JsonCodec
-import org.springframework.expression.common.TemplateParserContext
 import org.springframework.expression.spel.{SpelNode, SpelParserConfiguration}
 import org.springframework.expression.spel.ast._
 import org.springframework.expression.spel.standard.{SpelExpression => SpringSpelExpression}
@@ -19,8 +18,7 @@ import pl.touk.nussknacker.engine.extension.CastOrConversionExt
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language.JsonTemplate
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser.{Standard, Template}
-import pl.touk.nussknacker.engine.spel.Typer.TypingResultWithContext
+import pl.touk.nussknacker.engine.spel.SpelTyper.TypingResultWithContext
 import pl.touk.nussknacker.engine.spel.ast.SpelAst.{RichSpelNode, SpelNodeId}
 import pl.touk.nussknacker.engine.spel.parser.NuSpelExpressionParser
 import pl.touk.nussknacker.engine.util.CaretPosition2d
@@ -30,7 +28,7 @@ import pl.touk.nussknacker.engine.util.classes.Extensions.{ClassesExtensions, Cl
 import scala.collection.compat.immutable.LazyList
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 class SpelExpressionSuggester(
     expressionConfig: ExpressionConfigDefinition,
@@ -41,7 +39,7 @@ class SpelExpressionSuggester(
   private val successfulNil = Future.successful[List[ExpressionSuggestion]](Nil)
 
   private val typer =
-    Typer.default(
+    SpelTyper.default(
       classLoader,
       expressionConfig,
       new LabelsDictTyper(uiDictServices.dictRegistry),
@@ -376,7 +374,7 @@ class SpelExpressionSuggester(
           ExpressionSuggestion(
             c.resultTypeClass.simpleName(),
             c.typingFunction(invocationTargetTyping).getOrElse(c.typingResult),
-            false,
+            fromClass = false,
             None,
             Nil
           )
@@ -445,7 +443,7 @@ class SpelExpressionSuggester(
 
 }
 
-private class NuSpelNodeParser(typer: Typer) extends LazyLogging {
+private class NuSpelNodeParser(typer: SpelTyper) extends LazyLogging {
   private val parser = new NuSpelExpressionParser(new SpelParserConfiguration)
 
   def parse(
@@ -454,29 +452,31 @@ private class NuSpelNodeParser(typer: Typer) extends LazyLogging {
       position: Int,
       validationContext: ValidationContext
   ): Try[Option[NuSpelNode]] = {
-    val parsedExpressionAndFlavourTry = language match {
-      case Language.Spel => Try(parser.parseExpression(input, null)).map((_, Standard))
-      case Language.SpelTemplate | JsonTemplate =>
-        Try(parser.parseExpression(input, new TemplateParserContext())).map((_, Template))
+    val flavourTry = language match {
+      case Language.Spel                        => Success(SpelFlavour.Standard)
+      case Language.SpelTemplate | JsonTemplate => Success(SpelFlavour.Template)
       case Language.DictKeyWithLabel | Language.TabularDataDefinition | Language.Json =>
         Failure(new IllegalArgumentException(s"Language $language is not supported"))
     }
-    parsedExpressionAndFlavourTry
-      .map { case (parsedExpressions, flavour) =>
-        val astTypingResults =
-          typer.typeExpressionWithTextRange(parsedExpressions, validationContext, flavour)._2.intermediateResults
-        parsedExpressions.findSubexpressionByPosition(position).toScala.flatMap { expressionWithTextRange =>
-          expressionWithTextRange.getExpression match {
-            case springExpression: SpringSpelExpression =>
-              Some(createNuSpelNode(springExpression.getAST, astTypingResults, expressionWithTextRange.getTextRange))
-            case _ => None
-          }
+    (for {
+      flavour           <- flavourTry
+      parsedExpressions <- Try(parser.parseExpression(input, flavour.parserContext.orNull))
+      astTypingResults = typer
+        .typeExpressionWithTextRange(parsedExpressions, validationContext, flavour)
+        ._2
+        .intermediateResults
+      subExpressionOpt = parsedExpressions.findSubexpressionByPosition(position).toScala
+      spelNodeOpt = subExpressionOpt.flatMap { expressionWithTextRange =>
+        expressionWithTextRange.getExpression match {
+          case springExpression: SpringSpelExpression =>
+            Some(createNuSpelNode(springExpression.getAST, astTypingResults, expressionWithTextRange.getTextRange))
+          case _ => None
         }
       }
-      .recoverWith { case e =>
-        logger.debug(s"Failed to parse $language expression: $input, error: ${e.getMessage}")
-        Failure(e)
-      }
+    } yield spelNodeOpt).recoverWith { case e =>
+      logger.debug(s"Failed to parse $language expression: $input, error: ${e.getMessage}")
+      Failure(e)
+    }
   }
 
   private def createNuSpelNode(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelFlavour.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelFlavour.scala
@@ -1,0 +1,15 @@
+package pl.touk.nussknacker.engine.spel
+
+import org.springframework.expression.ParserContext
+import pl.touk.nussknacker.engine.graph.expression.{Expression => GraphExpression}
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language
+
+sealed abstract class SpelFlavour(val languageId: Language, val parserContext: Option[ParserContext])
+
+object SpelFlavour {
+
+  object Standard extends SpelFlavour(GraphExpression.Language.Spel, None)
+
+  object Template extends SpelFlavour(GraphExpression.Language.SpelTemplate, Some(ParserContext.TEMPLATE_EXPRESSION))
+
+}

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelTyper.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelTyper.scala
@@ -1,63 +1,41 @@
 package pl.touk.nussknacker.engine.spel
 
-import cats.data.{NonEmptyList, Validated, ValidatedNel, Writer}
 import cats.data.Validated.{Invalid, Valid}
+import cats.data.{NonEmptyList, Validated, ValidatedNel, Writer}
 import cats.instances.list._
 import cats.instances.map._
 import cats.kernel.{Monoid, Semigroup}
 import cats.syntax.traverse._
 import com.typesafe.scalalogging.LazyLogging
-import org.springframework.expression.{EvaluationContext, Expression}
 import org.springframework.expression.common.{CompositeStringExpression, LiteralExpression}
-import org.springframework.expression.spel.{standard, SpelNode}
 import org.springframework.expression.spel.ast._
+import org.springframework.expression.spel.{SpelNode, standard}
+import org.springframework.expression.{EvaluationContext, Expression}
 import pl.touk.nussknacker.engine.api.Context
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.expression._
-import pl.touk.nussknacker.engine.api.typed.{AssignabilityDeterminer, ConversionStrategy}
 import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.NoConversion
 import pl.touk.nussknacker.engine.api.typed.StandardTypesClasses._
 import pl.touk.nussknacker.engine.api.typed.supertype.{CommonSupertypeFinder, NumberTypesPromotionStrategy}
-import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.api.typed.typing.Typed.typedListWithElementValues
+import pl.touk.nussknacker.engine.api.typed.typing._
+import pl.touk.nussknacker.engine.api.typed.{AssignabilityDeterminer, ConversionStrategy}
 import pl.touk.nussknacker.engine.definition.clazz.ClassDefinitionSet
 import pl.touk.nussknacker.engine.definition.globalvariables.ExpressionConfigDefinition
 import pl.touk.nussknacker.engine.dict.SpelDictTyper
 import pl.touk.nussknacker.engine.expression.{IndexBasedTextRange, NullExpression}
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser.{Flavour, Template}
-import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.{
-  ArgumentTypeError,
-  PartTypeError,
-  SpelExpressionTypingError,
-  SpelExpressionTypingErrorWithTextRange
-}
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.IllegalOperationError._
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.MissingObjectError._
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.OperatorError._
-import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.SelectionProjectionError.{
-  IllegalProjectionError,
-  IllegalSelectionError,
-  IllegalSelectionTypeError
-}
-import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.TernaryOperatorError.{
-  InvalidTernaryOperator,
-  TernaryOperatorNotBooleanError
-}
-import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.UnsupportedOperationError.{
-  ArrayConstructorError,
-  BeanReferenceError,
-  MapWithExpressionKeysError,
-  ModificationError
-}
-import pl.touk.nussknacker.engine.spel.Typer._
+import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.SelectionProjectionError.{IllegalProjectionError, IllegalSelectionError, IllegalSelectionTypeError}
+import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.TernaryOperatorError.{InvalidTernaryOperator, TernaryOperatorNotBooleanError}
+import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.UnsupportedOperationError.{ArrayConstructorError, BeanReferenceError, MapWithExpressionKeysError, ModificationError}
+import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.{ArgumentTypeError, PartTypeError, SpelExpressionTypingError, SpelExpressionTypingErrorWithTextRange}
+import pl.touk.nussknacker.engine.spel.SpelTyper._
 import pl.touk.nussknacker.engine.spel.ast.SpelAst.{RichSpelNode, SpelNodeId}
 import pl.touk.nussknacker.engine.spel.ast.SpelNodePrettyPrinter
 import pl.touk.nussknacker.engine.spel.internal.EvaluationContextPreparer
-import pl.touk.nussknacker.engine.spel.parser.{
-  CompositeExpressionsWithTextRanges,
-  ExpressionWithTextRange,
-  SingleExpressionWithTextRange
-}
+import pl.touk.nussknacker.engine.spel.parser.{CompositeExpressionsWithTextRanges, ExpressionWithTextRange, SingleExpressionWithTextRange}
 import pl.touk.nussknacker.engine.spel.typer.{MapLikePropertyTyper, MethodReferenceTyper, TypeReferenceTyper}
 import pl.touk.nussknacker.engine.util.MathUtils
 
@@ -66,7 +44,7 @@ import scala.jdk.CollectionConverters._
 import scala.reflect.runtime._
 import scala.util.{Failure, Success, Try}
 
-private[spel] class Typer(
+private[spel] class SpelTyper(
     dictTyper: SpelDictTyper,
     strictMethodsChecking: Boolean,
     staticMethodInvocationsChecking: Boolean,
@@ -92,7 +70,7 @@ private[spel] class Typer(
   def typeExpression(
       expr: ExpressionWithTextRange,
       ctx: ValidationContext,
-      flavour: Flavour
+      flavour: SpelFlavour
   ): ValidatedNel[SpelExpressionTypingErrorWithTextRange, CollectedTypingResult] = {
     val (errors, result) = typeExpressionWithTextRange(expr, ctx, flavour)
     NonEmptyList.fromList(errors).map(Invalid(_)).getOrElse(Valid(result))
@@ -101,7 +79,7 @@ private[spel] class Typer(
   def typeExpressionWithTextRange(
       expressionWithTextRange: ExpressionWithTextRange,
       ctx: ValidationContext,
-      flavour: Flavour
+      flavour: SpelFlavour
   ): (List[SpelExpressionTypingErrorWithTextRange], CollectedTypingResult) = {
     expressionWithTextRange match {
       case composite: CompositeExpressionsWithTextRanges =>
@@ -123,7 +101,7 @@ private[spel] class Typer(
       case single: SingleExpressionWithTextRange =>
         val (errors, collectedTypingResult) = doTypeSingleExpression(single.getExpression, ctx, single.getTextRange)
         val collectedTypingResultWithFinalTypingResultAdjustedForTemplates =
-          if (flavour == Template)
+          if (flavour == SpelFlavour.Template)
             collectedTypingResult.withFinalTypingResult(Typed[String])
           else
             collectedTypingResult
@@ -841,7 +819,7 @@ private[spel] class Typer(
   private def valid[T](value: T): TypingR[T] = Writer(List.empty[SpelExpressionTypingErrorWithTextRange], value)
 
   def withDictTyper(dictTyper: SpelDictTyper) =
-    new Typer(
+    new SpelTyper(
       dictTyper,
       strictMethodsChecking = strictMethodsChecking,
       staticMethodInvocationsChecking,
@@ -852,8 +830,8 @@ private[spel] class Typer(
       absentVariableReferenceAllowed
     )
 
-  def withAbsentVariableReferenceAllowed(value: Boolean): Typer =
-    new Typer(
+  def withAbsentVariableReferenceAllowed(value: Boolean): SpelTyper =
+    new SpelTyper(
       dictTyper,
       strictMethodsChecking,
       staticMethodInvocationsChecking,
@@ -866,7 +844,7 @@ private[spel] class Typer(
 
 }
 
-object Typer {
+object SpelTyper {
 
   def default(
       classLoader: ClassLoader,
@@ -874,10 +852,10 @@ object Typer {
       spelDictTyper: SpelDictTyper,
       classDefinitionSet: ClassDefinitionSet,
       absentVariableReferenceAllowed: Boolean
-  ): Typer = {
+  ): SpelTyper = {
     val evaluationContextPreparer = EvaluationContextPreparer.default(classLoader, expressionConfig, classDefinitionSet)
 
-    new Typer(
+    new SpelTyper(
       spelDictTyper,
       expressionConfig.strictMethodsChecking,
       expressionConfig.staticMethodInvocationsChecking,

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/language/json/JsonTemplateParserTest.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/language/json/JsonTemplateParserTest.scala
@@ -18,6 +18,7 @@ import pl.touk.nussknacker.engine.expression.parse.TypedExpression
 import pl.touk.nussknacker.engine.language.json.JsonParsingFailureToExpressionParseErrorConverter.JsonParseError
 import pl.touk.nussknacker.engine.language.json.JsonTemplateParser.JsonTemplateDecodingException
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser
+import pl.touk.nussknacker.engine.spel.SpelFlavour
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage.convertValidatedToValuable
 
@@ -34,7 +35,7 @@ class JsonTemplateParserTest extends AnyFunSuite with Matchers with EitherValues
     ModelDefinitionBuilder.emptyExpressionConfig,
     new SimpleDictRegistry(Map.empty),
     enableSpelForceCompile = false,
-    SpelExpressionParser.Template,
+    SpelFlavour.Template,
     ClassDefinitionTestUtils.createDefinitionWithDefaultsAndExtensions,
   )
 
@@ -43,7 +44,7 @@ class JsonTemplateParserTest extends AnyFunSuite with Matchers with EitherValues
     ModelDefinitionBuilder.emptyExpressionConfig,
     new SimpleDictRegistry(Map.empty),
     enableSpelForceCompile = false,
-    SpelExpressionParser.Standard,
+    SpelFlavour.Standard,
     ClassDefinitionTestUtils.createDefinitionWithDefaultsAndExtensions,
   )
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionGenSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionGenSpec.scala
@@ -125,7 +125,7 @@ class SpelExpressionGenSpec
       ModelDefinitionBuilder.emptyExpressionConfig,
       new SimpleDictRegistry(Map.empty),
       enableSpelForceCompile = false,
-      SpelExpressionParser.Standard,
+      SpelFlavour.Standard,
       ClassDefinitionTestUtils.createDefinitionForDefaultAdditionalClasses
     )
     implicit val nodeId: NodeId = NodeId("fooNode")

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -45,7 +45,6 @@ import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.{
   SpelExpressionTypingParseError,
   SpelExpressionUnderlyingParserError
 }
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser.{Flavour, Standard}
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.{ArgumentTypeError, GenericFunctionError}
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.IllegalOperationError.{
   IllegalInvocationError,
@@ -171,7 +170,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
       expr: String,
       context: Context = ctx,
       dictionaries: Map[String, DictDefinition] = Map.empty,
-      flavour: Flavour = Standard,
+      flavour: SpelFlavour = SpelFlavour.Standard,
       strictMethodsChecking: Boolean = defaultStrictMethodsChecking,
       staticMethodInvocationsChecking: Boolean = defaultStaticMethodInvocationsChecking,
       methodExecutionForUnknownAllowed: Boolean = defaultMethodExecutionForUnknownAllowed,
@@ -194,7 +193,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
       expr: String,
       validationCtx: ValidationContext,
       dictionaries: Map[String, DictDefinition] = Map.empty,
-      flavour: Flavour = Standard,
+      flavour: SpelFlavour = SpelFlavour.Standard,
       strictMethodsChecking: Boolean = defaultStrictMethodsChecking,
       staticMethodInvocationsChecking: Boolean = defaultStaticMethodInvocationsChecking,
       methodExecutionForUnknownAllowed: Boolean = defaultMethodExecutionForUnknownAllowed,
@@ -215,7 +214,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   private def expressionParser(
       globalVariableTypes: Seq[TypingResult] = Seq.empty,
       dictionaries: Map[String, DictDefinition] = Map.empty,
-      flavour: Flavour = Standard,
+      flavour: SpelFlavour = SpelFlavour.Standard,
       strictMethodsChecking: Boolean = defaultStrictMethodsChecking,
       staticMethodInvocationsChecking: Boolean = defaultStaticMethodInvocationsChecking,
       methodExecutionForUnknownAllowed: Boolean = defaultMethodExecutionForUnknownAllowed,
@@ -1240,19 +1239,19 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   }
 
   test("parses expression with template context") {
-    parse[String]("alamakota #{444}", ctx, flavour = SpelExpressionParser.Template) shouldBe Symbol("valid")
-    parse[String]("alamakota #{444 + #obj.value}", ctx, flavour = SpelExpressionParser.Template) shouldBe Symbol(
+    parse[String]("alamakota #{444}", ctx, flavour = SpelFlavour.Template) shouldBe Symbol("valid")
+    parse[String]("alamakota #{444 + #obj.value}", ctx, flavour = SpelFlavour.Template) shouldBe Symbol(
       "valid"
     )
-    parse[String]("alamakota #{444 + #nothing}", ctx, flavour = SpelExpressionParser.Template) shouldBe Symbol(
+    parse[String]("alamakota #{444 + #nothing}", ctx, flavour = SpelFlavour.Template) shouldBe Symbol(
       "invalid"
     )
-    parse[String]("#{'raz'},#{'dwa'}", ctx, flavour = SpelExpressionParser.Template) shouldBe Symbol("valid")
-    parse[String]("#{'raz'},#{12345}", ctx, flavour = SpelExpressionParser.Template) shouldBe Symbol("valid")
+    parse[String]("#{'raz'},#{'dwa'}", ctx, flavour = SpelFlavour.Template) shouldBe Symbol("valid")
+    parse[String]("#{'raz'},#{12345}", ctx, flavour = SpelFlavour.Template) shouldBe Symbol("valid")
   }
 
   test("return correct error location when parsing expression with template context") {
-    parse[String]("ala #{.}", ctx, flavour = SpelExpressionParser.Template).invalidValue.toList should matchPattern {
+    parse[String]("ala #{.}", ctx, flavour = SpelFlavour.Template).invalidValue.toList should matchPattern {
       case SpelExpressionUnderlyingParserError(
             "Unexpectedly ran out of input",
             Some(CoordinatesBasedTextRange(TextCoordinates(start, 0), TextCoordinates(end, 0)))
@@ -1261,13 +1260,13 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   }
 
   test("return correct error location when using blank placeholder in template expression") {
-    parse[String]("ala #{}", ctx, flavour = SpelExpressionParser.Template).invalidValue.toList should matchPattern {
+    parse[String]("ala #{}", ctx, flavour = SpelFlavour.Template).invalidValue.toList should matchPattern {
       case SpelExpressionUnderlyingParserError(
             "Empty placeholder",
             Some(CoordinatesBasedTextRange(TextCoordinates(start, 0), TextCoordinates(end, 0)))
           ) :: Nil if start == "ala ".length && end == "ala #{}".length =>
     }
-    parse[String]("ala #{  }", ctx, flavour = SpelExpressionParser.Template).invalidValue.toList should matchPattern {
+    parse[String]("ala #{  }", ctx, flavour = SpelFlavour.Template).invalidValue.toList should matchPattern {
       case SpelExpressionUnderlyingParserError(
             "Empty placeholder",
             Some(CoordinatesBasedTextRange(TextCoordinates(start, 0), TextCoordinates(end, 0)))
@@ -1276,7 +1275,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   }
 
   test("return correct error location when placeholder is not finished correctly in template expression") {
-    parse[String]("ala #{ aaa", ctx, flavour = SpelExpressionParser.Template).invalidValue.toList should matchPattern {
+    parse[String]("ala #{ aaa", ctx, flavour = SpelFlavour.Template).invalidValue.toList should matchPattern {
       case SpelExpressionUnderlyingParserError(
             "Placeholder is not finished correctly, missing closing }",
             Some(CoordinatesBasedTextRange(TextCoordinates(start, 0), TextCoordinates(end, 0)))
@@ -1288,7 +1287,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     parse[String](
       "ala #{ aaa) }",
       ctx,
-      flavour = SpelExpressionParser.Template
+      flavour = SpelFlavour.Template
     ).invalidValue.toList should matchPattern {
       case SpelExpressionUnderlyingParserError(
             "Illegal syntax: closing ')' without an opening '('",
@@ -1298,7 +1297,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     parse[String](
       "ala #{ (aaa }",
       ctx,
-      flavour = SpelExpressionParser.Template
+      flavour = SpelFlavour.Template
     ).invalidValue.toList should matchPattern {
       case SpelExpressionUnderlyingParserError(
             "Illegal syntax: unclosed '('",
@@ -1308,7 +1307,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     parse[String](
       "ala #{ \" }",
       ctx,
-      flavour = SpelExpressionParser.Template
+      flavour = SpelFlavour.Template
     ).invalidValue.toList should matchPattern {
       case SpelExpressionUnderlyingParserError(
             "String literal is not finished correctly, missing closing '\"'",
@@ -1321,7 +1320,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     parse[String](
       "#{ #notExisting }",
       ctx,
-      flavour = SpelExpressionParser.Template
+      flavour = SpelFlavour.Template
     ).invalidValue.toList should matchPattern {
       case SpelExpressionTypingParseError(
             _,
@@ -1331,13 +1330,13 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   }
 
   test("evaluates expression with template context") {
-    parse[TemplateEvaluationResult]("alamakota #{444}", ctx, flavour = SpelExpressionParser.Template).validExpression
+    parse[TemplateEvaluationResult]("alamakota #{444}", ctx, flavour = SpelFlavour.Template).validExpression
       .evaluateSync[TemplateEvaluationResult](skipReturnTypeCheck = true)
       .renderedTemplate shouldBe "alamakota 444"
     parse[TemplateEvaluationResult](
       "alamakota #{444 + #obj.value} #{#mapValue.foo}",
       ctx,
-      flavour = SpelExpressionParser.Template
+      flavour = SpelFlavour.Template
     ).validExpression
       .evaluateSync[TemplateEvaluationResult](skipReturnTypeCheck = true)
       .renderedTemplate shouldBe "alamakota 446 bar"
@@ -1347,7 +1346,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     val expression = parseV[String](
       "some value: #{ #variable }",
       ValidationContext.empty.withVariableUnsafe("variable", Unknown),
-      flavour = SpelExpressionParser.Template
+      flavour = SpelFlavour.Template
     ).validExpression
 
     expression.evaluateSync[String](Context.dummy.withVariable("variable", 1)) shouldBe "some value: 1"
@@ -1356,7 +1355,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   }
 
   test("evaluates empty template as empty string") {
-    parse[TemplateEvaluationResult]("", ctx, flavour = SpelExpressionParser.Template).validExpression
+    parse[TemplateEvaluationResult]("", ctx, flavour = SpelFlavour.Template).validExpression
       .evaluateSync[TemplateEvaluationResult](skipReturnTypeCheck = true)
       .renderedTemplate shouldBe ""
   }
@@ -1782,7 +1781,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
         |bar: #{ {1, 2}
         |  .contain }""".stripMargin,
       ctx,
-      flavour = SpelExpressionParser.Template,
+      flavour = SpelFlavour.Template,
     ).invalidValue.toList should matchPattern {
       case SpelExpressionTypingParseError(
             NoPropertyError(_, "contain"),
@@ -2493,7 +2492,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   ) {
     val spelExpression =
       parse[LocalDateTime]("T(java.time.LocalDateTime).now().minusDays(14)", ctx).validValue.expression
-        .asInstanceOf[SpelExpression]
+        .asInstanceOf[CompiledSpelExpression]
 
     val threadPool                                        = Executors.newFixedThreadPool(1000)
     implicit val customExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(threadPool)
@@ -2538,7 +2537,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
         ("#{ #mapValue }", "{foo=bar}"),
       )
     ) { (expression, result) =>
-      val parsed = parse[String](expr = expression, flavour = SpelExpressionParser.Template).validValue
+      val parsed = parse[String](expr = expression, flavour = SpelFlavour.Template).validValue
       parsed.evaluateSync[String]() shouldBe result
     }
   }

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelTyperSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelTyperSpec.scala
@@ -1,24 +1,20 @@
 package pl.touk.nussknacker.engine.spel
 
-import cats.data.{NonEmptyList, ValidatedNel}
 import cats.data.Validated.{Invalid, Valid}
+import cats.data.{NonEmptyList, ValidatedNel}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.springframework.expression.common.TemplateParserContext
 import pl.touk.nussknacker.engine.api.context.ValidationContext
-import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.api.typed.typing.Typed.typedListWithElementValues
+import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.definition.clazz.ClassDefinitionTestUtils
 import pl.touk.nussknacker.engine.dict.{KeysDictTyper, SimpleDictRegistry}
 import pl.touk.nussknacker.engine.expression.IndexBasedTextRange
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser.{Standard, Template}
-import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.MissingObjectError.{
-  NoPropertyError,
-  NoPropertyTypeError
-}
+import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.MissingObjectError.{NoPropertyError, NoPropertyTypeError}
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.SpelExpressionTypingError
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.UnsupportedOperationError.MapWithExpressionKeysError
-import pl.touk.nussknacker.engine.spel.Typer.TypingResultWithContext
+import pl.touk.nussknacker.engine.spel.SpelTyper.TypingResultWithContext
 import pl.touk.nussknacker.engine.spel.TyperSpecTestData.TestRecord._
 import pl.touk.nussknacker.engine.spel.parser.NuSpelExpressionParser
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
@@ -26,10 +22,10 @@ import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage
 
 import scala.jdk.CollectionConverters._
 
-class TyperSpec extends AnyFunSuite with Matchers with ValidatedValuesDetailedMessage {
+class SpelTyperSpec extends AnyFunSuite with Matchers with ValidatedValuesDetailedMessage {
 
-  private implicit val defaultTyper: Typer   = buildTyper()
-  private val dynamicAccessTyper: Typer      = buildTyper(dynamicPropertyAccessAllowed = true)
+  private implicit val defaultTyper: SpelTyper   = buildTyper()
+  private val dynamicAccessTyper: SpelTyper      = buildTyper(dynamicPropertyAccessAllowed = true)
   private val parser: NuSpelExpressionParser = new NuSpelExpressionParser()
 
   test("not allow maps with keys other than strings") {
@@ -201,7 +197,7 @@ class TyperSpec extends AnyFunSuite with Matchers with ValidatedValuesDetailedMe
     }
   }
 
-  private def buildTyper(dynamicPropertyAccessAllowed: Boolean = false) = new Typer(
+  private def buildTyper(dynamicPropertyAccessAllowed: Boolean = false) = new SpelTyper(
     dictTyper = new KeysDictTyper(new SimpleDictRegistry(Map.empty)),
     strictMethodsChecking = false,
     staticMethodInvocationsChecking = false,
@@ -216,33 +212,33 @@ class TyperSpec extends AnyFunSuite with Matchers with ValidatedValuesDetailedMe
       expr: String,
       variables: (String, Any)*
   )(
-      implicit typer: Typer
+      implicit typer: SpelTyper
   ): ValidatedNel[SpelExpressionTypingError, CollectedTypingResult] = {
     val parsed        = parser.parseExpression(expr)
     val validationCtx = ValidationContext(variables.toMap.mapValuesNow(Typed.fromInstance))
-    typer.typeExpression(parsed, validationCtx, Standard).leftMap(_.map(_.error))
+    typer.typeExpression(parsed, validationCtx, SpelFlavour.Standard).leftMap(_.map(_.error))
   }
 
   private def typeExpressionForcedType(
       expr: String,
       variablesTypes: (String, TypingResult)*
   )(
-      implicit typer: Typer
+      implicit typer: SpelTyper
   ): ValidatedNel[SpelExpressionTypingError, CollectedTypingResult] = {
     val parsed        = parser.parseExpression(expr)
     val validationCtx = ValidationContext(variablesTypes.toMap)
-    typer.typeExpression(parsed, validationCtx, Standard).leftMap(_.map(_.error))
+    typer.typeExpression(parsed, validationCtx, SpelFlavour.Standard).leftMap(_.map(_.error))
   }
 
   private def typeTemplate(
       expr: String,
       variables: (String, Any)*
   )(
-      implicit typer: Typer
+      implicit typer: SpelTyper
   ): ValidatedNel[SpelExpressionTypingError, CollectedTypingResult] = {
     val parsed        = parser.parseExpression(expr, new TemplateParserContext())
     val validationCtx = ValidationContext(variables.toMap.mapValuesNow(Typed.fromInstance))
-    typer.typeExpression(parsed, validationCtx, Template).leftMap(_.map(_.error))
+    typer.typeExpression(parsed, validationCtx, SpelFlavour.Template).leftMap(_.map(_.error))
   }
 
 }

--- a/utils/default-helpers/src/test/scala/pl/touk/nussknacker/engine/util/functions/BaseSpelSpec.scala
+++ b/utils/default-helpers/src/test/scala/pl/touk/nussknacker/engine/util/functions/BaseSpelSpec.scala
@@ -9,6 +9,7 @@ import pl.touk.nussknacker.engine.definition.clazz.ClassDefinitionTestUtils
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.expression.parse.CompiledExpression
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser
+import pl.touk.nussknacker.engine.spel.SpelFlavour
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 
@@ -36,7 +37,7 @@ trait BaseSpelSpec {
     ModelDefinitionBuilder.emptyExpressionConfig,
     new SimpleDictRegistry(Map.empty),
     enableSpelForceCompile = false,
-    SpelExpressionParser.Standard,
+    SpelFlavour.Standard,
     classDefinitions,
   )
 

--- a/utils/default-helpers/src/test/scala/pl/touk/nussknacker/engine/util/functions/CollectionUtilsSpec.scala
+++ b/utils/default-helpers/src/test/scala/pl/touk/nussknacker/engine/util/functions/CollectionUtilsSpec.scala
@@ -11,7 +11,7 @@ import pl.touk.nussknacker.engine.api.{Context, NodeId}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypedClass, Unknown}
 import pl.touk.nussknacker.engine.spel.SpelExpressionEvaluationException
-import pl.touk.nussknacker.engine.spel.Typer.SpelCompilationException
+import pl.touk.nussknacker.engine.spel.SpelTyper.SpelCompilationException
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 
 import java.text.ParseException

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/typed/SpelExpressionSchemedSpec.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/typed/SpelExpressionSchemedSpec.scala
@@ -11,7 +11,7 @@ import pl.touk.nussknacker.engine.definition.clazz.ClassDefinitionTestUtils
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.json.{JsonSchemaBuilder, SwaggerBasedJsonSchemaTypeDefinitionExtractor}
 import pl.touk.nussknacker.engine.spel.SpelExpressionParser
-import pl.touk.nussknacker.engine.spel.SpelExpressionParser.Standard
+import pl.touk.nussknacker.engine.spel.SpelFlavour
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage
 
@@ -24,7 +24,7 @@ class SpelExpressionSchemedSpec extends AnyFunSuite with Matchers with Validated
     ModelDefinitionBuilder.emptyExpressionConfig,
     new SimpleDictRegistry(Map.empty),
     enableSpelForceCompile = false,
-    Standard,
+    SpelFlavour.Standard,
     ClassDefinitionTestUtils.createDefinitionForClasses(classOf[GenericRecord])
   )
 


### PR DESCRIPTION
## Describe your changes

* `SpelExpressionParser` extracted from `SpelExpression.scala`
* `Flavour` extracted from `SpelExpressionParser` + renamed to `SpelFlavour` 
* `Typer` renamed to `SpelTyper` 
* `SpelExpression` renamed to `CompiledSpelExpression`

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
