### PR TITLE
Allow to create custom HTTP services before Nu model is loaded

### DIFF
--- a/designer/custom-http-service-api/src/main/scala/pl/touk/nussknacker/ui/customhttpservice/CustomHttpServiceProviderFactory.scala
+++ b/designer/custom-http-service-api/src/main/scala/pl/touk/nussknacker/ui/customhttpservice/CustomHttpServiceProviderFactory.scala
@@ -2,15 +2,49 @@ package pl.touk.nussknacker.ui.customhttpservice
 
 import cats.effect.{IO, Resource}
 import com.typesafe.config.Config
-import pl.touk.nussknacker.ui.customhttpservice.services.NussknackerServicesForCustomHttpService
+import pl.touk.nussknacker.ui.customhttpservice.CustomHttpServiceProviderFactory.CustomHttpServiceProviderCreator
+import pl.touk.nussknacker.ui.customhttpservice.services.{NussknackerDomainServices, NussknackerInfrastructureServices}
 
 trait CustomHttpServiceProviderFactory {
 
   def name: String
 
-  def create(
-      config: Config,
-      services: NussknackerServicesForCustomHttpService,
-  ): Resource[IO, CustomHttpServiceProvider]
+  def creator: CustomHttpServiceProviderCreator
+
+}
+
+object CustomHttpServiceProviderFactory {
+  sealed trait CustomHttpServiceProviderCreator
+
+  object CustomHttpServiceProviderCreator {
+
+    trait WithoutDependencies extends CustomHttpServiceProviderCreator {
+
+      def create(
+          config: Config,
+      ): Resource[IO, CustomHttpServiceProvider]
+
+    }
+
+    trait WithInfrastructureDependencies extends CustomHttpServiceProviderCreator {
+
+      def create(
+          config: Config,
+          infrastructureServices: NussknackerInfrastructureServices,
+      ): Resource[IO, CustomHttpServiceProvider]
+
+    }
+
+    trait WithInfrastructureAndDomainDependencies extends CustomHttpServiceProviderCreator {
+
+      def create(
+          config: Config,
+          infrastructureServices: NussknackerInfrastructureServices,
+          domainServices: NussknackerDomainServices,
+      ): Resource[IO, CustomHttpServiceProvider]
+
+    }
+
+  }
 
 }

--- a/designer/custom-http-service-api/src/main/scala/pl/touk/nussknacker/ui/customhttpservice/services/NussknackerDomainServices.scala
+++ b/designer/custom-http-service-api/src/main/scala/pl/touk/nussknacker/ui/customhttpservice/services/NussknackerDomainServices.scala
@@ -1,0 +1,5 @@
+package pl.touk.nussknacker.ui.customhttpservice.services
+
+final class NussknackerDomainServices(
+    val scenarioService: ScenarioService,
+)

--- a/designer/custom-http-service-api/src/main/scala/pl/touk/nussknacker/ui/customhttpservice/services/NussknackerInfrastructureServices.scala
+++ b/designer/custom-http-service-api/src/main/scala/pl/touk/nussknacker/ui/customhttpservice/services/NussknackerInfrastructureServices.scala
@@ -2,7 +2,6 @@ package pl.touk.nussknacker.ui.customhttpservice.services
 
 import pl.touk.nussknacker.engine.api.db.DbRef
 
-final class NussknackerServicesForCustomHttpService(
-    val scenarioService: ScenarioService,
+final class NussknackerInfrastructureServices(
     val dbRef: DbRef
 )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/factory/NussknackerAppFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/factory/NussknackerAppFactory.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.ui.factory
 
 import cats.effect.{IO, Resource}
+import cats.implicits.catsSyntaxSemigroup
 import com.typesafe.scalalogging.LazyLogging
 import io.dropwizard.metrics5.MetricRegistry
 import io.dropwizard.metrics5.jmx.JmxReporter
@@ -8,7 +9,12 @@ import pl.touk.nussknacker.engine.util.{JavaClassVersionChecker, SLF4JBridgeHand
 import pl.touk.nussknacker.ui.config.{DesignerConfig, DesignerConfigLoader}
 import pl.touk.nussknacker.ui.metrics.RepositoryGauges
 import pl.touk.nussknacker.ui.process.repository._
-import pl.touk.nussknacker.ui.server.{NussknackerHttpServer, PekkoHttpBasedRouteFactory}
+import pl.touk.nussknacker.ui.server.{
+  CustomHttpServiceProvidersLoader,
+  NussknackerHttpServer,
+  PekkoHttpBasedRouteFactory
+}
+import pl.touk.nussknacker.ui.server.CustomHttpServiceProvidersLoader.CustomHttpServiceLoadingMode
 
 import java.time.Clock
 import scala.concurrent.Future
@@ -23,19 +29,41 @@ class NussknackerAppFactory(
       _ <- Resource.eval(IO(SLF4JBridgeHandlerRegistrar.register()))
 
       alreadyLoadedConfig <- Resource.eval(designerConfigLoader.loadDesignerConfig())
-
+      customHttpServicesProvidersWithoutDependencies <-
+        CustomHttpServiceProvidersLoader
+          .loadCustomHttpServiceProviders(
+            alreadyLoadedConfig,
+            CustomHttpServiceLoadingMode.LoadServicesWithoutDependencies,
+          )
       infrastructureServices <- InfrastructureServices.create(clock, alreadyLoadedConfig)
-      domainServices         <- DomainServices.create(designerConfigLoader, alreadyLoadedConfig, infrastructureServices)
+      customHttpServiceProvidersWithInfrastructureDependencies <-
+        CustomHttpServiceProvidersLoader
+          .loadCustomHttpServiceProviders(
+            alreadyLoadedConfig,
+            CustomHttpServiceLoadingMode.LoadServicesWithInfrastructureDependencies(infrastructureServices),
+          )
+      domainServices <- DomainServices.create(designerConfigLoader, alreadyLoadedConfig, infrastructureServices)
+      customHttpServiceProvidersWithInfrastructureAndDomainDependencies <-
+        CustomHttpServiceProvidersLoader
+          .loadCustomHttpServiceProviders(
+            alreadyLoadedConfig,
+            CustomHttpServiceLoadingMode.LoadServicesWithInfrastructureAndDomainDependencies(
+              infrastructureServices,
+              domainServices,
+            ),
+          )
       _ = initMetrics(
         infrastructureServices.metricsRegistry,
         alreadyLoadedConfig,
         domainServices.futureProcessRepository
       )
-
       route <- PekkoHttpBasedRouteFactory.createRoute(
         designerConfig = alreadyLoadedConfig,
         infrastructureServices = infrastructureServices,
-        domainServices = domainServices
+        domainServices = domainServices,
+        customHttpServiceProviders = customHttpServicesProvidersWithoutDependencies |+|
+          customHttpServiceProvidersWithInfrastructureDependencies |+|
+          customHttpServiceProvidersWithInfrastructureAndDomainDependencies
       )
       _ <- new NussknackerHttpServer(infrastructureServices, alreadyLoadedConfig).start(route)
       _ <- startJmxReporter(infrastructureServices.metricsRegistry)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/CustomHttpServiceProvidersLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/CustomHttpServiceProvidersLoader.scala
@@ -60,53 +60,10 @@ object CustomHttpServiceProvidersLoader extends LazyLogging {
   ): Resource[IO, CustomHttpServiceProviders] = {
     customHttpServiceProviderFactories
       .traverse { factory =>
-        val created: Option[Resource[IO, CustomHttpServiceProvider]] = loadingMode match {
-          case LoadServicesWithoutDependencies =>
-            factory.creator match {
-              case c: WithoutDependencies =>
-                logger.info(s"Creating custom HTTP service ${factory.name} (without Nu dependencies)")
-                Some(c.create(designerConfig.rawConfig))
-              case _ =>
-                None
-            }
-          case mode: LoadServicesWithInfrastructureDependencies =>
-            factory.creator match {
-              case c: WithInfrastructureDependencies =>
-                logger.info(s"Creating custom HTTP service ${factory.name} (with Nu infrastructure dependencies)")
-                Some(
-                  c.create(
-                    config = designerConfig.rawConfig,
-                    infrastructureServices = nuInfrastructureServices(mode.infrastructureServices)
-                  )
-                )
-              case _ =>
-                None
-            }
-          case mode: LoadServicesWithInfrastructureAndDomainDependencies =>
-            factory.creator match {
-              case c: WithInfrastructureAndDomainDependencies =>
-                logger.info(
-                  s"Creating custom HTTP service ${factory.name} (with Nu infrastructure and domain dependencies)"
-                )
-                Some(
-                  c.create(
-                    config = designerConfig.rawConfig,
-                    infrastructureServices = nuInfrastructureServices(mode.infrastructureServices),
-                    domainServices = nuDomainServices(mode.domainServices)(
-                      mode.infrastructureServices.executionContextWithIORuntime
-                    )
-                  )
-                )
-              case _ =>
-                None
-            }
+        createCustomHttpServiceProvider(designerConfig, factory, loadingMode) match {
+          case Some(provider) => provider.map(Some(factory.name, _))
+          case None           => Resource.pure[IO, Option[(String, CustomHttpServiceProvider)]](None)
         }
-        val result: Resource[IO, Option[(String, CustomHttpServiceProvider)]] =
-          created.map(p => factory.name -> p) match {
-            case Some((name, resource)) => resource.map(Some(name, _))
-            case None                   => Resource.pure(None)
-          }
-        result
       }
       .map(_.flatten.toMap)
       .map { namedProviders =>
@@ -116,6 +73,52 @@ object CustomHttpServiceProvidersLoader extends LazyLogging {
           case (acc, (name, provider: TapirCustomHttpServiceProvider)) =>
             acc.copy(tapir = acc.tapir + (name -> provider))
         }
+      }
+  }
+
+  private def createCustomHttpServiceProvider(
+      designerConfig: DesignerConfig,
+      factory: CustomHttpServiceProviderFactory,
+      loadingMode: CustomHttpServiceLoadingMode,
+  ): Option[Resource[IO, CustomHttpServiceProvider]] = loadingMode match {
+    case LoadServicesWithoutDependencies =>
+      factory.creator match {
+        case c: WithoutDependencies =>
+          logger.info(s"Creating custom HTTP service ${factory.name} (without Nu dependencies)")
+          Some(c.create(designerConfig.rawConfig))
+        case _ =>
+          None
+      }
+    case mode: LoadServicesWithInfrastructureDependencies =>
+      factory.creator match {
+        case c: WithInfrastructureDependencies =>
+          logger.info(s"Creating custom HTTP service ${factory.name} (with Nu infrastructure dependencies)")
+          Some(
+            c.create(
+              config = designerConfig.rawConfig,
+              infrastructureServices = nuInfrastructureServices(mode.infrastructureServices)
+            )
+          )
+        case _ =>
+          None
+      }
+    case mode: LoadServicesWithInfrastructureAndDomainDependencies =>
+      factory.creator match {
+        case c: WithInfrastructureAndDomainDependencies =>
+          logger.info(
+            s"Creating custom HTTP service ${factory.name} (with Nu infrastructure and domain dependencies)"
+          )
+          Some(
+            c.create(
+              config = designerConfig.rawConfig,
+              infrastructureServices = nuInfrastructureServices(mode.infrastructureServices),
+              domainServices = nuDomainServices(mode.domainServices)(
+                mode.infrastructureServices.executionContextWithIORuntime
+              )
+            )
+          )
+        case _ =>
+          None
       }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/CustomHttpServiceProvidersLoader.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/CustomHttpServiceProvidersLoader.scala
@@ -1,38 +1,37 @@
 package pl.touk.nussknacker.ui.server
 
+import cats.Monoid
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import cats.implicits.toTraverseOps
+import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.util.loader.ScalaServiceLoader
 import pl.touk.nussknacker.engine.util.multiplicity.{Empty, Many, Multiplicity, One}
 import pl.touk.nussknacker.ui.config.DesignerConfig
-import pl.touk.nussknacker.ui.customhttpservice.{
-  CustomHttpServiceProviderFactory,
-  PekkoCustomHttpServiceProvider,
-  ProcessServiceBasedScenarioServiceAdapter,
-  TapirCustomHttpServiceProvider
-}
-import pl.touk.nussknacker.ui.customhttpservice.services.NussknackerServicesForCustomHttpService
+import pl.touk.nussknacker.ui.customhttpservice._
+import pl.touk.nussknacker.ui.customhttpservice.CustomHttpServiceProviderFactory.CustomHttpServiceProviderCreator._
+import pl.touk.nussknacker.ui.customhttpservice.services.{NussknackerDomainServices, NussknackerInfrastructureServices}
 import pl.touk.nussknacker.ui.factory.{DomainServices, InfrastructureServices}
+import pl.touk.nussknacker.ui.server.CustomHttpServiceProvidersLoader.CustomHttpServiceLoadingMode.{
+  LoadServicesWithInfrastructureAndDomainDependencies,
+  LoadServicesWithInfrastructureDependencies,
+  LoadServicesWithoutDependencies
+}
 
 import scala.concurrent.ExecutionContext
 
-object CustomHttpServiceProvidersLoader {
+object CustomHttpServiceProvidersLoader extends LazyLogging {
 
   def loadCustomHttpServiceProviders(
       designerConfig: DesignerConfig,
-      domainServices: DomainServices,
-      infrastructureServices: InfrastructureServices
-  )(
-      implicit executionContext: ExecutionContext
+      loadingMode: CustomHttpServiceLoadingMode,
   ): Resource[IO, CustomHttpServiceProviders] = for {
     providerFactories <- Resource.eval(loadHttpServiceProviderFactories)
     customHttpServiceProviders <- createHttpServiceProviders(
       providerFactories,
       designerConfig,
-      domainServices,
-      infrastructureServices
-    )(executionContext)
+      loadingMode,
+    )
   } yield customHttpServiceProviders
 
   private def loadHttpServiceProviderFactories: IO[List[CustomHttpServiceProviderFactory]] = {
@@ -57,15 +56,59 @@ object CustomHttpServiceProvidersLoader {
   private def createHttpServiceProviders(
       customHttpServiceProviderFactories: List[CustomHttpServiceProviderFactory],
       designerConfig: DesignerConfig,
-      domainServices: DomainServices,
-      infrastructureServices: InfrastructureServices
-  )(implicit executionContext: ExecutionContext): Resource[IO, CustomHttpServiceProviders] = {
-    lazy val nussknackerServices = new NussknackerServicesForCustomHttpService(
-      new ProcessServiceBasedScenarioServiceAdapter(domainServices.processService),
-      infrastructureServices.dbRef
-    )
+      loadingMode: CustomHttpServiceLoadingMode,
+  ): Resource[IO, CustomHttpServiceProviders] = {
     customHttpServiceProviderFactories
-      .traverse { factory => factory.create(designerConfig.rawConfig, nussknackerServices).map(factory.name -> _) }
+      .traverse { factory =>
+        val created: Option[Resource[IO, CustomHttpServiceProvider]] = loadingMode match {
+          case LoadServicesWithoutDependencies =>
+            factory.creator match {
+              case c: WithoutDependencies =>
+                logger.info(s"Creating custom HTTP service ${factory.name} (without Nu dependencies)")
+                Some(c.create(designerConfig.rawConfig))
+              case _ =>
+                None
+            }
+          case mode: LoadServicesWithInfrastructureDependencies =>
+            factory.creator match {
+              case c: WithInfrastructureDependencies =>
+                logger.info(s"Creating custom HTTP service ${factory.name} (with Nu infrastructure dependencies)")
+                Some(
+                  c.create(
+                    config = designerConfig.rawConfig,
+                    infrastructureServices = nuInfrastructureServices(mode.infrastructureServices)
+                  )
+                )
+              case _ =>
+                None
+            }
+          case mode: LoadServicesWithInfrastructureAndDomainDependencies =>
+            factory.creator match {
+              case c: WithInfrastructureAndDomainDependencies =>
+                logger.info(
+                  s"Creating custom HTTP service ${factory.name} (with Nu infrastructure and domain dependencies)"
+                )
+                Some(
+                  c.create(
+                    config = designerConfig.rawConfig,
+                    infrastructureServices = nuInfrastructureServices(mode.infrastructureServices),
+                    domainServices = nuDomainServices(mode.domainServices)(
+                      mode.infrastructureServices.executionContextWithIORuntime
+                    )
+                  )
+                )
+              case _ =>
+                None
+            }
+        }
+        val result: Resource[IO, Option[(String, CustomHttpServiceProvider)]] =
+          created.map(p => factory.name -> p) match {
+            case Some((name, resource)) => resource.map(Some(name, _))
+            case None                   => Resource.pure(None)
+          }
+        result
+      }
+      .map(_.flatten.toMap)
       .map { namedProviders =>
         namedProviders.foldLeft(CustomHttpServiceProviders(Map.empty, Map.empty)) {
           case (acc, (name, provider: PekkoCustomHttpServiceProvider)) =>
@@ -76,9 +119,50 @@ object CustomHttpServiceProvidersLoader {
       }
   }
 
+  private def nuInfrastructureServices(infrastructureServices: InfrastructureServices) = {
+    new NussknackerInfrastructureServices(infrastructureServices.dbRef)
+  }
+
+  private def nuDomainServices(domainServices: DomainServices)(implicit executionContext: ExecutionContext) = {
+    new NussknackerDomainServices(new ProcessServiceBasedScenarioServiceAdapter(domainServices.processService))
+  }
+
   final case class CustomHttpServiceProviders(
       pekko: Map[String, PekkoCustomHttpServiceProvider],
       tapir: Map[String, TapirCustomHttpServiceProvider]
   )
+
+  sealed trait CustomHttpServiceLoadingMode
+
+  object CustomHttpServiceLoadingMode {
+
+    case object LoadServicesWithoutDependencies extends CustomHttpServiceLoadingMode
+
+    final case class LoadServicesWithInfrastructureDependencies(
+        infrastructureServices: InfrastructureServices,
+    ) extends CustomHttpServiceLoadingMode
+
+    final case class LoadServicesWithInfrastructureAndDomainDependencies(
+        infrastructureServices: InfrastructureServices,
+        domainServices: DomainServices,
+    ) extends CustomHttpServiceLoadingMode
+
+  }
+
+  object CustomHttpServiceProviders {
+
+    implicit val monoid: Monoid[CustomHttpServiceProviders] =
+      new Monoid[CustomHttpServiceProviders] {
+        override def empty: CustomHttpServiceProviders =
+          CustomHttpServiceProviders(Map.empty, Map.empty)
+
+        override def combine(x: CustomHttpServiceProviders, y: CustomHttpServiceProviders): CustomHttpServiceProviders =
+          CustomHttpServiceProviders(
+            x.pekko ++ y.pekko,
+            x.tapir ++ y.tapir
+          )
+      }
+
+  }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/PekkoHttpBasedRouteFactory.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/server/PekkoHttpBasedRouteFactory.scala
@@ -8,6 +8,7 @@ import pl.touk.nussknacker.ui.api._
 import pl.touk.nussknacker.ui.config.DesignerConfig
 import pl.touk.nussknacker.ui.factory.{DomainServices, InfrastructureServices}
 import pl.touk.nussknacker.ui.security.api.{AuthenticationResources, AuthManager}
+import pl.touk.nussknacker.ui.server.CustomHttpServiceProvidersLoader.CustomHttpServiceProviders
 import pl.touk.nussknacker.ui.server.PekkoRoutesFactory.PekkoRoutes
 import pl.touk.nussknacker.ui.util._
 
@@ -16,7 +17,8 @@ object PekkoHttpBasedRouteFactory {
   def createRoute(
       designerConfig: DesignerConfig,
       infrastructureServices: InfrastructureServices,
-      domainServices: DomainServices
+      domainServices: DomainServices,
+      customHttpServiceProviders: CustomHttpServiceProviders
   ): Resource[IO, Route] = {
     import infrastructureServices._
     val authenticationResources =
@@ -27,37 +29,32 @@ object PekkoHttpBasedRouteFactory {
       )(executionContextWithIORuntime)
     val authManager = new AuthManager(authenticationResources)(executionContextWithIORuntime)
 
-    for {
-      customHttpServiceProviders <- CustomHttpServiceProvidersLoader.loadCustomHttpServiceProviders(
-        designerConfig,
-        domainServices,
-        infrastructureServices
-      )
-      pekkoRoutes = PekkoRoutesFactory.createRoutes(
-        designerConfig,
-        infrastructureServices,
-        domainServices,
-        authenticationResources,
-        customHttpServiceProviders.pekko
-      )
-      nuDesignerApi = TapirHttpServiceFactory.createHttpService(
-        designerConfig,
-        infrastructureServices,
-        domainServices,
-        authManager,
-        customHttpServiceProviders.tapir
-      )
+    val pekkoRoutes = PekkoRoutesFactory.createRoutes(
+      designerConfig,
+      infrastructureServices,
+      domainServices,
+      authenticationResources,
+      customHttpServiceProviders.pekko
+    )
+    val nuDesignerApi = TapirHttpServiceFactory.createHttpService(
+      designerConfig,
+      infrastructureServices,
+      domainServices,
+      authManager,
+      customHttpServiceProviders.tapir
+    )
 
-      pekkoHttpServerInterpreter = new NuPekkoHttpServerInterpreterForTapirPurposes()
+    val pekkoHttpServerInterpreter = new NuPekkoHttpServerInterpreterForTapirPurposes()
 
-      appRoute = createAppRoute(
+    Resource.pure(
+      createAppRoute(
         designerConfig = designerConfig,
         authManager = authManager,
         tapirRelatedRoutes = pekkoHttpServerInterpreter.toRoute(nuDesignerApi.allEndpoints) :: Nil,
         pekkoRoutes = pekkoRoutes,
         developmentMode = designerConfig.development
       )
-    } yield appRoute
+    )
   }
 
   private def createAppRoute(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/TestCustomHttpServiceProviderFactory.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/TestCustomHttpServiceProviderFactory.scala
@@ -11,8 +11,9 @@ import pl.touk.nussknacker.ui.customhttpservice.{
   PekkoCustomHttpServiceProvider,
   TapirCustomHttpServiceProvider
 }
+import pl.touk.nussknacker.ui.customhttpservice.CustomHttpServiceProviderFactory.CustomHttpServiceProviderCreator
 import pl.touk.nussknacker.ui.customhttpservice.TapirCustomHttpServiceProvider.CustomHttpServiceServerEndpointDefinition
-import pl.touk.nussknacker.ui.customhttpservice.services.NussknackerServicesForCustomHttpService
+import pl.touk.nussknacker.ui.customhttpservice.services.{NussknackerDomainServices, NussknackerInfrastructureServices}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 import sttp.model.StatusCode.UnprocessableEntity
 import sttp.tapir.derevo.schema
@@ -22,11 +23,11 @@ class TestCustomHttpServiceProviderFactory extends CustomHttpServiceProviderFact
 
   override def name: String = "testProvider"
 
-  override def create(
-      config: Config,
-      services: NussknackerServicesForCustomHttpService
-  ): Resource[IO, CustomHttpServiceProvider] =
-    Resource.pure(TestCustomHttpServiceProvider)
+  override def creator: CustomHttpServiceProviderCreator =
+    new CustomHttpServiceProviderCreator.WithoutDependencies {
+      override def create(config: Config): Resource[IO, CustomHttpServiceProvider] =
+        Resource.pure(TestCustomHttpServiceProvider)
+    }
 
 }
 
@@ -43,11 +44,14 @@ class SecondTestCustomHttpServiceProviderFactory extends CustomHttpServiceProvid
 
   override def name: String = "secondTestProvider"
 
-  override def create(
-      config: Config,
-      services: NussknackerServicesForCustomHttpService
-  ): Resource[IO, CustomHttpServiceProvider] =
-    Resource.pure(TestCustomHttpServiceProvider)
+  override def creator: CustomHttpServiceProviderCreator =
+    new CustomHttpServiceProviderCreator.WithInfrastructureDependencies {
+      override def create(
+          config: Config,
+          nussknackerInfrastructureServices: NussknackerInfrastructureServices,
+      ): Resource[IO, CustomHttpServiceProvider] =
+        Resource.pure(TestCustomHttpServiceProvider)
+    }
 
 }
 
@@ -135,10 +139,14 @@ class TapirTestCustomHttpServiceProviderFactory extends CustomHttpServiceProvide
 
   override def name: String = "tapirTestProvider"
 
-  override def create(
-      config: Config,
-      services: NussknackerServicesForCustomHttpService
-  ): Resource[IO, CustomHttpServiceProvider] =
-    Resource.pure(new TestTapirCustomHttpServiceProvider)
+  override def creator: CustomHttpServiceProviderCreator =
+    new CustomHttpServiceProviderCreator.WithInfrastructureAndDomainDependencies {
+      override def create(
+          config: Config,
+          infrastructureServices: NussknackerInfrastructureServices,
+          domainServices: NussknackerDomainServices,
+      ): Resource[IO, CustomHttpServiceProvider] =
+        Resource.pure(new TestTapirCustomHttpServiceProvider)
+    }
 
 }


### PR DESCRIPTION
## Describe your changes

- Before this change, CustomHttpServices were loaded after all Nu services and model
- now, the CustomHttpService SPI declares what it needs from Nu (nothing/infrastructure deps (like dbRef)/domain deps (like scenario service)
- SPI's that don't need domain dependencies from Nu may be loaded earlier

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
