### PR TITLE
Skip aligning the fragment input component to the fragment definition when the fragment is not found

### DIFF
--- a/designer/client/src/components/graph/utils/fragmentSchemaAligner.ts
+++ b/designer/client/src/components/graph/utils/fragmentSchemaAligner.ts
@@ -15,9 +15,15 @@ export function alignFragmentWithSchema(processDefinitionData: ProcessDefinition
         // In this case, there was an error, which is why we need to iterate through all groups.
         .flatMap((componentGroups) => componentGroups.components)
         .find((obj) => obj?.node?.ref?.id === fragmentId);
-    const fragmentSchemaParameters = fragmentSchema.node.ref.parameters;
-    const mergedParameters = fragmentSchemaParameters.map(
-        (param) => fragmentNode.ref.parameters.find((nodeParam) => nodeParam.name === param.name) || param,
-    );
-    return fp.set("ref.parameters", mergedParameters, fragmentNode);
+
+    if (fragmentSchema) {
+        const fragmentSchemaParameters = fragmentSchema.node.ref.parameters;
+        const mergedParameters = fragmentSchemaParameters.map(
+            (param) => fragmentNode.ref.parameters.find((nodeParam) => nodeParam.name === param.name) || param,
+        );
+        return fp.set("ref.parameters", mergedParameters, fragmentNode);
+    } else {
+        // There are some cases when the fragment does not exist (is archived, or a scenario using that fragment was imported)
+        return fragmentNode;
+    }
 }


### PR DESCRIPTION
## Describe your changes
The Apply button in the scenario properties form was getting stuck when the scenario contained a non-existent fragment

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
