### PR TITLE
Use consistent SpelExpressionParser defaults

### DIFF
--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ExpressionSuggesterSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ExpressionSuggesterSpec.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.ui.api
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
+import org.springframework.expression.spel.SpelParserConfiguration
 import pl.touk.nussknacker.engine.api.{Documentation, VariableConstants}
 import pl.touk.nussknacker.engine.api.dict.{DictInstance, UiDictServices}
 import pl.touk.nussknacker.engine.api.dict.embedded.EmbeddedDictDefinition
@@ -908,6 +909,11 @@ class ExpressionSuggesterSpec
       getSuggestion.refClazz shouldBe expectedTypingResult
     }
 
+  }
+
+  test("should work with long expressions") {
+    val longString = "'" + " ".padTo(SpelParserConfiguration.DEFAULT_MAX_EXPRESSION_LENGTH, ' ') + "abcd'."
+    spelSuggestionsFor(longString, column = longString.length) should not be empty
   }
 
   private def suggestions(

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -254,7 +254,7 @@ description: Stay informed with detailed changelogs covering new features, impro
      }
   ```
   * This setting is optional. If not specified, the default editors remain `SpelTemplateParameterEditor` and `SpelParameterEditor` (no change in behavior).
-* [#8366](https://github.com/TouK/nussknacker/pull/8366) Spring and SpEL upgraded 5.2.23.RELEASE -> 6.2.9.
+* [#8366](https://github.com/TouK/nussknacker/pull/8366)[#8561](https://github.com/TouK/nussknacker/pull/8561) Spring and SpEL upgraded 5.2.23.RELEASE -> 6.2.9.
   * [Safe navigation operator ?.](https://docs.spring.io/spring-framework/reference/core/expressions/language-ref/operator-safe-navigation.html)
     is supported for collections, maps and strings.
 * [#8375](https://github.com/TouK/nussknacker/pull/8375) Explicit definition of expression language for default parameter values in component configuration

--- a/scenario-compiler/src/main/java/pl/touk/nussknacker/engine/spel/parser/NuSpelExpressionParser.java
+++ b/scenario-compiler/src/main/java/pl/touk/nussknacker/engine/spel/parser/NuSpelExpressionParser.java
@@ -22,6 +22,7 @@ import org.springframework.expression.ParserContext;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.SpelParseException;
 import org.springframework.expression.spel.SpelParserConfiguration;
+import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.lang.Nullable;
 import pl.touk.nussknacker.engine.expression.IndexBasedTextRange;
@@ -48,11 +49,15 @@ public class NuSpelExpressionParser {
     private final SpelExpressionParser underlyingParser;
 
     public NuSpelExpressionParser() {
-        this.underlyingParser = new SpelExpressionParser(new SpelParserConfiguration());
+        this.underlyingParser = new SpelExpressionParser(new NuSpelParserConfiguration());
     }
 
     public NuSpelExpressionParser(SpelParserConfiguration configuration) {
         this.underlyingParser = new SpelExpressionParser(configuration);
+    }
+
+    public SpelExpression parseRaw(String expressionString) throws ParseException {
+        return doParseExpression(expressionString, null);
     }
 
     public ExpressionWithTextRange parseExpression(String expressionString) throws ParseException {
@@ -239,7 +244,7 @@ public class NuSpelExpressionParser {
     }
 
     // It returns AST nodes with position local to spel expression
-    private Expression doParseExpression(String expressionString, IndexBasedTextRange expressionTextRange) throws ParseException {
+    private SpelExpression doParseExpression(String expressionString, IndexBasedTextRange expressionTextRange) throws ParseException {
         try {
             return underlyingParser.parseRaw(expressionString);
         } catch (ParseException exception) {

--- a/scenario-compiler/src/main/java/pl/touk/nussknacker/engine/spel/parser/NuSpelParserConfiguration.java
+++ b/scenario-compiler/src/main/java/pl/touk/nussknacker/engine/spel/parser/NuSpelParserConfiguration.java
@@ -1,0 +1,31 @@
+package pl.touk.nussknacker.engine.spel.parser;
+
+import org.springframework.expression.spel.SpelCompilerMode;
+import org.springframework.expression.spel.SpelParserConfiguration;
+
+import javax.annotation.Nullable;
+
+/**
+ * {@link SpelParserConfiguration} with relaxed maximumExpressionLength limit
+ */
+public class NuSpelParserConfiguration extends SpelParserConfiguration {
+    public NuSpelParserConfiguration() {
+        this(null, null);
+    }
+
+    public NuSpelParserConfiguration(@Nullable SpelCompilerMode compilerMode) {
+        this(compilerMode, null);
+    }
+
+    public NuSpelParserConfiguration(@Nullable SpelCompilerMode compilerMode, @Nullable ClassLoader compilerClassLoader) {
+        // maximumExpressionLength in default configuration is limited to 10_000 (DEFAULT_MAX_EXPRESSION_LENGTH)
+        super(
+                compilerMode,
+                compilerClassLoader,
+                /* autoGrowNullReferences */ false,
+                /* autoGrowCollections */ false,
+                /* maximumAutoGrowSize */ Integer.MAX_VALUE,
+                /* maximumExpressionLength */ Integer.MAX_VALUE
+        );
+    }
+}

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionParser.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionParser.scala
@@ -4,7 +4,7 @@ import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.data.Validated.Valid
 import com.typesafe.scalalogging.LazyLogging
 import org.springframework.expression.ParseException
-import org.springframework.expression.spel.{SpelCompilerMode, SpelMessage, SpelParseException, SpelParserConfiguration}
+import org.springframework.expression.spel.{SpelCompilerMode, SpelMessage, SpelParseException}
 import pl.touk.nussknacker.engine.api.TemplateEvaluationResult
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.dict.DictRegistry
@@ -21,7 +21,8 @@ import pl.touk.nussknacker.engine.spel.internal.EvaluationContextPreparer
 import pl.touk.nussknacker.engine.spel.parser.{
   ExceptionWithExpressionTextRange,
   ExpressionWithTextRange,
-  NuSpelExpressionParser
+  NuSpelExpressionParser,
+  NuSpelParserConfiguration
 }
 
 class SpelExpressionParser(
@@ -176,7 +177,7 @@ object SpelExpressionParser extends LazyLogging {
 
     // we have to pass classloader, because default contextClassLoader can be sth different than we expect...
     val immediateCompileParser = new NuSpelExpressionParser(
-      createSpelParserConfiguration(classLoader)
+      new NuSpelParserConfiguration(SpelCompilerMode.IMMEDIATE, classLoader)
     )
     val evaluationContextPreparer = EvaluationContextPreparer.default(classLoader, expressionConfig, classDefinitionSet)
     val typer = SpelTyper.default(
@@ -193,22 +194,6 @@ object SpelExpressionParser extends LazyLogging {
       enableSpelForceCompile,
       flavour,
       evaluationContextPreparer
-    )
-  }
-
-  private def createSpelParserConfiguration(classLoader: ClassLoader) = {
-    val autoGrowNullReferences = false
-    val autoGrowCollections    = false
-    val maximumAutoGrowSize    = Integer.MAX_VALUE
-    val maximumExpressionLength =
-      Integer.MAX_VALUE // By default, it is limited to 10_000 (DEFAULT_MAX_EXPRESSION_LENGTH)
-    new SpelParserConfiguration(
-      SpelCompilerMode.IMMEDIATE,
-      classLoader,
-      autoGrowNullReferences,
-      autoGrowCollections,
-      maximumAutoGrowSize,
-      maximumExpressionLength
     )
   }
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSuggester.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.spel
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.JsonCodec
-import org.springframework.expression.spel.{SpelNode, SpelParserConfiguration}
+import org.springframework.expression.spel.SpelNode
 import org.springframework.expression.spel.ast._
 import org.springframework.expression.spel.standard.{SpelExpression => SpringSpelExpression}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
@@ -444,7 +444,7 @@ class SpelExpressionSuggester(
 }
 
 private class NuSpelNodeParser(typer: SpelTyper) extends LazyLogging {
-  private val parser = new NuSpelExpressionParser(new SpelParserConfiguration)
+  private val parser = new NuSpelExpressionParser()
 
   def parse(
       input: String,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/ast/SpelSubstitutionsCollector.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/ast/SpelSubstitutionsCollector.scala
@@ -6,13 +6,14 @@ import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.expression.{ExpressionSubstitution, ExpressionSubstitutionsCollector}
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.spel.ast
+import pl.touk.nussknacker.engine.spel.parser.NuSpelExpressionParser
 
 class SpelSubstitutionsCollector(typeForNode: SpelNode => Option[TypingResult], replacingStrategy: ReplacingStrategy)
     extends ExpressionSubstitutionsCollector {
 
   import ast.SpelAst._
 
-  private lazy val parser = new org.springframework.expression.spel.standard.SpelExpressionParser
+  private lazy val parser = new NuSpelExpressionParser()
 
   override def collectSubstitutions(expression: Expression): List[ExpressionSubstitution] = {
     // TODO: handle other languages, especially spel template

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/expression/ExpressionSubstitutorSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/expression/ExpressionSubstitutorSpec.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.expression
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.springframework.expression.spel.SpelParserConfiguration
 import org.springframework.expression.spel.ast._
 import pl.touk.nussknacker.engine.spel.ast.{
   OptionallyTypedNode,
@@ -48,6 +49,14 @@ class ExpressionSubstitutorSpec extends AnyFunSuite with Matchers {
     val result = replace(expression, replacementPF)
 
     result shouldEqual "#foo.barbar != #foo.bazbaz"
+  }
+
+  test("very long expressions") {
+    val expression = s"#foo == '${"x".padTo(SpelParserConfiguration.DEFAULT_MAX_EXPRESSION_LENGTH, "x")}'"
+
+    val result = replace(expression, PartialFunction.empty)
+
+    result shouldEqual expression
   }
 
   private def replace(expression: String, replacementPF: PartialFunction[List[TypedTreeLevel], String]) = {

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -14,6 +14,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.springframework.expression.spel.SpelParserConfiguration
 import org.springframework.util.{NumberUtils, StringUtils}
 import pl.touk.nussknacker.engine.api.{
   Context,
@@ -141,7 +142,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     .withVariable("processHelper", SampleGlobalObject)
     .withVariable("javaClassWithVarargs", new JavaClassWithVarargs)
 
-  val maxSpelExpressionLimit = 10000
+  val maxSpelExpressionLimit = SpelParserConfiguration.DEFAULT_MAX_EXPRESSION_LENGTH
 
   private def bigExpression(stringVar: String, length: Int): String = {
     val builder = new StringBuilder()

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelTyperSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelTyperSpec.scala
@@ -1,17 +1,21 @@
 package pl.touk.nussknacker.engine.spel
 
-import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.springframework.expression.common.TemplateParserContext
+import org.springframework.expression.spel.SpelParserConfiguration
 import pl.touk.nussknacker.engine.api.context.ValidationContext
-import pl.touk.nussknacker.engine.api.typed.typing.Typed.typedListWithElementValues
 import pl.touk.nussknacker.engine.api.typed.typing._
+import pl.touk.nussknacker.engine.api.typed.typing.Typed.typedListWithElementValues
 import pl.touk.nussknacker.engine.definition.clazz.ClassDefinitionTestUtils
 import pl.touk.nussknacker.engine.dict.{KeysDictTyper, SimpleDictRegistry}
 import pl.touk.nussknacker.engine.expression.IndexBasedTextRange
-import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.MissingObjectError.{NoPropertyError, NoPropertyTypeError}
+import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.MissingObjectError.{
+  NoPropertyError,
+  NoPropertyTypeError
+}
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.SpelExpressionTypingError
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.UnsupportedOperationError.MapWithExpressionKeysError
 import pl.touk.nussknacker.engine.spel.SpelTyper.TypingResultWithContext
@@ -24,9 +28,9 @@ import scala.jdk.CollectionConverters._
 
 class SpelTyperSpec extends AnyFunSuite with Matchers with ValidatedValuesDetailedMessage {
 
-  private implicit val defaultTyper: SpelTyper   = buildTyper()
-  private val dynamicAccessTyper: SpelTyper      = buildTyper(dynamicPropertyAccessAllowed = true)
-  private val parser: NuSpelExpressionParser = new NuSpelExpressionParser()
+  private implicit val defaultTyper: SpelTyper = buildTyper()
+  private val dynamicAccessTyper: SpelTyper    = buildTyper(dynamicPropertyAccessAllowed = true)
+  private val parser: NuSpelExpressionParser   = new NuSpelExpressionParser()
 
   test("not allow maps with keys other than strings") {
     typeExpression("{1L: 'foo'}") shouldBe Invalid(
@@ -195,6 +199,12 @@ class SpelTyperSpec extends AnyFunSuite with Matchers with ValidatedValuesDetail
     typeExpression("{a: 5, b: 10}[4]").invalidValue.toList should matchPattern {
       case NoPropertyTypeError(_, _) :: Nil =>
     }
+  }
+
+  test("works with very long expressions") {
+    val longString = " ".padTo(SpelParserConfiguration.DEFAULT_MAX_EXPRESSION_LENGTH, ' ') + "abcd"
+    typeExpression(s"'$longString'").validValue.finalResult.typingResult shouldBe
+      TypedObjectWithValue(Typed.typedClass[String], longString)
   }
 
   private def buildTyper(dynamicPropertyAccessAllowed: Boolean = false) = new SpelTyper(


### PR DESCRIPTION
## Describe your changes

Use consistent defaults in all parser instances, i.e. a consistent `maximumExpressionLength` value. Previous change in #8366 handled only the parser used in typer, but missed suggester and substitutions collector.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
