### PR TITLE
Adapt dictionary values when migrating scenario

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -4,7 +4,7 @@ import cats.Applicative
 import cats.data.{NonEmptyList, ValidatedNel}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.InASingleNode
-import pl.touk.nussknacker.engine.api.definition.ParameterEditor
+import pl.touk.nussknacker.engine.api.definition.{FixedExpressionValue, ParameterEditor}
 import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.ErrorDetails
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.ProcessName
@@ -274,14 +274,14 @@ object ProcessCompilationError {
       paramName: ParameterName,
       label: Option[String],
       value: String,
-      values: List[String],
+      values: List[FixedExpressionValue],
       nodeId: String
   ) extends PartSubGraphCompilationError
       with InASingleNode
 
   object InvalidPropertyFixedValue {
 
-    def apply(paramName: ParameterName, label: Option[String], value: String, values: List[String])(
+    def apply(paramName: ParameterName, label: Option[String], value: String, values: List[FixedExpressionValue])(
         implicit nodeId: NodeId
     ): PartSubGraphCompilationError =
       InvalidPropertyFixedValue(paramName, label, value, values, nodeId.id)

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
@@ -137,7 +137,7 @@ case class FixedValuesValidator(possibleValues: List[FixedExpressionValue]) exte
     expression.expression match {
       case e if e.isBlank          => valid(())
       case e if values.contains(e) => valid(())
-      case e => invalid(InvalidPropertyFixedValue(paramName, label, e, possibleValues.map(_.expression)))
+      case e                       => invalid(InvalidPropertyFixedValue(paramName, label, e, possibleValues))
     }
   }
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/generics/ExpressionParseError.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/generics/ExpressionParseError.scala
@@ -3,8 +3,11 @@ package pl.touk.nussknacker.engine.api.generics
 import io.circe.{Codec, Decoder, Encoder}
 import io.circe.generic.JsonCodec
 import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec}
+import pl.touk.nussknacker.engine.api.definition.ParameterEditor
 import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.ErrorDetails
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language
 
 import scala.util.Try
 
@@ -40,6 +43,12 @@ object ExpressionParseError {
     )
     Codec.forProduct2("name", "aType")(ColumnDefinition.apply)(cd => (cd.name, cd.aType))
   }
+
+  final case class IncompatibleParameterDefinitionErrorDetails(
+      paramName: ParameterName,
+      parameterEditors: List[ParameterEditor],
+      nodeId: String,
+  ) extends ErrorDetails
 
 }
 

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -350,7 +350,7 @@ object PrettyValidationErrors {
     NodeValidationError(
       typ = typ,
       message = s"Property $propertyName$labelText has invalid value",
-      description = s"Expected one of ${values.mkString(", ")}, got: $value.",
+      description = s"Expected one of ${values.map(_.expression).mkString(", ")}, got: $value.",
       fieldName = Some(propertyName),
       errorType = NodeValidationErrorType.SaveAllowed,
       details = Some(

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -3,28 +3,7 @@ package pl.touk.nussknacker.restmodel.validation
 import org.apache.commons.lang3.StringUtils
 import pl.touk.nussknacker.engine.api.context.{ParameterValidationError, ProcessCompilationError}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
-import pl.touk.nussknacker.engine.api.definition.{
-  BoolParameterEditor,
-  CronParameterEditor,
-  DateParameterEditor,
-  DateTimeParameterEditor,
-  DictParameterEditor,
-  DurationParameterEditor,
-  FixedExpressionValue,
-  FixedValuesParameterEditor,
-  FixedValuesWithIconParameterEditor,
-  FixedValuesWithRadioParameterEditor,
-  JsonParameterEditor,
-  JsonTemplateParameterEditor,
-  ParameterEditor,
-  PeriodParameterEditor,
-  SpelParameterEditor,
-  SpelTemplateParameterEditor,
-  SqlParameterEditor,
-  TabularTypedDataEditor,
-  TextareaParameterEditor,
-  TimeParameterEditor
-}
+import pl.touk.nussknacker.engine.api.definition.{FixedExpressionValue, FixedValuesParameterEditor}
 import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.{
   ErrorDetails,
   IncompatibleParameterDefinitionErrorDetails
@@ -32,7 +11,6 @@ import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.{
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.util.ReflectUtils
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.graph.expression.Expression.Language.TabularDataDefinition
 import pl.touk.nussknacker.engine.graph.node._
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeValidationError, NodeValidationErrorType}
 

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -3,10 +3,36 @@ package pl.touk.nussknacker.restmodel.validation
 import org.apache.commons.lang3.StringUtils
 import pl.touk.nussknacker.engine.api.context.{ParameterValidationError, ProcessCompilationError}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
-import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.ErrorDetails
+import pl.touk.nussknacker.engine.api.definition.{
+  BoolParameterEditor,
+  CronParameterEditor,
+  DateParameterEditor,
+  DateTimeParameterEditor,
+  DictParameterEditor,
+  DurationParameterEditor,
+  FixedExpressionValue,
+  FixedValuesParameterEditor,
+  FixedValuesWithIconParameterEditor,
+  FixedValuesWithRadioParameterEditor,
+  JsonParameterEditor,
+  JsonTemplateParameterEditor,
+  ParameterEditor,
+  PeriodParameterEditor,
+  SpelParameterEditor,
+  SpelTemplateParameterEditor,
+  SqlParameterEditor,
+  TabularTypedDataEditor,
+  TextareaParameterEditor,
+  TimeParameterEditor
+}
+import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.{
+  ErrorDetails,
+  IncompatibleParameterDefinitionErrorDetails
+}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.util.ReflectUtils
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language.TabularDataDefinition
 import pl.touk.nussknacker.engine.graph.node._
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeValidationError, NodeValidationErrorType}
 
@@ -182,8 +208,8 @@ object PrettyValidationErrors {
         )
       case MissingRequiredProperty(paramName, label, _) => missingRequiredProperty(typ, paramName.value, label)
       case UnknownProperty(paramName, _)                => unknownProperty(typ, paramName.value)
-      case InvalidPropertyFixedValue(paramName, label, value, values, _) =>
-        invalidPropertyFixedValue(typ, paramName.value, label, value, values)
+      case InvalidPropertyFixedValue(paramName, label, value, values, nodeId) =>
+        invalidPropertyFixedValue(typ, paramName.value, label, value, values, nodeId)
       case CustomNodeError(_, message, paramName) =>
         NodeValidationError(typ, message, message, paramName.map(_.value), NodeValidationErrorType.SaveAllowed, None)
       case e: DuplicateFragmentOutputNames =>
@@ -278,13 +304,14 @@ object PrettyValidationErrors {
           description = message,
           paramName = Some(paramName)
         )
-      case IncompatibleParameterDefinitionModification(paramName, language, parameterEditor, _) =>
+      case IncompatibleParameterDefinitionModification(paramName, language, parameterEditors, nodeId) =>
         node(
           message =
-            "There was an incompatible change to the component's parameter definition. Please choose a new valid value",
+            s"There is an incompatible parameter [${paramName.value}] in component [$nodeId]. Its value cannot be used for target editors [${parameterEditors.mkString(", ")}] ",
           description =
-            s"Incompatible change to the parameter's definition detected. $parameterEditor editor doesn't support '$language' language",
-          paramName = Some(paramName)
+            s"Incompatible change to the parameter's definition detected. None of editors $parameterEditors supports '$language' language",
+          paramName = Some(paramName),
+          details = Some(IncompatibleParameterDefinitionErrorDetails(paramName, parameterEditors, nodeId)),
         )
     }
   }
@@ -316,7 +343,8 @@ object PrettyValidationErrors {
       propertyName: String,
       label: Option[String],
       value: String,
-      values: List[String]
+      values: List[FixedExpressionValue],
+      nodeId: String,
   ) = {
     val labelText = getLabel(label)
     NodeValidationError(
@@ -325,7 +353,13 @@ object PrettyValidationErrors {
       description = s"Expected one of ${values.mkString(", ")}, got: $value.",
       fieldName = Some(propertyName),
       errorType = NodeValidationErrorType.SaveAllowed,
-      details = None
+      details = Some(
+        IncompatibleParameterDefinitionErrorDetails(
+          ParameterName(propertyName),
+          List(FixedValuesParameterEditor(values)),
+          nodeId
+        )
+      ),
     )
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/RemoteEnvironmentResources.scala
@@ -66,6 +66,7 @@ class RemoteEnvironmentResources(
                 withProcess(
                   processIdWithName,
                   version,
+                  GetScenarioWithDetailsOptions.withScenarioGraph,
                   details =>
                     remoteEnvironment.compare(details.scenarioGraphUnsafe, processIdWithName.name, Some(otherVersion))
                 )
@@ -78,6 +79,9 @@ class RemoteEnvironmentResources(
               withProcess(
                 processIdWithName,
                 version,
+                // Scenario validation is needed in order to validate and resolve
+                // dictionaries before sending migration request to remote environment.
+                GetScenarioWithDetailsOptions.withScenarioGraph.withValidation,
                 details =>
                   {
                     for {
@@ -138,14 +142,11 @@ class RemoteEnvironmentResources(
   private def withProcess[T: Encoder](
       processIdWithName: ProcessIdWithName,
       version: VersionId,
-      fun: ScenarioWithDetails => Future[Either[NuDesignerError, T]]
+      fetchOptions: GetScenarioWithDetailsOptions,
+      fun: ScenarioWithDetails => Future[Either[NuDesignerError, T]],
   )(implicit user: LoggedUser) = {
     processService
-      .getProcessWithDetails(
-        processIdWithName,
-        version,
-        GetScenarioWithDetailsOptions.withScenarioGraph
-      )
+      .getProcessWithDetails(processIdWithName, version, fetchOptions)
       .flatMap(fun)
       .map(NuDesignerErrorToHttp.toResponseEither[T])
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
@@ -708,16 +708,14 @@ object NodesApiEndpoints {
     implicit lazy val cellErrorSchema: Schema[CellError]             = Schema.derived
     implicit lazy val textCoordinatesSchema: Schema[TextCoordinates] = Schema.derived
     import pl.touk.nussknacker.ui.api.TapirCodecs.ClassCodec._
-    implicit lazy val columnDefinitionSchema: Schema[ColumnDefinition]                         = Schema.derived
-    implicit lazy val errorDetailsSchema: Schema[ErrorDetails]                                 = Schema.derived
-    implicit lazy val nodeValidationErrorSchema: Schema[NodeValidationError]                   = Schema.derived
-    implicit lazy val fixedExpressionValueSchema: Schema[FixedExpressionValue]                 = Schema.derived
+    implicit lazy val columnDefinitionSchema: Schema[ColumnDefinition]         = Schema.derived
+    implicit lazy val languageSchema: Schema[Language]                         = Schema.string[Language]
+    implicit lazy val parameterEditorSchema: Schema[ParameterEditor]           = Schema.anyObject[ParameterEditor]
+    implicit lazy val errorDetailsSchema: Schema[ErrorDetails]                 = Schema.derived
+    implicit lazy val nodeValidationErrorSchema: Schema[NodeValidationError]   = Schema.derived
+    implicit lazy val fixedExpressionValueSchema: Schema[FixedExpressionValue] = Schema.derived
     implicit lazy val fixedExpressionValueWithIconSchema: Schema[FixedExpressionValueWithIcon] = Schema.derived
-
-    implicit lazy val expressionSchema: Schema[Expression] = {
-      implicit val languageSchema: Schema[Language] = Schema.string[Language]
-      Schema.derived
-    }
+    implicit lazy val expressionSchema: Schema[Expression]                                     = Schema.derived
 
     implicit lazy val caretPosition2dSchema: Schema[CaretPosition2d] = Schema.derived
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/migrations/MigrationService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/migrations/MigrationService.scala
@@ -1,12 +1,18 @@
 package pl.touk.nussknacker.ui.migrations
 
 import cats.data.EitherT
+import cats.implicits._
+import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.IncompatibleParameterDefinitionErrorDetails
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
-import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessIdWithName, ProcessingType, ProcessName}
+import pl.touk.nussknacker.engine.api.process._
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcessConverter
+import pl.touk.nussknacker.engine.dict.DictKeyParameterAdapter
+import pl.touk.nussknacker.engine.dict.DictKeyParameterAdapter.ParameterToAdapt
 import pl.touk.nussknacker.engine.util.Implicits._
 import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioParameters
 import pl.touk.nussknacker.restmodel.validation.ValidationResults
-import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationErrors
+import pl.touk.nussknacker.restmodel.validation.ValidationResults.{ValidationErrors, ValidationResult}
 import pl.touk.nussknacker.security.Permission
 import pl.touk.nussknacker.ui.{FatalError, NuDesignerError, UnauthorizedError}
 import pl.touk.nussknacker.ui.api.{AuthorizeProcess, ListenerApiUser}
@@ -42,7 +48,7 @@ class MigrationService(
     processChangeListener: ProcessChangeListener,
     scenarioParametersService: ProcessingTypeDataProvider[_, ScenarioParametersService],
     useLegacyCreateScenarioApi: Boolean,
-    migrationApiAdapterService: MigrationApiAdapterService
+    migrationApiAdapterService: MigrationApiAdapterService,
 )(implicit val ec: ExecutionContext) {
 
   def migrate(
@@ -86,15 +92,6 @@ class MigrationService(
     val isFragment     = migrateScenarioData.isFragment
     val scenarioLabels = migrateScenarioData.scenarioLabels.map(ScenarioLabel.apply)
 
-    val migrateScenarioCommand =
-      MigrateScenarioCommand(
-        scenarioGraph = scenarioGraph,
-        scenarioLabels = Some(scenarioLabels.map(_.value)),
-        sourceEnvironment = sourceEnvironmentId,
-        targetEnvironment = targetEnvironmentId,
-        sourceScenarioVersionId = migrateScenarioData.sourceScenarioVersionId,
-      )
-
     val processingTypeValidated = scenarioParametersService.combined.queryProcessingTypeWithWritePermission(
       Some(parameters.category),
       Some(parameters.processingMode),
@@ -111,7 +108,30 @@ class MigrationService(
           scenarioLabels,
           processingType
         )
-      _ <- checkForValidationErrors(validationResult)
+      processVersion = ProcessVersion(
+        versionId = migrateScenarioData.sourceScenarioVersionId.getOrElse(VersionId.initialVersionId),
+        processName = processName,
+        processId = ProcessId(1),
+        labels = migrateScenarioData.scenarioLabels,
+        user = loggedUser.username,
+        modelVersion = None
+      )
+      scenarioGraphAfterAdaptations = adaptDictionaryParameters(
+        scenarioGraph,
+        processVersion,
+        processingType,
+        isFragment,
+        validationResult,
+      )
+      validationResultAfterAdaptations <-
+        validateProcessingTypeAndUIProcessResolver(
+          scenarioGraphAfterAdaptations,
+          processName,
+          isFragment,
+          scenarioLabels,
+          processingType
+        )
+      _ <- checkForValidationErrors(validationResultAfterAdaptations)
       _ <- checkOrCreateAndCheckArchivedProcess(
         processName,
         targetEnvironmentId,
@@ -121,10 +141,51 @@ class MigrationService(
       processId <- getProcessId(processName)
       processIdWithName = ProcessIdWithName(processId, processName)
       _ <- checkLoggedUserCanWriteToProcess(processId)
+      migrateScenarioCommand =
+        MigrateScenarioCommand(
+          scenarioGraph = scenarioGraphAfterAdaptations,
+          scenarioLabels = Some(scenarioLabels.map(_.value)),
+          sourceEnvironment = sourceEnvironmentId,
+          targetEnvironment = targetEnvironmentId,
+          sourceScenarioVersionId = migrateScenarioData.sourceScenarioVersionId,
+        )
       _ <- migrateProcessAndNotifyListeners(migrateScenarioCommand, processIdWithName)
     } yield ()
 
     result.value
+  }
+
+  private def adaptDictionaryParameters(
+      scenarioGraph: ScenarioGraph,
+      processVersion: ProcessVersion,
+      processingType: ProcessingType,
+      isFragment: Boolean,
+      validationResult: ValidationResult,
+  )(implicit loggedUser: LoggedUser): ScenarioGraph = {
+    val dictionaryParametersToAdapt = validationResult.errors.invalidNodes.values
+      .flatMap(_.flatMap(_.details))
+      .collect { case details: IncompatibleParameterDefinitionErrorDetails => details }
+      .map(error => ParameterToAdapt(error.nodeId, error.paramName, error.parameterEditors))
+      .toList
+      .toNel
+
+    dictionaryParametersToAdapt match {
+      case Some(parametersToAdapt) =>
+        val process         = CanonicalProcessConverter.fromScenarioGraph(scenarioGraph, processVersion.processName)
+        val modifiedProcess = DictKeyParameterAdapter.adaptParameters(process, parametersToAdapt.toList)
+        val resolver        = processResolver.forProcessingTypeUnsafe(processingType)
+        val modifiedScenarioGraph = resolver
+          .validateAndReverseResolve(
+            canonical = modifiedProcess,
+            processVersion = processVersion,
+            isFragment = isFragment,
+            removeDictLabels = false,
+          )
+          .scenarioGraph
+        modifiedScenarioGraph
+      case None =>
+        scenarioGraph
+    }
   }
 
   private def checkLoggedUserCanWriteToProcess(processId: ProcessId)(implicit loggedUser: LoggedUser) = {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/ProcessService.scala
@@ -362,6 +362,7 @@ class DBProcessService(
           canonical,
           entity.toEngineProcessVersion,
           entity.isFragment,
+          removeDictLabels = false,
         )
       },
       parameters

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ScenarioParametersDeterminer.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/processingtype/ScenarioParametersDeterminer.scala
@@ -50,9 +50,13 @@ object ScenarioParametersDeterminer {
   def determineEngineSetupNames(
       nameInputDatas: Map[ProcessingType, EngineNameInputData]
   ): Map[ProcessingType, EngineSetupName] = {
-    val grouped = nameInputDatas.toList.map { case (processingType, in) =>
-      (in.nameSpecifiedInConfig.getOrElse(in.defaultName), in.identity) -> processingType
-    }.toGroupedMap
+    // Sort by ProcessingType in order to make engine name consistent across Scala 2.12 and Scala 2.13
+    val grouped = nameInputDatas.toList
+      .sortBy(_._1)
+      .map { case (processingType, in) =>
+        (in.nameSpecifiedInConfig.getOrElse(in.defaultName), in.identity) -> processingType
+      }
+      .toGroupedMap
 
     grouped
       .foldLeft((ListMap.empty[ProcessingType, EngineSetupName], Map.empty[EngineSetupName, Int])) {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/uiresolving/UIProcessResolver.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/uiresolving/UIProcessResolver.scala
@@ -66,9 +66,10 @@ class UIProcessResolver(uiValidator: UIProcessValidator, substitutor: ProcessDic
       canonical: CanonicalProcess,
       processVersion: ProcessVersion,
       isFragment: Boolean,
+      removeDictLabels: Boolean,
   )(implicit loggedUser: LoggedUser): ScenarioGraphWithValidationResult = {
     val validationResult = validateBeforeUiReverseResolving(canonical, processVersion, isFragment)
-    reverseResolveExpressions(canonical, processVersion, isFragment, validationResult)
+    reverseResolveExpressions(canonical, processVersion, isFragment, validationResult, removeDictLabels)
   }
 
   def validateBeforeUiReverseResolving(
@@ -84,9 +85,10 @@ class UIProcessResolver(uiValidator: UIProcessValidator, substitutor: ProcessDic
       canonical: CanonicalProcess,
       processVersion: ProcessVersion,
       isFragment: Boolean,
-      validationResult: ValidationResult
+      validationResult: ValidationResult,
+      removeDictLabels: Boolean,
   ): ScenarioGraphWithValidationResult = {
-    val substituted   = substitutor.reversed.substitute(canonical, validationResult.typingInfo)
+    val substituted   = substitutor.reversed(removeDictLabels).substitute(canonical, validationResult.typingInfo)
     val scenarioGraph = substituted.toScenarioGraph
     val uiValidations =
       uiValidator.uiValidation(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/WithCategoryUsedMoreThanOnceConfigScenarioHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/WithCategoryUsedMoreThanOnceConfigScenarioHelper.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.test.base.it
 
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
-import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName}
+import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessingType, ProcessName}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.test.base.db.WithTestDb
 import pl.touk.nussknacker.test.config.WithCategoryUsedMoreThanOnceDesignerConfig
@@ -20,6 +20,10 @@ trait WithCategoryUsedMoreThanOnceConfigScenarioHelper {
     rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, isFragment = false)
   }
 
+  def createSavedScenario(scenario: CanonicalProcess, processingType: ProcessingType): ProcessId = {
+    rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, processingType, isFragment = false)
+  }
+
   def prepareDeploy(scenarioId: ProcessId): Unit =
     rawScenarioHelper.prepareDeploy(scenarioId).futureValue
 
@@ -29,6 +33,10 @@ trait WithCategoryUsedMoreThanOnceConfigScenarioHelper {
 
   def createSavedFragment(scenario: CanonicalProcess): ProcessId = {
     rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, isFragment = true)
+  }
+
+  def createSavedFragment(scenario: CanonicalProcess, processingType: ProcessingType): ProcessId = {
+    rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, processingType, isFragment = true)
   }
 
   def updateScenario(scenarioName: ProcessName, scenario: CanonicalProcess): ProcessId = {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/WithCategoryUsedMoreThanOnceConfigScenarioHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/WithCategoryUsedMoreThanOnceConfigScenarioHelper.scala
@@ -1,11 +1,11 @@
 package pl.touk.nussknacker.test.base.it
 
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
-import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessingType, ProcessName}
+import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.test.base.db.WithTestDb
 import pl.touk.nussknacker.test.config.WithCategoryUsedMoreThanOnceDesignerConfig
-import pl.touk.nussknacker.test.config.WithSimplifiedDesignerConfig.TestCategory
+import pl.touk.nussknacker.test.config.WithCategoryUsedMoreThanOnceDesignerConfig.TestCategory
 import pl.touk.nussknacker.test.utils.domain.ScenarioHelper
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -20,10 +20,6 @@ trait WithCategoryUsedMoreThanOnceConfigScenarioHelper {
     rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, isFragment = false)
   }
 
-  def createSavedScenario(scenario: CanonicalProcess, processingType: ProcessingType): ProcessId = {
-    rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, processingType, isFragment = false)
-  }
-
   def prepareDeploy(scenarioId: ProcessId): Unit =
     rawScenarioHelper.prepareDeploy(scenarioId).futureValue
 
@@ -33,10 +29,6 @@ trait WithCategoryUsedMoreThanOnceConfigScenarioHelper {
 
   def createSavedFragment(scenario: CanonicalProcess): ProcessId = {
     rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, isFragment = true)
-  }
-
-  def createSavedFragment(scenario: CanonicalProcess, processingType: ProcessingType): ProcessId = {
-    rawScenarioHelper.createSavedScenario(scenario, usedCategory.stringify, processingType, isFragment = true)
   }
 
   def updateScenario(scenarioName: ProcessName, scenario: CanonicalProcess): ProcessId = {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/utils/domain/ScenarioHelper.scala
@@ -77,9 +77,18 @@ private[test] class ScenarioHelper(dbRef: DbRef, clock: Clock, designerConfig: C
   def createSavedScenario(
       scenario: CanonicalProcess,
       category: String,
+      processingType: String,
+      isFragment: Boolean,
+  ): ProcessId = {
+    saveAndGetId(scenario, category, processingType, isFragment).futureValue
+  }
+
+  def createSavedScenario(
+      scenario: CanonicalProcess,
+      category: String,
       isFragment: Boolean
   ): ProcessId = {
-    saveAndGetId(scenario, category, isFragment).futureValue
+    saveAndGetId(scenario, category, processingTypeBy(category), isFragment).futureValue
   }
 
   def createDeployedExampleScenario(scenarioName: ProcessName, category: String, isFragment: Boolean): ProcessId = {
@@ -169,12 +178,13 @@ private[test] class ScenarioHelper(dbRef: DbRef, clock: Clock, designerConfig: C
   ): Future[ProcessId] = {
     val validScenario = ProcessTestData.sampleScenario
     val withNameSet   = validScenario.withProcessName(scenarioName)
-    saveAndGetId(withNameSet, category, isFragment)
+    saveAndGetId(withNameSet, category, processingTypeBy(category), isFragment)
   }
 
   private def saveAndGetId(
       scenario: CanonicalProcess,
       category: String,
+      processingType: String,
       isFragment: Boolean
   ): Future[ProcessId] = {
     val scenarioName = scenario.name
@@ -182,7 +192,7 @@ private[test] class ScenarioHelper(dbRef: DbRef, clock: Clock, designerConfig: C
       scenarioName,
       category,
       scenario,
-      processingTypeBy(category),
+      processingType,
       isFragment,
     )
     for {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/MigrationApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/MigrationApiHttpServiceBusinessSpec.scala
@@ -260,8 +260,9 @@ class MigrationApiHttpServiceBusinessSpec
           expectedError = "Property param1 has invalid value"
         )
       }
-      "adapt spel value in source to dict expression in target" in {
-        testAdaptingParameter(
+      // todo: perhaps we should allow adapting spel value to dictionary value in the future
+      "cannot adapt spel value in source to dict expression in target" in {
+        testAdaptingParameterNotPossible(
           sourceExpression = Expression.spel("'Black'"),
           targetEditor = Some(
             ValueInputWithDictEditor(
@@ -269,7 +270,8 @@ class MigrationApiHttpServiceBusinessSpec
               allowOtherValue = false
             )
           ),
-          expectedParameterJsonPart = """[{"name":"param1","expression":{"language":"spel","expression":"'abc'"}}]"""
+          expectedError =
+            """There is an incompatible parameter [param1] in component [fragmentWithConfigurableParameterEditor]. Its value cannot be used for target editors [DictParameterEditor(rgb)]"""
         )
       }
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/MigrationApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/MigrationApiHttpServiceBusinessSpec.scala
@@ -32,9 +32,8 @@ import pl.touk.nussknacker.test.{
 }
 import pl.touk.nussknacker.test.ProcessUtils.convertToAnyShouldWrapper
 import pl.touk.nussknacker.test.base.it.{NuItTest, WithCategoryUsedMoreThanOnceConfigScenarioHelper}
-import pl.touk.nussknacker.test.config.WithAccessControlCheckingDesignerConfig.TestCategory.Category1
-import pl.touk.nussknacker.test.config.WithAccessControlCheckingDesignerConfig.TestProcessingType
 import pl.touk.nussknacker.test.config.WithCategoryUsedMoreThanOnceDesignerConfig
+import pl.touk.nussknacker.test.config.WithCategoryUsedMoreThanOnceDesignerConfig.TestCategory.Category1
 import pl.touk.nussknacker.test.processes.WithScenarioActivitySpecAsserts
 
 // FIXME: For migrating between different API version should be written end to end test (e2e-tests directory)
@@ -592,11 +591,8 @@ class MigrationApiHttpServiceBusinessSpec
     val scenario = scenarioWithConfigurableParameterExpression(sourceExpression)
     given()
       .applicationState {
-        createSavedFragment(
-          fragmentWithConfigurableParameterEditor(targetEditor),
-          TestProcessingType.Streaming2.stringify
-        )
-        createSavedScenario(scenario, TestProcessingType.Streaming2.stringify)
+        createSavedFragment(fragmentWithConfigurableParameterEditor(targetEditor))
+        createSavedScenario(scenario)
       }
       .when()
       .when()
@@ -620,11 +616,8 @@ class MigrationApiHttpServiceBusinessSpec
     val scenario = scenarioWithConfigurableParameterExpression(sourceExpression)
     given()
       .applicationState {
-        createSavedFragment(
-          fragmentWithConfigurableParameterEditor(targetEditor),
-          TestProcessingType.Streaming2.stringify
-        )
-        createSavedScenario(scenario, TestProcessingType.Streaming2.stringify)
+        createSavedFragment(fragmentWithConfigurableParameterEditor(targetEditor))
+        createSavedScenario(scenario)
       }
       .when()
       .when()

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/MigrationApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/MigrationApiHttpServiceBusinessSpec.scala
@@ -7,17 +7,33 @@ import io.restassured.response.ValidatableResponse
 import org.hamcrest.Matchers._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.must.Matchers.include
+import pl.touk.nussknacker.engine.api.{FragmentSpecificData, MetaData}
+import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
+import pl.touk.nussknacker.engine.api.parameter.{
+  ParameterName,
+  ParameterValueInput,
+  ValueInputWithDictEditor,
+  ValueInputWithFixedValuesProvided
+}
 import pl.touk.nussknacker.engine.api.process.ProcessName
-import pl.touk.nussknacker.engine.build.ScenarioBuilder
+import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
+import pl.touk.nussknacker.engine.canonicalgraph.{canonicalnode, CanonicalProcess}
+import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
+import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.graph.node.{FragmentInputDefinition, FragmentOutputDefinition}
+import pl.touk.nussknacker.engine.graph.node.FragmentInputDefinition.{FragmentClazzRef, FragmentParameter}
 import pl.touk.nussknacker.test.{
   NuRestAssureExtensions,
   NuRestAssureMatchers,
   RestAssuredVerboseLoggingIfValidationFails,
   StandardPatientScalaFutures
 }
+import pl.touk.nussknacker.test.ProcessUtils.convertToAnyShouldWrapper
 import pl.touk.nussknacker.test.base.it.{NuItTest, WithCategoryUsedMoreThanOnceConfigScenarioHelper}
 import pl.touk.nussknacker.test.config.WithAccessControlCheckingDesignerConfig.TestCategory.Category1
+import pl.touk.nussknacker.test.config.WithAccessControlCheckingDesignerConfig.TestProcessingType
 import pl.touk.nussknacker.test.config.WithCategoryUsedMoreThanOnceDesignerConfig
 import pl.touk.nussknacker.test.processes.WithScenarioActivitySpecAsserts
 
@@ -166,6 +182,95 @@ class MigrationApiHttpServiceBusinessSpec
               )
             }
           }
+      }
+    }
+    "migrate scenario when parameter adaptation is required" - {
+      "adapt dictionary value from label in source to spel expression in target when label defined" in {
+        testAdaptingParameter(
+          sourceExpression = Expression.dictKeyWithLabel("H000", Some("Black")),
+          targetEditor = None,
+          expectedParameterJsonPart = """[{"name":"param1","expression":{"language":"spel","expression":"'Black'"}}]"""
+        )
+      }
+      "adapt dictionary value from key in source to spel expression in target when label not defined" in {
+        testAdaptingParameter(
+          sourceExpression = Expression.dictKeyWithLabel("H000", None),
+          targetEditor = None,
+          expectedParameterJsonPart = """[{"name":"param1","expression":{"language":"spel","expression":"'H000'"}}]"""
+        )
+      }
+      "adapt dictionary value in source to fixed list expression in target taking value from label" in {
+        testAdaptingParameter(
+          sourceExpression = Expression.dictKeyWithLabel("H000", Some("Black")),
+          targetEditor = Some(
+            ValueInputWithFixedValuesProvided(
+              fixedValuesList = List(FixedExpressionValue("'Black'", "Black")),
+              allowOtherValue = false
+            )
+          ),
+          expectedParameterJsonPart = """[{"name":"param1","expression":{"language":"spel","expression":"'Black'"}}]"""
+        )
+      }
+      "adapt dictionary value in source to fixed list expression in target taking value from key" in {
+        testAdaptingParameter(
+          sourceExpression = Expression.dictKeyWithLabel("Black", Some("ABC")),
+          targetEditor = Some(
+            ValueInputWithFixedValuesProvided(
+              fixedValuesList = List(FixedExpressionValue("'Black'", "Black")),
+              allowOtherValue = false
+            )
+          ),
+          expectedParameterJsonPart = """[{"name":"param1","expression":{"language":"spel","expression":"'Black'"}}]"""
+        )
+      }
+      "cannot adapt dictionary value in source to fixed list expression in target" in {
+        testAdaptingParameterNotPossible(
+          sourceExpression = Expression.dictKeyWithLabel("Green", Some("Green")),
+          targetEditor = Some(
+            ValueInputWithFixedValuesProvided(
+              fixedValuesList = List(FixedExpressionValue("'Black'", "Black")),
+              allowOtherValue = false
+            )
+          ),
+          expectedError =
+            "There is an incompatible parameter [param1] in component [fragmentWithConfigurableParameterEditor]. Its value cannot be used for target editors [FixedValuesParameterEditor(List(FixedExpressionValue(,), FixedExpressionValue('Black',Black)))]"
+        )
+      }
+      "adapt spel value in source to fixed list expression in target" in {
+        testAdaptingParameter(
+          sourceExpression = Expression.spel("'abc'"),
+          targetEditor = Some(
+            ValueInputWithFixedValuesProvided(
+              fixedValuesList = List(FixedExpressionValue("'abc'", "abc")),
+              allowOtherValue = false
+            )
+          ),
+          expectedParameterJsonPart = """[{"name":"param1","expression":{"language":"spel","expression":"'abc'"}}]"""
+        )
+      }
+      "cannot adapt spel value in source to fixed list expression in target" in {
+        testAdaptingParameterNotPossible(
+          sourceExpression = Expression.spel("'Green'"),
+          targetEditor = Some(
+            ValueInputWithFixedValuesProvided(
+              fixedValuesList = List(FixedExpressionValue("'Black'", "Black")),
+              allowOtherValue = false
+            )
+          ),
+          expectedError = "Property param1 has invalid value"
+        )
+      }
+      "adapt spel value in source to dict expression in target" in {
+        testAdaptingParameter(
+          sourceExpression = Expression.spel("'Black'"),
+          targetEditor = Some(
+            ValueInputWithDictEditor(
+              dictId = "rgb",
+              allowOtherValue = false
+            )
+          ),
+          expectedParameterJsonPart = """[{"name":"param1","expression":{"language":"spel","expression":"'abc'"}}]"""
+        )
       }
     }
     "fail when scenario name contains illegal character(s)" in {
@@ -464,5 +569,108 @@ class MigrationApiHttpServiceBusinessSpec
         "modelVersion",
         equalTo(modelVersion)
       )
+
+  private def fetchScenario(scenarioName: String): String =
+    given()
+      .when()
+      .basicAuthAllPermUser()
+      .get(
+        s"$nuDesignerHttpAddress/api/processes/$scenarioName?skipValidateAndResolve=true&skipNodeResults=true"
+      )
+      .Then()
+      .extract()
+      .body()
+      .asString()
+
+  private def testAdaptingParameter(
+      sourceExpression: Expression,
+      targetEditor: Option[ParameterValueInput],
+      expectedParameterJsonPart: String,
+  ) = {
+    val scenario = scenarioWithConfigurableParameterExpression(sourceExpression)
+    given()
+      .applicationState {
+        createSavedFragment(
+          fragmentWithConfigurableParameterEditor(targetEditor),
+          TestProcessingType.Streaming2.stringify
+        )
+        createSavedScenario(scenario, TestProcessingType.Streaming2.stringify)
+      }
+      .when()
+      .when()
+      .basicAuthAllPermUser()
+      .impersonateRemoteUser()
+      .jsonBody(prepareRequestJsonDataV1(scenario.name.value, scenario.toScenarioGraph, isFragment = false))
+      .post(s"$nuDesignerHttpAddress/api/migrate")
+      .Then()
+      .statusCode(200)
+      .equalsPlainBody("")
+
+    val scenarioGraphJsonStr = fetchScenario(scenario.name.value)
+    scenarioGraphJsonStr should include(expectedParameterJsonPart)
+  }
+
+  private def testAdaptingParameterNotPossible(
+      sourceExpression: Expression,
+      targetEditor: Option[ParameterValueInput],
+      expectedError: String,
+  ) = {
+    val scenario = scenarioWithConfigurableParameterExpression(sourceExpression)
+    given()
+      .applicationState {
+        createSavedFragment(
+          fragmentWithConfigurableParameterEditor(targetEditor),
+          TestProcessingType.Streaming2.stringify
+        )
+        createSavedScenario(scenario, TestProcessingType.Streaming2.stringify)
+      }
+      .when()
+      .when()
+      .basicAuthAllPermUser()
+      .impersonateRemoteUser()
+      .jsonBody(prepareRequestJsonDataV1(scenario.name.value, scenario.toScenarioGraph, isFragment = false))
+      .post(s"$nuDesignerHttpAddress/api/migrate")
+      .Then()
+      .statusCode(400)
+      .body(containsString(expectedError))
+  }
+
+  private def scenarioWithConfigurableParameterExpression(parameterValueExpression: Expression) =
+    ScenarioBuilder
+      .withCustomMetaData(exampleProcessName.value, Map("environment" -> "test"))
+      .source("source", "csv-source-lite")
+      .fragment(
+        fragmentWithConfigurableParameterEditorName.value,
+        fragmentWithConfigurableParameterEditorName.value,
+        List(("param1", parameterValueExpression)),
+        Map("output" -> "fragmentResult"),
+        Map(
+          "output" -> GraphBuilder.emptySink("sink", "dead-end-lite")
+        )
+      )
+
+  private def fragmentWithConfigurableParameterEditor(editor: Option[ParameterValueInput]): CanonicalProcess =
+    CanonicalProcess(
+      MetaData(fragmentWithConfigurableParameterEditorName.value, FragmentSpecificData()),
+      List(
+        FlatNode(
+          FragmentInputDefinition(
+            "in",
+            List(
+              FragmentParameter(
+                ParameterName("param1"),
+                FragmentClazzRef[String]
+              ).copy(valueEditor = editor)
+            )
+          )
+        ),
+        canonicalnode.FlatNode(FragmentOutputDefinition("out1", "output", List.empty))
+      ),
+      List.empty
+    )
+
+  private def fragmentWithConfigurableParameterEditorName: ProcessName = ProcessName(
+    "fragmentWithConfigurableParameterEditor"
+  )
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceBusinessSpec.scala
@@ -626,7 +626,26 @@ class NodesApiHttpServiceBusinessSpec
              |      "description": "Expected one of 1, 2, got: a.",
              |      "fieldName": "numberOfThreads",
              |      "errorType": "SaveAllowed",
-             |      "details": null
+             |      "details": {
+             |      "paramName": "numberOfThreads",
+             |      "parameterEditors": [
+             |        {
+             |          "possibleValues": [
+             |            {
+             |              "expression": "1",
+             |              "label": "1"
+             |            },
+             |            {
+             |              "expression": "2",
+             |              "label": "2"
+             |            }
+             |          ],
+             |          "type": "FixedValuesParameterEditor"
+             |        }
+             |      ],
+             |      "nodeId": "properties",
+             |      "type": "IncompatibleParameterDefinitionErrorDetails"
+             |      }
              |    }
              |  ],
              |  "validationPerformed": true

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceSecuritySpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceSecuritySpec.scala
@@ -550,7 +550,26 @@ class NodesApiHttpServiceSecuritySpec
                |      "description": "Expected one of 1, 2, got: a.",
                |      "fieldName": "numberOfThreads",
                |      "errorType": "SaveAllowed",
-               |      "details": null
+               |      "details": {
+               |                "paramName": "numberOfThreads",
+               |                "parameterEditors": [
+               |                    {
+               |                        "possibleValues": [
+               |                            {
+               |                                "expression": "1",
+               |                                "label": "1"
+               |                            },
+               |                            {
+               |                                "expression": "2",
+               |                                "label": "2"
+               |                            }
+               |                        ],
+               |                        "type": "FixedValuesParameterEditor"
+               |                    }
+               |                ],
+               |                "nodeId": "properties",
+               |                "type": "IncompatibleParameterDefinitionErrorDetails"
+               |            }
                |    }
                |  ],
                |  "validationPerformed": true
@@ -644,7 +663,26 @@ class NodesApiHttpServiceSecuritySpec
                |      "description": "Expected one of 1, 2, got: a.",
                |      "fieldName": "numberOfThreads",
                |      "errorType": "SaveAllowed",
-               |      "details": null
+               |      "details": {
+               |                "paramName": "numberOfThreads",
+               |                "parameterEditors": [
+               |                    {
+               |                        "possibleValues": [
+               |                            {
+               |                                "expression": "1",
+               |                                "label": "1"
+               |                            },
+               |                            {
+               |                                "expression": "2",
+               |                                "label": "2"
+               |                            }
+               |                        ],
+               |                        "type": "FixedValuesParameterEditor"
+               |                    }
+               |                ],
+               |                "nodeId": "properties",
+               |                "type": "IncompatibleParameterDefinitionErrorDetails"
+               |            }
                |    }
                |  ],
                |  "validationPerformed": true

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/validation/ScenarioPropertiesValidatorTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/validation/ScenarioPropertiesValidatorTest.scala
@@ -201,7 +201,7 @@ class ScenarioPropertiesValidatorTest extends AnyFunSuite with Matchers {
               _,
               Some(_),
               NodeValidationErrorType.SaveAllowed,
-              None
+              _
             ),
             NodeValidationError(
               "MissingRequiredProperty",
@@ -232,7 +232,7 @@ class ScenarioPropertiesValidatorTest extends AnyFunSuite with Matchers {
               _,
               Some(_),
               NodeValidationErrorType.SaveAllowed,
-              None
+              _
             ),
             NodeValidationError(
               "MissingRequiredProperty",

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/validation/UIProcessValidatorSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/validation/UIProcessValidatorSpec.scala
@@ -1109,7 +1109,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
               _,
               Some("subParam1"),
               NodeValidationErrorType.SaveAllowed,
-              None
+              _
             )
           ) =>
     }
@@ -1879,7 +1879,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
               _,
               Some("numberOfThreads"),
               NodeValidationErrorType.SaveAllowed,
-              None
+              _
             )
           ) =>
     }

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -5741,6 +5741,7 @@ components:
       title: ErrorDetails
       oneOf:
       - $ref: '#/components/schemas/CoordinatesBasedTextRange'
+      - $ref: '#/components/schemas/IncompatibleParameterDefinitionErrorDetails'
       - $ref: '#/components/schemas/TabularDataDefinitionParserErrorDetails'
     ExceptionResult_Json:
       title: ExceptionResult_Json
@@ -6050,6 +6051,21 @@ components:
           uniqueItems: true
           items:
             type: string
+    IncompatibleParameterDefinitionErrorDetails:
+      title: IncompatibleParameterDefinitionErrorDetails
+      type: object
+      required:
+      - paramName
+      - nodeId
+      properties:
+        paramName:
+          type: string
+        parameterEditors:
+          type: array
+          items:
+            type: object
+        nodeId:
+          type: string
     InvalidScenario:
       title: InvalidScenario
       type: object

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/UniversalKafkaSinkValidationSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/UniversalKafkaSinkValidationSpec.scala
@@ -15,6 +15,7 @@ import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.definition.{
   EngineScenarioCompilationDependencies,
+  FixedExpressionValue,
   JsonTemplateParameterEditor,
   SpelParameterEditor
 }
@@ -156,14 +157,14 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
         paramName = topicParamName,
         label = None,
         value = "'tereferer'",
-        values = List("", s"'$exampleAvroTopic'", s"'$exampleJsonTopic'", s"'$fullnameTopic'"),
+        values = List("", exampleAvroTopic, exampleJsonTopic, fullnameTopic).map(fixedExpressionValue),
         nodeId = sinkNodeId.id
       ),
       InvalidPropertyFixedValue(
         paramName = schemaVersionParamName,
         label = None,
         value = "'1'",
-        values = List("'latest'"),
+        values = List(FixedExpressionValue(s"'latest'", "Latest version")),
         nodeId = sinkNodeId.id
       )
     )
@@ -183,7 +184,8 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
       paramName = schemaVersionParamName,
       label = None,
       value = "'343543'",
-      values = List("'latest'", "'1'", "'2'", "'3'", "'4'"),
+      values =
+        List(FixedExpressionValue(s"'latest'", "Latest version")) ++ List("1", "2", "3", "4").map(fixedExpressionValue),
       nodeId = sinkNodeId.id
     ) :: Nil
   }
@@ -558,6 +560,11 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
 
     val factory: SchemaRegistryClientFactory = MockSchemaRegistryClientFactory.confluentBased(schemaRegistryMockClient)
 
+  }
+
+  private def fixedExpressionValue(value: String) = {
+    if (value == "") FixedExpressionValue("", "")
+    else FixedExpressionValue(s"'$value'", value)
   }
 
 }

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/KafkaAvroPayloadSourceFactorySpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/KafkaAvroPayloadSourceFactorySpec.scala
@@ -13,7 +13,7 @@ import pl.touk.nussknacker.engine.ScenarioCompilationDependencies
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{CustomNodeError, InvalidPropertyFixedValue}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
-import pl.touk.nussknacker.engine.api.definition.EngineScenarioCompilationDependencies
+import pl.touk.nussknacker.engine.api.definition.{EngineScenarioCompilationDependencies, FixedExpressionValue}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.ComponentUseContext.LiveRuntime
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, Unknown}
@@ -316,15 +316,15 @@ class KafkaAvroPayloadSourceFactorySpec
         "'terefere'",
         List(
           "",
-          "'testArrayOfNumbersTopic'",
-          "'testArrayOfRecordsTopic'",
-          "'testAvroIntTopic1NoKey'",
-          "'testAvroIntTopic1WithKey'",
-          "'testAvroInvalidDefaultsTopic1'",
-          "'testAvroRecordTopic1'",
-          "'testAvroRecordTopic1WithKey'",
-          "'testPaymentDateTopic'"
-        ),
+          "testArrayOfNumbersTopic",
+          "testArrayOfRecordsTopic",
+          "testAvroIntTopic1NoKey",
+          "testAvroIntTopic1WithKey",
+          "testAvroInvalidDefaultsTopic1",
+          "testAvroRecordTopic1",
+          "testAvroRecordTopic1WithKey",
+          "testPaymentDateTopic"
+        ).map(fixedExpressionValue),
         "id"
       ) :: Nil
     result.outputContext shouldBe ValidationContext(
@@ -345,7 +345,7 @@ class KafkaAvroPayloadSourceFactorySpec
       paramName = schemaVersionParamName,
       label = None,
       value = "'12345'",
-      values = List("'latest'", "'1'", "'2'"),
+      values = List(FixedExpressionValue(s"'latest'", "Latest version")) ++ List("1", "2").map(fixedExpressionValue),
       nodeId = "id"
     ) :: Nil
     result.outputContext shouldBe ValidationContext(
@@ -400,6 +400,11 @@ class KafkaAvroPayloadSourceFactorySpec
       )
       .toOption
       .get
+  }
+
+  private def fixedExpressionValue(value: String) = {
+    if (value == "") FixedExpressionValue("", "")
+    else FixedExpressionValue(s"'$value'", value)
   }
 
 }

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/ProcessNodesRewriter.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/ProcessNodesRewriter.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.canonicalgraph
 
 import pl.touk.nussknacker.engine.api.{MetaData, NodeId}
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode._
 import pl.touk.nussknacker.engine.graph.evaluatedparam.{Parameter => NodeParameter}
 import pl.touk.nussknacker.engine.graph.evaluatedparam.BranchParameters
@@ -135,7 +136,7 @@ trait ExpressionRewriter {
     }
 
   private def rewriteFields(list: List[Field])(implicit metaData: MetaData, nodeId: NodeId): List[Field] =
-    list.map(f => f.copy(expression = rewriteExpressionInternal(f.expression, f.name)))
+    list.map(f => f.copy(expression = rewriteExpressionInternal(f.expression, f.name, None)))
 
   private def rewriteBranchParameters(
       list: List[BranchParameters]
@@ -143,7 +144,9 @@ trait ExpressionRewriter {
     list.map(bp =>
       bp.copy(
         parameters = bp.parameters.map(p =>
-          p.copy(expression = rewriteExpressionInternal(p.expression, branchParameterExpressionId(p.name, bp.branchId)))
+          p.copy(expression =
+            rewriteExpressionInternal(p.expression, branchParameterExpressionId(p.name, bp.branchId), Some(p.name))
+          )
         )
       )
     )
@@ -151,17 +154,18 @@ trait ExpressionRewriter {
   private def rewriteParameters(
       list: List[NodeParameter]
   )(implicit metaData: MetaData, nodeId: NodeId): List[NodeParameter] =
-    list.map(p => p.copy(expression = rewriteExpressionInternal(p.expression, p.name.value)))
+    list.map(p => p.copy(expression = rewriteExpressionInternal(p.expression, p.name.value, Some(p.name))))
 
   private def rewriteDefaultExpressionInternal(e: Expression)(implicit metaData: MetaData, nodeId: NodeId): Expression =
-    rewriteExpressionInternal(e, DefaultExpressionIdParamName.value)
+    rewriteExpressionInternal(e, DefaultExpressionIdParamName.value, None)
 
   private def rewriteExpressionInternal(
       e: Expression,
-      expressionId: String
+      expressionId: String,
+      parameterName: Option[ParameterName],
   )(implicit metaData: MetaData, nodeId: NodeId): Expression = {
     try {
-      rewriteExpression(e)(ExpressionIdWithMetaData(metaData, NodeExpressionId(nodeId, expressionId)))
+      rewriteExpression(e)(ExpressionIdWithMetaData(metaData, NodeExpressionId(nodeId, expressionId), parameterName))
     } catch {
       case NonFatal(ex) =>
         throw new IllegalArgumentException(
@@ -177,4 +181,8 @@ trait ExpressionRewriter {
 
 }
 
-case class ExpressionIdWithMetaData(metaData: MetaData, expressionId: NodeExpressionId)
+case class ExpressionIdWithMetaData(
+    metaData: MetaData,
+    expressionId: NodeExpressionId,
+    parameterName: Option[ParameterName]
+)

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/dict/DictKeyParameterAdapter.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/dict/DictKeyParameterAdapter.scala
@@ -1,0 +1,175 @@
+package pl.touk.nussknacker.engine.dict
+
+import cats.data.{Validated, ValidatedNel}
+import cats.data.Validated.{invalidNel, Invalid, Valid}
+import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.api.NodeId
+import pl.touk.nussknacker.engine.api.context.PartSubGraphCompilationError
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.IncompatibleParameterDefinitionModification
+import pl.touk.nussknacker.engine.api.definition._
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.canonicalgraph.{CanonicalProcess, ProcessNodesRewriter}
+import pl.touk.nussknacker.engine.graph.expression.{DictKeyWithLabelExpression, Expression}
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language
+import pl.touk.nussknacker.engine.language.dictWithLabel.DictKeyWithLabelExpressionParser
+
+object DictKeyParameterAdapter extends LazyLogging {
+
+  def adaptParameters(
+      canonicalProcess: CanonicalProcess,
+      parametersToAdapt: List[ParameterToAdapt],
+  ): CanonicalProcess = {
+    val rewriter = ProcessNodesRewriter.rewritingAllExpressions { exprIdWithMetadata => original =>
+      val parameterToAdaptForExpressionOpt = parametersToAdapt.find { error =>
+        error.nodeId == exprIdWithMetadata.expressionId.nodeId.id &&
+        exprIdWithMetadata.parameterName.contains(error.paramName)
+      }
+      parameterToAdaptForExpressionOpt match {
+        case Some(parameterToAdapt) =>
+          logger.info(
+            s"Found parameter [${parameterToAdapt.paramName.value}] in node [${parameterToAdapt.nodeId}] that needs to be adapted to editors [${parameterToAdapt.parameterEditors.mkString(",")}]"
+          )
+          adaptDictKeyExpressionToAvailableEditors(
+            original,
+            parameterToAdapt.parameterEditors,
+            parameterToAdapt.paramName
+          )(
+            exprIdWithMetadata.expressionId.nodeId
+          ) match {
+            case Valid(modified) =>
+              logger.info(
+                s"Adaptation successful for parameter [${parameterToAdapt.paramName.value}] in node [${parameterToAdapt.nodeId}]: [$original] adapted to [$modified]"
+              )
+              modified
+            case Invalid(_) =>
+              logger.info(
+                s"Adaptation not successful for parameter [${parameterToAdapt.paramName.value}] in node [${parameterToAdapt.nodeId}]: using original value without modification"
+              )
+              original
+          }
+        case None =>
+          original
+      }
+    }
+    rewriter.rewriteProcess(canonicalProcess)
+  }
+
+  private def adaptDictKeyExpressionToAvailableEditors(
+      expression: Expression,
+      editors: List[ParameterEditor],
+      paramName: ParameterName,
+  )(
+      implicit nodeId: NodeId
+  ): ValidatedNel[PartSubGraphCompilationError, Expression] = {
+    val incompatibleChangeToParameterDefinitionDetected: ValidatedNel[PartSubGraphCompilationError, Expression] =
+      invalidNel(IncompatibleParameterDefinitionModification(paramName, expression.language, editors, nodeId.id))
+
+    def adaptToSpel(
+        expression: Expression
+    ): ValidatedNel[PartSubGraphCompilationError, Expression] = {
+      expression.language match {
+        case Language.DictKeyWithLabel =>
+          DictKeyWithLabelExpressionParser.parseDictKeyWithLabelExpression(expression.expression) match {
+            case Valid(DictKeyWithLabelExpression(key, label)) =>
+              val rawValue = label.getOrElse(key)
+              logger.info(
+                s"Using raw value with quotes ['$rawValue'] as value of [$expression] for editors [${editors.mkString(", ")}]"
+              )
+              Valid(Expression.spel(s"'$rawValue'"))
+            case Invalid(_) =>
+              incompatibleChangeToParameterDefinitionDetected
+          }
+        case Language.TabularDataDefinition =>
+          incompatibleChangeToParameterDefinitionDetected
+        case Language.Json =>
+          incompatibleChangeToParameterDefinitionDetected
+        case Language.JsonTemplate =>
+          incompatibleChangeToParameterDefinitionDetected
+        case Language.Spel =>
+          incompatibleChangeToParameterDefinitionDetected
+        case Language.SpelTemplate =>
+          incompatibleChangeToParameterDefinitionDetected
+      }
+    }
+
+    def adaptToOneOfAllowedValues(
+        expression: Expression,
+        allowed: List[String]
+    ): ValidatedNel[PartSubGraphCompilationError, Expression] = {
+      expression.language match {
+        case Language.Spel | Language.SpelTemplate =>
+          if (allowed.contains(expression.expression)) {
+            logger.info(
+              s"Value of expression [$expression] is valid as one of fixed values [${allowed.mkString(", ")}] for editors [${editors.mkString(", ")}]"
+            )
+            Valid(expression)
+          } else {
+            logger.warn(
+              s"Value of expression [$expression] is not valid as one of fixed values [${allowed.mkString(", ")}] for editors [${editors.mkString(", ")}]"
+            )
+            incompatibleChangeToParameterDefinitionDetected
+          }
+        case Language.DictKeyWithLabel =>
+          DictKeyWithLabelExpressionParser.parseDictKeyWithLabelExpression(expression.expression) match {
+            case Valid(DictKeyWithLabelExpression(key, label)) =>
+              val quotedKey      = s"'$key'"
+              val quotedLabelOpt = label.map(l => s"'$l'")
+
+              val matchingAllowedValue = {
+                if (allowed.contains(quotedKey)) Some(quotedKey)
+                else if (quotedLabelOpt.exists(allowed.contains)) quotedLabelOpt
+                else None
+              }
+
+              matchingAllowedValue match {
+                case Some(matchingValue) =>
+                  val adapted = Expression.spel(matchingValue)
+                  logger.info(
+                    s"Value of expression [$expression] is adapted to [$adapted] for editors [${editors.mkString(", ")}]"
+                  )
+                  Valid(adapted)
+                case None =>
+                  logger.warn(
+                    s"Value of expression [$expression] cannot be adapted for editors [${editors.mkString(", ")}]"
+                  )
+                  incompatibleChangeToParameterDefinitionDetected
+              }
+            case Invalid(_) =>
+              incompatibleChangeToParameterDefinitionDetected
+          }
+        case Language.TabularDataDefinition =>
+          incompatibleChangeToParameterDefinitionDetected
+        case Language.Json =>
+          incompatibleChangeToParameterDefinitionDetected
+        case Language.JsonTemplate =>
+          incompatibleChangeToParameterDefinitionDetected
+      }
+    }
+
+    def adapt(expression: Expression): ValidatedNel[PartSubGraphCompilationError, Expression] = {
+      editors
+        .collectFirst {
+          case SpelParameterEditor =>
+            adaptToSpel(expression)
+          case SpelTemplateParameterEditor =>
+            adaptToSpel(expression)
+          case FixedValuesParameterEditor(possibleValues) =>
+            adaptToOneOfAllowedValues(expression, possibleValues.map(_.expression))
+          case FixedValuesWithIconParameterEditor(possibleValues) =>
+            adaptToOneOfAllowedValues(expression, possibleValues.map(_.expression))
+          case FixedValuesWithRadioParameterEditor(possibleValues) =>
+            adaptToOneOfAllowedValues(expression, possibleValues.map(_.expression))
+        }
+        .collect { case v @ Validated.Valid(_) => v }
+        .getOrElse(incompatibleChangeToParameterDefinitionDetected)
+    }
+    adapt(expression)
+  }
+
+  final case class ParameterToAdapt(
+      nodeId: String,
+      paramName: ParameterName,
+      parameterEditors: List[ParameterEditor],
+  )
+
+}

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/dict/ProcessDictSubstitutor.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/dict/ProcessDictSubstitutor.scala
@@ -32,7 +32,7 @@ class ProcessDictSubstitutor(
         ExpressionTypingInfo,
         ReplacingStrategy
     ) => Option[ExpressionSubstitutionsCollector],
-    isReverse: Boolean
+    removeLabels: Boolean,
 ) extends LazyLogging {
 
   def substitute(
@@ -46,10 +46,10 @@ class ProcessDictSubstitutor(
       val optionalExpressionTypingInfo = nodeTypingInfo.get(nodeExpressionId.expressionId)
 
       if (expr.language == Expression.Language.DictKeyWithLabel && !expr.expression.isBlank) {
-        if (isReverse)
-          addLabelToDictKeyExpression(process, expr, optionalExpressionTypingInfo, nodeExpressionId)
+        if (removeLabels)
+          removeLabelFromDictKeyExpression(process, expr, nodeExpressionId)
         else
-          removeLabelFromDictKeyExpression(process, expr, nodeExpressionId) // no need to keep label in BE
+          addLabelToDictKeyExpression(process, expr, optionalExpressionTypingInfo, nodeExpressionId)
       } else
         substituteExpression(process, expr, optionalExpressionTypingInfo, nodeExpressionId)
     }
@@ -109,11 +109,11 @@ class ProcessDictSubstitutor(
     expr.copy(expression = substitutedExpression)
   }
 
-  def reversed: ProcessDictSubstitutor = new ProcessDictSubstitutor(
-    dictRegistry,
-    new KeyToLabelReplacingStrategy(dictRegistry),
-    prepareSubstitutionsCollector,
-    isReverse = true
+  def reversed(removeLabels: Boolean): ProcessDictSubstitutor = new ProcessDictSubstitutor(
+    dictRegistry = dictRegistry,
+    replacingStrategy = new KeyToLabelReplacingStrategy(dictRegistry),
+    prepareSubstitutionsCollector = prepareSubstitutionsCollector,
+    removeLabels = removeLabels
   )
 
 }
@@ -125,7 +125,7 @@ object ProcessDictSubstitutor extends LazyLogging {
       dictRegistry,
       new LabelToKeyReplacingStrategy(dictRegistry),
       prepareSubstitutionsCollector,
-      isReverse = false
+      removeLabels = true
     )
   }
 


### PR DESCRIPTION
## Describe your changes

When we have dictionary value of a parameter on a source environment, and the target environment accepts spel values or fixed list of values, we should be able to adapt the ductionary value to raw spel value or value from fixed list (when it matches one of allowed items.

This PR introduces adaptatation logic, which is applied on target environment and adapts (when possible) dictionary values to value types accepted on target env - instead of returning errors.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
