### PR TITLE
Using NodeId in most places of an API instead of switching between String and NodeId and vice versa

### DIFF
--- a/common-api/src/main/scala/pl/touk/nussknacker/engine/api/NodeId.scala
+++ b/common-api/src/main/scala/pl/touk/nussknacker/engine/api/NodeId.scala
@@ -12,4 +12,6 @@ object NodeId {
 
   implicit val keyEncoder: KeyEncoder[NodeId] = KeyEncoder.encodeKeyString.contramap(_.id)
   implicit val keyDecoder: KeyDecoder[NodeId] = KeyDecoder.decodeKeyString.map(NodeId(_))
+
+  implicit val ordering: Ordering[NodeId] = Ordering.by[NodeId, String](_.id)
 }

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/Context.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/Context.scala
@@ -1,5 +1,7 @@
 package pl.touk.nussknacker.engine.api
 
+import pl.touk.nussknacker.engine.api.process.ProcessName
+
 import scala.jdk.CollectionConverters._
 
 object Context {
@@ -15,8 +17,8 @@ object Context {
 }
 
 final case class ContextId private (
-    scenarioName: String,
-    originatingNodeId: String,
+    scenarioName: ProcessName,
+    originatingNodeId: NodeId,
     taskId: Long,
     index: Long,
     // We need to use java.util.List instead of the Scala List implementation, because of Flink typing issues:
@@ -30,15 +32,15 @@ final case class ContextId private (
 
   def path: List[ContextIdPathPart] = contextIdPath.asScala.toList
 
-  def withContextIdPathPart(nodeId: String, value: String): ContextId = {
+  def withContextIdPathPart(nodeId: NodeId, value: String): ContextId = {
     val copied = copy(contextIdPath = new java.util.ArrayList(contextIdPath))
     copied.contextIdPath.add(ContextIdPathPart(nodeId, value))
     copied
   }
 
-  lazy val legacyString: String = List(
-    List(scenarioName),
-    List(originatingNodeId),
+  lazy val legacyString: String = List[Seq[String]](
+    List(scenarioName.value),
+    List(originatingNodeId.id),
     List(taskId.toString),
     List(index.toString),
     contextIdPath.asScala.map(_.value),
@@ -46,31 +48,31 @@ final case class ContextId private (
 
 }
 
-case class ContextIdPathPart(nodeId: String, value: String)
+case class ContextIdPathPart(nodeId: NodeId, value: String)
 
 object ContextId {
 
   // Override and hide the default apply, in order to hide java list
   private def apply(
-      scenarioId: String,
-      originatingNodeId: String,
+      scenarioName: ProcessName,
+      originatingNodeId: NodeId,
       taskId: Long,
       index: Long,
       contextIdPath: java.util.List[ContextIdPathPart]
   ): ContextId =
-    new ContextId(scenarioId, originatingNodeId, taskId, index, contextIdPath)
+    new ContextId(scenarioName, originatingNodeId, taskId, index, contextIdPath)
 
   def apply(
-      scenarioId: String,
-      originatingNodeId: String,
+      scenarioName: ProcessName,
+      originatingNodeId: NodeId,
       taskId: Long,
       index: Long,
       path: List[ContextIdPathPart] = List.empty
   ): ContextId =
-    new ContextId(scenarioId, originatingNodeId, taskId, index, path.asJava)
+    new ContextId(scenarioName, originatingNodeId, taskId, index, path.asJava)
 
   // The dummy ContextId should only be used in test suites, perhaps also Nu scenario test mechanism or examples
-  def dummy: ContextId = new ContextId("dummy", "dummy", 0, 0, List.empty.asJava)
+  def dummy: ContextId = new ContextId(ProcessName("dummy"), NodeId("dummy"), 0, 0, List.empty.asJava)
 }
 
 /**
@@ -86,7 +88,7 @@ case class Context(
     parentContext: Option[Context]
 ) {
 
-  def withContextIdPathPart(nodeId: String, transformation: String): Context =
+  def withContextIdPathPart(nodeId: NodeId, transformation: String): Context =
     copy(id = id.withContextIdPathPart(nodeId, transformation))
 
   // TODO: all methods should has NotNothing type check to avoid situation when scala's compiler implicitly put Nothing

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/component/NodeComponentInfo.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/component/NodeComponentInfo.scala
@@ -1,11 +1,12 @@
 package pl.touk.nussknacker.engine.api.component
 
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ComponentType.ComponentType
 
 object NodeComponentInfo {
 
   // TODO: remove this method - in every place of usage, should be accessible ComponentId
-  def apply(nodeId: String, componentType: ComponentType, componentName: String): NodeComponentInfo = {
+  def apply(nodeId: NodeId, componentType: ComponentType, componentName: String): NodeComponentInfo = {
     NodeComponentInfo(nodeId, Some(ComponentId(componentType, componentName)))
   }
 
@@ -14,4 +15,4 @@ object NodeComponentInfo {
 // componentId is not used anywhere in this repo - it is only for external project's purpose for now
 // TODO: Remove Option from componentId - every Node used in runtime is related with some Component. After doing it, we should
 //       report this id in KafkaExceptionInfo - see KafkaJsonExceptionSerializationSchema
-final case class NodeComponentInfo(nodeId: String, componentId: Option[ComponentId])
+final case class NodeComponentInfo(nodeId: NodeId, componentId: Option[ComponentId])

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ContextTransformation.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ContextTransformation.scala
@@ -90,7 +90,7 @@ object ContextTransformation {
     contextMap.values.map(_.parent).toList.distinct match {
       case Nil      => Valid(None)
       case a :: Nil => Valid(a)
-      case more => Invalid(NonEmptyList.of(CustomNodeError(nodeId.id, s"Not consistent parent contexts: $more", None)))
+      case more     => Invalid(NonEmptyList.of(CustomNodeError(nodeId, s"Not consistent parent contexts: $more", None)))
     }
   }
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/ProcessCompilationError.scala
@@ -12,7 +12,7 @@ import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language
 
 sealed trait ProcessCompilationError {
-  def nodeIds: Set[String]
+  def nodeIds: Set[NodeId]
 }
 
 sealed trait ProcessUncanonizationError extends ProcessCompilationError
@@ -37,9 +37,9 @@ object ProcessCompilationError {
   sealed trait InASingleNode {
     self: ProcessCompilationError =>
 
-    override def nodeIds: Set[String] = Set(nodeId)
+    override def nodeIds: Set[NodeId] = Set(nodeId)
 
-    protected def nodeId: String
+    protected def nodeId: NodeId
 
   }
 
@@ -49,55 +49,55 @@ object ProcessCompilationError {
   // All errors which we want to be seen in process as properties errors should extend this trait
   sealed trait ScenarioPropertiesError {
     self: ProcessCompilationError =>
-    override def nodeIds: Set[String] = Set()
+    override def nodeIds: Set[NodeId] = Set()
   }
 
-  final case class UnsupportedPart(nodeId: String) extends ProcessCompilationError with InASingleNode
+  final case class UnsupportedPart(nodeId: NodeId) extends ProcessCompilationError with InASingleNode
 
-  final case class MissingPart(nodeId: String) extends ProcessCompilationError with InASingleNode
+  final case class MissingPart(nodeId: NodeId) extends ProcessCompilationError with InASingleNode
 
-  final case class InvalidRootNode(nodeIds: Set[String]) extends ProcessUncanonizationError with ScenarioGraphLevelError
+  final case class InvalidRootNode(nodeIds: Set[NodeId]) extends ProcessUncanonizationError with ScenarioGraphLevelError
 
   object EmptyProcess extends ProcessUncanonizationError with ScenarioGraphLevelError {
     override def nodeIds = Set()
   }
 
-  final case class InvalidTailOfBranch(nodeIds: Set[String])
+  final case class InvalidTailOfBranch(nodeIds: Set[NodeId])
       extends ProcessUncanonizationError
       with ScenarioGraphLevelError
 
-  final case class DuplicatedNodeIds(nodeIds: Set[String]) extends ProcessCompilationError with ScenarioGraphLevelError
+  final case class DuplicatedNodeIds(nodeIds: Set[NodeId]) extends ProcessCompilationError with ScenarioGraphLevelError
 
-  final case class NonUniqueEdgeType(edgeType: String, nodeId: String)
+  final case class NonUniqueEdgeType(edgeType: String, nodeId: NodeId)
       extends ProcessCompilationError
       with InASingleNode
 
-  final case class NonUniqueEdge(nodeId: String, target: String) extends ProcessCompilationError with InASingleNode
+  final case class NonUniqueEdge(nodeId: NodeId, target: String) extends ProcessCompilationError with InASingleNode
 
-  final case class LooseNode(nodeIds: Set[String]) extends ProcessCompilationError with ScenarioGraphLevelError
+  final case class LooseNode(nodeIds: Set[NodeId]) extends ProcessCompilationError with ScenarioGraphLevelError
 
-  final case class StickyNotesLimitExceeded(nodeId: String, notesCount: Int, notesLimit: Int)
+  final case class StickyNotesLimitExceeded(nodeId: NodeId, notesCount: Int, notesLimit: Int)
       extends ProcessCompilationError
       with InASingleNode
 
-  final case class StickyNoteContentTooLong(nodeId: String, length: Int, max: Int)
+  final case class StickyNoteContentTooLong(nodeId: NodeId, length: Int, max: Int)
       extends ProcessCompilationError
       with InASingleNode
 
-  final case class DisabledNode(nodeId: String) extends ProcessCompilationError with InASingleNode
+  final case class DisabledNode(nodeId: NodeId) extends ProcessCompilationError with InASingleNode
 
-  final case class NotSupportedExpressionLanguage(languageId: Language, nodeId: String)
+  final case class NotSupportedExpressionLanguage(languageId: Language, nodeId: NodeId)
       extends PartSubGraphCompilationError
       with InASingleNode
 
   object NotSupportedExpressionLanguage {
     def apply(languageId: Language)(implicit nodeId: NodeId): PartSubGraphCompilationError =
-      NotSupportedExpressionLanguage(languageId, nodeId.id)
+      NotSupportedExpressionLanguage(languageId, nodeId)
   }
 
   final case class ExpressionParserCompilationError(
       message: String,
-      nodeId: String,
+      nodeId: NodeId,
       paramName: Option[ParameterName],
       originalExpr: String,
       details: Option[ErrorDetails]
@@ -106,7 +106,7 @@ object ProcessCompilationError {
 
   final case class ExpressionParserCompilationErrorInFragmentDefinition(
       message: String,
-      nodeId: String,
+      nodeId: NodeId,
       paramName: ParameterName,
       subFieldName: Option[String],
       originalExpr: String
@@ -115,7 +115,7 @@ object ProcessCompilationError {
 
   final case class InvalidValidationExpression(
       message: String,
-      nodeId: String,
+      nodeId: NodeId,
       paramName: ParameterName,
       originalExpr: String
   ) extends PartSubGraphCompilationError
@@ -126,65 +126,65 @@ object ProcessCompilationError {
     def apply(message: String, paramName: Option[ParameterName], originalExpr: String, details: Option[ErrorDetails])(
         implicit nodeId: NodeId
     ): PartSubGraphCompilationError =
-      ExpressionParserCompilationError(message, nodeId.id, paramName, originalExpr, details)
+      ExpressionParserCompilationError(message, nodeId, paramName, originalExpr, details)
 
   }
 
-  final case class FragmentParamClassLoadError(paramName: ParameterName, refClazzName: String, nodeId: String)
+  final case class FragmentParamClassLoadError(paramName: ParameterName, refClazzName: String, nodeId: NodeId)
       extends PartSubGraphCompilationError
       with InASingleNode
 
-  final case class MissingService(serviceId: String, nodeId: String)
+  final case class MissingService(serviceId: String, nodeId: NodeId)
       extends PartSubGraphCompilationError
       with InASingleNode
 
   object MissingService {
     def apply(serviceId: String)(implicit nodeId: NodeId): PartSubGraphCompilationError =
-      MissingService(serviceId, nodeId.id)
+      MissingService(serviceId, nodeId)
   }
 
-  final case class MissingSourceFactory(typ: String, nodeId: String) extends ProcessCompilationError with InASingleNode
+  final case class MissingSourceFactory(typ: String, nodeId: NodeId) extends ProcessCompilationError with InASingleNode
 
   object MissingSourceFactory {
     def apply(typ: String)(implicit nodeId: NodeId): ProcessCompilationError =
-      MissingSourceFactory(typ, nodeId.id)
+      MissingSourceFactory(typ, nodeId)
   }
 
-  final case class MissingSinkFactory(typ: String, nodeId: String) extends ProcessCompilationError with InASingleNode
+  final case class MissingSinkFactory(typ: String, nodeId: NodeId) extends ProcessCompilationError with InASingleNode
 
   object MissingSinkFactory {
     def apply(typ: String)(implicit nodeId: NodeId): ProcessCompilationError =
-      MissingSinkFactory(typ, nodeId.id)
+      MissingSinkFactory(typ, nodeId)
   }
 
-  final case class MissingCustomNodeExecutor(name: String, nodeId: String)
+  final case class MissingCustomNodeExecutor(name: String, nodeId: NodeId)
       extends ProcessCompilationError
       with InASingleNode
 
   object MissingCustomNodeExecutor {
     def apply(name: String)(implicit nodeId: NodeId): ProcessCompilationError =
-      MissingCustomNodeExecutor(name, nodeId.id)
+      MissingCustomNodeExecutor(name, nodeId)
   }
 
-  case class MissingParameters(params: Set[ParameterName], nodeId: String)
+  case class MissingParameters(params: Set[ParameterName], nodeId: NodeId)
       extends PartSubGraphCompilationError
       with InASingleNode
 
-  case class DuplicatedParameters(params: Set[ParameterName], nodeId: String)
+  case class DuplicatedParameters(params: Set[ParameterName], nodeId: NodeId)
       extends PartSubGraphCompilationError
       with InASingleNode
 
-  final case class UnresolvedFragment(nodeId: String) extends PartSubGraphCompilationError with InASingleNode
+  final case class UnresolvedFragment(nodeId: NodeId) extends PartSubGraphCompilationError with InASingleNode
 
   object MissingParameters {
     def apply(params: Set[ParameterName])(implicit nodeId: NodeId): PartSubGraphCompilationError =
-      MissingParameters(params, nodeId.id)
+      MissingParameters(params, nodeId)
   }
 
   final case class WrongParameters(
       requiredParameters: Set[ParameterName],
       passedParameters: Set[ParameterName],
-      nodeId: String
+      nodeId: NodeId
   ) extends PartSubGraphCompilationError
       with InASingleNode
 
@@ -193,81 +193,81 @@ object ProcessCompilationError {
     def apply(requiredParameters: Set[ParameterName], passedParameters: Set[ParameterName])(
         implicit nodeId: NodeId
     ): PartSubGraphCompilationError =
-      WrongParameters(requiredParameters, passedParameters, nodeId.id)
+      WrongParameters(requiredParameters, passedParameters, nodeId)
 
   }
 
-  final case class BlankParameter(message: String, description: String, paramName: ParameterName, nodeId: String)
+  final case class BlankParameter(message: String, description: String, paramName: ParameterName, nodeId: NodeId)
       extends ParameterValidationError
 
   final case class EmptyMandatoryParameter(
       message: String,
       description: String,
       paramName: ParameterName,
-      nodeId: String
+      nodeId: NodeId
   ) extends ParameterValidationError
 
   final case class CompileTimeEvaluableParameterNotEvaluated(
       message: String,
       description: String,
       paramName: ParameterName,
-      nodeId: String
+      nodeId: NodeId
   ) extends ParameterValidationError
 
   final case class InvalidIntegerLiteralParameter(
       message: String,
       description: String,
       paramName: ParameterName,
-      nodeId: String
+      nodeId: NodeId
   ) extends ParameterValidationError
 
-  final case class MismatchParameter(message: String, description: String, paramName: ParameterName, nodeId: String)
+  final case class MismatchParameter(message: String, description: String, paramName: ParameterName, nodeId: NodeId)
       extends ParameterValidationError
 
   final case class LowerThanRequiredParameter(
       message: String,
       description: String,
       paramName: ParameterName,
-      nodeId: String
+      nodeId: NodeId
   ) extends ParameterValidationError
 
   final case class GreaterThanRequiredParameter(
       message: String,
       description: String,
       paramName: ParameterName,
-      nodeId: String
+      nodeId: NodeId
   ) extends ParameterValidationError
 
   final case class JsonRequiredParameter(
       message: String,
       description: String,
       paramName: ParameterName,
-      nodeId: String
+      nodeId: NodeId
   ) extends ParameterValidationError
 
   final case class CustomParameterValidationError(
       message: String,
       description: String,
       paramName: ParameterName,
-      nodeId: String
+      nodeId: NodeId
   ) extends ParameterValidationError
 
-  final case class MissingRequiredProperty(paramName: ParameterName, label: Option[String], nodeId: String)
+  final case class MissingRequiredProperty(paramName: ParameterName, label: Option[String], nodeId: NodeId)
       extends PartSubGraphCompilationError
       with InASingleNode
 
   object MissingRequiredProperty {
     def apply(paramName: ParameterName, label: Option[String])(implicit nodeId: NodeId): PartSubGraphCompilationError =
-      MissingRequiredProperty(paramName, label, nodeId.id)
+      MissingRequiredProperty(paramName, label, nodeId)
   }
 
-  final case class UnknownProperty(paramName: ParameterName, nodeId: String)
+  final case class UnknownProperty(paramName: ParameterName, nodeId: NodeId)
       extends PartSubGraphCompilationError
       with InASingleNode
 
   object UnknownProperty {
     def apply(paramName: ParameterName)(implicit nodeId: NodeId): PartSubGraphCompilationError =
-      UnknownProperty(paramName, nodeId.id)
+      UnknownProperty(paramName, nodeId)
   }
 
   final case class InvalidPropertyFixedValue(
@@ -275,7 +275,7 @@ object ProcessCompilationError {
       label: Option[String],
       value: String,
       values: List[FixedExpressionValue],
-      nodeId: String
+      nodeId: NodeId
   ) extends PartSubGraphCompilationError
       with InASingleNode
 
@@ -284,11 +284,11 @@ object ProcessCompilationError {
     def apply(paramName: ParameterName, label: Option[String], value: String, values: List[FixedExpressionValue])(
         implicit nodeId: NodeId
     ): PartSubGraphCompilationError =
-      InvalidPropertyFixedValue(paramName, label, value, values, nodeId.id)
+      InvalidPropertyFixedValue(paramName, label, value, values, nodeId)
 
   }
 
-  final case class OverwrittenVariable(variableName: String, nodeId: String, paramName: Option[ParameterName])
+  final case class OverwrittenVariable(variableName: String, nodeId: NodeId, paramName: Option[ParameterName])
       extends PartSubGraphCompilationError
       with InASingleNode
 
@@ -297,11 +297,11 @@ object ProcessCompilationError {
     def apply(variableName: String, paramName: Option[ParameterName])(
         implicit nodeId: NodeId
     ): PartSubGraphCompilationError =
-      OverwrittenVariable(variableName, nodeId.id, paramName)
+      OverwrittenVariable(variableName, nodeId, paramName)
 
   }
 
-  final case class InvalidVariableName(name: String, nodeId: String, paramName: Option[ParameterName])
+  final case class InvalidVariableName(name: String, nodeId: NodeId, paramName: Option[ParameterName])
       extends PartSubGraphCompilationError
       with InASingleNode
 
@@ -310,71 +310,71 @@ object ProcessCompilationError {
     def apply(variableName: String, paramName: Option[ParameterName])(
         implicit nodeId: NodeId
     ): PartSubGraphCompilationError =
-      InvalidVariableName(variableName, nodeId.id, paramName)
+      InvalidVariableName(variableName, nodeId, paramName)
 
   }
 
-  final case class FragmentOutputNotDefined(id: String, nodeIds: Set[String]) extends ProcessCompilationError
+  final case class FragmentOutputNotDefined(id: String, nodeIds: Set[NodeId]) extends ProcessCompilationError
 
-  final case class DuplicateFragmentInputParameter(paramName: ParameterName, nodeId: String)
+  final case class DuplicateFragmentInputParameter(paramName: ParameterName, nodeId: NodeId)
       extends PartSubGraphCompilationError
       with InASingleNode
 
-  final case class EmptyFixedListForRequiredField(paramName: ParameterName, nodeIds: Set[String])
+  final case class EmptyFixedListForRequiredField(paramName: ParameterName, nodeIds: Set[NodeId])
       extends PartSubGraphCompilationError
 
-  final case class InitialValueNotPresentInPossibleValues(paramName: ParameterName, nodeIds: Set[String])
+  final case class InitialValueNotPresentInPossibleValues(paramName: ParameterName, nodeIds: Set[NodeId])
       extends PartSubGraphCompilationError
 
-  final case class UnsupportedFixedValuesType(paramName: ParameterName, typ: String, nodeIds: Set[String])
+  final case class UnsupportedFixedValuesType(paramName: ParameterName, typ: String, nodeIds: Set[NodeId])
       extends PartSubGraphCompilationError
 
-  final case class UnsupportedDictParameterEditorType(paramName: ParameterName, typ: String, nodeIds: Set[String])
+  final case class UnsupportedDictParameterEditorType(paramName: ParameterName, typ: String, nodeIds: Set[NodeId])
       extends PartSubGraphCompilationError
 
   final case class IncompatibleParameterDefinitionModification(
       paramName: ParameterName,
       language: Language,
       parameterEditors: List[ParameterEditor],
-      nodeId: String
+      nodeId: NodeId
   ) extends PartSubGraphCompilationError
       with InASingleNode
 
-  final case class UnknownFragmentOutput(id: String, nodeIds: Set[String]) extends ProcessCompilationError
+  final case class UnknownFragmentOutput(id: String, nodeIds: Set[NodeId]) extends ProcessCompilationError
 
-  final case class DisablingManyOutputsFragment(fragmentNodeId: String)
+  final case class DisablingManyOutputsFragment(fragmentNodeId: NodeId)
       extends ProcessCompilationError
       with ScenarioGraphLevelError {
-    override def nodeIds: Set[String] = Set(fragmentNodeId)
+    override def nodeIds: Set[NodeId] = Set(fragmentNodeId)
   }
 
-  final case class DisablingNoOutputsFragment(fragmentNodeId: String)
+  final case class DisablingNoOutputsFragment(fragmentNodeId: NodeId)
       extends ProcessCompilationError
       with ScenarioGraphLevelError {
-    override def nodeIds: Set[String] = Set(fragmentNodeId)
+    override def nodeIds: Set[NodeId] = Set(fragmentNodeId)
   }
 
-  final case class UnknownFragment(id: String, nodeId: String) extends ProcessCompilationError with InASingleNode
+  final case class UnknownFragment(id: String, nodeId: NodeId) extends ProcessCompilationError with InASingleNode
 
-  final case class InvalidFragment(id: String, nodeId: String) extends ProcessCompilationError with InASingleNode
+  final case class InvalidFragment(id: String, nodeId: NodeId) extends ProcessCompilationError with InASingleNode
 
   sealed trait DuplicateFragmentOutputNames extends ProcessCompilationError {
     val duplicatedVarName: String
   }
 
-  final case class DuplicateFragmentOutputNamesInScenario(duplicatedVarName: String, nodeId: String)
+  final case class DuplicateFragmentOutputNamesInScenario(duplicatedVarName: String, nodeId: NodeId)
       extends DuplicateFragmentOutputNames
       with InASingleNode
 
-  final case class DuplicateFragmentOutputNamesInFragment(duplicatedVarName: String, nodeIds: Set[String])
+  final case class DuplicateFragmentOutputNamesInFragment(duplicatedVarName: String, nodeIds: Set[NodeId])
       extends DuplicateFragmentOutputNames
       with ScenarioGraphLevelError
 
-  final case class EmptyMandatoryField(nodeId: String, qualifiedFieldName: ParameterName)
+  final case class EmptyMandatoryField(nodeId: NodeId, qualifiedFieldName: ParameterName)
       extends PartSubGraphCompilationError
       with InASingleNode
 
-  final case class DictNotDeclared(dictId: String, nodeId: String, paramName: ParameterName)
+  final case class DictNotDeclared(dictId: String, nodeId: NodeId, paramName: ParameterName)
       extends PartSubGraphCompilationError
       with InASingleNode
 
@@ -382,7 +382,7 @@ object ProcessCompilationError {
       dictId: String,
       actualType: TypingResult,
       expectedType: TypingResult,
-      nodeId: String,
+      nodeId: NodeId,
       paramName: ParameterName
   ) extends PartSubGraphCompilationError
       with InASingleNode
@@ -391,7 +391,7 @@ object ProcessCompilationError {
       dictId: String,
       label: String,
       possibleLabels: Option[List[String]],
-      nodeId: String,
+      nodeId: NodeId,
       paramName: ParameterName
   ) extends PartSubGraphCompilationError
       with InASingleNode
@@ -400,7 +400,7 @@ object ProcessCompilationError {
       dictId: String,
       key: String,
       possibleKeys: Option[List[String]],
-      nodeId: String,
+      nodeId: NodeId,
       paramName: ParameterName
   ) extends PartSubGraphCompilationError
       with InASingleNode
@@ -408,7 +408,7 @@ object ProcessCompilationError {
   final case class DictLabelByKeyResolutionFailed(
       dictId: String,
       key: String,
-      nodeId: String,
+      nodeId: NodeId,
       paramName: ParameterName
   ) extends PartSubGraphCompilationError
       with InASingleNode
@@ -417,32 +417,32 @@ object ProcessCompilationError {
       keyWithLabel: String,
       message: String,
       paramName: ParameterName,
-      nodeId: String
+      nodeId: NodeId
   ) extends PartSubGraphCompilationError
       with InASingleNode
 
-  final case class CustomNodeError(nodeId: String, message: String, paramName: Option[ParameterName])
+  final case class CustomNodeError(nodeId: NodeId, message: String, paramName: Option[ParameterName])
       extends ProcessCompilationError
       with InASingleNode
 
   object CustomNodeError {
     def apply(message: String, paramName: Option[ParameterName])(implicit nodeId: NodeId): CustomNodeError =
-      CustomNodeError(nodeId.id, message, paramName)
+      CustomNodeError(nodeId, message, paramName)
   }
 
   final case class FatalUnknownError(message: String) extends ProcessCompilationError {
-    override def nodeIds: Set[String] = Set()
+    override def nodeIds: Set[NodeId] = Set()
   }
 
-  final case class CannotCreateObjectError(message: String, nodeId: String, cause: Option[Throwable])
+  final case class CannotCreateObjectError(message: String, nodeId: NodeId, cause: Option[Throwable])
       extends ProcessCompilationError
       with InASingleNode
 
   object CannotCreateObjectError {
 
-    def apply(message: String, nodeId: String) = new CannotCreateObjectError(message, nodeId, cause = None)
+    def apply(message: String, nodeId: NodeId) = new CannotCreateObjectError(message, nodeId, cause = None)
 
-    def apply(cause: Throwable, nodeId: String) =
+    def apply(cause: Throwable, nodeId: NodeId) =
       new CannotCreateObjectError(cause.getMessage, nodeId, cause = Some(cause))
   }
 
@@ -469,8 +469,10 @@ object ProcessCompilationError {
     override val id: String = name.value
   }
 
-  final case class NodeIdValidationError(errorType: IdErrorType, id: String) extends IdError with InASingleNode {
-    override protected def nodeId: String = id
+  final case class NodeIdValidationError(errorType: IdErrorType, override val nodeId: NodeId)
+      extends IdError
+      with InASingleNode {
+    override val id: String = nodeId.id
   }
 
   sealed trait IdErrorType

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/transformation/DynamicComponent.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/context/transformation/DynamicComponent.scala
@@ -66,7 +66,7 @@ sealed trait DynamicComponent[T] extends Component {
       ex: Throwable
   )(implicit nodeId: NodeId): FinalResults = {
     val fallback = fallbackFinalResult(step, inputContext, outputVariable)
-    fallback.copy(errors = fallback.errors :+ CannotCreateObjectError(ex, nodeId.id))
+    fallback.copy(errors = fallback.errors :+ CannotCreateObjectError(ex, nodeId))
   }
 
   protected def fallbackFinalResult(

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
@@ -47,14 +47,14 @@ case object MandatoryParameterValidator extends ParameterValidator {
     expression.language match {
       case Language.Spel | Language.DictKeyWithLabel | Language.TabularDataDefinition | Language.Json |
           Language.JsonTemplate =>
-        Validated.cond(!expression.expression.isBlank, (), error(paramName, nodeId.id))
+        Validated.cond(!expression.expression.isBlank, (), error(paramName, nodeId))
       case Language.SpelTemplate =>
         valid(())
     }
 
   }
 
-  private def error(paramName: ParameterName, nodeId: String): EmptyMandatoryParameter = EmptyMandatoryParameter(
+  private def error(paramName: ParameterName, nodeId: NodeId): EmptyMandatoryParameter = EmptyMandatoryParameter(
     message = s"Field: ${paramName.value} is mandatory and can not be empty",
     description = "Please fill field for this parameter",
     paramName = paramName,
@@ -69,12 +69,12 @@ case object NotNullParameterValidator extends ParameterValidator {
       implicit nodeId: NodeId
   ): Validated[PartSubGraphCompilationError, Unit] = {
     value match {
-      case Some(null) => invalid(error(paramName, nodeId.id))
+      case Some(null) => invalid(error(paramName, nodeId))
       case _          => valid(())
     }
   }
 
-  private def error(paramName: ParameterName, nodeId: String): EmptyMandatoryParameter = EmptyMandatoryParameter(
+  private def error(paramName: ParameterName, nodeId: NodeId): EmptyMandatoryParameter = EmptyMandatoryParameter(
     message = "This field is required and can not be null",
     description = "Please fill field for this parameter",
     paramName = paramName,
@@ -89,12 +89,12 @@ case object CompileTimeEvaluableValueValidator extends ParameterValidator {
       implicit nodeId: NodeId
   ): Validated[PartSubGraphCompilationError, Unit] = {
     value match {
-      case None => invalid(error(paramName, nodeId.id))
+      case None => invalid(error(paramName, nodeId))
       case _    => valid(())
     }
   }
 
-  private def error(paramName: ParameterName, nodeId: String): CompileTimeEvaluableParameterNotEvaluated =
+  private def error(paramName: ParameterName, nodeId: NodeId): CompileTimeEvaluableParameterNotEvaluated =
     CompileTimeEvaluableParameterNotEvaluated(
       message = "This field's value has to be evaluable at deployment time",
       description = "Please provide a value that is evaluable at deployment time",
@@ -112,11 +112,11 @@ case object NotBlankParameterValidator extends ParameterValidator {
     value match {
       case None                         => valid(())
       case Some(null)                   => valid(())
-      case Some(s: String) if s.isBlank => invalid(error(paramName, nodeId.id))
+      case Some(s: String) if s.isBlank => invalid(error(paramName, nodeId))
       case _                            => valid(())
     }
 
-  private def error(paramName: ParameterName, nodeId: String): BlankParameter = BlankParameter(
+  private def error(paramName: ParameterName, nodeId: NodeId): BlankParameter = BlankParameter(
     "This field value is required and can not be blank",
     "Please fill field value for this parameter",
     paramName,
@@ -155,7 +155,7 @@ case class RegExpParameterValidator(pattern: String, message: String, descriptio
       case None                                                  => valid(())
       case Some(null)                                            => valid(())
       case Some(s: String) if regexpPattern.matcher(s).matches() => valid(())
-      case _ => invalid(MismatchParameter(message, description, paramName, nodeId.id))
+      case _ => invalid(MismatchParameter(message, description, paramName, nodeId))
     }
   }
 
@@ -172,10 +172,10 @@ case object LiteralIntegerValidator extends ParameterValidator {
     expression.expression match {
       case e if e.isBlank              => valid(())
       case e if Try(e.toInt).isSuccess => valid(())
-      case _                           => invalid(error(paramName, nodeId.id))
+      case _                           => invalid(error(paramName, nodeId))
     }
 
-  private def error(paramName: ParameterName, nodeId: String): InvalidIntegerLiteralParameter =
+  private def error(paramName: ParameterName, nodeId: NodeId): InvalidIntegerLiteralParameter =
     InvalidIntegerLiteralParameter(
       "This field value has to be an integer number",
       "Please fill field by proper integer type",
@@ -196,10 +196,10 @@ case class MinimalNumberValidator(minimalNumber: BigDecimal) extends ParameterVa
       case Some(null)                                                 => valid(())
       case Some(n: BigDecimal) if n >= minimalNumber                  => valid(())
       case Some(n: Number) if BigDecimal(n.toString) >= minimalNumber => valid(())
-      case _                                                          => invalid(error(paramName, nodeId.id))
+      case _                                                          => invalid(error(paramName, nodeId))
     }
 
-  private def error(paramName: ParameterName, nodeId: String): LowerThanRequiredParameter = LowerThanRequiredParameter(
+  private def error(paramName: ParameterName, nodeId: NodeId): LowerThanRequiredParameter = LowerThanRequiredParameter(
     s"This field value has to be a number greater than or equal to ${minimalNumber}",
     "Please fill field with proper number",
     paramName,
@@ -219,10 +219,10 @@ case class MaximalNumberValidator(maximalNumber: BigDecimal) extends ParameterVa
       case Some(null)                                                 => valid(())
       case Some(n: BigDecimal) if n <= maximalNumber                  => valid(())
       case Some(n: Number) if BigDecimal(n.toString) <= maximalNumber => valid(())
-      case _                                                          => invalid(error(paramName, nodeId.id))
+      case _                                                          => invalid(error(paramName, nodeId))
     }
 
-  private def error(paramName: ParameterName, nodeId: String): GreaterThanRequiredParameter =
+  private def error(paramName: ParameterName, nodeId: NodeId): GreaterThanRequiredParameter =
     GreaterThanRequiredParameter(
       s"This field value has to be a number lower than or equal to ${maximalNumber}",
       "Please fill field with proper number",
@@ -246,16 +246,16 @@ case object JsonValidator extends ParameterValidator {
       case Some(s: String) =>
         parse(s.trim) match {
           case Right(_)             => valid(())
-          case Left(parsingFailure) => invalid(error(parsingFailure.message, paramName, nodeId.id))
+          case Left(parsingFailure) => invalid(error(parsingFailure.message, paramName, nodeId))
         }
       case o =>
         invalid(
-          error(s"Expected String with valid json, got object of class: ${o.getClass.getName}", paramName, nodeId.id)
+          error(s"Expected String with valid json, got object of class: ${o.getClass.getName}", paramName, nodeId)
         )
     }
   }
 
-  private def error(message: String, paramName: ParameterName, nodeId: String): JsonRequiredParameter =
+  private def error(message: String, paramName: ParameterName, nodeId: NodeId): JsonRequiredParameter =
     JsonRequiredParameter(
       message,
       "Please fill field with valid json",

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/generics/ExpressionParseError.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/generics/ExpressionParseError.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.api.generics
 import io.circe.{Codec, Decoder, Encoder}
 import io.circe.generic.JsonCodec
 import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec}
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.definition.ParameterEditor
 import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.ErrorDetails
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
@@ -47,7 +48,7 @@ object ExpressionParseError {
   final case class IncompatibleParameterDefinitionErrorDetails(
       paramName: ParameterName,
       parameterEditors: List[ParameterEditor],
-      nodeId: String,
+      nodeId: NodeId,
   ) extends ErrorDetails
 
 }

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/runtimecontext/ContextIdGenerator.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/runtimecontext/ContextIdGenerator.scala
@@ -1,10 +1,9 @@
 package pl.touk.nussknacker.engine.api.runtimecontext
 
-import pl.touk.nussknacker.engine.api.{ContextId, JobData, MetaData}
+import pl.touk.nussknacker.engine.api.{ContextId, JobData, MetaData, NodeId}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 
 import java.util.concurrent.atomic.AtomicLong
-import scala.jdk.CollectionConverters._
 
 /**
   * Context id generator - it should fulfill rules:
@@ -20,23 +19,23 @@ trait ContextIdGenerator {
 }
 
 class IncContextIdGenerator(
-    scenarioId: ProcessName,
-    nodeId: String,
+    scenarioName: ProcessName,
+    nodeId: NodeId,
     taskId: Long,
     counter: AtomicLong = new AtomicLong(0),
 ) extends ContextIdGenerator {
 
   override def nextContextId(): ContextId =
-    ContextId(scenarioId.value, nodeId, taskId, counter.getAndIncrement(), List.empty)
+    ContextId(scenarioName, nodeId, taskId, counter.getAndIncrement(), List.empty)
 
 }
 
 object IncContextIdGenerator {
 
-  def withProcessIdNodeIdPrefix(jobData: JobData, nodeId: String, taskId: Long): IncContextIdGenerator =
+  def withProcessIdNodeIdPrefix(jobData: JobData, nodeId: NodeId, taskId: Long): IncContextIdGenerator =
     withProcessIdNodeIdPrefix(jobData.metaData, nodeId, taskId)
 
-  def withProcessIdNodeIdPrefix(metaData: MetaData, nodeId: String, taskId: Long): IncContextIdGenerator =
+  def withProcessIdNodeIdPrefix(metaData: MetaData, nodeId: NodeId, taskId: Long): IncContextIdGenerator =
     new IncContextIdGenerator(metaData.name, nodeId, taskId)
 
 }

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/runtimecontext/EngineRuntimeContext.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/runtimecontext/EngineRuntimeContext.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.api.runtimecontext
 
-import pl.touk.nussknacker.engine.api.JobData
+import pl.touk.nussknacker.engine.api.{JobData, NodeId}
 import pl.touk.nussknacker.engine.util.metrics.MetricsProviderForScenario
 
 trait EngineRuntimeContext {
@@ -9,6 +9,6 @@ trait EngineRuntimeContext {
 
   def metricsProvider: MetricsProviderForScenario
 
-  def contextIdGenerator(nodeId: String): ContextIdGenerator
+  def contextIdGenerator(nodeId: NodeId): ContextIdGenerator
 
 }

--- a/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/http/backend/SharedHttpClientBackendProviderTest.scala
+++ b/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/http/backend/SharedHttpClientBackendProviderTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
-import pl.touk.nussknacker.engine.api.{JobData, MetaData, ProcessAdditionalFields, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{JobData, MetaData, NodeId, ProcessAdditionalFields, ProcessVersion}
 import pl.touk.nussknacker.engine.api.runtimecontext.{ContextIdGenerator, EngineRuntimeContext}
 import pl.touk.nussknacker.engine.util.metrics.MetricsProviderForScenario
 import pl.touk.nussknacker.http.backend.DefaultHttpClientConfig
@@ -52,7 +52,7 @@ class SharedHttpClientBackendProviderTest
       ProcessVersion.empty
     )
     override def metricsProvider: MetricsProviderForScenario            = ???
-    override def contextIdGenerator(nodeId: String): ContextIdGenerator = ???
+    override def contextIdGenerator(nodeId: NodeId): ContextIdGenerator = ???
   }
 
   test("should throw exception on every localhost address if localhost is not allowed") {

--- a/designer/processReports/src/it/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxCountsReporterSpec.scala
+++ b/designer/processReports/src/it/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxCountsReporterSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.{Assertion, BeforeAndAfterAll}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.processCounts.{CannotFetchCountsError, ExecutionCount, RangeCount}
 import pl.touk.nussknacker.test.VeryPatientScalaFutures
@@ -56,9 +57,9 @@ class InfluxCountsReporterSpec
     data.writePointForCount(process, "node2", 20, startTime)
 
     val results = data.reporter(QueryMode.OnlySingleDifference).prepareRawCounts(process, ExecutionCount(startTime))
-    results("node1") shouldBe Some(10)
-    results("node2") shouldBe Some(20)
-    results("node3") shouldBe None
+    results(NodeId("node1")) shouldBe Some(10)
+    results(NodeId("node2")) shouldBe Some(20)
+    results(NodeId("node3")) shouldBe None
 
   }
 
@@ -83,9 +84,9 @@ class InfluxCountsReporterSpec
       val results = data
         .reporter(mode)
         .prepareRawCounts(process, RangeCount(startTime.minusHours(1), startTime.plusHours(2)))
-      results("node1") shouldBe Some(9)
-      results("node2") shouldBe Some(30)
-      results("node3") shouldBe None
+      results(NodeId("node1")) shouldBe Some(9)
+      results(NodeId("node2")) shouldBe Some(30)
+      results(NodeId("node3")) shouldBe None
     }
   }
 
@@ -113,7 +114,7 @@ class InfluxCountsReporterSpec
       val value = data
         .reporter(mode)
         .prepareRawCounts(process, RangeCount(startTime.minusHours(1), startTime.plusHours(2)))
-      value("node1") shouldBe Some(10 + 15)
+      value(NodeId("node1")) shouldBe Some(10 + 15)
 
     }
   }

--- a/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/CountsReporter.scala
+++ b/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/CountsReporter.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.processCounts
 
 import com.typesafe.config.Config
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import sttp.client3.SttpBackend
 
@@ -25,7 +26,7 @@ trait CountsReporterCreator {
 
 trait CountsReporter[F[_]] extends AutoCloseable {
 
-  def prepareRawCounts(processName: ProcessName, countsRequest: CountsRequest): F[String => Option[Long]]
+  def prepareRawCounts(processName: ProcessName, countsRequest: CountsRequest): F[NodeId => Option[Long]]
 
 }
 

--- a/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxCountsReporter.scala
+++ b/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxCountsReporter.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.processCounts.influxdb
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.processCounts._
 import sttp.client3.SttpBackend
@@ -25,7 +26,7 @@ class InfluxCountsReporter[F[_]](env: String, config: InfluxConfig)(implicit bac
 
   private val metricsConfig = config.metricsConfig.getOrElse(MetricsConfig())
 
-  override def prepareRawCounts(processName: ProcessName, countsRequest: CountsRequest): F[String => Option[Long]] =
+  override def prepareRawCounts(processName: ProcessName, countsRequest: CountsRequest): F[NodeId => Option[Long]] =
     (countsRequest match {
       case RangeCount(fromDate, toDate) => prepareRangeCounts(processName, fromDate, toDate)
       case ExecutionCount(pointInTime) =>
@@ -34,7 +35,7 @@ class InfluxCountsReporter[F[_]](env: String, config: InfluxConfig)(implicit bac
 
   override def close(): Unit = {}
 
-  private def prepareRangeCounts(processName: ProcessName, fromDate: Instant, toDate: Instant): F[Map[String, Long]] = {
+  private def prepareRangeCounts(processName: ProcessName, fromDate: Instant, toDate: Instant): F[Map[NodeId, Long]] = {
 
     influxGenerator.detectRestarts(processName, fromDate, toDate, metricsConfig).flatMap { restarts =>
       (restarts, config.queryMode) match {

--- a/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxGenerator.scala
+++ b/designer/processReports/src/main/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxGenerator.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.processCounts.influxdb
 
 import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import sttp.client3.SttpBackend
@@ -25,16 +26,16 @@ private[influxdb] class InfluxGenerator[F[_]](config: InfluxConfig, env: String)
       dateFrom: Option[Instant],
       dateTo: Instant,
       config: MetricsConfig
-  ): F[Map[String, Long]] = {
+  ): F[Map[NodeId, Long]] = {
     val pointInTimeQuery = new PointInTimeQuery(influxClient.query, processName, env, config)
 
     for {
       valuesAtEnd <- pointInTimeQuery.query(dateTo)
       valuesAtStart <- dateFrom
         .map(pointInTimeQuery.query)
-        .getOrElse(monadError.unit(Map[String, Long]()))
-    } yield valuesAtEnd.map { case (key, value) =>
-      key -> (value - valuesAtStart.getOrElse(key, 0L))
+        .getOrElse(monadError.unit(Map[NodeId, Long]()))
+    } yield valuesAtEnd.map { case (nodeId, value) =>
+      nodeId -> (value - valuesAtStart.getOrElse(nodeId, 0L))
     }
   }
 
@@ -43,7 +44,7 @@ private[influxdb] class InfluxGenerator[F[_]](config: InfluxConfig, env: String)
       dateFrom: Instant,
       dateTo: Instant,
       config: MetricsConfig
-  ): F[Map[String, Long]] = {
+  ): F[Map[NodeId, Long]] = {
     val query = s"""select sum(diff) as count from (SELECT non_negative_difference("${config.countField}") AS diff
      FROM "${config.nodeCountMetric}"
      WHERE ${config.envTag} = '$env' AND ${config.scenarioTag} = '$processName'
@@ -91,7 +92,7 @@ object InfluxGenerator extends LazyLogging {
       config: MetricsConfig,
       invokeQuery: String => F[List[InfluxSeries]],
       queryString: String
-  ): F[Map[String, Long]] = {
+  ): F[Map[NodeId, Long]] = {
 
     val groupedResults = invokeQuery(queryString).map { seriesList =>
       seriesList
@@ -103,7 +104,7 @@ object InfluxGenerator extends LazyLogging {
             firstResult.getOrElse("count", 0L).asInstanceOf[Number].longValue()
           )
         }
-        .groupBy(_._1)
+        .groupBy { case (nodeId, _) => NodeId(nodeId) }
         .mapValuesNow(_.map(_._2).sum)
     }
     groupedResults.map { evaluated =>
@@ -125,7 +126,7 @@ object InfluxGenerator extends LazyLogging {
     // two hour window is for possible delays in sending metrics from taskmanager to jobmanager (or upd sending problems...)
     // it's VERY unclear how large it should be. If it's too large, we may overlap with end and still generate
     // bad results...
-    def query(date: Instant): F[Map[String, Long]] = {
+    def query(date: Instant): F[Map[NodeId, Long]] = {
       def query(timeCondition: String, aggregateFunction: String) =
         s"""select ${config.nodeIdTag} as nodeId, $aggregateFunction(${config.countField}) as count
            | from "${config.nodeCountMetric}" where ${config.scenarioTag} = '$processName'

--- a/designer/processReports/src/test/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxGeneratorSpec.scala
+++ b/designer/processReports/src/test/scala/pl/touk/nussknacker/processCounts/influxdb/InfluxGeneratorSpec.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.processCounts.influxdb
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.CirceUtil
+import pl.touk.nussknacker.engine.api.{CirceUtil, NodeId}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.test.PatientScalaFutures
 import sttp.client3.Identity
@@ -21,8 +21,8 @@ class InfluxGeneratorSpec extends AnyFunSuite with Matchers with PatientScalaFut
       new PointInTimeQuery[Identity](_ => sampleInfluxOutput, ProcessName("process1"), "test", MetricsConfig())(IdMonad)
 
     pointInTimeQuery.query(Instant.now()) shouldBe Map(
-      "start" -> (552855221L + 557871409L),
-      "end"   -> (412793677L + 414963365L)
+      NodeId("start") -> (552855221L + 557871409L),
+      NodeId("end")   -> (412793677L + 414963365L)
     )
   }
 

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrors.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.restmodel.validation
 
 import org.apache.commons.lang3.StringUtils
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.{ParameterValidationError, ProcessCompilationError}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.definition.{FixedExpressionValue, FixedValuesParameterEditor}
@@ -322,7 +323,7 @@ object PrettyValidationErrors {
       label: Option[String],
       value: String,
       values: List[FixedExpressionValue],
-      nodeId: String,
+      nodeId: NodeId,
   ) = {
     val labelText = getLabel(label)
     NodeValidationError(

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/ValidationResults.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/ValidationResults.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.restmodel.validation
 import cats.implicits._
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.JsonCodec
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.expression.ExpressionTypingInfo
 import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.ErrorDetails
 import pl.touk.nussknacker.engine.api.json.encoders.TypeEncoders
@@ -82,16 +83,16 @@ object ValidationResults {
   )
 
   @JsonCodec final case class ValidationErrors(
-      invalidNodes: Map[String, List[NodeValidationError]],
+      invalidNodes: Map[NodeId, List[NodeValidationError]],
       processPropertiesErrors: List[NodeValidationError],
       globalErrors: List[UIGlobalError]
   ) {
     def isEmpty: Boolean = invalidNodes.isEmpty && processPropertiesErrors.isEmpty && globalErrors.isEmpty
   }
 
-  @JsonCodec final case class UIGlobalError(error: NodeValidationError, nodeIds: List[String])
+  @JsonCodec final case class UIGlobalError(error: NodeValidationError, nodeIds: List[NodeId])
 
-  @JsonCodec final case class ValidationWarnings(invalidNodes: Map[String, List[NodeValidationError]])
+  @JsonCodec final case class ValidationWarnings(invalidNodes: Map[NodeId, List[NodeValidationError]])
 
   @JsonCodec final case class NodeValidationError(
       typ: String,
@@ -118,7 +119,7 @@ object ValidationResults {
       ValidationResult.errors(Map.empty, List.empty, globalErrors)
 
     def errors(
-        invalidNodes: Map[String, List[NodeValidationError]],
+        invalidNodes: Map[NodeId, List[NodeValidationError]],
         processPropertiesErrors: List[NodeValidationError],
         globalErrors: List[UIGlobalError]
     ): ValidationResult = {
@@ -133,7 +134,7 @@ object ValidationResults {
       )
     }
 
-    def warnings(invalidNodes: Map[String, List[NodeValidationError]]): ValidationResult = {
+    def warnings(invalidNodes: Map[NodeId, List[NodeValidationError]]): ValidationResult = {
       ValidationResult(
         ValidationErrors.success,
         ValidationWarnings(invalidNodes = invalidNodes),

--- a/designer/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrorsTest.scala
+++ b/designer/restmodel/src/test/scala/pl/touk/nussknacker/restmodel/validation/PrettyValidationErrorsTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks.{forAll, Table}
 import org.scalatest.prop.TableFor3
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{
   BlankId,
@@ -51,29 +52,30 @@ object IdErrorTestData {
 
   val emptyIdScenarioError: ScenarioNameError = ScenarioNameError(EmptyValue, ProcessName(""), isFragment = false)
   val emptyIdFragmentError: ScenarioNameError = ScenarioNameError(EmptyValue, ProcessName(""), isFragment = true)
-  val emptyIdNodeError: NodeIdValidationError = NodeIdValidationError(EmptyValue, "")
+  val emptyIdNodeError: NodeIdValidationError = NodeIdValidationError(EmptyValue, NodeId(""))
 
   val blankIdScenarioError: ScenarioNameError = ScenarioNameError(BlankId, ProcessName(" "), isFragment = false)
   val blankIdFragmentError: ScenarioNameError = ScenarioNameError(BlankId, ProcessName(" "), isFragment = true)
-  val blankIdNodeError: NodeIdValidationError = NodeIdValidationError(BlankId, " ")
+  val blankIdNodeError: NodeIdValidationError = NodeIdValidationError(BlankId, NodeId(" "))
 
   val leadingSpacesIdScenarioError: ScenarioNameError =
     ScenarioNameError(LeadingSpacesId, ProcessName(" leadingSpace"), isFragment = false)
   val leadingSpacesIdFragmentError: ScenarioNameError =
     ScenarioNameError(LeadingSpacesId, ProcessName(" leadingSpace"), isFragment = true)
-  val leadingSpacesIdNodeError: NodeIdValidationError = NodeIdValidationError(LeadingSpacesId, " leadingSpace")
+  val leadingSpacesIdNodeError: NodeIdValidationError = NodeIdValidationError(LeadingSpacesId, NodeId(" leadingSpace"))
 
   val trailingSpacesIdScenarioError: ScenarioNameError =
     ScenarioNameError(TrailingSpacesId, ProcessName("trailingSpace "), isFragment = false)
   val trailingSpacesIdFragmentError: ScenarioNameError =
     ScenarioNameError(TrailingSpacesId, ProcessName("trailingSpace "), isFragment = true)
-  val trailingSpacesIdNodeError: NodeIdValidationError = NodeIdValidationError(TrailingSpacesId, "trailingSpace ")
+  val trailingSpacesIdNodeError: NodeIdValidationError =
+    NodeIdValidationError(TrailingSpacesId, NodeId("trailingSpace "))
 
   val illegalCharsReadable = "Some illegal character (x), another illegal character (!)"
   val illegalCharactersIdScenarioError: ScenarioNameError =
     ScenarioNameError(IllegalCharactersId(illegalCharsReadable), ProcessName("idWithIllegalChars!"), isFragment = false)
   val illegalCharactersIdNodeError: NodeIdValidationError =
-    NodeIdValidationError(IllegalCharactersId(illegalCharsReadable), "idWithIllegalChars!")
+    NodeIdValidationError(IllegalCharactersId(illegalCharsReadable), NodeId("idWithIllegalChars!"))
 
   val allIdErrors: Set[IdError] =
     Set(

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessReportResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ProcessReportResources.scala
@@ -8,6 +8,7 @@ import org.apache.pekko.http.scaladsl.server._
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.Materializer
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcessConverter
@@ -89,7 +90,7 @@ class ProcessReportResources(
       processName: ProcessName,
       scenarioGraph: ScenarioGraph,
       isFragment: Boolean,
-      nodeCountFunction: String => Option[Long]
+      nodeCountFunction: NodeId => Option[Long]
   )(implicit loggedUser: LoggedUser): ToResponseMarshallable = {
     val computedCounts = processCounter.computeCounts(
       CanonicalProcessConverter.fromScenarioGraph(scenarioGraph, processName),

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ScenarioLiveDataApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ScenarioLiveDataApiHttpService.scala
@@ -97,7 +97,7 @@ class ScenarioLiveDataApiHttpService(
 
   private def computeCounts(scenarioWithDetails: ScenarioWithDetails, liveData: CollectedLiveData)(
       implicit loggedUser: LoggedUser
-  ): Map[String, NodeCount] = {
+  ): Map[NodeId, NodeCount] = {
     val incomingCounts =
       liveData.nodeTransitions.toList
         .flatMap { case (transition, data) => transition.destinationNodeId.map(_ -> data.totalCount) }
@@ -110,13 +110,13 @@ class ScenarioLiveDataApiHttpService(
         .toGroupedMap
         .mapValuesNow(_.sum)
 
-    def getCount(nodeId: String): Option[RawCount] = Some(
+    def getCount(nodeId: NodeId): Option[RawCount] = Some(
       RawCount(
         incomingCounts
           .get(nodeId)
           .orElse(outgoingCounts.get(nodeId))
           .getOrElse(0),
-        liveData.exceptions.getOrElse(NodeId(nodeId), List.empty).size.toLong
+        liveData.exceptions.getOrElse(nodeId, List.empty).size.toLong
       )
     )
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ScenarioTestingApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ScenarioTestingApiHttpService.scala
@@ -294,10 +294,10 @@ class ScenarioTestingApiHttpService(
 
   private def collectInvalidNodes(
       nodesWithErrors: NonEmptyList[(NodeId, NonEmptyList[ProcessCompilationError])]
-  ): Map[String, List[ValidationResults.NodeValidationError]] = {
+  ): Map[NodeId, List[ValidationResults.NodeValidationError]] = {
     nodesWithErrors
       .map { case (nodeId, errors) =>
-        (nodeId.id, errors.map(PrettyValidationErrors.formatErrorMessage).toList)
+        (nodeId, errors.map(PrettyValidationErrors.formatErrorMessage).toList)
       }
       .toList
       .toMap

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/DeploymentApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/DeploymentApiEndpoints.scala
@@ -86,7 +86,7 @@ class DeploymentApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseE
                     value = ScenarioGraphValidationError(
                       ValidationErrors(
                         invalidNodes = Map(
-                          "filter" -> List(
+                          NodeId("filter") -> List(
                             PrettyValidationErrors.formatErrorMessage(
                               ExpressionParserCompilationError(
                                 message = "Bad expression",

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/MigrationApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/MigrationApiEndpoints.scala
@@ -5,6 +5,7 @@ import derevo.circe._
 import derevo.derive
 import io.circe.{Decoder, Encoder}
 import io.circe.syntax.EncoderOps
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ProcessingMode
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.process.{ProcessName, VersionId}
@@ -139,7 +140,7 @@ class MigrationApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseEn
                         NodeValidationErrorType.SaveAllowed,
                         None
                       ),
-                      List("node1")
+                      List(NodeId("node1"))
                     )
                   )
                 )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
@@ -9,7 +9,7 @@ import io.circe.generic.JsonCodec
 import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 import org.springframework.util.ClassUtils
 import pl.touk.nussknacker.engine.additionalInfo.{AdditionalInfo, MarkdownAdditionalInfo}
-import pl.touk.nussknacker.engine.api.{LayoutData, ProcessAdditionalFields, StreamMetaData}
+import pl.touk.nussknacker.engine.api.{LayoutData, NodeId, ProcessAdditionalFields, StreamMetaData}
 import pl.touk.nussknacker.engine.api.CirceUtil._
 import pl.touk.nussknacker.engine.api.definition.{
   FixedExpressionValue,
@@ -711,6 +711,7 @@ object NodesApiEndpoints {
     implicit lazy val columnDefinitionSchema: Schema[ColumnDefinition]         = Schema.derived
     implicit lazy val languageSchema: Schema[Language]                         = Schema.string[Language]
     implicit lazy val parameterEditorSchema: Schema[ParameterEditor]           = Schema.anyObject[ParameterEditor]
+    implicit lazy val nodeIdSchema: Schema[NodeId]                             = Schema.string[NodeId]
     implicit lazy val errorDetailsSchema: Schema[ErrorDetails]                 = Schema.derived
     implicit lazy val nodeValidationErrorSchema: Schema[NodeValidationError]   = Schema.derived
     implicit lazy val fixedExpressionValueSchema: Schema[FixedExpressionValue] = Schema.derived

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDto.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDto.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.ui.api.description.scenarioTesting
 
 import io.circe._
-import pl.touk.nussknacker.engine.api.ContextId
+import pl.touk.nussknacker.engine.api.{ContextId, NodeId}
 import pl.touk.nussknacker.engine.livedata.CollectedLiveData
 import pl.touk.nussknacker.engine.testmode.TestProcess._
 import pl.touk.nussknacker.ui.api.description.scenarioTesting.Dtos.Test.{SkipResultsPerNode, SkipResultsPerTransition}
@@ -16,7 +16,7 @@ import sttp.tapir.Schema
 import java.time.Instant
 import scala.collection.compat._
 
-final case class ResultsWithCountsDto(timestamp: Instant, results: TestResultsDto, counts: Map[String, NodeCount])
+final case class ResultsWithCountsDto(timestamp: Instant, results: TestResultsDto, counts: Map[NodeId, NodeCount])
 
 object ResultsWithCountsDto {
 
@@ -53,10 +53,10 @@ object ResultsWithCountsDto {
     )
   }
 
-  def from(liveData: CollectedLiveData, counts: Map[String, NodeCount]): ResultsWithCountsDto = {
+  def from(liveData: CollectedLiveData, counts: Map[NodeId, NodeCount]): ResultsWithCountsDto = {
     lazy val exceptionsByNodeId = liveData.exceptions.map { case (nodeId, results) =>
-      nodeId.id -> results.map(e =>
-        ExceptionResult(ResultContext(e.contextId, e.timestamp, e.variables), Some(nodeId.id), e.throwable)
+      nodeId -> results.map(e =>
+        ExceptionResult(ResultContext(e.contextId, e.timestamp, e.variables), Some(nodeId), e.throwable)
       )
     }
     ResultsWithCountsDto(
@@ -75,10 +75,10 @@ object ResultsWithCountsDto {
           }.toList
         ),
         invocationResults = liveData.invocationResults.map { case (nodeId, results) =>
-          nodeId.id -> results.map(r => ExpressionInvocationResult(r.contextId, r.timestamp, r.name, r.value))
+          nodeId -> results.map(r => ExpressionInvocationResult(r.contextId, r.timestamp, r.name, r.value))
         },
         externalInvocationResults = liveData.externalInvocationResults.map { case (nodeId, results) =>
-          nodeId.id -> results.map(r => ExternalInvocationResult(r.contextId, r.timestamp, r.name, r.value))
+          nodeId -> results.map(r => ExternalInvocationResult(r.contextId, r.timestamp, r.name, r.value))
         },
         exceptions = exceptionsByNodeId.values.toList.flatten,
         exceptionsByNodeId = exceptionsByNodeId,
@@ -89,6 +89,8 @@ object ResultsWithCountsDto {
 
   import sttp.tapir.json.circe._
 
+  implicit def nodeIdSchema: Schema[NodeId]                             = Schema.derived
+  implicit def nodeIdKeyMapSchema[V: Schema]: Schema[Map[NodeId, V]]    = Schema.schemaForMap[NodeId, V](_.id)
   implicit def contextIdPathPartDtoSchema: Schema[ContextIdPathPartDto] = Schema.derived
   implicit def contextIdSchema: Schema[ContextId] =
     Schema.derived[ContextIdDto].map(_ => None)(ContextIdDto.from)
@@ -105,17 +107,17 @@ object ResultsWithCountsDto {
 }
 
 final case class TestResultsDto(
-    nodeResults: Option[Map[String, List[ResultContext[Json]]]],
+    nodeResults: Option[Map[NodeId, List[ResultContext[Json]]]],
     nodeTransitionResults: Option[List[NodeTransitionResult]],
-    invocationResults: Map[String, List[ExpressionInvocationResult[Json]]],
-    externalInvocationResults: Map[String, List[ExternalInvocationResult[Json]]],
+    invocationResults: Map[NodeId, List[ExpressionInvocationResult[Json]]],
+    externalInvocationResults: Map[NodeId, List[ExternalInvocationResult[Json]]],
     exceptions: List[ExceptionResult[Json]],
-    exceptionsByNodeId: Map[String, List[ExceptionResult[Json]]],
+    exceptionsByNodeId: Map[NodeId, List[ExceptionResult[Json]]],
 )
 
 final case class NodeTransitionResult(
-    sourceNodeId: String,
-    destinationNodeId: Option[String],
+    sourceNodeId: NodeId,
+    destinationNodeId: Option[NodeId],
     results: List[ResultContext[Json]],
     totalCount: Option[Long],
     currentThroughput: Option[BigDecimal],

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDtoCodecs.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDtoCodecs.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.ui.api.description.scenarioTesting
 import io.circe.{Decoder, DecodingFailure, Encoder, Json, JsonObject}
 import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
 import io.circe.generic.semiauto.deriveEncoder
-import pl.touk.nussknacker.engine.api.ContextId
+import pl.touk.nussknacker.engine.api.{ContextId, NodeId}
 import pl.touk.nussknacker.engine.testmode.TestProcess.{
   ExceptionResult,
   ExpressionInvocationResult,
@@ -51,7 +51,7 @@ object ResultsWithCountsDtoCodecs {
 
     implicit val nodeTransitionResultEncoder: Encoder[NodeTransitionResult] = Encoder.instance { value =>
       val baseFields: List[(String, Option[Json])] = List(
-        "sourceNodeId"      -> Some(Json.fromString(value.sourceNodeId)),
+        "sourceNodeId"      -> Some(value.sourceNodeId.id.asJson),
         "destinationNodeId" -> Some(value.destinationNodeId.asJson), // Always include json field (even when None)
         "results"           -> Some(value.results.asJson),
         "totalCount"        -> value.totalCount.map(Json.fromLong),  // Drop json field when None
@@ -83,7 +83,10 @@ object ResultsWithCountsDtoCodecs {
           "nodeResults" -> nodeResults
             .map(_.map { case (node, list) => node -> list.sortBy(_.id.legacyString) }.asJson)
             .getOrElse(Json.Null),
-          "nodeTransitionResults" -> nodeTransitionResults.asJson.deepDropNullValues,
+          "nodeTransitionResults" -> nodeTransitionResults
+            .map(_.sortBy(r => (r.sourceNodeId, r.destinationNodeId)))
+            .asJson
+            .deepDropNullValues,
           "invocationResults" -> invocationResults.map { case (node, list) =>
             node -> list.sortBy(_.contextId.legacyString)
           }.asJson,
@@ -111,7 +114,7 @@ object ResultsWithCountsDtoCodecs {
   }
 
   final case class ContextIdDto(
-      nid: String,
+      nid: NodeId,
       tid: Long,
       idx: Long,
       path: List[ContextIdPathPartDto]
@@ -130,6 +133,6 @@ object ResultsWithCountsDtoCodecs {
 
   }
 
-  final case class ContextIdPathPartDto(n: String, t: String)
+  final case class ContextIdPathPartDto(n: NodeId, t: String)
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ScenarioTestingApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ScenarioTestingApiEndpoints.scala
@@ -279,7 +279,7 @@ class ScenarioTestingApiEndpoints(auth: EndpointInput[AuthCredentials]) extends 
               value = SourcesCompilationError(
                 ValidationErrors(
                   invalidNodes = Map(
-                    "source" -> List(
+                    NodeId("source") -> List(
                       PrettyValidationErrors.formatErrorMessage(
                         ExpressionParserCompilationError(
                           message = "Bad expression",

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ActionInfoService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/ActionInfoService.scala
@@ -71,7 +71,7 @@ class ActionInfoService(
       .map { case (scenarioActionName, nodeParamsMap) =>
         scenarioActionName -> nodeParamsMap.map { case (nodeComponentInfo, params) =>
           UiActionNodeParameters(
-            NodeId(nodeComponentInfo.nodeId),
+            nodeComponentInfo.nodeId,
             nodeComponentInfo.componentId.getOrElse(
               throw new IllegalStateException("ComponentId is not present")
             ),

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/deployment/DeploymentService.scala
@@ -265,7 +265,7 @@ class DeploymentService(
             .map { params =>
               val paramsMap = params.toList
                 .map { case (nodeComponentInfo, paramsForNode) =>
-                  NodeId(nodeComponentInfo.nodeId) -> paramsForNode
+                  nodeComponentInfo.nodeId -> paramsForNode
                     // Important NOTICE! If the user hasn't provided any (quick deploy/redeploy action) deploy parameters,
                     // we take parameters with defined default values.
                     // Parameters without default values (even required ones) are skipped.

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrations.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrations.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.ui.process.migrate
 
 import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.process.{ProcessingType, ProcessName}
 import pl.touk.nussknacker.engine.canonicalgraph.{CanonicalProcess, CanonicalProcessConverter}
@@ -127,7 +128,7 @@ class TestModelMigrations(
       after.filterNot(error => errorsBefore.contains(errorToKey(error)))
     }
 
-    def diffOnMap(before: Map[String, List[NodeValidationError]], after: Map[String, List[NodeValidationError]]) = {
+    def diffOnMap(before: Map[NodeId, List[NodeValidationError]], after: Map[NodeId, List[NodeValidationError]]) = {
       after
         .map { case (nodeId, errorsAfter) =>
           (nodeId, diffErrorLists(before.getOrElse(nodeId, List.empty), errorsAfter))

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/cron/CronParameterValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/cron/CronParameterValidator.scala
@@ -21,7 +21,7 @@ object CronParameterValidator extends CustomParameterValidatorDelegate("cron_val
         message = "Expression is not valid cron expression",
         description = s"Expression '$value' is not valid cron expression",
         paramName = paramName,
-        nodeId = nodeId.id
+        nodeId = nodeId
       )
     }
     value match {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecords.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecords.scala
@@ -4,22 +4,23 @@ import cats.data.NonEmptyList
 import io.circe._
 import io.circe.DecodingFailure.Reason.CustomReason
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import pl.touk.nussknacker.engine.api.NodeId
 
 case class PreliminaryScenarioRecords(records: NonEmptyList[PreliminaryScenarioRecord])
 
 sealed trait PreliminaryScenarioRecord {
-  def sourceId: String
+  def sourceId: NodeId
   def timestamp: Option[Long]
 }
 
 final case class SourceSpecificFormatPreliminaryScenarioRecord(
-    override val sourceId: String,
+    override val sourceId: NodeId,
     record: Json,
     override val timestamp: Option[Long]
 ) extends PreliminaryScenarioRecord
 
 final case class CommonFormatPreliminaryScenarioRecord(
-    override val sourceId: String,
+    override val sourceId: NodeId,
     variables: Map[String, Json],
     override val timestamp: Option[Long]
 ) extends PreliminaryScenarioRecord

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ResultsWithCounts.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ResultsWithCounts.scala
@@ -1,9 +1,10 @@
 package pl.touk.nussknacker.ui.process.test
 
 import io.circe.Json
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 import pl.touk.nussknacker.ui.processreport.NodeCount
 
 import java.time.Instant
 
-final case class ResultsWithCounts(timestamp: Instant, results: TestResults[Json], counts: Map[String, NodeCount])
+final case class ResultsWithCounts(timestamp: Instant, results: TestResults[Json], counts: Map[NodeId, NodeCount])

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
@@ -345,7 +345,7 @@ class ScenarioTestService(
   ): Either[PerformTestError, ScenarioTestData] = {
     import cats.implicits._
 
-    val allScenarioSourceIds = scenario.collectAllSources.map(_.id).toSet
+    val allScenarioSourceIds = scenario.collectAllSources.map(n => NodeId(n.id)).toSet
     preliminaryScenarioRecords.records.zipWithIndex
       .map {
         case (SourceSpecificFormatPreliminaryScenarioRecord(sourceId, record, timestamp), _)
@@ -353,9 +353,9 @@ class ScenarioTestService(
           Right(ScenarioTestSourceSpecificFormatJsonRecord(sourceId, record, timestamp))
         case (CommonFormatPreliminaryScenarioRecord(sourceId, variables, timestamp), _)
             if allScenarioSourceIds.contains(sourceId) =>
-          Right(ScenarioTestCommonFormatJsonRecord(NodeId(sourceId), variables, timestamp))
+          Right(ScenarioTestCommonFormatJsonRecord(sourceId, variables, timestamp))
         case (record, recordIdx) =>
-          Left(PerformTestError.MissingSourceError(NodeId(record.sourceId), recordIdx))
+          Left(PerformTestError.MissingSourceError(record.sourceId, recordIdx))
       }
       .sequence
       .map(scenarioTestRecords => ScenarioTestData(scenarioTestRecords.toList))
@@ -423,7 +423,7 @@ class ScenarioTestService(
 
   private def computeCounts(canonical: CanonicalProcess, isFragment: Boolean, results: TestResults[_])(
       implicit loggedUser: LoggedUser
-  ): Map[String, NodeCount] = {
+  ): Map[NodeId, NodeCount] = {
     val counts = results.nodeResults.map { case (key, nresults) =>
       key -> RawCount(
         nresults.size.toLong,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testdataformat/CommonDataFormatHandler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testdataformat/CommonDataFormatHandler.scala
@@ -58,7 +58,7 @@ class CommonDataFormatHandler(modelData: ModelData) extends TestDataFormatHandle
           sourceRecords
             .map { record =>
               val variablesAsJson = record.variables.mapValuesNow(toJsonEncoder.encodeUnsafe)
-              CommonFormatPreliminaryScenarioRecord(sourceId.id, variablesAsJson, record.timestamp)
+              CommonFormatPreliminaryScenarioRecord(sourceId, variablesAsJson, record.timestamp)
             }
         }
         Right(records)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testdataformat/SourceSpecificDataFormatHandler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testdataformat/SourceSpecificDataFormatHandler.scala
@@ -44,7 +44,7 @@ class SourceSpecificDataFormatHandler(modelData: ModelData) extends TestDataForm
         Right(
           sourceRecords
             .map { record =>
-              SourceSpecificFormatPreliminaryScenarioRecord(sourceId.id, record.json, record.timestamp)
+              SourceSpecificFormatPreliminaryScenarioRecord(sourceId, record.json, record.timestamp)
             }
         )
       }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/processreport/ProcessCounter.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/processreport/ProcessCounter.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.ui.processreport
 
 import cats.data.NonEmptyList
 import io.circe.generic.JsonCodec
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode._
@@ -11,11 +12,11 @@ import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 class ProcessCounter(fragmentRepository: FragmentRepository) {
 
-  def computeCounts(canonicalProcess: CanonicalProcess, isFragment: Boolean, counts: String => Option[RawCount])(
+  def computeCounts(canonicalProcess: CanonicalProcess, isFragment: Boolean, counts: NodeId => Option[RawCount])(
       implicit user: LoggedUser
-  ): Map[String, NodeCount] = {
+  ): Map[NodeId, NodeCount] = {
 
-    def computeCounts(prefixes: List[String])(nodes: NonEmptyList[Iterable[CanonicalNode]]): Map[String, NodeCount] = {
+    def computeCounts(prefixes: List[NodeId])(nodes: NonEmptyList[Iterable[CanonicalNode]]): Map[NodeId, NodeCount] = {
       nodes
         .map(startNode => computeCountsForSingle(prefixes)(startNode))
         .toList
@@ -23,15 +24,16 @@ class ProcessCounter(fragmentRepository: FragmentRepository) {
         .getOrElse(Map.empty)
     }
 
-    def computeCountsForSingle(prefixes: List[String])(nodes: Iterable[CanonicalNode]): Map[String, NodeCount] = {
+    def computeCountsForSingle(prefixes: List[NodeId])(nodes: Iterable[CanonicalNode]): Map[NodeId, NodeCount] = {
 
       val computeCountsSamePrefixes = computeCountsForSingle(prefixes) _
 
-      def nodeCount(id: String, fragmentCounts: Map[String, NodeCount] = Map()): NodeCount =
-        nodeCountOption(Some(id), fragmentCounts)
+      def nodeCount(nodeId: NodeId, fragmentCounts: Map[NodeId, NodeCount] = Map()): NodeCount =
+        nodeCountOption(Some(nodeId), fragmentCounts)
 
-      def nodeCountOption(id: Option[String], fragmentCounts: Map[String, NodeCount] = Map()): NodeCount = {
-        val countId = (prefixes ++ id).mkString("-")
+      def nodeCountOption(nodeId: Option[NodeId], fragmentCounts: Map[NodeId, NodeCount] = Map()): NodeCount = {
+        // TODO: we should distinguish between NodeId for nodes of graph and something like "node invocation path"
+        val countId = NodeId((prefixes ++ nodeId).mkString("-"))
         val count   = counts(countId).getOrElse(RawCount(0L, 0L))
         NodeCount(count.all, count.errors, fragmentCounts)
       }
@@ -40,22 +42,24 @@ class ProcessCounter(fragmentRepository: FragmentRepository) {
         // TODO: this is a bit of a hack. Metric for fragment input is counted in node with fragment occurrence id...
         // We want to count it though while testing fragments
         case FlatNode(FragmentInputDefinition(id, _, _)) if !isFragment =>
-          Map(id -> nodeCountOption(None))
+          Map(NodeId(id) -> nodeCountOption(None))
         // BranchEndData is kind of artificial entity
-        case FlatNode(BranchEndData(_))  => Map.empty[String, NodeCount]
-        case FlatNode(node)              => Map(node.id -> nodeCount(node.id))
-        case FilterNode(node, nextFalse) => computeCountsSamePrefixes(nextFalse) + (node.id -> nodeCount(node.id))
+        case FlatNode(BranchEndData(_)) => Map.empty[NodeId, NodeCount]
+        case FlatNode(node)             => Map(NodeId(node.id) -> nodeCount(NodeId(node.id)))
+        case FilterNode(node, nextFalse) =>
+          computeCountsSamePrefixes(nextFalse) + (NodeId(node.id) -> nodeCount(NodeId(node.id)))
         case SwitchNode(node, nexts, defaultNext) =>
           computeCountsSamePrefixes(nexts.flatMap(_.nodes)) ++ computeCountsSamePrefixes(
             defaultNext
-          ) + (node.id -> nodeCount(node.id))
-        case SplitNode(node, nexts)  => computeCountsSamePrefixes(nexts.flatten) + (node.id -> nodeCount(node.id))
+          ) + (NodeId(node.id) -> nodeCount(NodeId(node.id)))
+        case SplitNode(node, nexts) =>
+          computeCountsSamePrefixes(nexts.flatten) + (NodeId(node.id) -> nodeCount(NodeId(node.id)))
         case Fragment(node, outputs) =>
           // TODO: validate that process exists
           val fragment = fragmentRepository.fetchLatestFragmentSync(ProcessName(node.ref.id)).get
-          computeCountsSamePrefixes(outputs.values.flatten) + (node.id -> nodeCount(
-            node.id,
-            computeCounts(prefixes :+ node.id)(fragment.allStartNodes)
+          computeCountsSamePrefixes(outputs.values.flatten) + (NodeId(node.id) -> nodeCount(
+            NodeId(node.id),
+            computeCounts(prefixes :+ NodeId(node.id))(fragment.allStartNodes)
           ))
       }.toMap
 
@@ -68,4 +72,4 @@ class ProcessCounter(fragmentRepository: FragmentRepository) {
 
 final case class RawCount(all: Long, errors: Long)
 
-@JsonCodec final case class NodeCount(all: Long, errors: Long, fragmentCounts: Map[String, NodeCount] = Map())
+@JsonCodec final case class NodeCount(all: Long, errors: Long, fragmentCounts: Map[NodeId, NodeCount] = Map())

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/validation/UIProcessValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/validation/UIProcessValidator.scala
@@ -5,7 +5,7 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.effect.SyncIO
 import cats.effect.kernel.Resource
 import pl.touk.nussknacker.engine.{CustomProcessValidator, ScenarioCompilationDependencies}
-import pl.touk.nussknacker.engine.api.{JobData, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{JobData, NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.component.ScenarioPropertyConfig
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
@@ -203,7 +203,9 @@ class UIProcessValidator(
       case d: NodeData with Disableable if d.isDisabled.getOrElse(false) => d
     }
     val disabledNodesWarnings =
-      disabledNodes.map(node => (node.id, List(PrettyValidationErrors.formatErrorMessage(DisabledNode(node.id))))).toMap
+      disabledNodes
+        .map(node => (NodeId(node.id), List(PrettyValidationErrors.formatErrorMessage(DisabledNode(NodeId(node.id))))))
+        .toMap
     ValidationResult.warnings(disabledNodesWarnings)
   }
 
@@ -216,7 +218,7 @@ class UIProcessValidator(
 
   private def validateNodesId(scenarioGraph: ScenarioGraph): ValidationResult = {
     val nodeIdErrors = scenarioGraph.nodes
-      .map(n => IdValidator.validateNodeId(n.id))
+      .map(n => IdValidator.validateNodeId(NodeId(n.id)))
       .collect { case Invalid(e) =>
         e
       }
@@ -257,9 +259,9 @@ class UIProcessValidator(
   }
 
   private def validateEdgeUniqueness(scenarioGraph: ScenarioGraph): ValidationResult = {
-    val edgesByFrom = scenarioGraph.edges.groupBy(_.from)
+    val edgesByFrom = scenarioGraph.edges.groupBy(e => NodeId(e.from))
 
-    def findNonUniqueEdge(nodeId: String, edgesFromNode: List[Edge]) = {
+    def findNonUniqueEdge(nodeId: NodeId, edgesFromNode: List[Edge]) = {
       val nonUniqueByType = edgesFromNode.groupBy(_.edgeType).collect {
         case (Some(eType), list) if eType.mustBeUnique && list.size > 1 =>
           PrettyValidationErrors.formatErrorMessage(NonUniqueEdgeType(eType.toString, nodeId))
@@ -286,7 +288,7 @@ class UIProcessValidator(
       formatErrors(
         NonEmptyList.fromListUnsafe(
           tooLongStickyNotes.map(n =>
-            StickyNoteContentTooLong(n.id, n.content.length, stickyNotesSettings.maxContentLength)
+            StickyNoteContentTooLong(NodeId(n.id), n.content.length, stickyNotesSettings.maxContentLength)
           )
         )
       )
@@ -299,7 +301,7 @@ class UIProcessValidator(
       if (numberOfStickyNotes > notesLimit)
         formatErrors(
           NonEmptyList.fromListUnsafe(
-            scenarioGraph.stickyNotes.map(n => StickyNotesLimitExceeded(n.id, numberOfStickyNotes, notesLimit))
+            scenarioGraph.stickyNotes.map(n => StickyNotesLimitExceeded(NodeId(n.id), numberOfStickyNotes, notesLimit))
           )
         )
       else ValidationResult.success
@@ -311,7 +313,7 @@ class UIProcessValidator(
       // source & fragment inputs don't have inputs
       .filterNot(n => n.isInstanceOf[FragmentInputDefinition] || n.isInstanceOf[Source])
       .filterNot(n => scenarioGraph.edges.exists(_.to == n.id))
-      .map(_.id)
+      .map(n => NodeId(n.id))
 
     if (looseNodesIds.isEmpty) {
       ValidationResult.success
@@ -321,7 +323,7 @@ class UIProcessValidator(
   }
 
   private def validateDuplicates(scenarioGraph: ScenarioGraph): ValidationResult = {
-    val nodeIds    = scenarioGraph.nodes.map(_.id)
+    val nodeIds    = scenarioGraph.nodes.map(n => NodeId(n.id))
     val duplicates = nodeIds.groupBy(identity).filter(_._2.size > 1).keys.toList
 
     if (duplicates.isEmpty) {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ProcessesResourcesSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.LoneElement._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.development.manager.MockableDeploymentManagerProvider.MockableDeploymentManager
-import pl.touk.nussknacker.engine.api.ProcessAdditionalFields
+import pl.touk.nussknacker.engine.api.{NodeId, ProcessAdditionalFields}
 import pl.touk.nussknacker.engine.api.component.ProcessingMode
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.{SimpleProcessStateDefinitionManager, SimpleStateStatus}
@@ -270,7 +270,7 @@ class ProcessesResourcesSpec
       val scenarioDetails = responseAs[ScenarioWithDetails]
       scenarioDetails.validationResult.value.errors.invalidNodes should not be empty
       scenarioDetails.validationResult.value.errors.invalidNodes
-        .get(fragmentName)
+        .get(NodeId(fragmentName))
         .value
         .find(_.typ == "IncompatibleParameterDefinitionModification")
         .value

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
@@ -9,7 +9,7 @@ import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unm
 import org.scalatest.{Assertion, BeforeAndAfterAll, BeforeAndAfterEach, OptionValues}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.StreamMetaData
+import pl.touk.nussknacker.engine.api.{NodeId, StreamMetaData}
 import pl.touk.nussknacker.engine.api.component.ScenarioPropertyConfig
 import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.api.graph.{Edge, ProcessProperties, ScenarioGraph}
@@ -213,13 +213,13 @@ class ValidationResourcesSpec
     createAndValidateScenario(process) {
       status shouldEqual StatusCodes.OK
       val validation = responseAs[ValidationResult]
-      validation.errors.invalidNodes("filter").head.message should include(
+      validation.errors.invalidNodes(NodeId("filter")).head.message should include(
         "This field is required and can not be null"
       )
-      validation.errors.invalidNodes("variable1").head.message should include(
+      validation.errors.invalidNodes(NodeId("variable1")).head.message should include(
         "Field: $expression is mandatory and can not be empty"
       )
-      validation.errors.invalidNodes.get("variable2") shouldBe None
+      validation.errors.invalidNodes.get(NodeId("variable2")) shouldBe None
     }
   }
 
@@ -236,8 +236,8 @@ class ValidationResourcesSpec
     createAndValidateScenario(processWithDisabledFilterAndProcessor, ProcessName("p1")) {
       status shouldEqual StatusCodes.OK
       val validation = responseAs[ValidationResult]
-      validation.warnings.invalidNodes("filter1").head.message should include("Node filter1 is disabled")
-      validation.warnings.invalidNodes("proc1").head.message should include("Node proc1 is disabled")
+      validation.warnings.invalidNodes(NodeId("filter1")).head.message should include("Node filter1 is disabled")
+      validation.warnings.invalidNodes(NodeId("proc1")).head.message should include("Node proc1 is disabled")
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/livedata/ScenarioLiveDataApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/livedata/ScenarioLiveDataApiHttpServiceSpec.scala
@@ -8,12 +8,12 @@ import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.scalatest.freespec.AnyFreeSpecLike
 import pl.touk.nussknacker.development.manager.MockableDeploymentManagerProvider.MockableDeploymentManager
 import pl.touk.nussknacker.engine.ModelConfig.LiveDataPreviewMode
-import pl.touk.nussknacker.engine.api.{Context, ContextId}
+import pl.touk.nussknacker.engine.api.{Context, ContextId, NodeId}
 import pl.touk.nussknacker.engine.api.component.ComponentType.Source
 import pl.touk.nussknacker.engine.api.component.NodeComponentInfo
 import pl.touk.nussknacker.engine.api.deployment.{LiveDataPreviewStoredInDesignerJvm, NoLiveDataPreviewSupport}
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
-import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessIdWithName}
+import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessIdWithName, ProcessName}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.livedata.LiveDataCollectingListener
@@ -112,30 +112,45 @@ class ScenarioLiveDataApiHttpServiceSpec
         skipLiveDataUploaderWithReason = None
       )
       listener.transitionToNextNode(
-        nodeId = "start",
-        nextNodeId = "variable",
+        nodeId = NodeId("start"),
+        nextNodeId = NodeId("variable"),
         context = Context(
-          ContextId(scenarioId = "mocked-scenario-id", originatingNodeId = "source", taskId = 0, index = 0),
+          ContextId(
+            scenarioName = ProcessName("mocked-scenario-id"),
+            originatingNodeId = NodeId("source"),
+            taskId = 0,
+            index = 0
+          ),
           Map("v1" -> Json.obj("a" -> "aaa".asJson, "b" -> 1.asJson))
         ),
         processMetaData = exampleScenario.metaData
       )
       listener.expressionEvaluated(
-        nodeId = "start",
+        nodeId = NodeId("start"),
         expressionId = "var",
         expression = "ignored_by_live_data_collector",
         context = Context(
-          ContextId(scenarioId = "mocked-scenario-id", originatingNodeId = "source", taskId = 0, index = 0),
+          ContextId(
+            scenarioName = ProcessName("mocked-scenario-id"),
+            originatingNodeId = NodeId("source"),
+            taskId = 0,
+            index = 0
+          ),
           Map.empty
         ),
         processMetaData = exampleScenario.metaData,
         result = 1
       )
       listener.serviceInvoked(
-        nodeId = "start",
+        nodeId = NodeId("start"),
         id = "var",
         context = Context(
-          ContextId(scenarioId = "mocked-scenario-id", originatingNodeId = "source", taskId = 0, index = 0),
+          ContextId(
+            scenarioName = ProcessName("mocked-scenario-id"),
+            originatingNodeId = NodeId("source"),
+            taskId = 0,
+            index = 0
+          ),
           Map.empty
         ),
         processMetaData = exampleScenario.metaData,
@@ -143,10 +158,15 @@ class ScenarioLiveDataApiHttpServiceSpec
       )
       listener.exceptionThrown(
         NuExceptionInfo(
-          nodeComponentInfo = Some(NodeComponentInfo("start", Source, "start")),
+          nodeComponentInfo = Some(NodeComponentInfo(NodeId("start"), Source, "start")),
           throwable = new Exception("Something bad happened"),
           context = Context(
-            ContextId(scenarioId = "mocked-scenario-id", originatingNodeId = "source", taskId = 0, index = 0),
+            ContextId(
+              scenarioName = ProcessName("mocked-scenario-id"),
+              originatingNodeId = NodeId("source"),
+              taskId = 0,
+              index = 0
+            ),
             Map("var1" -> Json.obj("pretty" -> "abc".asJson))
           ),
           input = "ignored_by_live_data_collector",

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.typelevel.ci._
-import pl.touk.nussknacker.engine.api.{FragmentSpecificData, StreamMetaData}
+import pl.touk.nussknacker.engine.api.{FragmentSpecificData, NodeId, StreamMetaData}
 import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.api.graph.{Edge, ProcessProperties, ScenarioGraph}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
@@ -392,7 +392,7 @@ class BaseFlowTest
         .response(asJson[ValidationResult])
     )
     updateResponse.code shouldEqual StatusCode.Ok
-    updateResponse.body.rightValue.errors.invalidNodes("input1") should matchPattern {
+    updateResponse.body.rightValue.errors.invalidNodes(NodeId("input1")) should matchPattern {
       case List(
             NodeValidationError(
               "FragmentParamClassLoadError",

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrationsSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/migrate/TestModelMigrationsSpec.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.ui.process.migrate
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{MissingService, MissingSourceFactory}
 import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
@@ -60,7 +61,7 @@ class TestModelMigrationsSpec extends AnyFunSuite with Matchers {
 
     val results = testMigration.testMigrations(List(process), List(), batchingExecutionContext)
 
-    errorTypes(results.head.newErrors) shouldBe Map("processor" -> List(classOf[MissingService].getSimpleName))
+    errorTypes(results.head.newErrors) shouldBe Map(NodeId("processor") -> List(classOf[MissingService].getSimpleName))
   }
 
   test("should detect failed migration on multiple sources scenario") {
@@ -70,8 +71,8 @@ class TestModelMigrationsSpec extends AnyFunSuite with Matchers {
     val results = testMigration.testMigrations(List(scenarioGraph), List(), batchingExecutionContext)
 
     errorTypes(results.head.newErrors) shouldBe Map(
-      "source1" -> List(classOf[MissingSourceFactory].getSimpleName),
-      "source2" -> List(classOf[MissingSourceFactory].getSimpleName)
+      NodeId("source1") -> List(classOf[MissingSourceFactory].getSimpleName),
+      NodeId("source2") -> List(classOf[MissingSourceFactory].getSimpleName)
     )
   }
 
@@ -97,7 +98,7 @@ class TestModelMigrationsSpec extends AnyFunSuite with Matchers {
 
     val results = testMigration.testMigrations(List(process), List(), batchingExecutionContext)
 
-    errorTypes(results.head.newErrors) shouldBe Map("processor" -> List(classOf[MissingService].getSimpleName))
+    errorTypes(results.head.newErrors) shouldBe Map(NodeId("processor") -> List(classOf[MissingService].getSimpleName))
   }
 
   test("should migrate fragment and its usage within scenario") {
@@ -166,7 +167,7 @@ class TestModelMigrationsSpec extends AnyFunSuite with Matchers {
     }
   }
 
-  private def errorTypes(validationResult: ValidationResult): Map[String, List[String]] =
+  private def errorTypes(validationResult: ValidationResult): Map[NodeId, List[String]] =
     validationResult.errors.invalidNodes.mapValuesNow(_.map(_.typ))
 
   private def newTestModelMigrations(testMigrations: TestMigrations): TestModelMigrations =

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecordTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecordTest.scala
@@ -5,13 +5,14 @@ import io.circe.parser.decode
 import io.circe.syntax._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
 
 class PreliminaryScenarioRecordTest extends AnyFunSuite with Matchers with EitherValuesDetailedMessage {
 
   test("should encode and decode source-specific format record") {
     val inputRecord: PreliminaryScenarioRecord = SourceSpecificFormatPreliminaryScenarioRecord(
-      sourceId = "source 1",
+      sourceId = NodeId("source 1"),
       record = Json.obj("f1" -> Json.fromLong(42), "f2" -> Json.fromString("str")),
       timestamp = Some(159L)
     )
@@ -23,7 +24,7 @@ class PreliminaryScenarioRecordTest extends AnyFunSuite with Matchers with Eithe
 
   test("should encode and decode common format record") {
     val inputRecord: PreliminaryScenarioRecord = CommonFormatPreliminaryScenarioRecord(
-      sourceId = "source 1",
+      sourceId = NodeId("source 1"),
       variables = Map("input" -> Json.obj("f1" -> Json.fromLong(42), "f2" -> Json.fromString("str"))),
       timestamp = Some(159L)
     )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecordsSerDeTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecordsSerDeTest.scala
@@ -6,6 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables.Table
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
 import pl.touk.nussknacker.ui.api.TestDataFormat
 import pl.touk.nussknacker.ui.process.test.PreliminaryScenarioRecordsSerDe.{DeserializationError, SerializationError}
@@ -23,7 +24,7 @@ class PreliminaryScenarioRecordsSerDeTest extends AnyFunSuite with Matchers with
   )
 
   private val correctSourceSpecificFormatRecord = SourceSpecificFormatPreliminaryScenarioRecord(
-    sourceId = "source1",
+    sourceId = NodeId("source1"),
     record = Json.obj("f1" -> Json.fromString("field value"), "f2" -> Json.fromLong(42L)),
     timestamp = Some(24L)
   )
@@ -32,7 +33,7 @@ class PreliminaryScenarioRecordsSerDeTest extends AnyFunSuite with Matchers with
     """{"sourceId":"source1","record":{"f1":"field value","f2":42},"timestamp":24}""".stripMargin
 
   private val correctCommonFormatRecord = CommonFormatPreliminaryScenarioRecord(
-    sourceId = "source1",
+    sourceId = NodeId("source1"),
     variables = Map(
       "input" -> Json.obj(
         "f1" -> Json.fromString("field value"),

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
@@ -255,24 +255,36 @@ class ScenarioTestServiceSpec
       format match {
         case TestDataFormat.SourceSpecific =>
           liveDataRecords shouldBe List(
-            SourceSpecificFormatPreliminaryScenarioRecord("source1", Json.fromString("record 1"), timestamp = Some(1)),
-            SourceSpecificFormatPreliminaryScenarioRecord("source1", Json.fromString("record 2"), timestamp = Some(2)),
-            SourceSpecificFormatPreliminaryScenarioRecord("source1", Json.fromString("record 3"), timestamp = Some(3)),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source1"),
+              Json.fromString("record 1"),
+              timestamp = Some(1)
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source1"),
+              Json.fromString("record 2"),
+              timestamp = Some(2)
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source1"),
+              Json.fromString("record 3"),
+              timestamp = Some(3)
+            ),
           )
         case TestDataFormat.CommonFormat =>
           liveDataRecords shouldBe List(
             CommonFormatPreliminaryScenarioRecord(
-              "source1",
+              NodeId("source1"),
               Map("input" -> Json.fromString("record 1")),
               timestamp = Some(1)
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source1",
+              NodeId("source1"),
               Map("input" -> Json.fromString("record 2")),
               timestamp = Some(2)
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source1",
+              NodeId("source1"),
               Map("input" -> Json.fromString("record 3")),
               timestamp = Some(3)
             ),
@@ -296,24 +308,36 @@ class ScenarioTestServiceSpec
       format match {
         case TestDataFormat.SourceSpecific =>
           liveDataRecords shouldBe List(
-            SourceSpecificFormatPreliminaryScenarioRecord("source1", Json.fromString("record 1"), timestamp = None),
-            SourceSpecificFormatPreliminaryScenarioRecord("source1", Json.fromString("record 2"), timestamp = None),
-            SourceSpecificFormatPreliminaryScenarioRecord("source1", Json.fromString("record 3"), timestamp = None),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source1"),
+              Json.fromString("record 1"),
+              timestamp = None
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source1"),
+              Json.fromString("record 2"),
+              timestamp = None
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source1"),
+              Json.fromString("record 3"),
+              timestamp = None
+            ),
           )
         case TestDataFormat.CommonFormat =>
           liveDataRecords shouldBe List(
             CommonFormatPreliminaryScenarioRecord(
-              "source1",
+              NodeId("source1"),
               Map("input" -> Json.fromString("record 1")),
               timestamp = None
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source1",
+              NodeId("source1"),
               Map("input" -> Json.fromString("record 2")),
               timestamp = None
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source1",
+              NodeId("source1"),
               Map("input" -> Json.fromString("record 3")),
               timestamp = None
             ),
@@ -369,54 +393,86 @@ class ScenarioTestServiceSpec
       format match {
         case TestDataFormat.SourceSpecific =>
           liveDataRecords shouldBe List(
-            SourceSpecificFormatPreliminaryScenarioRecord("source1", Json.fromString("record 1"), timestamp = Some(1)),
-            SourceSpecificFormatPreliminaryScenarioRecord("source3", Json.fromString("record 1"), timestamp = Some(1)),
-            SourceSpecificFormatPreliminaryScenarioRecord("source1", Json.fromString("record 2"), timestamp = Some(2)),
-            SourceSpecificFormatPreliminaryScenarioRecord("source3", Json.fromString("record 2"), timestamp = Some(2)),
-            SourceSpecificFormatPreliminaryScenarioRecord("source1", Json.fromString("record 3"), timestamp = Some(3)),
-            SourceSpecificFormatPreliminaryScenarioRecord("source2", Json.fromString("record 1"), timestamp = None),
-            SourceSpecificFormatPreliminaryScenarioRecord("source2", Json.fromString("record 2"), timestamp = None),
-            SourceSpecificFormatPreliminaryScenarioRecord("source2", Json.fromString("record 3"), timestamp = None),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source1"),
+              Json.fromString("record 1"),
+              timestamp = Some(1)
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source3"),
+              Json.fromString("record 1"),
+              timestamp = Some(1)
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source1"),
+              Json.fromString("record 2"),
+              timestamp = Some(2)
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source3"),
+              Json.fromString("record 2"),
+              timestamp = Some(2)
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source1"),
+              Json.fromString("record 3"),
+              timestamp = Some(3)
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source2"),
+              Json.fromString("record 1"),
+              timestamp = None
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source2"),
+              Json.fromString("record 2"),
+              timestamp = None
+            ),
+            SourceSpecificFormatPreliminaryScenarioRecord(
+              NodeId("source2"),
+              Json.fromString("record 3"),
+              timestamp = None
+            ),
           )
         case TestDataFormat.CommonFormat =>
           liveDataRecords shouldBe List(
             CommonFormatPreliminaryScenarioRecord(
-              "source1",
+              NodeId("source1"),
               Map("input" -> Json.fromString("record 1")),
               timestamp = Some(1)
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source3",
+              NodeId("source3"),
               Map("input" -> Json.fromString("record 1")),
               timestamp = Some(1)
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source1",
+              NodeId("source1"),
               Map("input" -> Json.fromString("record 2")),
               timestamp = Some(2)
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source3",
+              NodeId("source3"),
               Map("input" -> Json.fromString("record 2")),
               timestamp = Some(2)
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source1",
+              NodeId("source1"),
               Map("input" -> Json.fromString("record 3")),
               timestamp = Some(3)
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source2",
+              NodeId("source2"),
               Map("input" -> Json.fromString("record 1")),
               timestamp = None
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source2",
+              NodeId("source2"),
               Map("input" -> Json.fromString("record 2")),
               timestamp = None
             ),
             CommonFormatPreliminaryScenarioRecord(
-              "source2",
+              NodeId("source2"),
               Map("input" -> Json.fromString("record 3")),
               timestamp = None
             ),
@@ -430,13 +486,33 @@ class ScenarioTestServiceSpec
       ("scenario", "size", "expected size", "expected size by source id"),
       (createScenarioWithSingleSource(), 0, None, Map.empty),
       (createScenarioWithMultipleSources(), 0, None, Map.empty),
-      (createScenarioWithSingleSource(), 1, Some(1), Map("source1" -> 1)),
-      (createScenarioWithMultipleSources(), 1, Some(1), Map("source1" -> 1)),
-      (createScenarioWithMultipleSources(), 2, Some(2), Map("source1" -> 1, "source2" -> 1)),
-      (createScenarioWithMultipleSources(), 3, Some(3), Map("source1" -> 1, "source2" -> 1, "source3" -> 1)),
-      (createScenarioWithMultipleSources(), 4, Some(4), Map("source1" -> 2, "source2" -> 1, "source3" -> 1)),
-      (createScenarioWithMultipleSources(), 5, Some(5), Map("source1" -> 2, "source2" -> 2, "source3" -> 1)),
-      (createScenarioWithMultipleSources(), 6, Some(6), Map("source1" -> 2, "source2" -> 2, "source3" -> 2)),
+      (createScenarioWithSingleSource(), 1, Some(1), Map(NodeId("source1") -> 1)),
+      (createScenarioWithMultipleSources(), 1, Some(1), Map(NodeId("source1") -> 1)),
+      (createScenarioWithMultipleSources(), 2, Some(2), Map(NodeId("source1") -> 1, NodeId("source2") -> 1)),
+      (
+        createScenarioWithMultipleSources(),
+        3,
+        Some(3),
+        Map(NodeId("source1") -> 1, NodeId("source2") -> 1, NodeId("source3") -> 1)
+      ),
+      (
+        createScenarioWithMultipleSources(),
+        4,
+        Some(4),
+        Map(NodeId("source1") -> 2, NodeId("source2") -> 1, NodeId("source3") -> 1)
+      ),
+      (
+        createScenarioWithMultipleSources(),
+        5,
+        Some(5),
+        Map(NodeId("source1") -> 2, NodeId("source2") -> 2, NodeId("source3") -> 1)
+      ),
+      (
+        createScenarioWithMultipleSources(),
+        6,
+        Some(6),
+        Map(NodeId("source1") -> 2, NodeId("source2") -> 2, NodeId("source3") -> 2)
+      ),
     )
 
     forAll(allFormats) { format =>
@@ -466,12 +542,12 @@ class ScenarioTestServiceSpec
     val scenarioRecords = PreliminaryScenarioRecords(
       NonEmptyList(
         SourceSpecificFormatPreliminaryScenarioRecord(
-          sourceId = "source1",
+          sourceId = NodeId("source1"),
           record = Json.fromString("record 1"),
           timestamp = Some(1)
         ),
         SourceSpecificFormatPreliminaryScenarioRecord(
-          sourceId = "source2",
+          sourceId = NodeId("source2"),
           record = Json.fromString("record 2"),
           timestamp = None
         ) :: Nil,
@@ -482,8 +558,8 @@ class ScenarioTestServiceSpec
       sourceSpecificFormatTestService.prepareTestData(scenarioRecords, createScenarioWithMultipleSources()).rightValue
 
     scenarioTestData.inputRecords shouldBe List(
-      ScenarioTestSourceSpecificFormatJsonRecord("source1", Json.fromString("record 1"), timestamp = Some(1L)),
-      ScenarioTestSourceSpecificFormatJsonRecord("source2", Json.fromString("record 2")),
+      ScenarioTestSourceSpecificFormatJsonRecord(NodeId("source1"), Json.fromString("record 1"), timestamp = Some(1L)),
+      ScenarioTestSourceSpecificFormatJsonRecord(NodeId("source2"), Json.fromString("record 2")),
     )
   }
 
@@ -491,12 +567,12 @@ class ScenarioTestServiceSpec
     val scenarioRecords = PreliminaryScenarioRecords(
       NonEmptyList(
         CommonFormatPreliminaryScenarioRecord(
-          sourceId = "source1",
+          sourceId = NodeId("source1"),
           variables = Map("input" -> Json.fromString("record 1")),
           timestamp = Some(1)
         ),
         CommonFormatPreliminaryScenarioRecord(
-          sourceId = "source2",
+          sourceId = NodeId("source2"),
           variables = Map("input" -> Json.fromString("record 2")),
           timestamp = None
         ) :: Nil,
@@ -530,17 +606,17 @@ class ScenarioTestServiceSpec
             PreliminaryScenarioRecords(
               NonEmptyList(
                 SourceSpecificFormatPreliminaryScenarioRecord(
-                  sourceId = "source1",
+                  sourceId = NodeId("source1"),
                   record = Json.fromString("record 1"),
                   timestamp = None
                 ),
                 SourceSpecificFormatPreliminaryScenarioRecord(
-                  sourceId = "non-existing source",
+                  sourceId = NodeId("non-existing source"),
                   record = Json.fromString("record 2"),
                   timestamp = None
                 ) ::
                   SourceSpecificFormatPreliminaryScenarioRecord(
-                    sourceId = "non-existing source 2",
+                    sourceId = NodeId("non-existing source 2"),
                     record = Json.fromString("record 3"),
                     timestamp = None
                   ) :: Nil
@@ -550,17 +626,17 @@ class ScenarioTestServiceSpec
             PreliminaryScenarioRecords(
               NonEmptyList(
                 CommonFormatPreliminaryScenarioRecord(
-                  sourceId = "source1",
+                  sourceId = NodeId("source1"),
                   variables = Map("input" -> Json.fromString("record 1")),
                   timestamp = None
                 ),
                 CommonFormatPreliminaryScenarioRecord(
-                  sourceId = "non-existing source",
+                  sourceId = NodeId("non-existing source"),
                   variables = Map("input" -> Json.fromString("record 2")),
                   timestamp = None
                 ) ::
                   CommonFormatPreliminaryScenarioRecord(
-                    sourceId = "non-existing source 2",
+                    sourceId = NodeId("non-existing source 2"),
                     variables = Map("input" -> Json.fromString("record 3")),
                     timestamp = None
                   ) :: Nil

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/processreport/ProcessCounterTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/processreport/ProcessCounterTest.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.ui.processreport
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.{FragmentSpecificData, MetaData}
+import pl.touk.nussknacker.engine.api.{FragmentSpecificData, MetaData, NodeId}
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
@@ -33,13 +33,16 @@ class ProcessCounterTest extends AnyFunSuite with Matchers {
       defaultCounter.computeCounts(
         process,
         isFragment = false,
-        Map("source1" -> RawCount(30L, 5L), "filter1" -> RawCount(20, 10)).get
+        Map(
+          NodeId("source1") -> RawCount(30L, 5L),
+          NodeId("filter1") -> RawCount(20, 10)
+        ).get
       )
 
     computed shouldBe Map(
-      "source1" -> NodeCount(30, 5),
-      "filter1" -> NodeCount(20, 10),
-      "sink11"  -> NodeCount(0, 0)
+      NodeId("source1") -> NodeCount(30, 5),
+      NodeId("filter1") -> NodeCount(20, 10),
+      NodeId("sink11")  -> NodeCount(0, 0)
     )
   }
 
@@ -69,18 +72,18 @@ class ProcessCounterTest extends AnyFunSuite with Matchers {
       process,
       isFragment = false,
       Map(
-        "source1" -> RawCount(1, 0),
-        "source2" -> RawCount(2, 0),
-        "join1"   -> RawCount(3, 0),
-        "end"     -> RawCount(4, 0)
+        NodeId("source1") -> RawCount(1, 0),
+        NodeId("source2") -> RawCount(2, 0),
+        NodeId("join1")   -> RawCount(3, 0),
+        NodeId("end")     -> RawCount(4, 0)
       ).get
     )
 
     result shouldBe Map(
-      "source1" -> NodeCount(1, 0),
-      "source2" -> NodeCount(2, 0),
-      "join1"   -> NodeCount(3, 0),
-      "end"     -> NodeCount(4, 0)
+      NodeId("source1") -> NodeCount(1, 0),
+      NodeId("source2") -> NodeCount(2, 0),
+      NodeId("join1")   -> NodeCount(3, 0),
+      NodeId("end")     -> NodeCount(4, 0)
     )
   }
 
@@ -114,29 +117,29 @@ class ProcessCounterTest extends AnyFunSuite with Matchers {
       process,
       isFragment = false,
       Map(
-        "source1"              -> RawCount(70L, 0L),
-        "filter1"              -> RawCount(60, 1),
-        "fragment1"            -> RawCount(55, 2),
-        "fragment1-subFilter1" -> RawCount(45, 4),
-        "fragment1-outId1"     -> RawCount(35, 5),
-        "sink11"               -> RawCount(30, 10)
+        NodeId("source1")              -> RawCount(70L, 0L),
+        NodeId("filter1")              -> RawCount(60, 1),
+        NodeId("fragment1")            -> RawCount(55, 2),
+        NodeId("fragment1-subFilter1") -> RawCount(45, 4),
+        NodeId("fragment1-outId1")     -> RawCount(35, 5),
+        NodeId("sink11")               -> RawCount(30, 10)
       ).get
     )
 
     computed shouldBe Map(
-      "source1" -> NodeCount(70, 0),
-      "filter1" -> NodeCount(60, 1),
-      "fragment1" -> NodeCount(
+      NodeId("source1") -> NodeCount(70, 0),
+      NodeId("filter1") -> NodeCount(60, 1),
+      NodeId("fragment1") -> NodeCount(
         55,
         2,
         Map(
-          "subInput1"  -> NodeCount(55, 2),
-          "subFilter1" -> NodeCount(45, 4),
-          "subFilter2" -> NodeCount(0, 0),
-          "outId1"     -> NodeCount(35, 5)
+          NodeId("subInput1")  -> NodeCount(55, 2),
+          NodeId("subFilter1") -> NodeCount(45, 4),
+          NodeId("subFilter2") -> NodeCount(0, 0),
+          NodeId("outId1")     -> NodeCount(35, 5)
         )
       ),
-      "sink11" -> NodeCount(30, 10)
+      NodeId("sink11") -> NodeCount(30, 10)
     )
   }
 
@@ -152,16 +155,16 @@ class ProcessCounterTest extends AnyFunSuite with Matchers {
       fragment,
       isFragment = true,
       Map(
-        "fragment1"   -> RawCount(30, 0),
-        "filter"      -> RawCount(20, 5),
-        "fragmentEnd" -> RawCount(15, 10)
+        NodeId("fragment1")   -> RawCount(30, 0),
+        NodeId("filter")      -> RawCount(20, 5),
+        NodeId("fragmentEnd") -> RawCount(15, 10)
       ).get
     )
 
     computed shouldBe Map(
-      "fragment1"   -> NodeCount(30, 0),
-      "filter"      -> NodeCount(20, 5),
-      "fragmentEnd" -> NodeCount(15, 10)
+      NodeId("fragment1")   -> NodeCount(30, 0),
+      NodeId("filter")      -> NodeCount(20, 5),
+      NodeId("fragmentEnd") -> NodeCount(15, 10)
     )
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/validation/UIProcessValidatorSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/validation/UIProcessValidatorSpec.scala
@@ -132,7 +132,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validateWithConfiguredProperties(process)
 
     result.errors.invalidNodes shouldBe Map(
-      "subIn" -> List(
+      NodeId("subIn") -> List(
         NodeValidationError(
           "NonUniqueEdgeType",
           "Edges are not unique",
@@ -181,7 +181,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validateWithConfiguredProperties(process)
 
     result.errors.invalidNodes shouldBe Map(
-      "subIn" -> List(
+      NodeId("subIn") -> List(
         NodeValidationError(
           typ = "NonUniqueEdge",
           message = "Edges are not unique",
@@ -215,7 +215,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
           errorType = SaveNotAllowed,
           details = None
         ),
-        List("loose")
+        List(NodeId("loose"))
       )
     )
   }
@@ -255,7 +255,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validateWithConfiguredProperties(process)
 
     result.warnings.invalidNodes shouldBe Map(
-      "filter" -> List(
+      NodeId("filter") -> List(
         NodeValidationError(
           typ = "DisabledNode",
           message = "Node filter is disabled",
@@ -289,7 +289,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
           errorType = RenderNotAllowed,
           details = None
         ),
-        List("inID")
+        List(NodeId("inID"))
       )
     )
   }
@@ -321,7 +321,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
           errorType = RenderNotAllowed,
           details = None
         ),
-        List("switchID")
+        List(NodeId("switchID"))
       )
     )
     result.errors.invalidNodes shouldBe empty
@@ -661,7 +661,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val validationResult = validateWithConfiguredProperties(fragmentGraph)
 
     validationResult.errors should not be empty
-    validationResult.errors.invalidNodes("in") should matchPattern {
+    validationResult.errors.invalidNodes(NodeId("in")) should matchPattern {
       case List(
             NodeValidationError(
               "FragmentParamClassLoadError",
@@ -741,7 +741,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val validationResult = validateWithConfiguredProperties(fragmentGraph)
 
     validationResult.errors should not be empty
-    validationResult.errors.invalidNodes("in") should matchPattern {
+    validationResult.errors.invalidNodes(NodeId("in")) should matchPattern {
       case List(
             NodeValidationError(
               "InitialValueNotPresentInPossibleValues",
@@ -897,7 +897,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     ).validate(fragmentGraph, sampleProcessName, isFragment = true, labels = List.empty)
 
     validationResult.errors should not be empty
-    validationResult.errors.invalidNodes("in") should matchPattern {
+    validationResult.errors.invalidNodes(NodeId("in")) should matchPattern {
       case List(
             NodeValidationError(
               "DictNotDeclared",
@@ -973,7 +973,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val validationResult = validateWithConfiguredProperties(fragmentGraph, isFragment = true)
 
     validationResult.errors should not be empty
-    validationResult.errors.invalidNodes("in") should matchPattern {
+    validationResult.errors.invalidNodes(NodeId("in")) should matchPattern {
       case List(
             NodeValidationError(
               "InvalidValidationExpression",
@@ -1030,7 +1030,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
 
     validationResult should matchPattern {
       case ValidationResult(ValidationErrors(invalidNodes, Nil, Nil), ValidationWarnings.success, _)
-          if invalidNodes("subIn").size == 1 && invalidNodes("subIn-subVar").size == 1 =>
+          if invalidNodes(NodeId("subIn")).size == 1 && invalidNodes(NodeId("subIn-subVar")).size == 1 =>
     }
   }
 
@@ -1101,7 +1101,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
       processValidation.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     validationResult.errors should not be empty
-    validationResult.errors.invalidNodes("subIn1") should matchPattern {
+    validationResult.errors.invalidNodes(NodeId("subIn1")) should matchPattern {
       case List(
             NodeValidationError(
               "InvalidPropertyFixedValue",
@@ -1113,7 +1113,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
             )
           ) =>
     }
-    validationResult.errors.invalidNodes("subIn2") should matchPattern {
+    validationResult.errors.invalidNodes(NodeId("subIn2")) should matchPattern {
       case List(
             NodeValidationError(
               "EmptyMandatoryParameter",
@@ -1236,7 +1236,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validateWithConfiguredProperties(process)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1272,7 +1272,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1308,7 +1308,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1344,7 +1344,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1380,7 +1380,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1429,7 +1429,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1478,7 +1478,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1531,7 +1531,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1584,7 +1584,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1632,7 +1632,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern { case None => }
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern { case None => }
     result.warnings shouldBe ValidationWarnings.success
   }
 
@@ -1666,7 +1666,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1726,7 +1726,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validator.validate(process, ProcessTestData.sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1755,7 +1755,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
       processValidatorWithDicts(Map.empty).validate(process, sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1779,7 +1779,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
       processValidatorWithDicts(Map.empty).validate(process, sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1805,7 +1805,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     ).validate(process, sampleProcessName, isFragment = false, labels = List.empty)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1842,7 +1842,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = validateWithConfiguredProperties(scenarioGraph)
 
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("custom") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("custom")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -1933,7 +1933,9 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
         labels = List.empty
       )
     validationResultWithCategory2.errors.invalidNodes shouldBe Map(
-      "subIn" -> List(PrettyValidationErrors.formatErrorMessage(UnknownFragment(fragment.name.value, "subIn")))
+      NodeId("subIn") -> List(
+        PrettyValidationErrors.formatErrorMessage(UnknownFragment(fragment.name.value, NodeId("subIn")))
+      )
     )
   }
 
@@ -1985,7 +1987,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
 
     result.hasErrors shouldBe true
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("subIn") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("subIn")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -2032,7 +2034,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
 
     result.hasErrors shouldBe true
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("subIn") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("subIn")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -2131,7 +2133,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     )
     result.hasErrors shouldBe true
     result.errors.globalErrors shouldBe empty
-    result.errors.invalidNodes.get("subIn") should matchPattern {
+    result.errors.invalidNodes.get(NodeId("subIn")) should matchPattern {
       case Some(
             List(
               NodeValidationError(
@@ -2194,7 +2196,11 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
       .errors
       .invalidNodes
     val nodeErrors =
-      Map(blankValue -> List(PrettyValidationErrors.formatErrorMessage(NodeIdValidationError(BlankId, blankValue))))
+      Map(
+        NodeId(blankValue) -> List(
+          PrettyValidationErrors.formatErrorMessage(NodeIdValidationError(BlankId, NodeId(blankValue)))
+        )
+      )
     result shouldBe nodeErrors
   }
 
@@ -2213,9 +2219,9 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
       )
     inside(result) { case ValidationResult(errors, _, _) =>
       inside(errors) { case ValidationErrors(nodeErrors, propertiesErrors, _) =>
-        nodeErrors should contain key " "
-        nodeErrors(" ") should contain(
-          PrettyValidationErrors.formatErrorMessage(NodeIdValidationError(BlankId, " "))
+        nodeErrors should contain key NodeId(" ")
+        nodeErrors(NodeId(" ")) should contain(
+          PrettyValidationErrors.formatErrorMessage(NodeIdValidationError(BlankId, NodeId(" ")))
         )
         propertiesErrors shouldBe List(
           PrettyValidationErrors.formatErrorMessage(ScenarioNameError(BlankId, ProcessName(" "), isFragment = false))
@@ -2245,9 +2251,9 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     result.errors.globalErrors shouldBe List(
       UIGlobalError(
         PrettyValidationErrors.formatErrorMessage(
-          DuplicateFragmentOutputNamesInFragment(`duplicatedOutputName`, Set("outNode1", "outNode2"))
+          DuplicateFragmentOutputNamesInFragment(`duplicatedOutputName`, Set(NodeId("outNode1"), NodeId("outNode2")))
         ),
-        List("outNode1", "outNode2")
+        List(NodeId("outNode1"), NodeId("outNode2"))
       )
     )
   }
@@ -2273,8 +2279,8 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
     val result = processValidator.validate(scenarioGraph, ProcessName(" "), isFragment = true, labels = List.empty)
 
     result.errors.invalidNodes shouldBe Map(
-      "fragment" -> List(
-        PrettyValidationErrors.formatErrorMessage(DuplicateFragmentOutputNamesInScenario("output1", "fragment"))
+      NodeId("fragment") -> List(
+        PrettyValidationErrors.formatErrorMessage(DuplicateFragmentOutputNamesInScenario("output1", NodeId("fragment")))
       )
     )
   }
@@ -2300,7 +2306,7 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
         case List(
               UIGlobalError(
                 NodeValidationError("InvalidTailOfBranch", _, _, _, NodeValidationErrorType.SaveAllowed, None),
-                List("e")
+                List(NodeId("e"))
               )
             ) =>
       }
@@ -2320,9 +2326,9 @@ class UIProcessValidatorSpec extends AnyFunSuite with Matchers with TableDrivenP
 
     inside(result.errors.globalErrors) { case UIGlobalError(error, nodeIds) :: Nil =>
       error shouldBe PrettyValidationErrors.formatErrorMessage(
-        InvalidTailOfBranch(Set(invalidEndingNodeId1, invalidEndingNodeId2))
+        InvalidTailOfBranch(Set(NodeId(invalidEndingNodeId1), NodeId(invalidEndingNodeId2)))
       )
-      nodeIds should contain theSameElementsAs List(invalidEndingNodeId1, invalidEndingNodeId2)
+      nodeIds should contain theSameElementsAs List(NodeId(invalidEndingNodeId1), NodeId(invalidEndingNodeId2))
     }
   }
 

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -5564,7 +5564,7 @@ components:
       - idx
       properties:
         nid:
-          type: string
+          $ref: '#/components/schemas/NodeId'
         tid:
           type: integer
           format: int64
@@ -5583,7 +5583,7 @@ components:
       - t
       properties:
         n:
-          type: string
+          $ref: '#/components/schemas/NodeId'
         t:
           type: string
     CoordinatesBasedTextRange:
@@ -5753,9 +5753,9 @@ components:
         context:
           $ref: '#/components/schemas/ResultContext_Json'
         nodeId:
-          type:
-          - string
-          - 'null'
+          anyOf:
+          - $ref: '#/components/schemas/NodeId'
+          - type: 'null'
         throwable:
           type: string
     Expression:
@@ -6113,34 +6113,6 @@ components:
       title: Map_Json
       type: object
       additionalProperties: {}
-    Map_List_ExceptionResult_Json:
-      title: Map_List_ExceptionResult_Json
-      type: object
-      additionalProperties:
-        type: array
-        items:
-          $ref: '#/components/schemas/ExceptionResult_Json'
-    Map_List_ExpressionInvocationResult_Json:
-      title: Map_List_ExpressionInvocationResult_Json
-      type: object
-      additionalProperties:
-        type: array
-        items:
-          $ref: '#/components/schemas/ExpressionInvocationResult_Json'
-    Map_List_ExternalInvocationResult_Json:
-      title: Map_List_ExternalInvocationResult_Json
-      type: object
-      additionalProperties:
-        type: array
-        items:
-          $ref: '#/components/schemas/ExternalInvocationResult_Json'
-    Map_List_ResultContext_Json:
-      title: Map_List_ResultContext_Json
-      type: object
-      additionalProperties:
-        type: array
-        items:
-          $ref: '#/components/schemas/ResultContext_Json'
     Map_List_String:
       title: Map_List_String
       type: object
@@ -6158,16 +6130,18 @@ components:
       type: object
       additionalProperties:
         $ref: '#/components/schemas/Map_String'
-    Map_NodeCount:
-      title: Map_NodeCount
-      type: object
-      additionalProperties:
-        type: object
     Map_NodeId_String:
       title: Map_NodeId_String
       type: object
       additionalProperties:
         type: string
+    Map_NodeId_V:
+      title: Map_NodeId_V
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          $ref: '#/components/schemas/ResultContext_Json'
     Map_ParameterName_Expression:
       title: Map_ParameterName_Expression
       type: object
@@ -6661,6 +6635,14 @@ components:
             type: string
           type:
             $ref: '#/components/schemas/NodeTypes12'
+    NodeId:
+      title: NodeId
+      type: object
+      required:
+      - id
+      properties:
+        id:
+          type: string
     NodeTransitionResult:
       title: NodeTransitionResult
       type: object
@@ -6668,11 +6650,11 @@ components:
       - sourceNodeId
       properties:
         sourceNodeId:
-          type: string
+          $ref: '#/components/schemas/NodeId'
         destinationNodeId:
-          type:
-          - string
-          - 'null'
+          anyOf:
+          - $ref: '#/components/schemas/NodeId'
+          - type: 'null'
         results:
           type: array
           items:
@@ -7162,7 +7144,7 @@ components:
         results:
           $ref: '#/components/schemas/TestResultsDto'
         counts:
-          $ref: '#/components/schemas/Map_NodeCount'
+          $ref: '#/components/schemas/Map_NodeId_V'
     RunDeploymentRequest:
       title: RunDeploymentRequest
       type: object
@@ -7665,7 +7647,7 @@ components:
       properties:
         nodeResults:
           anyOf:
-          - $ref: '#/components/schemas/Map_List_ResultContext_Json'
+          - $ref: '#/components/schemas/Map_NodeId_V'
           - type: 'null'
         nodeTransitionResults:
           type:
@@ -7674,15 +7656,15 @@ components:
           items:
             $ref: '#/components/schemas/NodeTransitionResult'
         invocationResults:
-          $ref: '#/components/schemas/Map_List_ExpressionInvocationResult_Json'
+          $ref: '#/components/schemas/Map_NodeId_V'
         externalInvocationResults:
-          $ref: '#/components/schemas/Map_List_ExternalInvocationResult_Json'
+          $ref: '#/components/schemas/Map_NodeId_V'
         exceptions:
           type: array
           items:
             $ref: '#/components/schemas/ExceptionResult_Json'
         exceptionsByNodeId:
-          $ref: '#/components/schemas/Map_List_ExceptionResult_Json'
+          $ref: '#/components/schemas/Map_NodeId_V'
     TestSourceParameters:
       title: TestSourceParameters
       type: object

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -167,6 +167,8 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   * `KafkaConfig` was renamed to `KafkaComponentsConfig`
   * `KafkaComponentsConfig.kafkaProperties` is mandatory now
   * `KafkaComponentsConfig.kafkaAddress` was removed
+* [#8576](https://github.com/TouK/nussknacker/pull/8576) `NodeId` value class become used more frequently in the API:
+  `NodeComponentInfo`, `ContextId`, `ProcessCompilationError`, `ProcessListener` and `FlinkCustomNodeContext` 
 
 ### Other changes
 

--- a/engine/common/components-tests/src/test/scala/pl/touk/nussknacker/engine/common/components/DecisionTableSpec.scala
+++ b/engine/common/components-tests/src/test/scala/pl/touk/nussknacker/engine/common/components/DecisionTableSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.{BeforeAndAfterAll, Inside}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.ExpressionParserCompilationError
 import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.{
@@ -103,7 +104,7 @@ trait DecisionTableSpec
           errors.toList should matchPattern {
             case ExpressionParserCompilationError(
                   "There is no property 'years' in type: Record{DoB: LocalDate, age: Integer, name: String}",
-                  "decision-table",
+                  NodeId("decision-table"),
                   Some(ParameterName("Match condition")),
                   "#ROW['years'] > #input.minAge",
                   _
@@ -127,7 +128,7 @@ trait DecisionTableSpec
             NonEmptyList.one(
               ExpressionParserCompilationError(
                 message = "Wrong part types",
-                nodeId = "decision-table",
+                nodeId = NodeId("decision-table"),
                 paramName = Some(ParameterName("Match condition")),
                 originalExpr = "#ROW['name'] > #input.minAge",
                 details = Some(CoordinatesBasedTextRange(TextCoordinates(13, 0), TextCoordinates(14, 0)))
@@ -154,7 +155,7 @@ trait DecisionTableSpec
             NonEmptyList.of(
               ExpressionParserCompilationError(
                 message = "Typing error in some cells",
-                nodeId = "decision-table",
+                nodeId = NodeId("decision-table"),
                 paramName = Some(ParameterName("Decision Table")),
                 originalExpr = invalidColumnTypeDecisionTableJson.expression,
                 details = Some(
@@ -189,7 +190,7 @@ trait DecisionTableSpec
               ),
               ExpressionParserCompilationError(
                 message = "Operator '==' used with not comparable types: Integer and String(John)",
-                nodeId = "decision-table",
+                nodeId = NodeId("decision-table"),
                 paramName = Some(ParameterName("Match condition")),
                 originalExpr = """#ROW.age > #input.minAge && #ROW.name == "John"""",
                 details = Some(CoordinatesBasedTextRange(TextCoordinates(38, 0), TextCoordinates(40, 0)))

--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/compat/ExplicitUidInOperatorsSupport.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/compat/ExplicitUidInOperatorsSupport.scala
@@ -24,16 +24,16 @@ import pl.touk.nussknacker.engine.flink.api.process.FlinkCustomNodeContext
 trait ExplicitUidInOperatorsSupport {
 
   protected def setUidToNodeIdIfNeed[T](nodeCtx: FlinkCustomNodeContext, stream: DataStream[T]): DataStream[T] =
-    ExplicitUidInOperatorsSupport.setUidIfNeed(explicitUidInStatefulOperators(nodeCtx), nodeCtx.nodeId)(stream)
+    ExplicitUidInOperatorsSupport.setUidIfNeed(explicitUidInStatefulOperators(nodeCtx), nodeCtx.nodeId.id)(stream)
 
   protected def setUidToNodeIdIfNeed[T](nodeCtx: FlinkCustomNodeContext, stream: DataStreamSink[T]): DataStreamSink[T] =
-    ExplicitUidInOperatorsSupport.setUidIfNeedSink(explicitUidInStatefulOperators(nodeCtx), nodeCtx.nodeId)(stream)
+    ExplicitUidInOperatorsSupport.setUidIfNeedSink(explicitUidInStatefulOperators(nodeCtx), nodeCtx.nodeId.id)(stream)
 
   protected def setUidToNodeIdIfNeed[T](
       nodeCtx: FlinkCustomNodeContext,
       stream: SingleOutputStreamOperator[T]
   ): SingleOutputStreamOperator[T] =
-    ExplicitUidInOperatorsSupport.setUidIfNeedJava(explicitUidInStatefulOperators(nodeCtx), nodeCtx.nodeId)(stream)
+    ExplicitUidInOperatorsSupport.setUidIfNeedJava(explicitUidInStatefulOperators(nodeCtx), nodeCtx.nodeId.id)(stream)
 
   /**
    * Rewrite it if you wan to change globally configured behaviour of setting uid with local one

--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkContextInitializingFunction.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkContextInitializingFunction.scala
@@ -1,13 +1,13 @@
 package pl.touk.nussknacker.engine.flink.api.process
 
 import org.apache.flink.api.common.functions.{OpenContext, RichMapFunction, RuntimeContext}
-import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.{Context, NodeId}
 import pl.touk.nussknacker.engine.api.process.ContextInitializer
 import pl.touk.nussknacker.engine.api.runtimecontext.{ContextIdGenerator, EngineRuntimeContext}
 
 class FlinkContextInitializingFunction[Raw](
     contextInitializer: ContextInitializer[Raw],
-    nodeId: String,
+    nodeId: NodeId,
     convertToEngineRuntimeContext: RuntimeContext => EngineRuntimeContext
 ) extends RichMapFunction[Raw, Context] {
 

--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkCustomNodeContext.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkCustomNodeContext.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.flink.api.process
 
 import org.apache.flink.api.common.functions.RuntimeContext
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import pl.touk.nussknacker.engine.api.{Context, JobData, MetaData, ValueWithContext}
+import pl.touk.nussknacker.engine.api.{Context, JobData, MetaData, NodeId, ValueWithContext}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.process.ComponentUseContext
 import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
@@ -17,7 +17,7 @@ import scala.reflect.ClassTag
 case class FlinkCustomNodeContext(
     jobData: JobData,
     // TODO: it can be used in state recovery - make sure that it won't change during renaming of nodes on gui
-    nodeId: String,
+    nodeId: NodeId,
     timeout: FiniteDuration,
     convertToEngineRuntimeContext: RuntimeContext => EngineRuntimeContext,
     lazyParameterHelper: FlinkLazyParameterFunctionHelper,

--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkSource.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkSource.scala
@@ -92,7 +92,7 @@ trait BaseFlinkSource { this: ExplicitUidInOperatorsSupport =>
       case singleOut: SingleOutputStreamOperator[_] =>
         setUidToNodeIdIfNeed[T](
           flinkNodeContext,
-          singleOut.name(flinkNodeContext.nodeId)
+          singleOut.name(flinkNodeContext.nodeId.id)
         )
       case _ => streamOfRaw
     }

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/richflink.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/richflink.scala
@@ -46,8 +46,10 @@ object richflink {
         implicit ctx: FlinkCustomNodeContext,
         explicitUidInStatefulOperators: FlinkCustomNodeContext => Boolean
     ): DataStream[T] =
-      ExplicitUidInOperatorsSupport.setUidIfNeed[T](explicitUidInStatefulOperators(ctx), ctx.nodeId)(dataStream) match {
-        case operator: SingleOutputStreamOperator[T] => operator.name(ctx.nodeId)
+      ExplicitUidInOperatorsSupport.setUidIfNeed[T](explicitUidInStatefulOperators(ctx), ctx.nodeId.id)(
+        dataStream
+      ) match {
+        case operator: SingleOutputStreamOperator[T] => operator.name(ctx.nodeId.id)
         case other                                   => other
       }
 

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/watermarkstrategy/FlinkWatermarkStrategyRuntimeHandler.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/watermarkstrategy/FlinkWatermarkStrategyRuntimeHandler.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.flink.watermarkstrategy
 import org.apache.flink.api.common.eventtime.{SerializableTimestampAssigner, WatermarkStrategy}
 import org.apache.flink.api.common.functions.{OpenContext, RichMapFunction, RuntimeContext}
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import pl.touk.nussknacker.engine.api.{Context, LazyParameter}
+import pl.touk.nussknacker.engine.api.{Context, LazyParameter, NodeId}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.process.ContextInitializer
 import pl.touk.nussknacker.engine.api.runtimecontext.{ContextIdGenerator, EngineRuntimeContext}
@@ -18,7 +18,7 @@ object FlinkWatermarkStrategyRuntimeHandler {
 
   class ContextInitializingFunction[Raw](
       contextInitializer: ContextInitializer[Raw],
-      nodeId: String,
+      nodeId: NodeId,
       convertToEngineRuntimeContext: RuntimeContext => EngineRuntimeContext,
       eventTimeLazyParam: LazyParameter[Instant],
       lazyParamHelper: FlinkLazyParameterFunctionHelper

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ExpressionEvaluationSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ExpressionEvaluationSpec.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.flink
 import cats.data.NonEmptyList
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.EmptyMandatoryParameter
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
@@ -48,7 +49,7 @@ class ExpressionEvaluationSpec extends AnyFunSuite with FlinkSpec with Matchers 
 
     val result = runScenario(scenario, List(""))
     result.invalidValue should matchPattern {
-      case NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName("value"), "end"), Nil) =>
+      case NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName("value"), NodeId("end")), Nil) =>
     }
   }
 

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/FlinkMiniClusterTestRunner.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/FlinkMiniClusterTestRunner.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.engine.flink
 
 import com.typesafe.config.ConfigFactory
-import pl.touk.nussknacker.engine.api.ContextId
+import pl.touk.nussknacker.engine.api.{ContextId, NodeId}
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.process.SourceFactory
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -89,7 +89,7 @@ trait FlinkMiniClusterTestRunner { _: FlinkSpec =>
       toNodeId: Option[String]
   ): Map[ContextId, Map[String, Any]] = {
     testResults
-      .nodeTransitionResults(NodeTransition(fromNodeId, toNodeId))
+      .nodeTransitionResults(NodeTransition(NodeId(fromNodeId), toNodeId.map(NodeId(_))))
       .map { result =>
         (result.id, result.variables.map { case (key, value) => (key, scalaMap(value)) })
       }
@@ -104,7 +104,7 @@ trait FlinkMiniClusterTestRunner { _: FlinkSpec =>
   }
 
   protected def assertNumberOfSamplesThatFinishedInNode(testResults: TestResults[Any], sinkId: String, expected: Int) =
-    testResults.nodeTransitionResults.get(NodeTransition(sinkId, None)).map(_.length) shouldBe Some(expected)
+    testResults.nodeTransitionResults.get(NodeTransition(NodeId(sinkId), None)).map(_.length) shouldBe Some(expected)
 
   protected def catchExceptionMessage(f: => Any): String = Try(f).failed.get.getMessage
 

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ResultCollectingListenerSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ResultCollectingListenerSpec.scala
@@ -4,7 +4,8 @@ import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.{ContextId, ContextIdPathPart}
+import pl.touk.nussknacker.engine.api.{ContextId, ContextIdPathPart, NodeId}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.compile.FragmentResolver
 import pl.touk.nussknacker.engine.flink.test.FlinkSpec
@@ -140,144 +141,164 @@ class ResultCollectingListenerSpec
         transitionVariables(testResults, "bv1", Some("end1")).size shouldBe 4
         transitionVariables(testResults, "bv2", Some("end2")).size shouldBe 4
         transitionVariablesByContextId(testResults, "start-foo", Some("split")) shouldBe Map(
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 0) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 0
+          ) -> Map(
             "input" -> 10
           ),
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 1) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 1
+          ) -> Map(
             "input" -> 20
           ),
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 2) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 2
+          ) -> Map(
             "input" -> 30
           ),
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 3) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 3
+          ) -> Map(
             "input" -> 40
           ),
         )
         transitionVariablesByContextId(testResults, "split", Some("bv1")) shouldBe Map(
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 0,
-            path = List(ContextIdPathPart("split", "bv1"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv1"))
           ) -> Map("input" -> 10),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 1,
-            path = List(ContextIdPathPart("split", "bv1"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv1"))
           ) -> Map("input" -> 20),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 2,
-            path = List(ContextIdPathPart("split", "bv1"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv1"))
           ) -> Map("input" -> 30),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 3,
-            path = List(ContextIdPathPart("split", "bv1"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv1"))
           ) -> Map("input" -> 40),
         )
         transitionVariablesByContextId(testResults, "split", Some("bv2")) shouldBe Map(
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 0,
-            path = List(ContextIdPathPart("split", "bv2"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv2"))
           ) -> Map("input" -> 10),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 1,
-            path = List(ContextIdPathPart("split", "bv2"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv2"))
           ) -> Map("input" -> 20),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 2,
-            path = List(ContextIdPathPart("split", "bv2"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv2"))
           ) -> Map("input" -> 30),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 3,
-            path = List(ContextIdPathPart("split", "bv2"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv2"))
           ) -> Map("input" -> 40),
         )
         transitionVariablesByContextId(testResults, "bv1", Some("end1")) shouldBe Map(
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 0,
-            path = List(ContextIdPathPart("split", "bv1"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv1"))
           ) ->
             Map("input" -> 10, "timesTwo" -> 20),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 1,
-            path = List(ContextIdPathPart("split", "bv1"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv1"))
           ) ->
             Map("input" -> 20, "timesTwo" -> 40),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 2,
-            path = List(ContextIdPathPart("split", "bv1"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv1"))
           ) ->
             Map("input" -> 30, "timesTwo" -> 60),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 3,
-            path = List(ContextIdPathPart("split", "bv1"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv1"))
           ) ->
             Map("input" -> 40, "timesTwo" -> 80),
         )
         transitionVariablesByContextId(testResults, "bv2", Some("end2")) shouldBe Map(
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 0,
-            path = List(ContextIdPathPart("split", "bv2"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv2"))
           ) ->
             Map("input" -> 10, "timesFour" -> 40),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 1,
-            path = List(ContextIdPathPart("split", "bv2"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv2"))
           ) ->
             Map("input" -> 20, "timesFour" -> 80),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 2,
-            path = List(ContextIdPathPart("split", "bv2"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv2"))
           ) ->
             Map("input" -> 30, "timesFour" -> 120),
           ContextId(
-            scenarioId = "sample-split",
-            originatingNodeId = "start-foo",
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
             taskId = 0,
             index = 3,
-            path = List(ContextIdPathPart("split", "bv2"))
+            path = List(ContextIdPathPart(NodeId("split"), "bv2"))
           ) ->
             Map("input" -> 40, "timesFour" -> 160),
         )
@@ -366,35 +387,75 @@ class ResultCollectingListenerSpec
         transitionVariables(testResults, "switch", Some("end1")).size shouldBe 2
         transitionVariables(testResults, "switch", Some("end2")).size shouldBe 2
         transitionVariablesByContextId(testResults, "start-foo", Some("switch")) shouldBe Map(
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 0) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 0
+          ) -> Map(
             "input" -> 10
           ),
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 1) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 1
+          ) -> Map(
             "input" -> 20
           ),
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 2) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 2
+          ) -> Map(
             "input" -> 30
           ),
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 3) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 3
+          ) -> Map(
             "input" -> 40
           ),
         )
         transitionVariablesByContextId(testResults, "switch", Some("end1")) shouldBe Map(
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 0) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 0
+          ) -> Map(
             "input" -> 10,
             "var"   -> ""
           ),
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 1) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 1
+          ) -> Map(
             "input" -> 20,
             "var"   -> ""
           ),
         )
         transitionVariablesByContextId(testResults, "switch", Some("end2")) shouldBe Map(
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 2) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 2
+          ) -> Map(
             "input" -> 30,
             "var"   -> ""
           ),
-          ContextId(scenarioId = "sample-split", originatingNodeId = "start-foo", taskId = 0, index = 3) -> Map(
+          ContextId(
+            scenarioName = ProcessName("sample-split"),
+            originatingNodeId = NodeId("start-foo"),
+            taskId = 0,
+            index = 3
+          ) -> Map(
             "input" -> 40,
             "var"   -> ""
           ),

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/aggregate/TableAggregationTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/aggregate/TableAggregationTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import pl.touk.nussknacker.engine.ModelConfig
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.{ComponentDefinition, ComponentDependencies}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomNodeError
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
@@ -97,7 +98,7 @@ class TableAggregationTest
       Boundedness.BOUNDED
     )
     result.invalidValue.toList.loneElement should matchPattern {
-      case CustomNodeError("agg0", _, Some(ParameterName("groupBy"))) =>
+      case CustomNodeError(NodeId("agg0"), _, Some(ParameterName("groupBy"))) =>
     }
   }
 
@@ -207,7 +208,7 @@ class TableAggregationTest
     scenarios.foreach(s => {
       val result = runner.runWithData(s, input, Boundedness.BOUNDED)
       result.invalidValue.toList.loneElement should matchPattern {
-        case CustomNodeError("agg0", _, Some(ParameterName("aggregateBy"))) =>
+        case CustomNodeError(NodeId("agg0"), _, Some(ParameterName("aggregateBy"))) =>
       }
     })
   }
@@ -225,7 +226,7 @@ class TableAggregationTest
     )
     results.foreach { r =>
       r.invalidValue.toList.loneElement should matchPattern {
-        case CustomNodeError("agg0", _, Some(ParameterName("aggregateBy"))) =>
+        case CustomNodeError(NodeId("agg0"), _, Some(ParameterName("aggregateBy"))) =>
       }
     }
   }

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/join/TableJoinTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/join/TableJoinTest.scala
@@ -6,6 +6,7 @@ import org.apache.flink.types.Row
 import org.scalatest.{BeforeAndAfterAll, Inside, LoneElement}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomNodeError
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
@@ -181,7 +182,7 @@ class TableJoinTest
 
     enrichedOrders.invalidValue.toList should matchPattern {
       case CustomNodeError(
-            `joinNodeId`,
+            NodeId(`joinNodeId`),
             "Types Integer and String are not comparable",
             Some(ParameterName("Key"))
           ) :: Nil =>

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/sink/TableFileSinkTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/sink/TableFileSinkTest.scala
@@ -8,6 +8,7 @@ import org.apache.flink.table.api.DataTypes
 import org.scalatest.{BeforeAndAfterAll, LoneElement}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomNodeError
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
@@ -647,7 +648,7 @@ class TableFileSinkTest
         |Incorrect type: actual: 'Record{arrayOfInts: List[Double]({1.23, 2.34}), map: Record{foo: Double(1.23)}}' expected: 'Record{arrayOfInts: List[Integer], map: Map[String,Integer]}'.""".stripMargin
     result.invalidValue.toList should matchPattern {
       case CustomNodeError(
-            "end",
+            NodeId("end"),
             `expectedMessage`,
             Some(ParameterName("Value"))
           ) :: Nil =>
@@ -674,7 +675,11 @@ class TableFileSinkTest
     val result  = runner.runWithData(scenario, List(0), Boundedness.BOUNDED)
     val intType = DataTypes.INT().getLogicalType
     result.validValue.errors should matchPattern {
-      case ExceptionResult(_, Some("end"), NotConvertibleResultOfAlignmentException("ala", "ala", `intType`)) :: Nil =>
+      case ExceptionResult(
+            _,
+            Some(NodeId("end")),
+            NotConvertibleResultOfAlignmentException("ala", "ala", `intType`)
+          ) :: Nil =>
     }
   }
 

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSinkParametersTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSinkParametersTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.Inside.inside
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ModelConfig
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{
   CustomNodeError,
@@ -169,14 +170,14 @@ class TableSinkParametersTest
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Bad expression type, expected: String, found: Double(123.11)",
-                "end",
+                NodeId("end"),
                 _,
                 _,
                 _
               ),
               ExpressionParserCompilationError(
                 "Bad expression type, expected: BigDecimal, found: String()",
-                "end",
+                NodeId("end"),
                 _,
                 _,
                 _
@@ -198,7 +199,8 @@ class TableSinkParametersTest
       )
 
     val result = runner.runWithoutData(scenario)
-    inside(result) { case Invalid(NonEmptyList(CustomNodeError("end", _, _), CustomNodeError("end", _, _) :: Nil)) =>
+    inside(result) {
+      case Invalid(NonEmptyList(CustomNodeError(NodeId("end"), _, _), CustomNodeError(NodeId("end"), _, _) :: Nil)) =>
     }
   }
 

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformerSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformerSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.Inside
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ScenarioCompilationDependencies
-import pl.touk.nussknacker.engine.api.{ContextId, ContextIdPathPart, JobData, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{ContextId, ContextIdPathPart, JobData, NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.definition.EngineScenarioCompilationDependencies
 import pl.touk.nussknacker.engine.api.process._
@@ -56,18 +56,18 @@ class ForEachTransformerSpec extends AnyFunSuite with FlinkSpec with Matchers wi
       val results = collectTestResults(model, testScenario, collectingListener)
       extractContextIds(results) shouldBe List(
         ContextId(
-          scenarioId = "forEachProcess",
-          originatingNodeId = "start",
+          scenarioName = ProcessName("forEachProcess"),
+          originatingNodeId = NodeId("start"),
           taskId = 0,
           index = 0,
-          path = List(ContextIdPathPart("for-each", "0"))
+          path = List(ContextIdPathPart(NodeId("for-each"), "0"))
         ),
         ContextId(
-          scenarioId = "forEachProcess",
-          originatingNodeId = "start",
+          scenarioName = ProcessName("forEachProcess"),
+          originatingNodeId = NodeId("start"),
           taskId = 0,
           index = 0,
-          path = List(ContextIdPathPart("for-each", "1"))
+          path = List(ContextIdPathPart(NodeId("for-each"), "1"))
         ),
       )
     }
@@ -137,11 +137,11 @@ class ForEachTransformerSpec extends AnyFunSuite with FlinkSpec with Matchers wi
   }
 
   private def extractResultValues(results: TestProcess.TestResults[_]): List[String] = results
-    .nodeResults(sinkId)
+    .nodeResults(NodeId(sinkId))
     .map(_.variableTyped(resultVariableName).get.asInstanceOf[String])
 
   private def extractContextIds(results: TestProcess.TestResults[_]): List[ContextId] =
-    results.nodeResults(forEachNodeResultId).map(_.id)
+    results.nodeResults(NodeId(forEachNodeResultId)).map(_.id)
 
   private def runScenario(model: LocalModelData, testScenario: CanonicalProcess): Unit = {
     flinkMiniCluster.withDetachedStreamExecutionEnvironment { env =>

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformerSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformerSpec.scala
@@ -5,6 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CannotCreateObjectError
 import pl.touk.nussknacker.engine.api.typed.CustomNodeValidationException
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
@@ -153,7 +154,9 @@ class UnionTransformerSpec
       )
 
     val result = testScenarioRunner.runWithData(scenario, data).invalidValue
-    result.toList should contain(CannotCreateObjectError("All branch values must be of the same type", UnionNodeId))
+    result.toList should contain(
+      CannotCreateObjectError("All branch values must be of the same type", NodeId(UnionNodeId))
+    )
   }
 
   test("should throw when one branch emits error") {

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformersTestModeSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformersTestModeSpec.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.{ContextId, ContextIdPathPart}
+import pl.touk.nussknacker.engine.api.{ContextId, ContextIdPathPart, NodeId}
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
@@ -34,9 +34,9 @@ class UnionTransformersTestModeSpec
 
   import pl.touk.nussknacker.engine.spel.SpelExtension._
 
-  private val scenarioName      = "sample-union"
-  private val sourceId          = "start-foo"
-  private val endSinkId         = "end"
+  private val scenarioName      = ProcessName("sample-union")
+  private val sourceId          = NodeId("start-foo")
+  private val endSinkId         = NodeId("end")
   private val leftBranchId      = "left"
   private val rightBranchId     = "right"
   private val unionNodeId       = "union-node-id"
@@ -76,10 +76,10 @@ class UnionTransformersTestModeSpec
 
   private def testDiamondLikeScenario(unionPart: GraphBuilder[node.SourceNode]): Unit = {
     val scenario = ScenarioBuilder
-      .streaming(scenarioName)
+      .streaming(scenarioName.value)
       .sources(
         GraphBuilder
-          .source(sourceId, "start")
+          .source(sourceId.id, "start")
           .split(
             "split",
             GraphBuilder
@@ -90,7 +90,7 @@ class UnionTransformersTestModeSpec
               .branchEnd(rightBranchId, unionNodeId)
           ),
         unionPart
-          .emptySink(endSinkId, "dead-end")
+          .emptySink(endSinkId.id, "dead-end")
       )
     ResultsCollectingListenerHolder.withListener { collectingListener =>
       val modelData = createModelData(data, collectingListener)
@@ -102,43 +102,43 @@ class UnionTransformersTestModeSpec
       contextIds should contain theSameElementsAs contextIds.toSet
       contextIds should contain only (
         ContextId(
-          scenarioId = scenarioName,
+          scenarioName = scenarioName,
           originatingNodeId = sourceId,
           taskId = firstSubtaskIndex,
           index = 0,
           path = List(
-            ContextIdPathPart("split", leftBranchId),
-            ContextIdPathPart("union-node-id", leftBranchId)
+            ContextIdPathPart(NodeId("split"), leftBranchId),
+            ContextIdPathPart(NodeId("union-node-id"), leftBranchId)
           )
         ),
         ContextId(
-          scenarioId = scenarioName,
+          scenarioName = scenarioName,
           originatingNodeId = sourceId,
           taskId = firstSubtaskIndex,
           index = 1,
           path = List(
-            ContextIdPathPart("split", leftBranchId),
-            ContextIdPathPart("union-node-id", leftBranchId)
+            ContextIdPathPart(NodeId("split"), leftBranchId),
+            ContextIdPathPart(NodeId("union-node-id"), leftBranchId)
           )
         ),
         ContextId(
-          scenarioId = scenarioName,
+          scenarioName = scenarioName,
           originatingNodeId = sourceId,
           taskId = firstSubtaskIndex,
           index = 0,
           path = List(
-            ContextIdPathPart("split", rightBranchId),
-            ContextIdPathPart("union-node-id", rightBranchId)
+            ContextIdPathPart(NodeId("split"), rightBranchId),
+            ContextIdPathPart(NodeId("union-node-id"), rightBranchId)
           )
         ),
         ContextId(
-          scenarioId = scenarioName,
+          scenarioName = scenarioName,
           originatingNodeId = sourceId,
           taskId = firstSubtaskIndex,
           index = 1,
           path = List(
-            ContextIdPathPart("split", rightBranchId),
-            ContextIdPathPart("union-node-id", rightBranchId)
+            ContextIdPathPart(NodeId("split"), rightBranchId),
+            ContextIdPathPart(NodeId("union-node-id"), rightBranchId)
           )
         ),
       )

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionWithMemoTransformerSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionWithMemoTransformerSpec.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ScenarioCompilationDependencies
-import pl.touk.nussknacker.engine.api.{JobData, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{JobData, NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomNodeError
 import pl.touk.nussknacker.engine.api.definition.EngineScenarioCompilationDependencies
@@ -34,9 +34,9 @@ class UnionWithMemoTransformerSpec extends AnyFunSuite with FlinkSpec with Match
 
   import UnionWithMemoTransformerSpec._
 
-  private val UnionNodeId = "joined-node-id"
+  private val UnionNodeId = NodeId("joined-node-id")
 
-  private val EndNodeId = "end-node-id"
+  private val EndNodeId = NodeId("end-node-id")
 
   private val OutVariableName = "outVar"
 
@@ -49,13 +49,13 @@ class UnionWithMemoTransformerSpec extends AnyFunSuite with FlinkSpec with Match
       .sources(
         GraphBuilder
           .source("start-foo", "start-foo")
-          .branchEnd(BranchFooId, UnionNodeId),
+          .branchEnd(BranchFooId, UnionNodeId.id),
         GraphBuilder
           .source("start-bar", "start-bar")
-          .branchEnd(BranchBarId, UnionNodeId),
+          .branchEnd(BranchBarId, UnionNodeId.id),
         GraphBuilder
           .join(
-            UnionNodeId,
+            UnionNodeId.id,
             "union-memo",
             Some(OutVariableName),
             List(
@@ -70,7 +70,7 @@ class UnionWithMemoTransformerSpec extends AnyFunSuite with FlinkSpec with Match
             ),
             "stateTimeout" -> s"T(${classOf[Duration].getName}).parse('PT2H')".spel
           )
-          .emptySink(EndNodeId, "dead-end")
+          .emptySink(EndNodeId.id, "dead-end")
       )
 
     val key       = "fooKey"
@@ -111,13 +111,13 @@ class UnionWithMemoTransformerSpec extends AnyFunSuite with FlinkSpec with Match
       .sources(
         GraphBuilder
           .source("start-foo", "start-foo")
-          .branchEnd(BranchFooId, UnionNodeId),
+          .branchEnd(BranchFooId, UnionNodeId.id),
         GraphBuilder
           .source("start-bar", "start-bar")
-          .branchEnd(BranchBarId, UnionNodeId),
+          .branchEnd(BranchBarId, UnionNodeId.id),
         GraphBuilder
           .join(
-            UnionNodeId,
+            UnionNodeId.id,
             "union-memo",
             Some(OutVariableName),
             List(
@@ -132,7 +132,7 @@ class UnionWithMemoTransformerSpec extends AnyFunSuite with FlinkSpec with Match
             ),
             "stateTimeout" -> s"T(${classOf[Duration].getName}).parse('PT2H')".spel
           )
-          .emptySink(EndNodeId, "dead-end")
+          .emptySink(EndNodeId.id, "dead-end")
       )
 
     val sourceFoo = BlockingQueueSource.create[OneRecord](_.timestamp, Duration.ofHours(1))
@@ -163,13 +163,13 @@ class UnionWithMemoTransformerSpec extends AnyFunSuite with FlinkSpec with Match
       .sources(
         GraphBuilder
           .source("start-foo", "start-foo")
-          .branchEnd(BranchFooId, UnionNodeId),
+          .branchEnd(BranchFooId, UnionNodeId.id),
         GraphBuilder
           .source("start-bar", "start-bar")
-          .branchEnd(BranchBarId, UnionNodeId),
+          .branchEnd(BranchBarId, UnionNodeId.id),
         GraphBuilder
           .join(
-            UnionNodeId,
+            UnionNodeId.id,
             "union-memo",
             Some(OutVariableName),
             List(
@@ -184,7 +184,7 @@ class UnionWithMemoTransformerSpec extends AnyFunSuite with FlinkSpec with Match
             ),
             "stateTimeout" -> s"T(${classOf[Duration].getName}).parse('PT2H')".spel
           )
-          .emptySink(EndNodeId, "dead-end")
+          .emptySink(EndNodeId.id, "dead-end")
       )
 
     val sourceFoo = BlockingQueueSource.create[OneRecord](_.timestamp, Duration.ofHours(1))

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/FullOuterJoinTransformerSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/FullOuterJoinTransformerSpec.scala
@@ -44,7 +44,7 @@ class FullOuterJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Match
 
   private val JoinNodeId = "joined-node-id"
 
-  private val EndNodeId = "end-node-id"
+  private val EndNodeId = NodeId("end-node-id")
 
   private val KeyVariableName = "keyVar"
 
@@ -83,7 +83,7 @@ class FullOuterJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Match
             ),
             "windowLength" -> s"T(${classOf[Duration].getName}).parse('PT20H')".spel,
           )
-          .emptySink(EndNodeId, "dead-end")
+          .emptySink(EndNodeId.id, "dead-end")
       )
 
     val input1 = BlockingQueueSource.create[OneRecord](_.timestamp, Duration.ofHours(1))
@@ -453,7 +453,7 @@ class FullOuterJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Match
             ),
             "windowLength" -> s"T(${classOf[Duration].getName}).parse('PT20H')".spel,
           )
-          .emptySink(EndNodeId, "dead-end")
+          .emptySink(EndNodeId.id, "dead-end")
       )
 
     val sourceFoo = BlockingQueueSource.create[OneRecord](_.timestamp, Duration.ofHours(1))
@@ -502,7 +502,7 @@ class FullOuterJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Match
             ),
             "windowLength" -> s"T(${classOf[Duration].getName}).parse('PT20H')".spel,
           )
-          .emptySink(EndNodeId, "dead-end")
+          .emptySink(EndNodeId.id, "dead-end")
       )
 
     val sourceFoo = BlockingQueueSource.create[OneRecord](_.timestamp, Duration.ofHours(1))

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/JavaCollectionsSerializationTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/JavaCollectionsSerializationTest.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.Inside
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
@@ -57,7 +58,7 @@ class JavaCollectionsSerializationTest extends AnyFunSuite with FlinkSpec with M
       runScenario(model, process)
 
       val result = collectingListener.results
-        .nodeResults("end")
+        .nodeResults(NodeId("end"))
         .map(_.variableTyped[Record]("input"))
 
       result shouldBe List(Some(record))

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/ModelUtilExceptionHandlingSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/ModelUtilExceptionHandlingSpec.scala
@@ -7,7 +7,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.scalatest.LoneElement
 import org.scalatest.funsuite.AnyFunSuite
 import pl.touk.nussknacker.engine.ModelData
-import pl.touk.nussknacker.engine.api.{Context, EagerService, MethodToInvoke, ServiceInvoker}
+import pl.touk.nussknacker.engine.api.{Context, EagerService, MethodToInvoke, NodeId, ServiceInvoker}
 import pl.touk.nussknacker.engine.api.component.{ComponentDefinition, NodeComponentInfo}
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 import pl.touk.nussknacker.engine.api.process.ComponentUseContext
@@ -160,7 +160,13 @@ class ModelUtilExceptionHandlingSpec
       RecordingExceptionConsumer
         .exceptionsFor(runId)
         .collect {
-          case NuExceptionInfo(Some(NodeComponentInfo("join", _)), e: SpelExpressionEvaluationException, _, _, _) =>
+          case NuExceptionInfo(
+                Some(NodeComponentInfo(NodeId("join"), _)),
+                e: SpelExpressionEvaluationException,
+                _,
+                _,
+                _
+              ) =>
             e.expression
         }
         .toSet shouldBe Set(

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/SingleSideJoinTransformerSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/SingleSideJoinTransformerSpec.scala
@@ -45,9 +45,9 @@ class SingleSideJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Matc
 
   private val JoinedBranchId = "joined"
 
-  private val JoinNodeId = "joined-node-id"
+  private val JoinNodeId = NodeId("joined-node-id")
 
-  private val EndNodeId = "end-node-id"
+  private val EndNodeId = NodeId("end-node-id")
 
   private val KeyVariableName = "keyVar"
 
@@ -60,13 +60,13 @@ class SingleSideJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Matc
         GraphBuilder
           .source("source", "start-main")
           .buildSimpleVariable("build-key", KeyVariableName, "#input.key".spel)
-          .branchEnd(MainBranchId, JoinNodeId),
+          .branchEnd(MainBranchId, JoinNodeId.id),
         GraphBuilder
           .source("joined-source", "start-joined")
-          .branchEnd(JoinedBranchId, JoinNodeId),
+          .branchEnd(JoinedBranchId, JoinNodeId.id),
         GraphBuilder
           .join(
-            JoinNodeId,
+            JoinNodeId.id,
             customElementName,
             Some(OutVariableName),
             List(
@@ -83,7 +83,7 @@ class SingleSideJoinTransformerSpec extends AnyFunSuite with FlinkSpec with Matc
             "windowLength" -> s"T(${classOf[Duration].getName}).parse('PT2H')".spel,
             "aggregateBy" -> "{last: #input.value, list: #input.value, approxCardinality: #input.value, sum: #input.value } ".spel
           )
-          .emptySink(EndNodeId, "dead-end")
+          .emptySink(EndNodeId.id, "dead-end")
       )
 
     val key    = "fooKey"

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/TransformersTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/TransformersTest.scala
@@ -9,7 +9,14 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables.Table
 import pl.touk.nussknacker.engine.ScenarioCompilationDependencies
-import pl.touk.nussknacker.engine.api.{FragmentSpecificData, JobData, MetaData, ProcessVersion, VariableConstants}
+import pl.touk.nussknacker.engine.api.{
+  FragmentSpecificData,
+  JobData,
+  MetaData,
+  NodeId,
+  ProcessVersion,
+  VariableConstants
+}
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{
   CannotCreateObjectError,
@@ -84,13 +91,13 @@ class TransformersTest extends AnyFunSuite with FlinkSpec with Matchers with Ins
 
     def endVariablesForKey[K <: Any](key: K): List[TestProcess.ResultContext[Any]] = {
       collectingListener.results
-        .nodeResults("end")
+        .nodeResults(NodeId("end"))
         .filter(_.variableTyped[K](VariableConstants.KeyVariableName).contains(key))
     }
 
     def keyVariables[T <: AnyRef]: List[T] = {
       collectingListener.results
-        .nodeResults("end")
+        .nodeResults(NodeId("end"))
         .map(_.variableTyped[T]("key").get)
     }
 
@@ -351,7 +358,13 @@ class TransformersTest extends AnyFunSuite with FlinkSpec with Matchers with Ins
     inside(result.result) {
       case Invalid(
             NonEmptyList(
-              ExpressionParserCompilationError("Unresolved reference 'input'", "after-aggregate-expression-", _, _, _),
+              ExpressionParserCompilationError(
+                "Unresolved reference 'input'",
+                NodeId("after-aggregate-expression-"),
+                _,
+                _,
+                _
+              ),
               _
             )
           ) =>
@@ -508,7 +521,13 @@ class TransformersTest extends AnyFunSuite with FlinkSpec with Matchers with Ins
         runScenario(model, resolvedScenario)
       } should matchPattern {
         case ScenarioCompilationErrors(
-              ExpressionParserCompilationError("Unresolved reference 'input'", "inputVarAccessTest", _, _, _) :: Nil
+              ExpressionParserCompilationError(
+                "Unresolved reference 'input'",
+                NodeId("inputVarAccessTest"),
+                _,
+                _,
+                _
+              ) :: Nil
             ) =>
       }
     }
@@ -1057,7 +1076,7 @@ class TransformersTest extends AnyFunSuite with FlinkSpec with Matchers with Ins
   private def validateError(aggregator: String, aggregateBy: String, error: String): Unit = {
     val result = validateConfig(aggregator, aggregateBy)
     result.result shouldBe Symbol("invalid")
-    result.result.swap.toOption.get shouldBe NonEmptyList.of(CannotCreateObjectError(error, "transform"))
+    result.result.swap.toOption.get shouldBe NonEmptyList.of(CannotCreateObjectError(error, NodeId("transform")))
   }
 
   private def validateOk(aggregator: String, aggregateBy: String, typingResult: TypingResult): Unit = {

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/Aggregator.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/Aggregator.scala
@@ -80,7 +80,7 @@ abstract class Aggregator extends AggregateFunction[AnyRef, AnyRef, AnyRef] {
   ): ValidationContext => ValidatedNel[ProcessCompilationError, ValidationContext] = validationCtx =>
     computeOutputType(aggregateBy.returnType)
       // TODO: better error?
-      .leftMap(message => NonEmptyList.of(CannotCreateObjectError(message, nodeId.id)))
+      .leftMap(message => NonEmptyList.of(CannotCreateObjectError(message, nodeId)))
       .andThen { outputType =>
         val ctx = if (emitContext) validationCtx else validationCtx.clearVariables
         ctx.withVariable(variableName, outputType, paramName = None)

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/EmitExtraWindowWhenNoDataTumblingAggregatorFunction.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/EmitExtraWindowWhenNoDataTumblingAggregatorFunction.scala
@@ -49,7 +49,7 @@ class EmitExtraWindowWhenNoDataTumblingAggregatorFunction[MapT[K, V]](
 
   override def open(openContext: OpenContext): Unit = {
     state = getRuntimeContext.getState(stateDescriptor)
-    contextIdGenerator = convertToEngineRuntimeContext(getRuntimeContext).contextIdGenerator(nodeId.id)
+    contextIdGenerator = convertToEngineRuntimeContext(getRuntimeContext).contextIdGenerator(nodeId)
   }
 
   override protected val minimalResolutionMs: Long = timeWindowLengthMillis

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/EmitWhenEventLeftAggregatorFunction.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/EmitWhenEventLeftAggregatorFunction.scala
@@ -45,7 +45,7 @@ class EmitWhenEventLeftAggregatorFunction[MapT[K, V]](
 
   override def open(openContext: OpenContext): Unit = {
     super.open(openContext)
-    contextIdGenerator = convertToEngineRuntimeContext(getRuntimeContext).contextIdGenerator(nodeId.id)
+    contextIdGenerator = convertToEngineRuntimeContext(getRuntimeContext).contextIdGenerator(nodeId)
   }
 
   override def processElement(

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/EnrichingWithKeyFunction.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/EnrichingWithKeyFunction.scala
@@ -4,14 +4,14 @@ import org.apache.flink.api.common.functions.{OpenContext, RuntimeContext}
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow
 import org.apache.flink.util.Collector
-import pl.touk.nussknacker.engine.api.{Context => NkContext, ValueWithContext}
+import pl.touk.nussknacker.engine.api.{Context => NkContext, NodeId, ValueWithContext}
 import pl.touk.nussknacker.engine.api.runtimecontext.{ContextIdGenerator, EngineRuntimeContext}
 import pl.touk.nussknacker.engine.flink.api.process.FlinkCustomNodeContext
 import pl.touk.nussknacker.engine.flink.util.keyed.KeyEnricher
 
 import java.lang
 
-class EnrichingWithKeyFunction(convertToEngineRuntimeContext: RuntimeContext => EngineRuntimeContext, nodeId: String)
+class EnrichingWithKeyFunction(convertToEngineRuntimeContext: RuntimeContext => EngineRuntimeContext, nodeId: NodeId)
     extends ProcessWindowFunction[AnyRef, ValueWithContext[AnyRef], AnyRef, TimeWindow] {
 
   @transient

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/ExtendedWindowOperator.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/ExtendedWindowOperator.scala
@@ -13,7 +13,7 @@ import org.apache.flink.streaming.runtime.operators.windowing.functions.Internal
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api
-import pl.touk.nussknacker.engine.api.ValueWithContext
+import pl.touk.nussknacker.engine.api.{NodeId, ValueWithContext}
 import pl.touk.nussknacker.engine.api.runtimecontext.{ContextIdGenerator, EngineRuntimeContext}
 import pl.touk.nussknacker.engine.flink.api.process.FlinkCustomNodeContext
 import pl.touk.nussknacker.engine.flink.util.keyed.KeyEnricher
@@ -118,7 +118,7 @@ private[aggregate] class ExtendedWindowOperator[A](
 
 private class ValueEmittingWindowFunction(
     convertToEngineRuntimeContext: RuntimeContext => EngineRuntimeContext,
-    nodeId: String,
+    nodeId: NodeId,
     private val contextHolderRef: NuWindowContextHolder
 ) extends ProcessWindowFunction[AnyRef, ValueWithContext[AnyRef], AnyRef, TimeWindow] {
 

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/FullOuterJoinTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/FullOuterJoinTransformer.scala
@@ -185,7 +185,7 @@ class FullOuterJoinTransformer(
         inputType,
         storedTypeInfo,
         context.convertToEngineRuntimeContext
-      )(NodeId(context.nodeId))
+      )(context.nodeId)
       val outputType = aggregator.computeOutputTypeUnsafe(inputType)
       val outputTypeInfo =
         TypeInformationDetection.instance.forValueWithContext[AnyRef](ValidationContext(), outputType)

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/SingleSideJoinTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/SingleSideJoinTransformer.scala
@@ -154,7 +154,7 @@ class SingleSideJoinTransformer(
           aggregateBy.returnType,
           storedTypeInfo,
           context.convertToEngineRuntimeContext
-        )(NodeId(context.nodeId))
+        )(context.nodeId)
 
         val statefulStreamWithUid = keyedMainBranchStream
           .connect(keyedJoinedStream)

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionTransformer.scala
@@ -38,7 +38,7 @@ object UnionTransformer extends UnionTransformer(None) {
     }
     unifiedReturnType
       .map(unionValidationContext(variableName, contexts, _))
-      .getOrElse(Validated.invalidNel(CannotCreateObjectError("All branch values must be of the same type", nodeId.id)))
+      .getOrElse(Validated.invalidNel(CannotCreateObjectError("All branch values must be of the same type", nodeId)))
   }
 
   private def findSuperTypeCheckingAllFieldsMatchingForObjects(

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/aggregate/TableAggregation.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/aggregate/TableAggregation.scala
@@ -116,7 +116,7 @@ class TableAggregation(
     private var contextIdGenerator: ContextIdGenerator = _
 
     override def open(openContext: OpenContext): Unit = {
-      contextIdGenerator = convertToEngineRuntimeContext(getRuntimeContext).contextIdGenerator(nodeId.toString)
+      contextIdGenerator = convertToEngineRuntimeContext(getRuntimeContext).contextIdGenerator(nodeId)
     }
 
     override def processElement(

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSink.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSink.scala
@@ -9,7 +9,7 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
 import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
-import pl.touk.nussknacker.engine.api.{Context, LazyParameter, ValueWithContext}
+import pl.touk.nussknacker.engine.api.{Context, LazyParameter, NodeId, ValueWithContext}
 import pl.touk.nussknacker.engine.api.component.{ComponentType, NodeComponentInfo}
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.flink.api.exception.{ExceptionHandler, WithExceptionHandler}
@@ -76,7 +76,7 @@ class TableSink(
 
 class EncodeAsTableTypeFunction private (
     override protected val exceptionHandlerPreparer: RuntimeContext => ExceptionHandler,
-    nodeId: String,
+    nodeId: NodeId,
     sinkRowType: RowType,
     producedType: TypeInformation[Row]
 ) extends RichFlatMapFunction[ValueWithContext[AnyRef], Row]

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSinkFactory.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSinkFactory.scala
@@ -170,7 +170,7 @@ class TableSinkFactory(
           invalid(
             NonEmptyList.one(
               CustomNodeError(
-                nodeId.id,
+                nodeId,
                 s"Sink's output record's field name '${field.getName}' is restricted. Please use raw editor for this case.",
                 None
               )

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/RowConversions.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/utils/RowConversions.scala
@@ -5,8 +5,9 @@ import io.circe.syntax.EncoderOps
 import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.types.Row
-import pl.touk.nussknacker.engine.api.{Context, ContextId, ContextIdPathPart}
+import pl.touk.nussknacker.engine.api.{Context, ContextId, ContextIdPathPart, NodeId}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.flink.api.typeinformation.TypeInformationDetection
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 
@@ -73,8 +74,8 @@ object RowConversions {
   private implicit def contextIdCodec: Codec[ContextId] =
     Codec.forProduct5("sn", "nid", "tid", "idx", "path")(
       (
-          scenarioName: String,
-          nodeId: String,
+          scenarioName: ProcessName,
+          nodeId: NodeId,
           taskId: Long,
           index: Long,
           path: List[ContextIdPathPart]

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkEngineRuntimeContextImpl.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkEngineRuntimeContextImpl.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.process.compiler
 
 import org.apache.flink.api.common.functions.RuntimeContext
 import pl.touk.nussknacker.engine.RuntimeMode
-import pl.touk.nussknacker.engine.api.JobData
+import pl.touk.nussknacker.engine.api.{JobData, NodeId}
 import pl.touk.nussknacker.engine.api.runtimecontext.{ContextIdGenerator, IncContextIdGenerator}
 import pl.touk.nussknacker.engine.flink.api.FlinkEngineRuntimeContext
 import pl.touk.nussknacker.engine.process.compiler.MetricsProviderForFlink.createMetricsProvider
@@ -14,7 +14,7 @@ case class FlinkEngineRuntimeContextImpl(
     metricsProvider: MetricsProviderForScenario
 ) extends FlinkEngineRuntimeContext {
 
-  override def contextIdGenerator(nodeId: String): ContextIdGenerator =
+  override def contextIdGenerator(nodeId: NodeId): ContextIdGenerator =
     new IncContextIdGenerator(
       jobData.metaData.name,
       nodeId,

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkProcessCompilerDataFactory.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/compiler/FlinkProcessCompilerDataFactory.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.process.compiler
 
 import pl.touk.nussknacker.engine.{CustomProcessValidatorLoader, ModelConfig, ModelData, RuntimeMode}
 import pl.touk.nussknacker.engine.ModelData.ExtractDefinitionFun
-import pl.touk.nussknacker.engine.api.{JobData, MetaData, ProcessListener, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{JobData, MetaData, NodeId, ProcessListener, ProcessVersion}
 import pl.touk.nussknacker.engine.api.component.{
   ComponentAdditionalConfig,
   ComponentDependencies,
@@ -114,7 +114,9 @@ class FlinkProcessCompilerDataFactory(
       nodeData.isInstanceOf[CustomNode] || nodeData.isInstanceOf[node.Sink]
     List(
       LoggingListener,
-      new NodeCountingListener(usedNodes.nodes.filterNot(nodesHandledInNextParts).map(_.id) ++ usedNodes.nextParts),
+      new NodeCountingListener(
+        usedNodes.nodes.filterNot(nodesHandledInNextParts).map(n => NodeId(n.id)) ++ usedNodes.nextParts
+      ),
       new EndCountingListener(usedNodes.nodes)
     )
   }
@@ -174,7 +176,7 @@ class FlinkProcessCompilerDataFactory(
 //ProcessListener.nodeEntered method is invoked in Interpreter, when PartRef is encountered. This is because CustomNode/Sink
 //in Interpreter is invoked *after* node execution in Flink/Lite. To initialize Metric listeners correctly we need
 //to pass list of nextParts, so when Interpreter invokes nodeEntered on PartRef, the counter is properly initialized
-private[process] case class UsedNodes(nodes: Iterable[NodeData], nextParts: Iterable[String])
+private[process] case class UsedNodes(nodes: Iterable[NodeData], nextParts: Iterable[NodeId])
 
 object UsedNodes {
   val empty: UsedNodes = UsedNodes(Nil, Nil)

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/CollectingSinkFunction.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/CollectingSinkFunction.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.engine.process.registrar
 
 import org.apache.flink.streaming.api.functions.sink.{RichSinkFunction, SinkFunction}
-import pl.touk.nussknacker.engine.api.ValueWithContext
+import pl.touk.nussknacker.engine.api.{NodeId, ValueWithContext}
 import pl.touk.nussknacker.engine.api.component.{ComponentType, NodeComponentInfo}
 import pl.touk.nussknacker.engine.process.ExceptionHandlerFunction
 import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
@@ -13,7 +13,7 @@ import scala.annotation.nowarn
 private[registrar] class CollectingSinkFunction[T](
     val compilerDataForClassloader: ClassLoader => FlinkProcessCompilerData,
     collectingSink: SinkInvocationCollector,
-    sinkId: String
+    sinkId: NodeId
 ) extends RichSinkFunction[ValueWithContext[T]]
     with ExceptionHandlerFunction {
 

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
@@ -143,7 +143,7 @@ class FlinkProcessRegistrar(
         globalParameters = globalParameters,
         validationContext,
         compilerData.runtimeMode.createContext(
-          deploymentData.nodesData.get(NodeId(nodeComponentId.nodeId))
+          deploymentData.nodesData.get(nodeComponentId.nodeId)
         ),
         // TODO: we should verify if component supports given node data type. If not, we should throw some error instead
         //       of silently skip these data
@@ -284,7 +284,7 @@ class FlinkProcessRegistrar(
       val withSinkAdded = resultCollector match {
         case testResultCollector: TestServiceInvocationCollector =>
           val typ                 = part.node.data.ref.typ
-          val collectingSink      = testResultCollector.createSinkInvocationCollector(part.id, typ)
+          val collectingSink      = testResultCollector.createSinkInvocationCollector(NodeId(part.id), typ)
           val prepareTestValueFun = sink.prepareTestValueFunction
           withValuePrepared
             .map(
@@ -292,7 +292,9 @@ class FlinkProcessRegistrar(
               customNodeContext.valueWithContextInfo.forUnknown
             )
             // FIXME: ...
-            .addSink(new CollectingSinkFunction[AnyRef](compilerDataForProcessPart(None), collectingSink, part.id))
+            .addSink(
+              new CollectingSinkFunction[AnyRef](compilerDataForProcessPart(None), collectingSink, NodeId(part.id))
+            )
         case _ =>
           sink.registerSink(withValuePrepared, nodeContext(nodeComponentInfoFrom(part), Left(contextBefore)))
       }
@@ -412,7 +414,7 @@ object FlinkProcessRegistrar {
       .map { part =>
         (
           SplittedNodesCollector.collectNodes(part.node).map(_.data),
-          part.cast[PotentiallyStartPart].toList.flatMap(_.nextParts).map(_.id)
+          part.cast[PotentiallyStartPart].toList.flatMap(_.nextParts).map(p => NodeId(p.id))
         )
       }
       .getOrElse((Set.empty, Nil))

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/internal/ContextTypeHelpers.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/internal/ContextTypeHelpers.scala
@@ -2,7 +2,8 @@ package pl.touk.nussknacker.engine.process.typeinformation.internal
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.ListTypeInfo
-import pl.touk.nussknacker.engine.api.{Context, ContextId, ContextIdPathPart}
+import pl.touk.nussknacker.engine.api.{Context, ContextId, ContextIdPathPart, NodeId}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.flink.api.typeinfo.option.OptionTypeInfo
 import pl.touk.nussknacker.engine.flink.typeinformation.{ConcreteCaseClassTypeInfo, FixedValueTypeInformationHelper}
 
@@ -28,20 +29,26 @@ object ContextTypeHelpers {
     infoFromVariablesAndParent(variables, parentCtx)
   }
 
-  private def contextIdInfo: TypeInformation[ContextId] = {
+  private val processNameTypeInformation: TypeInformation[ProcessName] =
+    ConcreteCaseClassTypeInfo[ProcessName](("value", TypeInformation.of(classOf[String])))
+
+  private val nodeIdTypeInformation: TypeInformation[NodeId] =
+    ConcreteCaseClassTypeInfo[NodeId](("id", TypeInformation.of(classOf[String])))
+
+  private val contextIdPathPartInfo: TypeInformation[ContextIdPathPart] = {
     ConcreteCaseClassTypeInfo(
-      ("scenarioId", TypeInformation.of(classOf[String])),
-      ("originatingNodeId", TypeInformation.of(classOf[String])),
-      ("taskId", TypeInformation.of(classOf[Long])),
-      ("index", TypeInformation.of(classOf[Long])),
-      ("contextIdPath", new ListTypeInfo[ContextIdPathPart](contextIdPathPartInfo)),
+      ("nodeId", nodeIdTypeInformation),
+      ("value", TypeInformation.of(classOf[String])),
     )
   }
 
-  private def contextIdPathPartInfo: TypeInformation[ContextIdPathPart] = {
+  private val contextIdInfo: TypeInformation[ContextId] = {
     ConcreteCaseClassTypeInfo(
-      ("nodeId", TypeInformation.of(classOf[String])),
-      ("value", TypeInformation.of(classOf[String])),
+      ("scenarioName", processNameTypeInformation),
+      ("originatingNodeId", nodeIdTypeInformation),
+      ("taskId", TypeInformation.of(classOf[Long])),
+      ("index", TypeInformation.of(classOf[Long])),
+      ("contextIdPath", new ListTypeInfo[ContextIdPathPart](contextIdPathPartInfo)),
     )
   }
 

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/functional/CustomNodeProcessSpec.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.process.functional
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.ExpressionParserCompilationError
 import pl.touk.nussknacker.engine.api.context.ScenarioCompilationErrors
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
@@ -264,7 +265,7 @@ class CustomNodeProcessSpec extends AnyFunSuite with Matchers with ProcessTestHe
       processInvoker.invokeWithSampleData(process, data)
     } should matchPattern {
       case ScenarioCompilationErrors(
-            ExpressionParserCompilationError("Unresolved reference 'input'", "proc2", _, _, _) :: _
+            ExpressionParserCompilationError("Unresolved reference 'input'", NodeId("proc2"), _, _, _) :: _
           ) =>
     }
   }
@@ -284,7 +285,7 @@ class CustomNodeProcessSpec extends AnyFunSuite with Matchers with ProcessTestHe
       case ScenarioCompilationErrors(
             ExpressionParserCompilationError(
               "There is no property 'value999' in type: SimpleRecord",
-              "delta",
+              NodeId("delta"),
               _,
               _,
               _
@@ -336,9 +337,11 @@ class CustomNodeProcessSpec extends AnyFunSuite with Matchers with ProcessTestHe
       )
     val data = List(SimpleRecord("terefere", 3, "a", new Date(0)), SimpleRecord("kuku", 3, "b", new Date(0)))
 
-    CountingNodesListener.listen {
-      processInvoker.invokeWithSampleData(process, data)
-    } shouldBe List("id", "testVar", "custom", "split", "out", "custom-ending", "id", "testVar", "custom")
+    CountingNodesListener
+      .listen {
+        processInvoker.invokeWithSampleData(process, data)
+      }
+      .map(_.id) shouldBe List("id", "testVar", "custom", "split", "out", "custom-ending", "id", "testVar", "custom")
   }
 
 }

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/functional/FlinkSinkSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/functional/FlinkSinkSpec.scala
@@ -28,7 +28,7 @@ class FlinkSinkSpec extends AnyFunSuite with Matchers with ProcessTestHelpers {
     // without certain hack (see SpelHack & SpelMapHack) this throws exception.
     processInvoker.invokeWithSampleData(process, data)
 
-    SinkAccessingNodeContext.nodeId shouldBe "out"
+    SinkAccessingNodeContext.nodeId.id shouldBe "out"
   }
 
 }

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/functional/ProcessSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/functional/ProcessSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.LoneElement._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.RuntimeMode
-import pl.touk.nussknacker.engine.api.StreamMetaData
+import pl.touk.nussknacker.engine.api.{NodeId, StreamMetaData}
 import pl.touk.nussknacker.engine.api.component.{ComponentType, NodeComponentInfo}
 import pl.touk.nussknacker.engine.api.exception.NonTransientException
 import pl.touk.nussknacker.engine.api.process.ComponentUseContext
@@ -336,7 +336,11 @@ class ProcessSpec extends AnyFunSuite with Matchers with ProcessTestHelpers {
       val exception = RecordingExceptionConsumer.exceptionsFor(runId).loneElement
       exception.throwable shouldBe a[NonTransientException]
       exception.nodeComponentInfo shouldBe Some(
-        NodeComponentInfo("throwingNonTransientErrorsNodeId", ComponentType.Service, "throwingNonTransientErrors")
+        NodeComponentInfo(
+          NodeId("throwingNonTransientErrorsNodeId"),
+          ComponentType.Service,
+          "throwingNonTransientErrors"
+        )
       )
       ProcessTestHelpers.sinkForStringsResultsHolder.results.loneElement shouldBe "b"
     }

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/helpers/ProcessTestHelpers.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/helpers/ProcessTestHelpers.scala
@@ -127,9 +127,9 @@ object ProcessTestHelpersConfigCreator extends EmptyProcessConfigCreator {
 
 case object SinkAccessingNodeContext extends EmptySink with Serializable {
 
-  @transient private var _nodeId: String = _
+  @transient private var _nodeId: NodeId = _
 
-  def nodeId: String = _nodeId
+  def nodeId: NodeId = _nodeId
 
   @nowarn("cat=deprecation")
   override def toFlinkFunction(flinkNodeContext: FlinkCustomNodeContext): SinkFunction[AnyRef] = {

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/scenariotesting/StubbedFlinkProcessCompilerDataFactoryTest.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/scenariotesting/StubbedFlinkProcessCompilerDataFactoryTest.scala
@@ -101,7 +101,7 @@ class StubbedFlinkProcessCompilerDataFactoryTest extends AnyFunSuite with Matche
   test("stubbing for test purpose should work for one source") {
     val scenarioTestData =
       ScenarioTestData(
-        List(1, 2, 3).map(v => ScenarioTestSourceSpecificFormatJsonRecord("left-source", Json.fromLong(v)))
+        List(1, 2, 3).map(v => ScenarioTestSourceSpecificFormatJsonRecord(NodeId("left-source"), Json.fromLong(v)))
       )
     val compiledProcess = testCompile(scenarioWithSingleSource, scenarioTestData)
     val sources = compiledProcess.sources.collect { case source: SourcePart =>
@@ -114,12 +114,12 @@ class StubbedFlinkProcessCompilerDataFactoryTest extends AnyFunSuite with Matche
   test("stubbing for test purpose should work for multiple sources") {
     val scenarioTestData = ScenarioTestData(
       List(
-        ScenarioTestSourceSpecificFormatJsonRecord("left-source", Json.fromLong(11)),
-        ScenarioTestSourceSpecificFormatJsonRecord("right-source", Json.fromLong(21)),
-        ScenarioTestSourceSpecificFormatJsonRecord("right-source", Json.fromLong(22)),
-        ScenarioTestSourceSpecificFormatJsonRecord("left-source", Json.fromLong(12)),
-        ScenarioTestSourceSpecificFormatJsonRecord("left-source", Json.fromLong(13)),
-        ScenarioTestSourceSpecificFormatJsonRecord("right-source", Json.fromLong(23)),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("left-source"), Json.fromLong(11)),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("right-source"), Json.fromLong(21)),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("right-source"), Json.fromLong(22)),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("left-source"), Json.fromLong(12)),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("left-source"), Json.fromLong(13)),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("right-source"), Json.fromLong(23)),
       )
     )
 

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/ConsumerGroupDeterminer.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/ConsumerGroupDeterminer.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.engine.kafka
 
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.flink.api.process.FlinkCustomNodeContext
 
@@ -9,10 +10,10 @@ class ConsumerGroupDeterminer(consumerGroupNamingStrategy: ConsumerGroupNamingSt
     consumerGroup(nodeContext.metaData.name, nodeContext.nodeId)
   }
 
-  def consumerGroup(processName: ProcessName, nodeId: String): String = {
+  def consumerGroup(processName: ProcessName, nodeId: NodeId): String = {
     consumerGroupNamingStrategy match {
       case ConsumerGroupNamingStrategy.ProcessId       => processName.value
-      case ConsumerGroupNamingStrategy.ProcessIdNodeId => processName.value + "-" + nodeId
+      case ConsumerGroupNamingStrategy.ProcessIdNodeId => processName.value + "-" + nodeId.id
     }
   }
 

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/serialization/FlinkSerializationSchemaConversions.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/serialization/FlinkSerializationSchemaConversions.scala
@@ -50,7 +50,7 @@ object FlinkSerializationSchemaConversions extends LazyLogging {
       val (exceptionHandler, contextIdGenerator, nodeId) = exceptionHandlingData
       exceptionHandler
         .handling(
-          Some(NodeComponentInfo(nodeId.id, ComponentType.Source, "unknown")),
+          Some(NodeComponentInfo(nodeId, ComponentType.Source, "unknown")),
           Context(contextIdGenerator.nextContextId())
         ) {
           deserializationSchema.deserialize(record)

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/flink/FlinkKafkaSource.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/flink/FlinkKafkaSource.scala
@@ -112,7 +112,7 @@ class FlinkKafkaSource[K, V](
       case singleOut: SingleOutputStreamOperator[_] =>
         setUidToNodeIdIfNeed[T](
           flinkNodeContext,
-          singleOut.name(flinkNodeContext.nodeId)
+          singleOut.name(flinkNodeContext.nodeId.id)
         )
       case _ => streamOfRaw
     }
@@ -219,7 +219,7 @@ class FlinkKafkaSource[K, V](
       KafkaUtils.toConsumerProperties(kafkaComponentsConfig, Some(consumerGroupId)),
       flinkNodeContext.exceptionHandlerPreparer,
       flinkNodeContext.convertToEngineRuntimeContext,
-      NodeId(flinkNodeContext.nodeId)
+      NodeId(flinkNodeContext.nodeId.id)
     )
   }
 
@@ -299,7 +299,7 @@ class FlinkKafkaConsumerHandlingExceptions[T](
     patchRestoredState()
     super.open(openContext)
     exceptionHandler = exceptionHandlerPreparer(getRuntimeContext)
-    exceptionPurposeContextIdGenerator = convertToEngineRuntimeContext(getRuntimeContext).contextIdGenerator(nodeId.id)
+    exceptionPurposeContextIdGenerator = convertToEngineRuntimeContext(getRuntimeContext).contextIdGenerator(nodeId)
     deserializationSchema.setExceptionHandlingData(exceptionHandler, exceptionPurposeContextIdGenerator, nodeId)
   }
 

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSerializationSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSerializationSpec.scala
@@ -33,7 +33,7 @@ class KafkaExceptionConsumerSerializationSpec extends AnyFunSuite with Matchers 
   private val context = Context(ContextId.dummy, variables, None)
 
   private val exception = NuExceptionInfo(
-    Some(NodeComponentInfo("nodeId", ComponentType.Service, "componentName")),
+    Some(NodeComponentInfo(NodeId("nodeId"), ComponentType.Service, "componentName")),
     new Exception("mess"),
     context,
     "input1",
@@ -62,7 +62,7 @@ class KafkaExceptionConsumerSerializationSpec extends AnyFunSuite with Matchers 
     val decodedPayload = CirceUtil.decodeJsonUnsafe[KafkaExceptionInfo](message.value())
 
     decodedPayload.processName shouldBe metaData.name
-    decodedPayload.nodeId shouldBe Some("nodeId")
+    decodedPayload.nodeId shouldBe Some(NodeId("nodeId"))
     decodedPayload.exceptionInput shouldBe Some("input1")
     decodedPayload.message shouldBe Some("mess")
     decodedPayload.timestamp shouldBe 111

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaExceptionConsumerSpec.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import org.scalatest.{EitherValues, OptionValues}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.process.SinkFactory
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
@@ -99,7 +100,7 @@ class KafkaExceptionConsumerSpec
       }
 
       message.processName.value shouldBe scenarioName
-      message.nodeId shouldBe Some("shouldFail")
+      message.nodeId shouldBe Some(NodeId("shouldFail"))
       message.message shouldBe Some("Expression [1/{0, 1}[0] != 10] evaluation failed, message: / by zero")
       message.exceptionInput shouldBe Some("1/{0, 1}[0] != 10")
       message.stackTrace.value should include("evaluation failed, message:")

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
@@ -114,7 +114,7 @@ trait BaseFlinkDeploymentManagerSpec
 
           // Wait until first 15 live data samples are collected
           liveDataSamples.nodeTransitions
-            .get(NodeTransition("start", Some("endSend")))
+            .get(NodeTransition(NodeId("start"), Some(NodeId("endSend"))))
             .map(_.samples.size) shouldBe Some(15)
 
           val (liveDataWithMockedTimestamp, mockedTimestamp) = withFixedTimestamp(liveDataSamples)
@@ -123,13 +123,13 @@ trait BaseFlinkDeploymentManagerSpec
           val expected = CollectedLiveData(
             timestamp = mockedTimestamp,
             nodeTransitions = Map(
-              NodeTransition("start", Some("endSend")) ->
+              NodeTransition(NodeId("start"), Some(NodeId("endSend"))) ->
                 LiveDataForNodeTransition(
                   samples = (0 to 14).map { idx =>
                     LiveDataSample(
                       ContextId(
-                        scenarioId = "runningFlinkEventGenerator",
-                        originatingNodeId = "start",
+                        scenarioName = ProcessName("runningFlinkEventGenerator"),
+                        originatingNodeId = NodeId("start"),
                         taskId = 0,
                         index = idx
                       ),
@@ -146,8 +146,8 @@ trait BaseFlinkDeploymentManagerSpec
                 (0 to 14).map { idx =>
                   InvocationResult(
                     ContextId(
-                      scenarioId = "runningFlinkEventGenerator",
-                      originatingNodeId = "start",
+                      scenarioName = ProcessName("runningFlinkEventGenerator"),
+                      originatingNodeId = NodeId("start"),
                       taskId = 0,
                       index = idx
                     ),
@@ -160,8 +160,8 @@ trait BaseFlinkDeploymentManagerSpec
                 (0 to 14).map { idx =>
                   InvocationResult(
                     ContextId(
-                      scenarioId = "runningFlinkEventGenerator",
-                      originatingNodeId = "start",
+                      scenarioName = ProcessName("runningFlinkEventGenerator"),
+                      originatingNodeId = NodeId("start"),
                       taskId = 0,
                       index = idx
                     ),

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkDeploymentManagerScenarioTestingSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkDeploymentManagerScenarioTestingSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ConfigWithUnresolvedVersion
-import pl.touk.nussknacker.engine.api.{ContextId, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{ContextId, NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.MissingSinkFactory
 import pl.touk.nussknacker.engine.api.context.ScenarioCompilationErrors
 import pl.touk.nussknacker.engine.api.deployment.DMTestScenarioCommand
@@ -45,7 +45,7 @@ class FlinkDeploymentManagerScenarioTestingSpec
   }
 
   private val scenarioTestData = ScenarioTestData(
-    List(ScenarioTestSourceSpecificFormatJsonRecord("startProcess", Json.fromString("terefere")))
+    List(ScenarioTestSourceSpecificFormatJsonRecord(NodeId("startProcess"), Json.fromString("terefere")))
   )
 
   private lazy val (deploymentManager, releaseDeploymentMangerResources) =
@@ -67,21 +67,21 @@ class FlinkDeploymentManagerScenarioTestingSpec
 
     whenReady(deploymentManager.processCommand(DMTestScenarioCommand(processVersion, process, scenarioTestData))) { r =>
       r.nodeResults.map(r => (r._1, r._2.map(r => (r.id, r.variables)))) shouldBe Map(
-        "startProcess" -> List(
+        NodeId("startProcess") -> List(
           (
-            ContextId(scenarioId = processName.value, originatingNodeId = "startProcess", taskId = 0, index = 0),
+            ContextId(scenarioName = processName, originatingNodeId = NodeId("startProcess"), taskId = 0, index = 0),
             Map("input" -> variable("terefere"))
           )
         ),
-        "nightFilter" -> List(
+        NodeId("nightFilter") -> List(
           (
-            ContextId(scenarioId = processName.value, originatingNodeId = "startProcess", taskId = 0, index = 0),
+            ContextId(scenarioName = processName, originatingNodeId = NodeId("startProcess"), taskId = 0, index = 0),
             Map("input" -> variable("terefere"))
           )
         ),
-        "endSend" -> List(
+        NodeId("endSend") -> List(
           (
-            ContextId(scenarioId = processName.value, originatingNodeId = "startProcess", taskId = 0, index = 0),
+            ContextId(scenarioName = processName, originatingNodeId = NodeId("startProcess"), taskId = 0, index = 0),
             Map("input" -> variable("terefere"))
           )
         )
@@ -99,7 +99,7 @@ class FlinkDeploymentManagerScenarioTestingSpec
     whenReady(deploymentManager.processCommand(DMTestScenarioCommand(processVersion, process, scenarioTestData))) { r =>
       val variablesInNodes = r.nodeResults.map { case (key, values) => (key, values.map(v => (v.id, v.variables))) }
       val timestampAsJson =
-        variablesInNodes("endSend")(0)._2("eventTimeTimestampCopy")
+        variablesInNodes(NodeId("endSend"))(0)._2("eventTimeTimestampCopy")
       val timestampReadAsObject = timestampAsJson.asObject
       val firstValue            = timestampReadAsObject.get.values.toList(0)
       val timestamp             = firstValue.asNumber.get.toLong.get
@@ -121,7 +121,8 @@ class FlinkDeploymentManagerScenarioTestingSpec
         deploymentManager.processCommand(DMTestScenarioCommand(processVersion, process, scenarioTestData)),
         patienceConfig.timeout
       )
-    } should matchPattern { case ScenarioCompilationErrors(MissingSinkFactory("sendSmsNotExist", "endSend") :: Nil) =>
+    } should matchPattern {
+      case ScenarioCompilationErrors(MissingSinkFactory("sendSmsNotExist", NodeId("endSend")) :: Nil) =>
     }
   }
 

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaAvroPayloadIntegrationSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaAvroPayloadIntegrationSpec.scala
@@ -8,6 +8,7 @@ import org.apache.kafka.common.record.TimestampType
 import org.scalatest.{Assertion, BeforeAndAfter}
 import org.scalatest.funsuite.AnyFunSuite
 import pl.touk.nussknacker.engine.ModelConfig
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.{ComponentType, NodeComponentInfo}
 import pl.touk.nussknacker.engine.api.process.TopicName
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
@@ -255,7 +256,7 @@ class KafkaAvroPayloadIntegrationSpec extends AnyFunSuite with FlinkKafkaAvroSpe
           val espExceptionInfo = RecordingExceptionConsumer.exceptionsFor(runId).head
 
           espExceptionInfo.nodeComponentInfo shouldBe Some(
-            NodeComponentInfo("end", ComponentType.Sink, "flinkKafkaAvroSink")
+            NodeComponentInfo(NodeId("end"), ComponentType.Sink, "flinkKafkaAvroSink")
           )
           espExceptionInfo.throwable shouldBe a[AvroRuntimeException]
           espExceptionInfo.throwable.getMessage should include("Not expected null for field: Some(street)")

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/UniversalKafkaSinkValidationSpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/UniversalKafkaSinkValidationSpec.scala
@@ -158,14 +158,14 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
         label = None,
         value = "'tereferer'",
         values = List("", exampleAvroTopic, exampleJsonTopic, fullnameTopic).map(fixedExpressionValue),
-        nodeId = sinkNodeId.id
+        nodeId = sinkNodeId
       ),
       InvalidPropertyFixedValue(
         paramName = schemaVersionParamName,
         label = None,
         value = "'1'",
         values = List(FixedExpressionValue(s"'latest'", "Latest version")),
-        nodeId = sinkNodeId.id
+        nodeId = sinkNodeId
       )
     )
   }
@@ -186,7 +186,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
       value = "'343543'",
       values =
         List(FixedExpressionValue(s"'latest'", "Latest version")) ++ List("1", "2", "3", "4").map(fixedExpressionValue),
-      nodeId = sinkNodeId.id
+      nodeId = sinkNodeId
     ) :: Nil
   }
 
@@ -201,7 +201,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
     )(defaultUniversalSinkFactory)
 
     result.errors shouldBe CustomNodeError(
-      sinkNodeId.id,
+      sinkNodeId,
       "Provided value does not match scenario output - errors:\nIncorrect type: actual: 'String()' expected: 'Record{id: String, amount: Double, currency: EnumSymbol[PLN | EUR | GBP | USD] | String, company: Record{name: String, address: Record{street: String, city: String}}, products: List[Record{id: String, name: String, price: Double}], vat: Integer | Null}'.",
       Some(sinkValueParamName)
     ) :: Nil
@@ -216,7 +216,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
         "Field: Topic is mandatory and can not be empty",
         "Please fill field for this parameter",
         topicParamName,
-        sinkNodeId.id
+        sinkNodeId
       )
     )
   }
@@ -279,7 +279,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
 
     laxValidationResult.errors shouldBe List(
       CustomNodeError(
-        "id",
+        NodeId("id"),
         "Provided value does not match scenario output - errors:\nIncorrect type: path 'bytesField' actual: 'String' expected: 'ByteBuffer'.",
         Some(sinkValueParamName)
       )
@@ -338,7 +338,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
 
     result.errors shouldBe List(
       CustomNodeError(
-        "id",
+        NodeId("id"),
         "Provided value does not match scenario output - errors:\nIncorrect type: path 'bytesField' actual: 'String' expected: 'ByteBuffer', path 'logicalTimestamp' actual: 'Integer' expected: 'Instant | Long'.",
         Some(sinkValueParamName)
       )
@@ -354,7 +354,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
 
     laxValidationResult.errors shouldBe List(
       CustomNodeError(
-        "id",
+        NodeId("id"),
         "Provided value does not match scenario output - errors:\nIncorrect type: path 'bytesField' actual: 'String' expected: 'ByteBuffer', path 'logicalTimestamp' actual: 'Integer' expected: 'Instant | Long'.",
         Some(sinkValueParamName)
       )
@@ -406,7 +406,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
       sinkValueParamName
     )
     result.errors shouldBe CustomNodeError(
-      sinkNodeId.id,
+      sinkNodeId,
       "Provided value does not match scenario output - errors:\nIncorrect type: path 'logicalDate' actual: 'String' expected: 'LocalDate | LocalDate', path 'logicalTimestamp' actual: 'String' expected: 'ZonedDateTime | LocalDateTime'.",
       Some(sinkValueParamName)
     ) :: Nil
@@ -425,7 +425,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
 
     laxValidationResult.errors shouldBe List(
       CustomNodeError(
-        "id",
+        NodeId("id"),
         "Provided value does not match scenario output - errors:\nIncorrect type: path 'logicalDate' actual: 'String' expected: 'LocalDate | LocalDate', path 'logicalTimestamp' actual: 'String' expected: 'ZonedDateTime | LocalDateTime'.",
         Some(sinkValueParamName)
       )
@@ -480,7 +480,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
     sinkValueParameter.defaultValue shouldBe Some(expectedDefaultValue)
 
     result.errors shouldBe CustomNodeError(
-      sinkNodeId.id,
+      sinkNodeId,
       "Provided value does not match scenario output - errors:\nIncorrect type: path 'logicalDate' actual: 'String' expected: 'LocalDate | LocalDate', path 'logicalTimestamp' actual: 'String' expected: 'ZonedDateTime | LocalDateTime'.",
       Some(sinkValueParamName)
     ) :: Nil
@@ -495,7 +495,7 @@ class UniversalKafkaSinkValidationSpec extends AnyFunSuite with KafkaSchemaRegis
 
     laxValidationResult.errors shouldBe List(
       CustomNodeError(
-        "id",
+        NodeId("id"),
         "Provided value does not match scenario output - errors:\nIncorrect type: path 'logicalDate' actual: 'String' expected: 'LocalDate | LocalDate', path 'logicalTimestamp' actual: 'String' expected: 'ZonedDateTime | LocalDateTime'.",
         Some(sinkValueParamName)
       )

--- a/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/KafkaAvroPayloadSourceFactorySpec.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/source/flink/KafkaAvroPayloadSourceFactorySpec.scala
@@ -325,7 +325,7 @@ class KafkaAvroPayloadSourceFactorySpec
           "testAvroRecordTopic1WithKey",
           "testPaymentDateTopic"
         ).map(fixedExpressionValue),
-        "id"
+        NodeId("id")
       ) :: Nil
     result.outputContext shouldBe ValidationContext(
       Map(
@@ -346,7 +346,7 @@ class KafkaAvroPayloadSourceFactorySpec
       label = None,
       value = "'12345'",
       values = List(FixedExpressionValue(s"'latest'", "Latest version")) ++ List("1", "2").map(fixedExpressionValue),
-      nodeId = "id"
+      nodeId = NodeId("id")
     ) :: Nil
     result.outputContext shouldBe ValidationContext(
       Map(

--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/process/helpers/SampleNodes.scala
@@ -81,7 +81,7 @@ object SampleNodes {
   }
 
   class JoinExprBranchFunction(
-      nodeId: String,
+      nodeId: NodeId,
       valueByBranchId: Map[String, LazyParameter[AnyRef]],
       val lazyParameterHelper: FlinkLazyParameterFunctionHelper
   ) extends RichCoFlatMapFunction[Context, Context, ValueWithContext[AnyRef]]
@@ -1131,10 +1131,10 @@ object SampleNodes {
   }
 
   object CountingNodesListener extends EmptyProcessListener {
-    @volatile private var nodesEntered: List[String] = Nil
+    @volatile private var nodesEntered: List[NodeId] = Nil
     @volatile private var listening                  = false
 
-    def listen(body: => Unit): List[String] = {
+    def listen(body: => Unit): List[NodeId] = {
       nodesEntered = Nil
       listening = true
       body
@@ -1142,7 +1142,7 @@ object SampleNodes {
       nodesEntered
     }
 
-    override def nodeEntered(nodeId: String, context: Context, processMetaData: MetaData): Unit = {
+    override def nodeEntered(nodeId: NodeId, context: Context, processMetaData: MetaData): Unit = {
       if (listening) nodesEntered = nodesEntered ::: nodeId :: Nil
     }
 
@@ -1161,37 +1161,37 @@ object SampleNodes {
       closed = true
     }
 
-    override def nodeEntered(nodeId: String, context: Context, processMetaData: MetaData): Unit =
+    override def nodeEntered(nodeId: NodeId, context: Context, processMetaData: MetaData): Unit =
       checkValidState("nodeEntered")
 
     override def transitionToNextNode(
-        nodeId: String,
-        nextNodeId: String,
+        nodeId: NodeId,
+        nextNodeId: NodeId,
         context: Context,
         processMetaData: MetaData
     ): Unit =
       checkValidState("transitionToNextNode")
 
     override def processingFinishedInNode(
-        nodeId: String,
+        nodeId: NodeId,
         context: Context,
         processMetaData: MetaData,
     ): Unit =
       checkValidState("processingFinishedInNode")
 
     override def endEncountered(
-        nodeId: String,
+        nodeId: NodeId,
         ref: String,
         context: Context,
         processMetaData: MetaData
     ): Unit =
       checkValidState("endEncountered")
 
-    override def deadEndEncountered(lastNodeId: String, context: Context, processMetaData: MetaData): Unit =
+    override def deadEndEncountered(lastNodeId: NodeId, context: Context, processMetaData: MetaData): Unit =
       checkValidState("deadEndEncountered")
 
     override def expressionEvaluated(
-        nodeId: String,
+        nodeId: NodeId,
         expressionId: String,
         expression: String,
         context: Context,
@@ -1201,7 +1201,7 @@ object SampleNodes {
       checkValidState("expressionEvaluated")
 
     override def serviceInvoked(
-        nodeId: String,
+        nodeId: NodeId,
         id: String,
         context: Context,
         processMetaData: MetaData,

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/kafkaschemaless/BaseKafkaJsonSchemalessItSpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/kafkaschemaless/BaseKafkaJsonSchemalessItSpec.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.defaultmodel.kafkaschemaless
 import com.typesafe.config.{Config, ConfigValueFactory}
 import io.circe.{parser, Json, ParsingFailure}
 import pl.touk.nussknacker.defaultmodel.FlinkWithKafkaSuite
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.process.TopicName.ForSource
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.graph.expression.Expression
@@ -233,7 +234,7 @@ abstract class BaseKafkaJsonSchemalessItSpec extends FlinkWithKafkaSuite with Pa
 
   def shouldDropEventsBasedOnTheInferredDataSampleType(): Unit = {
     def assertDecodingFailureException(e: ExceptionResult[_])(exceptionMessageSuffix: String) = {
-      e.nodeId shouldBe Some("start")
+      e.nodeId shouldBe Some(NodeId("start"))
       e.throwable shouldBe a[PayloadDeserializationException]
       e.throwable.getMessage shouldBe s"Exception during payload deserialization: $exceptionMessageSuffix"
     }

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/FlinkMiniClusterScenarioTestRunnerSpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/FlinkMiniClusterScenarioTestRunnerSpec.scala
@@ -22,7 +22,7 @@ import pl.touk.nussknacker.engine.api.parameter.{
   ParameterValueCompileTimeValidation,
   ValueInputWithDictEditor
 }
-import pl.touk.nussknacker.engine.api.process.ComponentUseContext
+import pl.touk.nussknacker.engine.api.process.{ComponentUseContext, ProcessName}
 import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, ScenarioTestSourceSpecificFormatJsonRecord}
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -71,8 +71,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
   private implicit val ec: ExecutionContext = ExecutionContext.global
   private implicit val ioRuntime: IORuntime = IORuntime.global
 
-  private val scenarioName      = "proc1"
-  private val sourceNodeId      = "id"
+  private val scenarioName      = ProcessName("proc1")
+  private val sourceNodeId      = NodeId("id")
   private val firstSubtaskIndex = 0
 
   private val miniClusterWithServices = FlinkMiniClusterFactory.createUnitTestsMiniClusterWithServices()
@@ -104,8 +104,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       val sleepSecondsInScenario = (patienceConfig.timeout * 2).toSeconds
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .customNodeNoOutput("sleep", "sleep", "seconds" -> sleepSecondsInScenario.toString.spel)
           .emptySink("out", "valueMonitor", "Value" -> "#input.value1".spel)
 
@@ -132,8 +132,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "be able to return test results" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .filter("filter1", "#input.value1 > 1".spel)
           .buildSimpleVariable("v1", "variable1", "'ala'".spel)
           .processor("eager1", "collectingEager", "static" -> "'s'".spel, "dynamic" -> "#input.id".spel)
@@ -158,18 +158,18 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       val nodeResults = nodeResultsWithoutTimestamp(results)
 
       nodeResults(sourceNodeId) shouldBe List(nodeResult(0, "input" -> input), nodeResult(1, "input" -> input2))
-      nodeResults("filter1") shouldBe List(nodeResult(0, "input" -> input), nodeResult(1, "input" -> input2))
-      nodeResults("v1") shouldBe List(nodeResult(1, "input" -> input2))
-      nodeResults("proc2") shouldBe List(nodeResult(1, "input" -> input2, "variable1" -> "ala"))
-      nodeResults("out") shouldBe List(nodeResult(1, "input" -> input2, "variable1" -> "ala"))
+      nodeResults(NodeId("filter1")) shouldBe List(nodeResult(0, "input" -> input), nodeResult(1, "input" -> input2))
+      nodeResults(NodeId("v1")) shouldBe List(nodeResult(1, "input" -> input2))
+      nodeResults(NodeId("proc2")) shouldBe List(nodeResult(1, "input" -> input2, "variable1" -> "ala"))
+      nodeResults(NodeId("out")) shouldBe List(nodeResult(1, "input" -> input2, "variable1" -> "ala"))
 
       val invocationResults = results.invocationResults
 
-      invocationResults("proc2").map(withMockedTimestamp) shouldBe
+      invocationResults(NodeId("proc2")).map(withMockedTimestamp) shouldBe
         List(
           ExpressionInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 1
@@ -180,11 +180,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
         )
 
-      invocationResults("out").map(withMockedTimestamp) shouldBe
+      invocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
           ExpressionInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 1
@@ -195,26 +195,41 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
         )
 
-      results.externalInvocationResults("proc2").map(r => (r.contextId, r.name, r.value)) shouldBe List(
+      results.externalInvocationResults(NodeId("proc2")).map(r => (r.contextId, r.name, r.value)) shouldBe List(
         (
-          ContextId(scenarioId = scenarioName, originatingNodeId = sourceNodeId, taskId = firstSubtaskIndex, index = 1),
+          ContextId(
+            scenarioName = scenarioName,
+            originatingNodeId = sourceNodeId,
+            taskId = firstSubtaskIndex,
+            index = 1
+          ),
           "logService",
           variable("0-collectedDuringServiceInvocation")
         )
       )
 
-      results.externalInvocationResults("out").map(withMockedTimestamp) shouldBe List(
+      results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe List(
         ExternalInvocationResult(
-          ContextId(scenarioId = scenarioName, originatingNodeId = sourceNodeId, taskId = firstSubtaskIndex, index = 1),
+          ContextId(
+            scenarioName = scenarioName,
+            originatingNodeId = sourceNodeId,
+            taskId = firstSubtaskIndex,
+            index = 1
+          ),
           mockedTimestamp,
           "valueMonitor",
           variable(11)
         )
       )
 
-      results.externalInvocationResults("eager1").map(withMockedTimestamp) shouldBe List(
+      results.externalInvocationResults(NodeId("eager1")).map(withMockedTimestamp) shouldBe List(
         ExternalInvocationResult(
-          ContextId(scenarioId = scenarioName, originatingNodeId = sourceNodeId, taskId = firstSubtaskIndex, index = 1),
+          ContextId(
+            scenarioName = scenarioName,
+            originatingNodeId = sourceNodeId,
+            taskId = firstSubtaskIndex,
+            index = 1
+          ),
           mockedTimestamp,
           "collectingEager",
           variable("static-s-dynamic-0")
@@ -228,8 +243,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "be able to run tests multiple time on the same mini cluster" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .emptySink("out", "valueMonitor", "Value" -> "#input.value1".spel)
 
       val input = SimpleRecord("0", 11, "2", new Date(3), Some(4), 5, "6")
@@ -251,15 +266,15 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         val nodeResults = nodeResultsWithoutTimestamp(results)
 
         nodeResults(sourceNodeId) shouldBe List(nodeResult(0, "input" -> input))
-        nodeResults("out") shouldBe List(nodeResult(0, "input" -> input))
+        nodeResults(NodeId("out")) shouldBe List(nodeResult(0, "input" -> input))
 
         val invocationResults = results.invocationResults
 
-        invocationResults("out").map(withMockedTimestamp) shouldBe
+        invocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
           List(
             ExpressionInvocationResult(
               ContextId(
-                scenarioId = scenarioName,
+                scenarioName = scenarioName,
                 originatingNodeId = sourceNodeId,
                 taskId = firstSubtaskIndex,
                 index = 0
@@ -270,10 +285,10 @@ class FlinkMiniClusterScenarioTestRunnerSpec
             )
           )
 
-        results.externalInvocationResults("out").map(withMockedTimestamp) shouldBe List(
+        results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe List(
           ExternalInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 0
@@ -292,8 +307,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "collect results for split" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .split("splitId1", GraphBuilder.emptySink("out1", "monitor"), GraphBuilder.emptySink("out2", "monitor"))
 
       val results = prepareTestRunner(useIOMonadInInterpreter)
@@ -303,7 +318,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         )
         .futureValue
 
-      nodeResultsWithoutTimestamp(results)("splitId1") shouldBe List(
+      nodeResultsWithoutTimestamp(results)(NodeId("splitId1")) shouldBe List(
         nodeResult(
           0,
           "input" ->
@@ -320,8 +335,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "return correct result for custom node" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .customNode("cid", "out", "stateCustom", "groupBy" -> "#input.id".spel, "stringVal" -> "'s'".spel)
           .emptySink("out", "valueMonitor", "Value" -> "#input.value1 + ' ' + #out.previous".spel)
 
@@ -341,20 +356,20 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       val nodeResults = nodeResultsWithoutTimestamp(results)
 
       nodeResults(sourceNodeId) shouldBe List(nodeResult(0, "input" -> input), nodeResult(1, "input" -> input2))
-      nodeResults("cid") shouldBe List(nodeResult(0, "input" -> input), nodeResult(1, "input" -> input2))
-      nodeResults("out") shouldBe List(
+      nodeResults(NodeId("cid")) shouldBe List(nodeResult(0, "input" -> input), nodeResult(1, "input" -> input2))
+      nodeResults(NodeId("out")) shouldBe List(
         nodeResult(0, "input" -> input, "out"  -> aggregate),
         nodeResult(1, "input" -> input2, "out" -> aggregate2)
       )
 
       val invocationResults = results.invocationResults
 
-      invocationResults("cid").map(withMockedTimestamp) shouldBe
+      invocationResults(NodeId("cid")).map(withMockedTimestamp) shouldBe
         List(
           // we record only LazyParameter execution results
           ExpressionInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 0
@@ -365,7 +380,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           ),
           ExpressionInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 1
@@ -376,11 +391,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
         )
 
-      invocationResults("out").map(withMockedTimestamp) shouldBe
+      invocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
           ExpressionInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 0
@@ -391,7 +406,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           ),
           ExpressionInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 1
@@ -402,11 +417,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
         )
 
-      results.externalInvocationResults("out").map(withMockedTimestamp) shouldBe
+      results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
           ExternalInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 0
@@ -417,7 +432,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           ),
           ExternalInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 1
@@ -432,9 +447,9 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "handle large parallelism" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
+          .streaming(scenarioName.value)
           .parallelism(FlinkMiniClusterFactory.DefaultTaskSlots + 1)
-          .source(sourceNodeId, "input")
+          .source(sourceNodeId.id, "input")
           .emptySink("out", "monitor")
 
       val results =
@@ -453,8 +468,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "detect errors" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .processor("failing", "throwingService", "throw" -> "#input.value1 == 2".spel)
           .filter("filter", "1 / #input.value1 >= 0".spel)
           .emptySink("out", "monitor")
@@ -476,12 +491,12 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       val nodeResults = nodeResultsWithoutTimestamp(results)
 
       nodeResults(sourceNodeId) should have length 4
-      nodeResults("out") should have length 2
+      nodeResults(NodeId("out")) should have length 2
 
       results.exceptions should have length 2
 
       val exceptionFromExpression = results.exceptions.head
-      exceptionFromExpression.nodeId shouldBe Some("filter")
+      exceptionFromExpression.nodeId shouldBe Some(NodeId("filter"))
       exceptionFromExpression.context
         .variables("input")
         .asInstanceOf[Json]
@@ -494,7 +509,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       exceptionFromExpression.throwable.getMessage shouldBe "Expression [1 / #input.value1 >= 0] evaluation failed, message: / by zero"
 
       val exceptionFromService = results.exceptions.last
-      exceptionFromService.nodeId shouldBe Some("failing")
+      exceptionFromService.nodeId shouldBe Some(NodeId("failing"))
       exceptionFromService.context
         .variables("input")
         .asInstanceOf[Json]
@@ -510,8 +525,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "ignore real exception handler" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .processor("failing", "throwingService", "throw" -> "#input.value1 == 2".spel)
           .filter("filter", "1 / #input.value1 >= 0".spel)
           .emptySink("out", "monitor")
@@ -535,7 +550,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       val nodeResults = nodeResultsWithoutTimestamp(results)
 
       nodeResults(sourceNodeId) should have length 4
-      nodeResults("out") should have length 2
+      nodeResults(NodeId("out")) should have length 2
 
       results.exceptions should have length 2
       RecordingExceptionConsumer.exceptionsFor(exceptionConsumerId) shouldBe Symbol("empty")
@@ -544,8 +559,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "handle transient errors" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .processor("failing", "throwingTransientService", "throw" -> "#input.value1 == 2".spel)
           .emptySink("out", "monitor")
 
@@ -565,22 +580,22 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "handle json input" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "jsonInput")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "jsonInput")
           .emptySink("out", "valueMonitor", "Value" -> "#input".spel)
       val testData = ScenarioTestData(
         List(
           ScenarioTestSourceSpecificFormatJsonRecord(
             sourceNodeId,
-            Json.obj(sourceNodeId -> Json.fromString("1"), "field" -> Json.fromString("11"))
+            Json.obj(sourceNodeId.id -> Json.fromString("1"), "field" -> Json.fromString("11"))
           ),
           ScenarioTestSourceSpecificFormatJsonRecord(
             sourceNodeId,
-            Json.obj(sourceNodeId -> Json.fromString("2"), "field" -> Json.fromString("22"))
+            Json.obj(sourceNodeId.id -> Json.fromString("2"), "field" -> Json.fromString("22"))
           ),
           ScenarioTestSourceSpecificFormatJsonRecord(
             sourceNodeId,
-            Json.obj(sourceNodeId -> Json.fromString("3"), "field" -> Json.fromString("33"))
+            Json.obj(sourceNodeId.id -> Json.fromString("3"), "field" -> Json.fromString("33"))
           ),
         )
       )
@@ -589,11 +604,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         prepareTestRunner(useIOMonadInInterpreter).runTests(process, testData).futureValue
 
       nodeResultsWithoutTimestamp(results)(sourceNodeId) should have size 3
-      results.externalInvocationResults("out").map(withMockedTimestamp) shouldBe
+      results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
           ExternalInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 0
@@ -604,7 +619,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           ),
           ExternalInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 1
@@ -615,7 +630,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           ),
           ExternalInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 2
@@ -629,8 +644,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
 
     "handle custom variables in source" in {
       val process = ScenarioBuilder
-        .streaming(scenarioName)
-        .source(sourceNodeId, "genericSourceWithCustomVariables", "elements" -> "{'abc'}".spel)
+        .streaming(scenarioName.value)
+        .source(sourceNodeId.id, "genericSourceWithCustomVariables", "elements" -> "{'abc'}".spel)
         .emptySink("out", "valueMonitor", "Value" -> "#additionalOne + '|' + #additionalTwo".spel)
       val testData =
         ScenarioTestData(List(ScenarioTestSourceSpecificFormatJsonRecord(sourceNodeId, Json.fromString("abc"))))
@@ -639,11 +654,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         prepareTestRunner(useIOMonadInInterpreter).runTests(process, testData).futureValue
 
       nodeResultsWithoutTimestamp(results)(sourceNodeId) should have size 1
-      results.externalInvocationResults("out").map(withMockedTimestamp) shouldBe
+      results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
           ExternalInvocationResult(
             ContextId(
-              scenarioId = scenarioName,
+              scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
               taskId = firstSubtaskIndex,
               index = 0
@@ -658,8 +673,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "give meaningful error messages for sink errors" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .emptySink("out", "sinkForInts", "Value" -> "15 / {0, 1}[0]".spel)
 
       val results =
@@ -671,15 +686,15 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           .futureValue
 
       results.exceptions should have length 1
-      results.exceptions.head.nodeId shouldBe Some("out")
+      results.exceptions.head.nodeId shouldBe Some(NodeId("out"))
       results.exceptions.head.throwable.getMessage should include("message: / by zero")
     }
 
     "be able to test process with time windows" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .customNode("cid", "count", "transformWithTime", "seconds" -> "10".spel)
           .emptySink("out", "monitor")
 
@@ -703,16 +718,19 @@ class FlinkMiniClusterScenarioTestRunnerSpec
 
       val nodeResults = results.nodeResults
 
-      nodeResults("out").map(_.variables) shouldBe List(Map("count" -> variable(4)), Map("count" -> variable(1)))
+      nodeResults(NodeId("out")).map(_.variables) shouldBe List(
+        Map("count" -> variable(4)),
+        Map("count" -> variable(1))
+      )
 
     }
 
     "be able to test typed map" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
+          .streaming(scenarioName.value)
           .source(
-            sourceNodeId,
+            sourceNodeId.id,
             "typedJsonInput",
             "type" -> """{"field1": "String", "field2": "java.lang.String"}""".spel
           )
@@ -730,7 +748,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         )
         .futureValue
 
-      results.invocationResults("out").map(_.value) shouldBe List(variable("abcdef"))
+      results.invocationResults(NodeId("out")).map(_.value) shouldBe List(variable("abcdef"))
     }
 
     "using dependent services" in {
@@ -738,8 +756,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       val valueToReturn = 18
 
       val process = ScenarioBuilder
-        .streaming(scenarioName)
-        .source(sourceNodeId, "input")
+        .streaming(scenarioName.value)
+        .source(sourceNodeId.id, "input")
         .enricher(
           "dependent",
           "parsed",
@@ -758,14 +776,14 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
           .futureValue
 
-      results.invocationResults("out").map(_.value) shouldBe List(variable(s"$countToPass $valueToReturn"))
+      results.invocationResults(NodeId("out")).map(_.value) shouldBe List(variable(s"$countToPass $valueToReturn"))
     }
 
     "switch value should be equal to variable value" in {
       val process = ScenarioBuilder
-        .streaming(scenarioName)
+        .streaming(scenarioName.value)
         .parallelism(1)
-        .source(sourceNodeId, "input")
+        .source(sourceNodeId.id, "input")
         .switch(
           "switch",
           "#input.id == 'ala'".spel,
@@ -786,11 +804,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
 
       val invocationResults = results.invocationResults
 
-      invocationResults("switch").filter(_.name == "expression").head.value shouldBe variable(true)
-      invocationResults("switch").filter(_.name == "expression").last.value shouldBe variable(false)
+      invocationResults(NodeId("switch")).filter(_.name == "expression").head.value shouldBe variable(true)
+      invocationResults(NodeId("switch")).filter(_.name == "expression").last.value shouldBe variable(false)
       // first record was filtered out
-      invocationResults("out").head.contextId shouldBe ContextId(
-        scenarioId = scenarioName,
+      invocationResults(NodeId("out")).head.contextId shouldBe ContextId(
+        scenarioName = scenarioName,
         originatingNodeId = sourceNodeId,
         taskId = firstSubtaskIndex,
         index = 1,
@@ -799,10 +817,10 @@ class FlinkMiniClusterScenarioTestRunnerSpec
 
     "should handle joins for one input (diamond-like) " in {
       val process = ScenarioBuilder
-        .streaming(scenarioName)
+        .streaming(scenarioName.value)
         .sources(
           GraphBuilder
-            .source(sourceNodeId, "input")
+            .source(sourceNodeId.id, "input")
             .split(
               "split",
               GraphBuilder.filter("left", "#input.id != 'a'".spel).branchEnd("end1", "join1"),
@@ -830,51 +848,51 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           .runTests(process, ScenarioTestData(List(recA, recB, recC)))
           .futureValue
 
-      results.invocationResults("proc2").map(_.contextId) should contain only (
+      results.invocationResults(NodeId("proc2")).map(_.contextId) should contain only (
         ContextId(
-          scenarioId = scenarioName,
+          scenarioName = scenarioName,
           originatingNodeId = sourceNodeId,
           taskId = firstSubtaskIndex,
           index = 1,
           path = List(
-            ContextIdPathPart("split", "left"),
-            ContextIdPathPart("join1", "end1"),
+            ContextIdPathPart(NodeId("split"), "left"),
+            ContextIdPathPart(NodeId("join1"), "end1"),
           )
         ),
         ContextId(
-          scenarioId = scenarioName,
+          scenarioName = scenarioName,
           originatingNodeId = sourceNodeId,
           taskId = firstSubtaskIndex,
           index = 2,
           path = List(
-            ContextIdPathPart("split", "left"),
-            ContextIdPathPart("join1", "end1"),
+            ContextIdPathPart(NodeId("split"), "left"),
+            ContextIdPathPart(NodeId("join1"), "end1"),
           )
         ),
         ContextId(
-          scenarioId = scenarioName,
+          scenarioName = scenarioName,
           originatingNodeId = sourceNodeId,
           taskId = firstSubtaskIndex,
           index = 0,
           path = List(
-            ContextIdPathPart("split", "right"),
-            ContextIdPathPart("join1", "end2"),
+            ContextIdPathPart(NodeId("split"), "right"),
+            ContextIdPathPart(NodeId("join1"), "end2"),
           )
         ),
         ContextId(
-          scenarioId = scenarioName,
+          scenarioName = scenarioName,
           originatingNodeId = sourceNodeId,
           taskId = firstSubtaskIndex,
           index = 2,
           path = List(
-            ContextIdPathPart("split", "right"),
-            ContextIdPathPart("join1", "end2"),
+            ContextIdPathPart(NodeId("split"), "right"),
+            ContextIdPathPart(NodeId("join1"), "end2"),
           )
         ),
       )
 
       results
-        .externalInvocationResults("proc2")
+        .externalInvocationResults(NodeId("proc2"))
         .map(_.value.asInstanceOf[Json]) should contain theSameElementsAs List(
         "b",
         "a",
@@ -885,7 +903,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
 
     "should test multiple source scenario" in {
       val process = ScenarioBuilder
-        .streaming(scenarioName)
+        .streaming(scenarioName.value)
         .sources(
           GraphBuilder
             .source("source1", "input")
@@ -926,36 +944,36 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         .futureValue
 
       val nodeResults = nodeResultsWithoutTimestamp(results)
-      nodeResults("source1") shouldBe List(
-        nodeResult(0, "source1", "input" -> recordA),
-        nodeResult(1, "source1", "input" -> recordD)
+      nodeResults(NodeId("source1")) shouldBe List(
+        nodeResult(0, NodeId("source1"), "input" -> recordA),
+        nodeResult(1, NodeId("source1"), "input" -> recordD)
       )
-      nodeResults("source2") shouldBe List(
-        nodeResult(0, "source2", "input" -> recordA),
-        nodeResult(1, "source2", "input" -> recordB),
-        nodeResult(2, "source2", "input" -> recordC)
+      nodeResults(NodeId("source2")) shouldBe List(
+        nodeResult(0, NodeId("source2"), "input" -> recordA),
+        nodeResult(1, NodeId("source2"), "input" -> recordB),
+        nodeResult(2, NodeId("source2"), "input" -> recordC)
       )
-      nodeResults("filter1") shouldBe nodeResults("source1")
-      nodeResults("filter2") shouldBe nodeResults("source2")
-      nodeResults("$edge-end1-join") shouldBe List(nodeResult(1, "source1", "input" -> recordD))
-      nodeResults("$edge-end2-join") shouldBe List(
-        nodeResult(0, "source2", "input" -> recordA),
-        nodeResult(2, "source2", "input" -> recordC)
+      nodeResults(NodeId("filter1")) shouldBe nodeResults(NodeId("source1"))
+      nodeResults(NodeId("filter2")) shouldBe nodeResults(NodeId("source2"))
+      nodeResults(NodeId("$edge-end1-join")) shouldBe List(nodeResult(1, NodeId("source1"), "input" -> recordD))
+      nodeResults(NodeId("$edge-end2-join")) shouldBe List(
+        nodeResult(0, NodeId("source2"), "input" -> recordA),
+        nodeResult(2, NodeId("source2"), "input" -> recordC)
       )
-      nodeResults("join") should contain only (
-        nodeResult(1, "source1", "end1", "input" -> recordD, "joinInput" -> recordD),
-        nodeResult(0, "source2", "end2", "input" -> recordA, "joinInput" -> recordA),
-        nodeResult(2, "source2", "end2", "input" -> recordC, "joinInput" -> recordC)
+      nodeResults(NodeId("join")) should contain only (
+        nodeResult(1, NodeId("source1"), "end1", "input" -> recordD, "joinInput" -> recordD),
+        nodeResult(0, NodeId("source2"), "end2", "input" -> recordA, "joinInput" -> recordA),
+        nodeResult(2, NodeId("source2"), "end2", "input" -> recordC, "joinInput" -> recordC)
       )
 
-      results.invocationResults("proc2").map(withMockedTimestamp) should contain only (
+      results.invocationResults(NodeId("proc2")).map(withMockedTimestamp) should contain only (
         ExpressionInvocationResult(
           ContextId(
-            scenarioId = scenarioName,
-            originatingNodeId = "source1",
+            scenarioName = scenarioName,
+            originatingNodeId = NodeId("source1"),
             taskId = firstSubtaskIndex,
             index = 1,
-            path = List(ContextIdPathPart("join", "end1"))
+            path = List(ContextIdPathPart(NodeId("join"), "end1"))
           ),
           mockedTimestamp,
           "all",
@@ -963,11 +981,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         ),
         ExpressionInvocationResult(
           ContextId(
-            scenarioId = scenarioName,
-            originatingNodeId = "source2",
+            scenarioName = scenarioName,
+            originatingNodeId = NodeId("source2"),
             taskId = firstSubtaskIndex,
             index = 0,
-            path = List(ContextIdPathPart("join", "end2"))
+            path = List(ContextIdPathPart(NodeId("join"), "end2"))
           ),
           mockedTimestamp,
           "all",
@@ -975,11 +993,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         ),
         ExpressionInvocationResult(
           ContextId(
-            scenarioId = scenarioName,
-            originatingNodeId = "source2",
+            scenarioName = scenarioName,
+            originatingNodeId = NodeId("source2"),
             taskId = firstSubtaskIndex,
             index = 2,
-            path = List(ContextIdPathPart("join", "end2"))
+            path = List(ContextIdPathPart(NodeId("join"), "end2"))
           ),
           mockedTimestamp,
           "all",
@@ -988,7 +1006,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       )
 
       results
-        .externalInvocationResults("proc2")
+        .externalInvocationResults(NodeId("proc2"))
         .map(_.value.asInstanceOf[Json]) should contain theSameElementsAs List("a", "c", "d")
         .map(_ + "-collectedDuringServiceInvocation")
         .map(variable)
@@ -996,7 +1014,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
 
     "should have correct run mode" in {
       val process = ScenarioBuilder
-        .streaming(scenarioName)
+        .streaming(scenarioName.value)
         .source("start", "input")
         .enricher("componentUseContextService", "componentUseContextService", "returningComponentUseContextService")
         .customNode(
@@ -1018,7 +1036,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
           .futureValue
 
-      results.invocationResults("out").map(_.value) shouldBe List(
+      results.invocationResults(NodeId("out")).map(_.value) shouldBe List(
         variable(List(ComponentUseContext.ScenarioTesting, ComponentUseContext.ScenarioTesting))
       )
     }
@@ -1026,8 +1044,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "should throw exception when parameter was modified by AdditionalUiConfigProvider with dict editor and flink wasn't provided with additional config" in {
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .processor(
             "eager1",
             "collectingEager",
@@ -1049,7 +1067,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
                 ParameterName("static"),
                 `DictKeyWithLabel`,
                 List(SpelTemplateParameterEditor, SpelParameterEditor),
-                "eager1"
+                NodeId("eager1")
               ) :: Nil
             ) =>
       }
@@ -1060,8 +1078,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       val modifiedParameterName = "static"
       val process =
         ScenarioBuilder
-          .streaming(scenarioName)
-          .source(sourceNodeId, "input")
+          .streaming(scenarioName.value)
+          .source(sourceNodeId.id, "input")
           .processor(
             "eager1",
             modifiedComponentName,
@@ -1092,7 +1110,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
     "should not throw exception when process fragment has parameter validation defined" in {
       val scenario = ScenarioBuilder
         .streaming("scenario1")
-        .source(sourceNodeId, "input")
+        .source(sourceNodeId.id, "input")
         .fragmentOneOut("sub", fragmentWithValidationName, "output", "fragmentResult", "param" -> "'asd'".spel)
         .emptySink("out", "valueMonitor", "Value" -> "1".spel)
 
@@ -1111,11 +1129,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
   }
 
   private def createTestRecord(
-      sourceId: String = sourceNodeId,
+      sourceId: String = sourceNodeId.id,
       id: String = "0",
       value1: Long = 1
   ): ScenarioTestSourceSpecificFormatJsonRecord =
-    ScenarioTestSourceSpecificFormatJsonRecord(sourceId, Json.fromString(s"$id|$value1|2|3|4|5|6"))
+    ScenarioTestSourceSpecificFormatJsonRecord(NodeId(sourceId), Json.fromString(s"$id|$value1|2|3|4|5|6"))
 
   private def prepareTestRunner(
       useIOMonadInInterpreter: Boolean,
@@ -1145,7 +1163,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
   private def nodeResult(count: Int, vars: (String, Any)*): (ContextId, Map[String, Json]) =
     nodeResult(count, sourceNodeId, vars: _*)
 
-  private def nodeResult(count: Int, sourceId: String, vars: (String, Any)*): (ContextId, Map[String, Json]) =
+  private def nodeResult(count: Int, sourceId: NodeId, vars: (String, Any)*): (ContextId, Map[String, Json]) =
     (
       ContextId(scenarioName, sourceId, firstSubtaskIndex, count),
       Map(vars: _*).mapValuesNow(variable)
@@ -1153,7 +1171,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
 
   private def nodeResult(
       count: Int,
-      sourceId: String,
+      sourceId: NodeId,
       branchId: String,
       vars: (String, Any)*
   ): (ContextId, Map[String, Json]) =
@@ -1163,7 +1181,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         sourceId,
         firstSubtaskIndex,
         count,
-        List(ContextIdPathPart("join", branchId)),
+        List(ContextIdPathPart(NodeId("join"), branchId)),
       ),
       Map(vars: _*).mapValuesNow(variable)
     )

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
@@ -11,8 +11,9 @@ import org.scalatest.{BeforeAndAfterAll, LoneElement, OptionValues}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ModelConfig
-import pl.touk.nussknacker.engine.api.ContextId
+import pl.touk.nussknacker.engine.api.{ContextId, NodeId}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, ScenarioTestSourceSpecificFormatJsonRecord}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.classloader.ModelClassLoader
@@ -132,11 +133,13 @@ class SchemedKafkaScenarioTestingSpec
     val testRecordJson =
       obj("keySchemaId" -> Null, "valueSchemaId" -> fromInt(id), "consumerRecord" -> consumerRecordJson)
     val scenarioTestData =
-      ScenarioTestData(ScenarioTestSourceSpecificFormatJsonRecord("start", testRecordJson, timestamp = None) :: Nil)
+      ScenarioTestData(
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("start"), testRecordJson, timestamp = None) :: Nil
+      )
 
     val results = testRunner.runTests(process, scenarioTestData).futureValue
 
-    val testResultVars = results.nodeResults("end").head.variables
+    val testResultVars = results.nodeResults(NodeId("end")).head.variables
     testResultVars("extractedTimestamp").hcursor.downField("pretty").as[Long].rightValue shouldBe givenTimestamp
     val expectedInputMetaInTestResults = Json.fromFields(
       Map(
@@ -180,7 +183,7 @@ class SchemedKafkaScenarioTestingSpec
 
     val results = testRunner.runTests(process, scenarioTestData).futureValue
     results
-      .invocationResults("end")
+      .invocationResults(NodeId("end"))
       .head
       .value
       .hcursor
@@ -203,14 +206,24 @@ class SchemedKafkaScenarioTestingSpec
     val results          = testRunner.runTests(fragment, scenarioTestData).futureValue
 
     nodeResults(results, "fragment1").loneElement shouldBe (
-      ContextId(scenarioId = "fragment1", originatingNodeId = "fragment1", taskId = 0, index = 0),
+      ContextId(
+        scenarioName = ProcessName("fragment1"),
+        originatingNodeId = NodeId("fragment1"),
+        taskId = 0,
+        index = 0
+      ),
       Map(
         "in" -> Json.fromFields(Seq("pretty" -> Json.fromString("some-text-id")))
       )
     )
 
     nodeResults(results, "fragmentEnd").loneElement shouldBe (
-      ContextId(scenarioId = "fragment1", originatingNodeId = "fragment1", taskId = 0, index = 0),
+      ContextId(
+        scenarioName = ProcessName("fragment1"),
+        originatingNodeId = NodeId("fragment1"),
+        taskId = 0,
+        index = 0
+      ),
       Map(
         "in"  -> Json.fromFields(Seq("pretty" -> Json.fromString("some-text-id"))),
         "out" -> Json.fromFields(Seq("pretty" -> Json.fromString("some-text-id")))
@@ -219,10 +232,15 @@ class SchemedKafkaScenarioTestingSpec
 
     val mockedTimestamp = Instant.now()
     results
-      .invocationResults("fragmentEnd")
+      .invocationResults(NodeId("fragmentEnd"))
       .loneElement
       .copy(timestamp = mockedTimestamp) shouldBe ExpressionInvocationResult(
-      ContextId(scenarioId = "fragment1", originatingNodeId = "fragment1", taskId = 0, index = 0),
+      ContextId(
+        scenarioName = ProcessName("fragment1"),
+        originatingNodeId = NodeId("fragment1"),
+        taskId = 0,
+        index = 0
+      ),
       mockedTimestamp,
       "out",
       Json.fromFields(Seq("pretty" -> Json.fromString("some-text-id")))
@@ -238,7 +256,7 @@ class SchemedKafkaScenarioTestingSpec
   }
 
   private def nodeResults[T](results: TestProcess.TestResults[T], key: String) =
-    results.nodeResults(key).map(r => (r.id, r.variables))
+    results.nodeResults(NodeId(key)).map(r => (r.id, r.variables))
 
 }
 

--- a/engine/lite/components-api/src/main/scala/pl/touk/nussknacker/engine/lite/api/customComponentTypes.scala
+++ b/engine/lite/components-api/src/main/scala/pl/touk/nussknacker/engine/lite/api/customComponentTypes.scala
@@ -2,7 +2,7 @@ package pl.touk.nussknacker.engine.lite.api
 
 import cats.{~>, Monad}
 import cats.data.ValidatedNel
-import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.{Context, NodeId}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.process.{Sink, Source}
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
@@ -21,7 +21,7 @@ object customComponentTypes {
   }
 
   case class CustomComponentContext[F[_]](
-      nodeId: String,
+      nodeId: NodeId,
       capabilityTransformer: CapabilityTransformer[F]
   )
 

--- a/engine/lite/components-api/src/main/scala/pl/touk/nussknacker/engine/lite/api/runtimecontext/LiteEngineRuntimeContextPreparer.scala
+++ b/engine/lite/components-api/src/main/scala/pl/touk/nussknacker/engine/lite/api/runtimecontext/LiteEngineRuntimeContextPreparer.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.lite.api.runtimecontext
 
-import pl.touk.nussknacker.engine.api.JobData
+import pl.touk.nussknacker.engine.api.{JobData, NodeId}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.runtimecontext.{ContextIdGenerator, EngineRuntimeContext, IncContextIdGenerator}
 import pl.touk.nussknacker.engine.util.metrics.{MetricsProviderForScenario, NoOpMetricsProviderForScenario}
@@ -26,7 +26,7 @@ case class LiteEngineRuntimeContext(jobData: JobData, metricsProvider: MetricsPr
     extends EngineRuntimeContext
     with AutoCloseable {
 
-  override def contextIdGenerator(nodeId: String): ContextIdGenerator = {
+  override def contextIdGenerator(nodeId: NodeId): ContextIdGenerator = {
     // We hardcode this taskId=0 instead of passing the real one. Currently, the information about the taskId is not available in this place. In the future it might change.
     IncContextIdGenerator.withProcessIdNodeIdPrefix(jobData, nodeId, taskId = 0)
   }

--- a/engine/lite/components-api/src/main/scala/pl/touk/nussknacker/engine/lite/api/utils/sources/BaseLiteSource.scala
+++ b/engine/lite/components-api/src/main/scala/pl/touk/nussknacker/engine/lite/api/utils/sources/BaseLiteSource.scala
@@ -23,7 +23,7 @@ trait BaseLiteSource[T] extends LiteSource[T] with Lifecycle {
 
   override def open(context: EngineRuntimeContext): Unit = {
     this.context = context
-    this.contextIdGenerator = context.contextIdGenerator(nodeId.id)
+    this.contextIdGenerator = context.contextIdGenerator(nodeId)
   }
 
   override def createTransformation[F[_]: Monad](

--- a/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/Union.scala
+++ b/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/Union.scala
@@ -36,7 +36,7 @@ object Union extends CustomStreamTransformer {
         unifiedReturnType
           .map(unionValidationContext(variableName, contexts, _))
           .getOrElse(
-            Validated.invalidNel(CannotCreateObjectError("All branch values must be of the same type", nodeId.id))
+            Validated.invalidNel(CannotCreateObjectError("All branch values must be of the same type", nodeId))
           )
       }
       .implementedBy(new LiteJoinCustomComponent {

--- a/engine/lite/components/base/src/test/scala/pl/touk/nussknacker/engine/lite/components/UnionTest.scala
+++ b/engine/lite/components/base/src/test/scala/pl/touk/nussknacker/engine/lite/components/UnionTest.scala
@@ -41,7 +41,7 @@ class UnionTest extends AnyFunSuite with Matchers with ValidatedValuesDetailedMe
   test("unification of different types") {
     val validationResult = validate("123", "'foo'")
     validationResult.result.invalidValue.toList should contain(
-      CannotCreateObjectError("All branch values must be of the same type", "union")
+      CannotCreateObjectError("All branch values must be of the same type", NodeId("union"))
     )
   }
 

--- a/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/FunctionalTestMixin.scala
+++ b/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/FunctionalTestMixin.scala
@@ -4,6 +4,7 @@ import cats.data.NonEmptyList
 import cats.data.Validated.{Invalid, Valid}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.Suite
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomNodeError
 import pl.touk.nussknacker.engine.kafka.KafkaSpec
@@ -47,7 +48,7 @@ trait FunctionalTestMixin extends KafkaSpec { self: Suite =>
     )
     Invalid(
       NonEmptyList.one(
-        CustomNodeError(sinkName, finalMessage, Some(KafkaUniversalComponentTransformer.sinkValueParamName))
+        CustomNodeError(NodeId(sinkName), finalMessage, Some(KafkaUniversalComponentTransformer.sinkValueParamName))
       )
     )
   }

--- a/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalJsonFunctionalTest.scala
+++ b/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalJsonFunctionalTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import pl.touk.nussknacker.engine.api.CirceUtil
+import pl.touk.nussknacker.engine.api.{CirceUtil, NodeId}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{
   CustomNodeError,
@@ -292,7 +292,7 @@ class LiteKafkaUniversalJsonFunctionalTest
 
     results.isValid shouldBe false
     val runtimeError = results.invalidValue.head
-    runtimeError.nodeIds shouldBe Set("my-sink")
+    runtimeError.nodeIds shouldBe Set(NodeId("my-sink"))
     runtimeError.asInstanceOf[CustomNodeError].message shouldBe
       """Provided value does not match scenario output - errors:
         |Incorrect type: actual: 'List[Integer]({1, 2})' expected: 'List[Integer]({1, 2, 3}) | String(A)'.""".stripMargin
@@ -329,7 +329,7 @@ class LiteKafkaUniversalJsonFunctionalTest
       (inputObject,                  objWithPatternPropsAndStringAdditionalSchema,         schemaLong,                                     SpecialSpELElement("#input['foo_int']"),      lax,                  valid(inputObjectIntPropValue)),
       (inputObject,                  objWithPatternPropsAndStringAdditionalSchema,         schemaLong,                                     SpecialSpELElement("#input['foo_int']"),      strict,               invalidTypes("actual: 'Long | String' expected: 'Long'")),
       (inputObject,                  objWithDefinedPropsPatternPropsAndAdditionalSchema,   schemaLong,                                     SpecialSpELElement("#input['foo_int']"),      lax,                  invalidNel(
-        ExpressionParserCompilationError("There is no property 'foo_int' in type: Record{definedProp: String}", "my-sink", Some(ParameterName("Value")), "#input['foo_int']", Some(CoordinatesBasedTextRange(TextCoordinates(6, 0), TextCoordinates(7, 0)))))),
+        ExpressionParserCompilationError("There is no property 'foo_int' in type: Record{definedProp: String}", NodeId("my-sink"), Some(ParameterName("Value")), "#input['foo_int']", Some(CoordinatesBasedTextRange(TextCoordinates(6, 0), TextCoordinates(7, 0)))))),
       (inputObjectWithDefinedProp,   objWithDefinedPropsPatternPropsAndAdditionalSchema,   schemaString,                                   SpecialSpELElement("#input.definedProp"),     strict,               valid(inputObjectDefinedPropValue)),
     )
     //@formatter:on
@@ -354,7 +354,7 @@ class LiteKafkaUniversalJsonFunctionalTest
   test("pattern properties validations should work in editor mode") {
     def invalidTypeInEditorMode(fieldName: String, error: String): Invalid[NonEmptyList[CustomNodeError]] = {
       val finalMessage = OutputValidatorErrorsMessageFormatter.makeMessage(List(error), Nil, Nil, Nil)
-      Invalid(NonEmptyList.one(CustomNodeError(sinkName, finalMessage, Some(ParameterName(fieldName)))))
+      Invalid(NonEmptyList.one(CustomNodeError(NodeId(sinkName), finalMessage, Some(ParameterName(fieldName)))))
     }
 
     val objWithNestedPatternPropertiesMapSchema =
@@ -423,7 +423,7 @@ class LiteKafkaUniversalJsonFunctionalTest
 
     def expectedMissingValue(result: ValidatedNel[ProcessCompilationError, Map[String, Json]]): Assertion =
       result.invalidValue should matchPattern {
-        case NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName(`ObjectFieldName`), `sinkName`), Nil) =>
+        case NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName(`ObjectFieldName`), NodeId(`sinkName`)), Nil) =>
       }
 
     forAll(
@@ -535,7 +535,7 @@ class LiteKafkaUniversalJsonFunctionalTest
     )
     val strictValidationErrors = runWithValueResults(strictConfig).invalidValue
     strictValidationErrors should matchPattern {
-      case NonEmptyList(CustomNodeError(`sinkName`, message, _), Nil)
+      case NonEmptyList(CustomNodeError(NodeId(`sinkName`), message, _), Nil)
           if message.contains(s"Redundant fields: $secondsField") =>
     }
 

--- a/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/UniversalCrossSourceLiteTest.scala
+++ b/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/UniversalCrossSourceLiteTest.scala
@@ -183,7 +183,7 @@ class UniversalCrossSourceLiteTest
 
     // Then
     val CustomNodeError(nodeId, message, _) = result.invalidValue.head
-    nodeId shouldBe "my-sink"
+    nodeId.id shouldBe "my-sink"
     message should include("Incorrect type: path 'age' actual: 'Long' expected: 'Integer'")
   }
 

--- a/engine/lite/components/request-response-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/CollectTransformerTest.scala
+++ b/engine/lite/components/request-response-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/CollectTransformerTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.OptionValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.ExpressionParserCompilationError
 import pl.touk.nussknacker.engine.build.{ProcessGraphBuilder, ScenarioBuilder}
@@ -94,7 +95,13 @@ class CollectTransformerTest
     val compilationError = runScenario(scenario, List(1)).invalidValue.toList.loneElement
 
     inside(compilationError) {
-      case ExpressionParserCompilationError("Unresolved reference 'previousCtxVar'", `nodeIdWithError`, _, _, _) =>
+      case ExpressionParserCompilationError(
+            "Unresolved reference 'previousCtxVar'",
+            NodeId(`nodeIdWithError`),
+            _,
+            _,
+            _
+          ) =>
     }
   }
 

--- a/engine/lite/components/request-response-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/LiteRequestResponseFunctionalTest.scala
+++ b/engine/lite/components/request-response-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/requestresponse/LiteRequestResponseFunctionalTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.Inside.inside
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{
   CustomNodeError,
@@ -139,7 +140,7 @@ class LiteRequestResponseFunctionalTest
     result should matchPattern {
       case Invalid(
             NonEmptyList(
-              ExpressionParserCompilationError(message, `sinkName`, Some(ParameterName("field")), _, _),
+              ExpressionParserCompilationError(message, NodeId(`sinkName`), Some(ParameterName("field")), _, _),
               Nil
             )
           ) if message.startsWith("Bad expression type") =>
@@ -344,7 +345,7 @@ class LiteRequestResponseFunctionalTest
   test("validate pattern properties on sink in editor mode") {
     def invalidTypeInEditorMode(fieldName: String, error: String): Invalid[NonEmptyList[CustomNodeError]] = {
       val finalMessage = OutputValidatorErrorsMessageFormatter.makeMessage(List(error), Nil, Nil, Nil)
-      Invalid(NonEmptyList.one(CustomNodeError(sinkName, finalMessage, Some(ParameterName(fieldName)))))
+      Invalid(NonEmptyList.one(CustomNodeError(NodeId(sinkName), finalMessage, Some(ParameterName(fieldName)))))
     }
     val objectWithNestedPatternPropertiesSchema = JsonSchemaBuilder.parseSchema("""{
         |  "type": "object",
@@ -555,7 +556,9 @@ class LiteRequestResponseFunctionalTest
       rangeTypeError
     )
     Invalid(
-      NonEmptyList.one(CustomNodeError(sinkName, finalMessage, Some(JsonRequestResponseSink.SinkRawValueParamName)))
+      NonEmptyList.one(
+        CustomNodeError(NodeId(sinkName), finalMessage, Some(JsonRequestResponseSink.SinkRawValueParamName))
+      )
     )
   }
 

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
@@ -4,7 +4,7 @@ import io.circe.Json
 import io.circe.Json._
 import io.circe.syntax._
 import org.scalatest.OptionValues
-import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.{NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.deployment._
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.{ProcessName, VersionId}
@@ -239,17 +239,17 @@ class StreamingEmbeddedDeploymentManagerTest
 
     val testData = ScenarioTestData(
       List(
-        ScenarioTestSourceSpecificFormatJsonRecord("source", testRecord("1")),
-        ScenarioTestSourceSpecificFormatJsonRecord("source", testRecord("2"))
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("source"), testRecord("1")),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("source"), testRecord("2"))
       )
     )
 
     val results = wrapInFailingLoader {
       manager.processCommand(DMTestScenarioCommand(processVersion, scenario, testData)).futureValue
     }
-    results.nodeResults("sink") should have length 2
-    val idGenerator       = IncContextIdGenerator.withProcessIdNodeIdPrefix(scenario.metaData, "source", taskId = 0)
-    val invocationResults = results.invocationResults("sink")
+    results.nodeResults(NodeId("sink")) should have length 2
+    val idGenerator = IncContextIdGenerator.withProcessIdNodeIdPrefix(scenario.metaData, NodeId("source"), taskId = 0)
+    val invocationResults = results.invocationResults(NodeId("sink"))
     val id1               = idGenerator.nextContextId()
     val id2               = idGenerator.nextContextId()
 

--- a/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
+++ b/engine/lite/kafka/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/kafka/KafkaTransactionalScenarioInterpreterTest.scala
@@ -205,7 +205,7 @@ class KafkaTransactionalScenarioInterpreterTest
       messages shouldBe List("original-add", "other-add")
 
       val error = kafkaClient.createConsumer().consumeWithJson[KafkaExceptionInfo](errorTopic).take(1).head.message()
-      error.nodeId shouldBe Some("throw on 0")
+      error.nodeId shouldBe Some(NodeId("throw on 0"))
       error.processName shouldBe scenario.name
       error.exceptionInput shouldBe Some("1 / #input.length")
     }
@@ -265,7 +265,7 @@ class KafkaTransactionalScenarioInterpreterTest
       val error =
         kafkaClient.createConsumer().consumeWithJson[KafkaExceptionInfo](fixture.errorTopic).take(1).head.message()
 
-      error.nodeId shouldBe Some("source")
+      error.nodeId shouldBe Some(NodeId("source"))
       error.processName shouldBe scenario.name
       // shouldn't it be just in error.message?
       error.exceptionInput.value should include(TestComponentProvider.SourceFailure.getMessage)

--- a/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseHttpHandler.scala
+++ b/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseHttpHandler.scala
@@ -5,7 +5,7 @@ import cats.data.{EitherT, NonEmptyList}
 import cats.implicits.toFunctorOps
 import io.circe.Json
 import org.apache.pekko.http.scaladsl.model.{HttpMethods, HttpRequest}
-import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.{Context, NodeId}
 import pl.touk.nussknacker.engine.api.component.NodeComponentInfo
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 import pl.touk.nussknacker.engine.lite.api.commonTypes.ErrorType
@@ -53,7 +53,7 @@ class RequestResponseHttpHandler[Effect[_]: Monad](
       Try(value).toEither.left.map(ex =>
         NonEmptyList.one(
           NuExceptionInfo(
-            Some(NodeComponentInfo(requestResponseInterpreter.sourceId.value, None)),
+            Some(NodeComponentInfo(NodeId(requestResponseInterpreter.sourceId.value), None)),
             ex,
             Context.dummy,
           )

--- a/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/ScenarioRoute.scala
+++ b/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/ScenarioRoute.scala
@@ -15,6 +15,7 @@ import org.apache.pekko.http.scaladsl.server.directives.{
   DebuggingDirectives,
   SecurityDirectives
 }
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.requestresponse.openapi.RequestResponseOpenApiGenerator
@@ -123,6 +124,6 @@ private[requestresponse] class ScenarioRoute(
 
   private def jsonStringToEntity(j: String): ResponseEntity = HttpEntity(contentType = `application/json`, string = j)
 
-  @JsonCodec sealed case class NuError(nodeId: Option[String], message: Option[String])
+  @JsonCodec sealed case class NuError(nodeId: Option[NodeId], message: Option[String])
 
 }

--- a/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/metrics/InvocationMetrics.scala
+++ b/engine/lite/request-response/runtime/src/main/scala/pl/touk/nussknacker/engine/requestresponse/metrics/InvocationMetrics.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.requestresponse.metrics
 import cats.Monad
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.data.Validated.{Invalid, Valid}
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
 import pl.touk.nussknacker.engine.lite.api.commonTypes.ErrorType
 import pl.touk.nussknacker.engine.util.metrics.MetricIdentifier
@@ -16,7 +17,7 @@ class InvocationMetrics(context: EngineRuntimeContext) {
 
   protected val instantTimerWindowInSeconds = 20
 
-  private val nodeErrorTimers: collection.concurrent.TrieMap[String, EspTimer] = collection.concurrent.TrieMap()
+  private val nodeErrorTimers: collection.concurrent.TrieMap[NodeId, EspTimer] = collection.concurrent.TrieMap()
 
   // TODO: maybe var initialized in `open`?
   private lazy val successTimer = espTimer(Map(), NonEmptyList.of("invocation", "success"))
@@ -38,10 +39,10 @@ class InvocationMetrics(context: EngineRuntimeContext) {
     }
   }
 
-  private def markErrorTimer(startTime: Long, nodeId: Option[String] = None): Unit = {
-    val id = nodeId.getOrElse("unknown")
+  private def markErrorTimer(startTime: Long, nodeId: Option[NodeId] = None): Unit = {
+    val id = nodeId.getOrElse(NodeId("unknown"))
     nodeErrorTimers
-      .getOrElseUpdate(id, espTimer(Map(nodeIdTag -> id), NonEmptyList.of("invocation", "failure")))
+      .getOrElseUpdate(id, espTimer(Map(nodeIdTag -> id.id), NonEmptyList.of("invocation", "failure")))
       .update(startTime)
   }
 

--- a/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseInterpreterSpec.scala
+++ b/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/RequestResponseInterpreterSpec.scala
@@ -274,7 +274,7 @@ class RequestResponseInterpreterSpec extends AnyFunSuite with Matchers with Pati
 
     result.invalidValue.toList should matchPattern {
       case NuExceptionInfo(
-            Some(NodeComponentInfo("sinkId", Some(ComponentId(ComponentType.Sink, "unknown")))),
+            Some(NodeComponentInfo(NodeId("sinkId"), Some(ComponentId(ComponentType.Sink, "unknown")))),
             SinkException("FailingSink failed"),
             Context(`contextId`, variables, None),
             _,
@@ -430,7 +430,7 @@ class RequestResponseInterpreterSpec extends AnyFunSuite with Matchers with Pati
 
   private def firstIdForFirstSource(scenario: CanonicalProcess): ContextId =
     IncContextIdGenerator
-      .withProcessIdNodeIdPrefix(scenario.metaData, scenario.nodes.head.id, taskId = 0)
+      .withProcessIdNodeIdPrefix(scenario.metaData, NodeId(scenario.nodes.head.id), taskId = 0)
       .nextContextId()
 
 }

--- a/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
+++ b/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.LoneElement._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.{ContextIdPathPart, DisplayJsonWithEncoder, JobData, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{ContextIdPathPart, DisplayJsonWithEncoder, JobData, NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.runtimecontext.IncContextIdGenerator
 import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, ScenarioTestSourceSpecificFormatJsonRecord}
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
@@ -40,14 +40,14 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
       RequestResponseComponentProvider.Components
   )
 
-  private val sourceId = "start"
+  private val sourceId = NodeId("start")
 
   private val mockedTimestamp = Instant.now()
 
   test("perform test on mocks") {
     val process = ScenarioBuilder
       .requestResponse("proc1")
-      .source(sourceId, "request1-post-source")
+      .source(sourceId.id, "request1-post-source")
       .filter("filter1", "#input.field1() == 'a'".spel)
       .enricher("enricher", "var1", "enricherService")
       .processor("processor", "processorService")
@@ -67,19 +67,19 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
       (secondId, Map("input" -> variable(Request1("c", "d"))))
     )
 
-    results.invocationResults("filter1").map(withMockedTimestamp).toSet shouldBe Set(
+    results.invocationResults(NodeId("filter1")).map(withMockedTimestamp).toSet shouldBe Set(
       ExpressionInvocationResult(firstId, mockedTimestamp, "expression", variable(true)),
       ExpressionInvocationResult(secondId, mockedTimestamp, "expression", variable(false))
     )
 
-    results.externalInvocationResults("processor").map(withMockedTimestamp).toSet shouldBe Set(
+    results.externalInvocationResults(NodeId("processor")).map(withMockedTimestamp).toSet shouldBe Set(
       ExternalInvocationResult(firstId, mockedTimestamp, "processorService", variable("processor service invoked"))
     )
-    results.externalInvocationResults("eagerProcessor").map(withMockedTimestamp).toSet shouldBe Set(
+    results.externalInvocationResults(NodeId("eagerProcessor")).map(withMockedTimestamp).toSet shouldBe Set(
       ExternalInvocationResult(firstId, mockedTimestamp, "collectingEager", variable("static-s-dynamic-a"))
     )
 
-    results.externalInvocationResults("endNodeIID").map(withMockedTimestamp).toSet shouldBe Set(
+    results.externalInvocationResults(NodeId("endNodeIID")).map(withMockedTimestamp).toSet shouldBe Set(
       ExternalInvocationResult(firstId, mockedTimestamp, "endNodeIID", variable(Response(s"alamakota-$firstId")))
     )
 
@@ -90,7 +90,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
   test("detect errors in nodes") {
     val process = ScenarioBuilder
       .requestResponse("proc1")
-      .source(sourceId, "request1-post-source")
+      .source(sourceId.id, "request1-post-source")
       .filter("occasionallyThrowFilter", "#input.field1() == 'a' ? 1/{0, 1}[0] == 0 : true".spel)
       .filter("filter1", "#input.field1() == 'a'".spel)
       .enricher("enricher", "var1", "enricherService")
@@ -105,21 +105,21 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
 
     val results = runTest(process, scenarioTestData)
 
-    results.invocationResults("occasionallyThrowFilter").map(withMockedTimestamp).toSet shouldBe Set(
+    results.invocationResults(NodeId("occasionallyThrowFilter")).map(withMockedTimestamp).toSet shouldBe Set(
       ExpressionInvocationResult(secondId, mockedTimestamp, "expression", variable(true))
     )
 
     results.exceptions should have size 1
     results.exceptions.head.context.id shouldBe firstId
     results.exceptions.head.context.variables shouldBe Map("input" -> variable(Request1("a", "b")))
-    results.exceptions.head.nodeId shouldBe Some("occasionallyThrowFilter")
+    results.exceptions.head.nodeId shouldBe Some(NodeId("occasionallyThrowFilter"))
     results.exceptions.head.throwable.getMessage shouldBe """Expression [#input.field1() == 'a' ? 1/{0, 1}[0] == 0 : true] evaluation failed, message: / by zero"""
   }
 
   test("get results on parameter sinks") {
     val process = ScenarioBuilder
       .requestResponse("proc1")
-      .source(sourceId, "request1-post-source")
+      .source(sourceId.id, "request1-post-source")
       .emptySink("endNodeIID", "parameterResponse-sink", "computed" -> "#input.field1()".spel)
 
     val scenarioTestData = ScenarioTestData(List(createTestRecord("a", "b")))
@@ -139,7 +139,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
       (firstId, Map("input" -> variable(Request1("a", "b"))))
     )
 
-    results.externalInvocationResults("endNodeIID").map(withMockedTimestamp).toSet shouldBe Set(
+    results.externalInvocationResults(NodeId("endNodeIID")).map(withMockedTimestamp).toSet shouldBe Set(
       ExternalInvocationResult(firstId, mockedTimestamp, "endNodeIID", variable("a withRandomString"))
     )
 
@@ -152,7 +152,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
       .streaming("proc1")
       .sources(
         GraphBuilder
-          .source(sourceId, "request1-post-source")
+          .source(sourceId.id, "request1-post-source")
           .split(
             "spl",
             GraphBuilder.buildSimpleVariable("v1", "v1", "'aa'".spel).branchEnd(branch1NodeId, "union1"),
@@ -176,28 +176,28 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     val results = runTest(process, scenarioTestData)
 
     val sourceContextId = contextIdGenForFirstSource(process).nextContextId()
-    results.nodeResults("union1") should have size 2
+    results.nodeResults(NodeId("union1")) should have size 2
 
-    val unionContextIds = results.nodeResults("union1").map(_.id)
+    val unionContextIds = results.nodeResults(NodeId("union1")).map(_.id)
     unionContextIds should contain only (
       sourceContextId.copy(
         contextIdPath = List(
-          ContextIdPathPart("spl", "v1"),
-          ContextIdPathPart("union1", branch1NodeId),
+          ContextIdPathPart(NodeId("spl"), "v1"),
+          ContextIdPathPart(NodeId("union1"), branch1NodeId),
         ).asJava
       ),
       sourceContextId.copy(
         contextIdPath = List(
-          ContextIdPathPart("spl", "v2"),
-          ContextIdPathPart("union1", branch2NodeId),
+          ContextIdPathPart(NodeId("spl"), "v2"),
+          ContextIdPathPart(NodeId("union1"), branch2NodeId),
         ).asJava
       ),
     )
     unionContextIds should contain theSameElementsAs unionContextIds.toSet
     nodeResults(results, "union1") shouldBe nodeResults(results, "collect1")
 
-    val endNodeIdInvocationResult = results.externalInvocationResults("endNodeIID").loneElement
-    endNodeIdInvocationResult.contextId shouldBe contextIdGenForNodeId(process, "collect1").nextContextId()
+    val endNodeIdInvocationResult = results.externalInvocationResults(NodeId("endNodeIID")).loneElement
+    endNodeIdInvocationResult.contextId shouldBe contextIdGenForNodeId(process, NodeId("collect1")).nextContextId()
 
     endNodeIdInvocationResult.value shouldBe variable(List("aa", "bb"))
   }
@@ -210,9 +210,9 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
   }
 
   private def contextIdGenForFirstSource(scenario: CanonicalProcess): IncContextIdGenerator =
-    contextIdGenForNodeId(scenario, scenario.nodes.head.id)
+    contextIdGenForNodeId(scenario, NodeId(scenario.nodes.head.id))
 
-  private def contextIdGenForNodeId(scenario: CanonicalProcess, nodeId: String): IncContextIdGenerator =
+  private def contextIdGenForNodeId(scenario: CanonicalProcess, nodeId: NodeId): IncContextIdGenerator =
     IncContextIdGenerator.withProcessIdNodeIdPrefix(scenario.metaData, nodeId, taskId = 0)
 
   private def runTest(process: CanonicalProcess, scenarioTestData: ScenarioTestData): TestResults[Json] = {
@@ -238,8 +238,8 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     Json.obj("pretty" -> toJson(value))
   }
 
-  private def nodeResults[T](results: TestProcess.TestResults[T], key: String) =
-    results.nodeResults(key).map(r => (r.id, r.variables))
+  private def nodeResults[T](results: TestProcess.TestResults[T], nodeId: String) =
+    results.nodeResults(NodeId(nodeId)).map(r => (r.id, r.variables))
 
   private def withMockedTimestamp(result: ExpressionInvocationResult[Json]) =
     result.copy(timestamp = mockedTimestamp)

--- a/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/ScenarioInterpreterFactory.scala
+++ b/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/ScenarioInterpreterFactory.scala
@@ -12,7 +12,7 @@ import pl.touk.nussknacker.engine.api.context.{JoinContextTransformation, Proces
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.UnsupportedPart
 import pl.touk.nussknacker.engine.api.definition.EngineScenarioCompilationDependencies
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
-import pl.touk.nussknacker.engine.api.process.{ServiceExecutionContext, Source}
+import pl.touk.nussknacker.engine.api.process.{ProcessName, ServiceExecutionContext, Source}
 import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -74,7 +74,7 @@ object ScenarioInterpreterFactory {
       val allNodes = process.collectAllNodes
       val countingListeners = List(
         LoggingListener,
-        new NodeCountingListener(allNodes.map(_.id)),
+        new NodeCountingListener(allNodes.map(n => NodeId(n.id))),
         new ExceptionCountingListener,
         new EndCountingListener(allNodes),
       )
@@ -182,7 +182,7 @@ object ScenarioInterpreterFactory {
           Monad[F].pure[ResultType[PartResult]](
             Writer(
               NuExceptionInfo(
-                Some(NodeComponentInfo(source.value, ComponentType.Source, "source")),
+                Some(NodeComponentInfo(NodeId(source.value), ComponentType.Source, "source")),
                 new IllegalArgumentException(s"Unknown source ${source.value}"),
                 Context.dummy,
               ) :: Nil,
@@ -255,7 +255,7 @@ object ScenarioInterpreterFactory {
         )
         .result
 
-    private def customComponentContext(nodeId: String) =
+    private def customComponentContext(nodeId: NodeId) =
       CustomComponentContext[F](nodeId, capabilityTransformer)
 
     private def compiledPartInvoker(
@@ -271,11 +271,11 @@ object ScenarioInterpreterFactory {
         case CustomNodePart(transformerObj, node, _, validationContext, parts, _) =>
           val validatedTransformer = transformerObj match {
             case t: LiteCustomComponent => Valid(t)
-            case _                      => Invalid(NonEmptyList.of(UnsupportedPart(node.id)))
+            case _                      => Invalid(NonEmptyList.of(UnsupportedPart(NodeId(node.id))))
           }
           validatedTransformer.andThen { transformer =>
             val result = compileWithCompilationErrors(node, validationContext).andThen(partInvoker(_, parts))
-            result.map(rs => rs.map(transformer.createTransformation(_, customComponentContext(node.id))))
+            result.map(rs => rs.map(transformer.createTransformation(_, customComponentContext(NodeId(node.id)))))
           }
       }
 
@@ -283,7 +283,8 @@ object ScenarioInterpreterFactory {
         it: WithSinkTypes[PartInterpreterType]
     ): WithSinkTypes[PartInterpreterType] = sink match {
       case sinkWithParams: LiteSink[Res @unchecked] =>
-        val (returnType, evaluation) = sinkWithParams.createTransformation[F](customComponentContext(compiledNode.id))
+        val (returnType, evaluation) =
+          sinkWithParams.createTransformation[F](customComponentContext(NodeId(compiledNode.id)))
 
         it.bimap(
           _.updated(NodeId(compiledNode.id), returnType),
@@ -391,15 +392,15 @@ object ScenarioInterpreterFactory {
         case (s: LiteSource[Input @unchecked], _) => Valid(s)
         // Used only in fragment testing, when FragmentInputDefinition is available
         case (_: Source, fragmentInputDef: FragmentInputDefinition) if runtimeMode == RuntimeMode.Test =>
-          sourceForFragmentInputTesting(fragmentInputDef)
-        case _ => Invalid(NonEmptyList.of(UnsupportedPart(node.id)))
+          sourceForFragmentInputTesting
+        case _ => Invalid(NonEmptyList.of(UnsupportedPart(NodeId(node.id))))
       }
       validatedSource.map { source =>
-        source.createTransformation(customComponentContext(node.id))
+        source.createTransformation(customComponentContext(NodeId(node.id)))
       }
     }
 
-    private def sourceForFragmentInputTesting(fragmentInputDef: FragmentInputDefinition): Valid[LiteSource[Input]] =
+    private val sourceForFragmentInputTesting: Valid[LiteSource[Input]] =
       Valid(
         new LiteSource[Input] {
 
@@ -408,7 +409,7 @@ object ScenarioInterpreterFactory {
           ): Input => ValidatedNel[ErrorType, Context] = { input =>
             Valid(
               Context(
-                ContextId(fragmentInputDef.id, evaluateLazyParameter.nodeId, 0, 0),
+                ContextId(processCompilerData.jobData.metaData.name, evaluateLazyParameter.nodeId, 0, 0),
                 input.asInstanceOf[Map[String, Any]],
                 None
               )
@@ -425,11 +426,11 @@ object ScenarioInterpreterFactory {
       val validatedTransformer = transformerObj match {
         case t: LiteJoinCustomComponent                               => Valid(t)
         case JoinContextTransformation(_, t: LiteJoinCustomComponent) => Valid(t)
-        case _ => Invalid(NonEmptyList.of(UnsupportedPart(node.id)))
+        case _ => Invalid(NonEmptyList.of(UnsupportedPart(NodeId(node.id))))
       }
       validatedTransformer.andThen { transformer =>
         val result = compileWithCompilationErrors(node, validationContext).andThen(partInvoker(_, parts))
-        result.map(rs => rs.map(transformer.createTransformation(_, customComponentContext(node.id))))
+        result.map(rs => rs.map(transformer.createTransformation(_, customComponentContext(NodeId(node.id)))))
       }
     }
 

--- a/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/TestRunner.scala
+++ b/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/TestRunner.scala
@@ -144,9 +144,8 @@ class InterpreterTestRunner[F[_]: Monad: InterpreterShape: CapabilityTransformer
   ): Unit = {
     val successfulResults = results.value
     successfulResults.foreach { result =>
-      val node = result.nodeId.id
       testServiceInvocationCollector
-        .createSinkInvocationCollector(node, node)
+        .createSinkInvocationCollector(result.nodeId, result.nodeId.id)
         .collect(result.context, result.result)
     }
   }

--- a/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/capabilities.scala
+++ b/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/capabilities.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.lite
 import cats.~>
 import cats.data.{Validated, ValidatedNel}
 import cats.data.Validated.Valid
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CannotCreateObjectError
 import pl.touk.nussknacker.engine.lite.api.customComponentTypes.CapabilityTransformer
@@ -31,7 +32,7 @@ object capabilities {
           override def apply[A](fa: From[A]): Target[A] = fa.asInstanceOf[Target[A]]
         })
       } else {
-        Validated.invalidNel(CannotCreateObjectError(s"Cannot convert capability: $tag", ""))
+        Validated.invalidNel(CannotCreateObjectError(s"Cannot convert capability: $tag", NodeId("")))
       }
     }
 

--- a/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/InterpreterTestRunnerTest.scala
+++ b/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/InterpreterTestRunnerTest.scala
@@ -3,8 +3,9 @@ package pl.touk.nussknacker.engine.lite
 import io.circe.Json
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.{ContextId, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{ContextId, NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, ScenarioTestSourceSpecificFormatJsonRecord}
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -33,38 +34,46 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
       .emptySink("end", "end", "value" -> "#input + ':' + #sum".spel)
     val scenarioTestData = ScenarioTestData(
       List(
-        ScenarioTestSourceSpecificFormatJsonRecord("start", Json.fromString("A|2")),
-        ScenarioTestSourceSpecificFormatJsonRecord("start", Json.fromString("B|1")),
-        ScenarioTestSourceSpecificFormatJsonRecord("start", Json.fromString("C|3")),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("start"), Json.fromString("A|2")),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("start"), Json.fromString("B|1")),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("start"), Json.fromString("C|3")),
       )
     )
 
     val results = sample.test(scenario, processVersionFor(scenario), scenarioTestData)
 
     nodeResults(results, "start") shouldBe List(
-      (ContextId("A", "", 0, 0), Map("input" -> variable(2))),
-      (ContextId("B", "", 0, 0), Map("input" -> variable(1))),
-      (ContextId("C", "", 0, 0), Map("input" -> variable(3)))
+      (ContextId(ProcessName("A"), NodeId(""), 0, 0), Map("input" -> variable(2))),
+      (ContextId(ProcessName("B"), NodeId(""), 0, 0), Map("input" -> variable(1))),
+      (ContextId(ProcessName("C"), NodeId(""), 0, 0), Map("input" -> variable(3)))
     )
 
     nodeResults(results, "sum") shouldBe List(
-      (ContextId("A", "", 0, 0), Map("input" -> 2, "out1" -> 2).mapValuesNow(variable)),
-      (ContextId("C", "", 0, 0), Map("input" -> 3, "out1" -> 3).mapValuesNow(variable))
+      (ContextId(ProcessName("A"), NodeId(""), 0, 0), Map("input" -> 2, "out1" -> 2).mapValuesNow(variable)),
+      (ContextId(ProcessName("C"), NodeId(""), 0, 0), Map("input" -> 3, "out1" -> 3).mapValuesNow(variable))
     )
 
     nodeResults(results, "end") shouldBe List(
-      (ContextId("A", "", 0, 0), Map("input" -> 2, "out1" -> 2, "sum" -> 2).mapValuesNow(variable)),
-      (ContextId("C", "", 0, 0), Map("input" -> 3, "out1" -> 3, "sum" -> 5).mapValuesNow(variable))
+      (
+        ContextId(ProcessName("A"), NodeId(""), 0, 0),
+        Map("input" -> 2, "out1" -> 2, "sum" -> 2).mapValuesNow(variable)
+      ),
+      (ContextId(ProcessName("C"), NodeId(""), 0, 0), Map("input" -> 3, "out1" -> 3, "sum" -> 5).mapValuesNow(variable))
     )
 
-    results.invocationResults("sum").map(withMockedTimestamp) shouldBe List(
-      ExpressionInvocationResult(ContextId("A", "", 0, 0), mockedTimestamp, "value", variable(2)),
-      ExpressionInvocationResult(ContextId("C", "", 0, 0), mockedTimestamp, "value", variable(3))
+    results.invocationResults(NodeId("sum")).map(withMockedTimestamp) shouldBe List(
+      ExpressionInvocationResult(ContextId(ProcessName("A"), NodeId(""), 0, 0), mockedTimestamp, "value", variable(2)),
+      ExpressionInvocationResult(ContextId(ProcessName("C"), NodeId(""), 0, 0), mockedTimestamp, "value", variable(3))
     )
 
-    results.externalInvocationResults("end").map(withMockedTimestamp) shouldBe List(
-      ExternalInvocationResult(ContextId("A", "", 0, 0), mockedTimestamp, "end", variable("2:2.0")),
-      ExternalInvocationResult(ContextId("C", "", 0, 0), mockedTimestamp, "end", variable("3:5.0"))
+    results.externalInvocationResults(NodeId("end")).map(withMockedTimestamp) shouldBe List(
+      ExternalInvocationResult(
+        ContextId(ProcessName("A"), NodeId(""), 0, 0),
+        mockedTimestamp,
+        "end",
+        variable("2:2.0")
+      ),
+      ExternalInvocationResult(ContextId(ProcessName("C"), NodeId(""), 0, 0), mockedTimestamp, "end", variable("3:5.0"))
     )
   }
 
@@ -77,26 +86,28 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
       )
     val scenarioTestData = ScenarioTestData(
       List(
-        ScenarioTestSourceSpecificFormatJsonRecord("source1", Json.fromString("A|1")),
-        ScenarioTestSourceSpecificFormatJsonRecord("source1", Json.fromString("B|2")),
-        ScenarioTestSourceSpecificFormatJsonRecord("source2", Json.fromString("C|3")),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("source1"), Json.fromString("A|1")),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("source1"), Json.fromString("B|2")),
+        ScenarioTestSourceSpecificFormatJsonRecord(NodeId("source2"), Json.fromString("C|3")),
       )
     )
 
     val results = sample.test(scenario, processVersionFor(scenario), scenarioTestData)
 
     nodeResults(results, "source1") shouldBe List(
-      (ContextId("A", "", 0, 0), Map("input" -> variable(1))),
-      (ContextId("B", "", 0, 0), Map("input" -> variable(2)))
+      (ContextId(ProcessName("A"), NodeId(""), 0, 0), Map("input" -> variable(1))),
+      (ContextId(ProcessName("B"), NodeId(""), 0, 0), Map("input" -> variable(2)))
     )
-    nodeResults(results, "source2") shouldBe List((ContextId("C", "", 0, 0), Map("input" -> variable(3))))
+    nodeResults(results, "source2") shouldBe List(
+      (ContextId(ProcessName("C"), NodeId(""), 0, 0), Map("input" -> variable(3)))
+    )
 
-    results.externalInvocationResults("end1").map(withMockedTimestamp) shouldBe List(
-      ExternalInvocationResult(ContextId("A", "", 0, 0), mockedTimestamp, "end1", variable(1)),
-      ExternalInvocationResult(ContextId("B", "", 0, 0), mockedTimestamp, "end1", variable(2))
+    results.externalInvocationResults(NodeId("end1")).map(withMockedTimestamp) shouldBe List(
+      ExternalInvocationResult(ContextId(ProcessName("A"), NodeId(""), 0, 0), mockedTimestamp, "end1", variable(1)),
+      ExternalInvocationResult(ContextId(ProcessName("B"), NodeId(""), 0, 0), mockedTimestamp, "end1", variable(2))
     )
-    results.externalInvocationResults("end2").map(withMockedTimestamp) shouldBe List(
-      ExternalInvocationResult(ContextId("C", "", 0, 0), mockedTimestamp, "end2", variable(3))
+    results.externalInvocationResults(NodeId("end2")).map(withMockedTimestamp) shouldBe List(
+      ExternalInvocationResult(ContextId(ProcessName("C"), NodeId(""), 0, 0), mockedTimestamp, "end2", variable(3))
     )
   }
 
@@ -115,11 +126,11 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
 
     nodeResults(results, "source1") shouldBe List(
       (
-        ContextId("some-ctx-id", "", 0, 0),
+        ContextId(ProcessName("some-ctx-id"), NodeId(""), 0, 0),
         Map(
           "input" -> variable(
             SampleInputWithListAndMap(
-              ContextId("some-ctx-id", "", 0, 0),
+              ContextId(ProcessName("some-ctx-id"), NodeId(""), 0, 0),
               List(1L, 2L, 3L).asJava,
               Map[String, Any]("unoDosTres" -> 123).asJava
             )
@@ -150,11 +161,11 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
 
     nodeResults(results, "source1") shouldBe List(
       (
-        ContextId("some-ctx-id", "", 0, 0),
+        ContextId(ProcessName("some-ctx-id"), NodeId(""), 0, 0),
         Map(
           "input" -> variable(
             SampleInputWithListAndMap(
-              ContextId("some-ctx-id", "", 0, 0),
+              ContextId(ProcessName("some-ctx-id"), NodeId(""), 0, 0),
               List(1L, 2L, 3L, 4L, 5L).asJava,
               Map[String, Any]("extraValue" -> 100).asJava
             )
@@ -163,17 +174,22 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
       )
     )
 
-    results.invocationResults("sumNumbers").map(withMockedTimestamp) shouldBe List(
+    results.invocationResults(NodeId("sumNumbers")).map(withMockedTimestamp) shouldBe List(
       ExpressionInvocationResult(
-        ContextId("some-ctx-id", "", 0, 0),
+        ContextId(ProcessName("some-ctx-id"), NodeId(""), 0, 0),
         mockedTimestamp,
         "value",
         variable(List(1, 2, 3, 4, 5))
       )
     )
 
-    results.externalInvocationResults("end").map(withMockedTimestamp) shouldBe List(
-      ExternalInvocationResult(ContextId("some-ctx-id", "", 0, 0), mockedTimestamp, "end", variable(120))
+    results.externalInvocationResults(NodeId("end")).map(withMockedTimestamp) shouldBe List(
+      ExternalInvocationResult(
+        ContextId(ProcessName("some-ctx-id"), NodeId(""), 0, 0),
+        mockedTimestamp,
+        "end",
+        variable(120)
+      )
     )
   }
 
@@ -190,17 +206,17 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
     val results          = sample.test(fragment, processVersionFor(fragment), scenarioTestData)
 
     nodeResults(results, "fragment1") shouldBe List(
-      (ContextId("fragment1", "fragment1", 0, 0), Map("in" -> variable("some-text-id")))
+      (ContextId(ProcessName("fragment1"), NodeId("fragment1"), 0, 0), Map("in" -> variable("some-text-id")))
     )
     nodeResults(results, "fragmentEnd") shouldBe List(
       (
-        ContextId("fragment1", "fragment1", 0, 0),
+        ContextId(ProcessName("fragment1"), NodeId("fragment1"), 0, 0),
         Map("in" -> variable("some-text-id"), "out" -> variable("some-text-id"))
       )
     )
-    results.invocationResults("fragmentEnd").map(withMockedTimestamp) shouldBe List(
+    results.invocationResults(NodeId("fragmentEnd")).map(withMockedTimestamp) shouldBe List(
       ExpressionInvocationResult(
-        ContextId("fragment1", "fragment1", 0, 0),
+        ContextId(ProcessName("fragment1"), NodeId("fragment1"), 0, 0),
         mockedTimestamp,
         "out",
         variable("some-text-id")
@@ -221,20 +237,20 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
     val results          = sample.test(fragment, processVersionFor(fragment), scenarioTestData)
 
     nodeResults(results, "fragment1") shouldBe List(
-      (ContextId("fragment1", "fragment1", 0, 0), Map("in" -> variable(0)))
+      (ContextId(ProcessName("fragment1"), NodeId("fragment1"), 0, 0), Map("in" -> variable(0)))
     )
     nodeResults(results, "fragmentEnd") shouldBe List(
-      (ContextId("fragment1", "fragment1", 0, 0), Map("in" -> variable(0)))
+      (ContextId(ProcessName("fragment1"), NodeId("fragment1"), 0, 0), Map("in" -> variable(0)))
     )
     results.exceptions.map(e => ((e.context.id, e.context.variables), e.nodeId, e.throwable.getMessage)) shouldBe List(
       (
-        (ContextId("fragment1", "fragment1", 0, 0), Map("in" -> variable(0))),
-        Some("fragmentEnd"),
+        (ContextId(ProcessName("fragment1"), NodeId("fragment1"), 0, 0), Map("in" -> variable(0))),
+        Some(NodeId("fragmentEnd")),
         "Expression [4 / #in] evaluation failed, message: / by zero"
       ),
       (
-        (ContextId("fragment1", "fragment1", 0, 0), Map("in" -> variable(0))),
-        Some("fragmentEnd"),
+        (ContextId(ProcessName("fragment1"), NodeId("fragment1"), 0, 0), Map("in" -> variable(0))),
+        Some(NodeId("fragmentEnd")),
         "Expression [8 / #in] evaluation failed, message: / by zero"
       )
     )
@@ -257,7 +273,7 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
   }
 
   private def nodeResults[T](results: TestProcess.TestResults[T], key: String) =
-    results.nodeResults(key).map(r => (r.id, r.variables))
+    results.nodeResults(NodeId(key)).map(r => (r.id, r.variables))
 
   private def withMockedTimestamp(result: ExpressionInvocationResult[Json]) =
     result.copy(timestamp = mockedTimestamp)

--- a/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/StateEngineTest.scala
+++ b/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/StateEngineTest.scala
@@ -3,7 +3,8 @@ package pl.touk.nussknacker.engine.lite
 import org.scalatest.OptionValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.ContextId
+import pl.touk.nussknacker.engine.api.{ContextId, NodeId}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.lite.api.interpreterTypes.{ScenarioInputBatch, SourceId}
@@ -24,11 +25,11 @@ class StateEngineTest extends AnyFunSuite with Matchers with OptionValues {
 
     // we start with 10, add 2 * each input, but omit 1 as enricher fails on that value
     results.value.map(er => (er.context.id, er.result)) shouldBe List(
-      ContextId("0", "", 0, 0) -> "0:10.0",
-      ContextId("2", "", 0, 0) -> "2:14.0",
-      ContextId("3", "", 0, 0) -> "3:20.0"
+      ContextId(ProcessName("0"), NodeId(""), 0, 0) -> "0:10.0",
+      ContextId(ProcessName("2"), NodeId(""), 0, 0) -> "2:14.0",
+      ContextId(ProcessName("3"), NodeId(""), 0, 0) -> "3:20.0"
     )
-    results.written.map(_.context.id) shouldBe List(ContextId("1", "", 0, 0))
+    results.written.map(_.context.id) shouldBe List(ContextId(ProcessName("1"), NodeId(""), 0, 0))
   }
 
   test("run scenario failing on source") {
@@ -42,12 +43,12 @@ class StateEngineTest extends AnyFunSuite with Matchers with OptionValues {
 
     // we start with 10, add 2 * each input, but omit 1 as enricher fails on that value
     results.value.map(er => (er.context.id, er.result)) shouldBe List(
-      ContextId("0", "", 0, 0) -> 0,
-      ContextId("2", "", 0, 0) -> 2,
-      ContextId("3", "", 0, 0) -> 3
+      ContextId(ProcessName("0"), NodeId(""), 0, 0) -> 0,
+      ContextId(ProcessName("2"), NodeId(""), 0, 0) -> 2,
+      ContextId(ProcessName("3"), NodeId(""), 0, 0) -> 3
     )
     val error = results.written.headOption.value
-    error.context.id shouldEqual ContextId("1", "", 0, 0)
+    error.context.id shouldEqual ContextId(ProcessName("1"), NodeId(""), 0, 0)
     error.throwable shouldEqual SourceFailure
   }
 

--- a/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/sample.scala
+++ b/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/sample.scala
@@ -52,7 +52,7 @@ object sample {
   // Example: ContextId("the_value_used_in_sample_engine", "", 0, 0, [])
   case class SampleInput(contextId: String, value: Int)
 
-  private def dummyContextId(str: String): ContextId = ContextId(str, "", 0, 0)
+  private def dummyContextId(str: String): ContextId = ContextId(ProcessName(str), NodeId(""), 0, 0)
 
   case class SampleInputWithListAndMap(
       contextId: ContextId,
@@ -220,7 +220,7 @@ object sample {
           if (input.value == 1) {
             Invalid(
               NuExceptionInfo(
-                Some(NodeComponentInfo(nodeId.id, ComponentType.Source, "failOnNumber1SourceFactory")),
+                Some(NodeComponentInfo(nodeId, ComponentType.Source, "failOnNumber1SourceFactory")),
                 SourceFailure,
                 Context(dummyContextId(input.contextId))
               )

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/ProcessListener.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/ProcessListener.scala
@@ -6,18 +6,18 @@ import scala.util.Try
 
 trait ProcessListener extends Lifecycle {
 
-  def nodeEntered(nodeId: String, context: Context, processMetaData: MetaData): Unit
+  def nodeEntered(nodeId: NodeId, context: Context, processMetaData: MetaData): Unit
 
-  def transitionToNextNode(nodeId: String, nextNodeId: String, context: Context, processMetaData: MetaData): Unit
+  def transitionToNextNode(nodeId: NodeId, nextNodeId: NodeId, context: Context, processMetaData: MetaData): Unit
 
-  def processingFinishedInNode(nodeId: String, context: Context, processMetaData: MetaData): Unit
+  def processingFinishedInNode(nodeId: NodeId, context: Context, processMetaData: MetaData): Unit
 
-  def endEncountered(nodeId: String, ref: String, context: Context, processMetaData: MetaData): Unit
+  def endEncountered(nodeId: NodeId, ref: String, context: Context, processMetaData: MetaData): Unit
 
-  def deadEndEncountered(lastNodeId: String, context: Context, processMetaData: MetaData): Unit
+  def deadEndEncountered(lastNodeId: NodeId, context: Context, processMetaData: MetaData): Unit
 
   def expressionEvaluated(
-      nodeId: String,
+      nodeId: NodeId,
       expressionId: String,
       expression: String,
       context: Context,
@@ -26,7 +26,7 @@ trait ProcessListener extends Lifecycle {
   ): Unit
 
   def serviceInvoked(
-      nodeId: String,
+      nodeId: NodeId,
       id: String,
       context: Context,
       processMetaData: MetaData,
@@ -38,36 +38,36 @@ trait ProcessListener extends Lifecycle {
 }
 
 trait EmptyProcessListener extends ProcessListener {
-  override def nodeEntered(nodeId: String, context: Context, processMetaData: MetaData): Unit = ()
+  override def nodeEntered(nodeId: NodeId, context: Context, processMetaData: MetaData): Unit = ()
 
   override def transitionToNextNode(
-      nodeId: String,
-      nextNodeId: String,
+      nodeId: NodeId,
+      nextNodeId: NodeId,
       context: Context,
       processMetaData: MetaData,
   ): Unit = ()
 
   override def processingFinishedInNode(
-      nodeId: String,
+      nodeId: NodeId,
       context: Context,
       processMetaData: MetaData,
   ): Unit = ()
 
   override def endEncountered(
-      nodeId: String,
+      nodeId: NodeId,
       ref: String,
       context: Context,
       processMetaData: MetaData
   ): Unit = {}
 
   override def deadEndEncountered(
-      lastNodeId: String,
+      lastNodeId: NodeId,
       context: Context,
       processMetaData: MetaData
   ): Unit = {}
 
   override def expressionEvaluated(
-      nodeId: String,
+      nodeId: NodeId,
       expressionId: String,
       expression: String,
       context: Context,
@@ -76,7 +76,7 @@ trait EmptyProcessListener extends ProcessListener {
   ): Unit = {}
 
   override def serviceInvoked(
-      nodeId: String,
+      nodeId: NodeId,
       id: String,
       context: Context,
       processMetaData: MetaData,

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/dict/DictRegistry.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/dict/DictRegistry.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.api.dict
 
 import cats.data.Validated
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, ProcessCompilationError}
 import pl.touk.nussknacker.engine.api.dict.DictRegistry._
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
@@ -40,13 +41,13 @@ trait EngineDictRegistry extends DictRegistry {
 object DictRegistry {
 
   sealed trait DictLookupError {
-    def toPartSubGraphCompilationError(nodeId: String, paramName: ParameterName): PartSubGraphCompilationError
+    def toPartSubGraphCompilationError(nodeId: NodeId, paramName: ParameterName): PartSubGraphCompilationError
   }
 
   case class DictNotDeclared(dictId: String) extends DictLookupError {
 
     override def toPartSubGraphCompilationError(
-        nodeId: String,
+        nodeId: NodeId,
         paramName: ParameterName
     ): PartSubGraphCompilationError =
       ProcessCompilationError.DictNotDeclared(dictId, nodeId, paramName)
@@ -57,7 +58,7 @@ object DictRegistry {
       extends DictLookupError {
 
     override def toPartSubGraphCompilationError(
-        nodeId: String,
+        nodeId: NodeId,
         paramName: ParameterName
     ): PartSubGraphCompilationError =
       ProcessCompilationError.DictEntryWithLabelNotExists(dictId, label, possibleLabels, nodeId, paramName)
@@ -68,7 +69,7 @@ object DictRegistry {
       extends DictLookupError {
 
     override def toPartSubGraphCompilationError(
-        nodeId: String,
+        nodeId: NodeId,
         paramName: ParameterName
     ): PartSubGraphCompilationError =
       ProcessCompilationError.DictEntryWithKeyNotExists(dictId, key, possibleKeys, nodeId, paramName)

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
@@ -9,24 +9,12 @@ sealed trait ScenarioTestRecord {
   val sourceId: NodeId
 }
 
-case class ScenarioTestSourceSpecificFormatJsonRecord(sourceId: NodeId, record: Json, timestamp: Option[Long])
+case class ScenarioTestSourceSpecificFormatJsonRecord(sourceId: NodeId, record: Json, timestamp: Option[Long] = None)
     extends ScenarioTestRecord
 case class ScenarioTestCommonFormatJsonRecord(sourceId: NodeId, variables: Map[String, Json], timestamp: Option[Long])
     extends ScenarioTestRecord
 case class ScenarioTestParametersRecord(sourceId: NodeId, parameterExpressions: Map[ParameterName, Expression])
     extends ScenarioTestRecord
-
-object ScenarioTestSourceSpecificFormatJsonRecord {
-
-  def apply(
-      sourceId: String,
-      record: Json,
-      timestamp: Option[Long] = None
-  ): ScenarioTestSourceSpecificFormatJsonRecord = {
-    ScenarioTestSourceSpecificFormatJsonRecord(NodeId(sourceId), record, timestamp)
-  }
-
-}
 
 /**
  * Holds test records for a scenario. The difference to [[TestData]] is that records are assigned to the individual sources in the scenario.

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/testmode/TestProcess.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/testmode/TestProcess.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.testmode
 
-import pl.touk.nussknacker.engine.api.{Context, ContextId}
+import pl.touk.nussknacker.engine.api.{Context, ContextId, NodeId}
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 
 import java.time.Instant
@@ -8,22 +8,22 @@ import java.time.Instant
 object TestProcess {
 
   case class TestResults[T](
-      nodeResults: Map[String, List[ResultContext[T]]],
+      nodeResults: Map[NodeId, List[ResultContext[T]]],
       nodeTransitionResults: Map[NodeTransition, List[ResultContext[T]]],
-      invocationResults: Map[String, List[ExpressionInvocationResult[T]]],
-      externalInvocationResults: Map[String, List[ExternalInvocationResult[T]]],
+      invocationResults: Map[NodeId, List[ExpressionInvocationResult[T]]],
+      externalInvocationResults: Map[NodeId, List[ExternalInvocationResult[T]]],
       exceptions: List[ExceptionResult[T]]
   ) {
 
-    def updateNodeResult(nodeId: String, context: Context, variableEncoder: Any => T): TestResults[T] =
+    def updateNodeResult(nodeId: NodeId, context: Context, variableEncoder: Any => T): TestResults[T] =
       copy(nodeResults =
         nodeResults + (nodeId -> (nodeResults.getOrElse(nodeId, List()) :+ ResultContext
           .fromContext(context, Instant.now(), variableEncoder)))
       )
 
     def updateNodeOutputResult(
-        nodeId: String,
-        nextNodeIdOpt: Option[String],
+        nodeId: NodeId,
+        nextNodeIdOpt: Option[NodeId],
         context: Context,
         variableEncoder: Any => T
     ): TestResults[T] = {
@@ -36,7 +36,7 @@ object TestProcess {
     }
 
     def updateExpressionResult(
-        nodeId: String,
+        nodeId: NodeId,
         context: Context,
         name: String,
         result: Any,
@@ -49,7 +49,7 @@ object TestProcess {
     }
 
     def updateExternalInvocationResult(
-        nodeId: String,
+        nodeId: NodeId,
         contextId: ContextId,
         name: String,
         result: Any,
@@ -104,7 +104,7 @@ object TestProcess {
 
   }
 
-  final case class NodeTransition(sourceNodeId: String, destinationNodeId: Option[String])
+  final case class NodeTransition(sourceNodeId: NodeId, destinationNodeId: Option[NodeId])
 
   case class ExpressionInvocationResult[T](contextId: ContextId, timestamp: Instant, name: String, value: T)
 
@@ -125,7 +125,7 @@ object TestProcess {
 
   }
 
-  case class ExceptionResult[T](context: ResultContext[T], nodeId: Option[String], throwable: Throwable)
+  case class ExceptionResult[T](context: ResultContext[T], nodeId: Option[NodeId], throwable: Throwable)
 
   object ResultContext {
     def fromContext[T](context: Context, timestamp: Instant, variableEncoder: Any => T): ResultContext[T] =

--- a/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/CollectedLiveData.scala
+++ b/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/CollectedLiveData.scala
@@ -5,6 +5,7 @@ import io.circe._
 import io.circe.generic.semiauto._
 import io.circe.syntax.EncoderOps
 import pl.touk.nussknacker.engine.api.{ContextId, ContextIdPathPart, NodeId}
+import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.util.Implicits.{RichScalaMap, RichTupleList}
 
 import java.time.Instant
@@ -27,8 +28,8 @@ object CollectedLiveData {
   private implicit def contextIdCodec: Codec[ContextId] =
     Codec.forProduct5("sn", "nid", "tid", "idx", "path")(
       (
-          scenarioName: String,
-          nodeId: String,
+          scenarioName: ProcessName,
+          nodeId: NodeId,
           taskId: Long,
           index: Long,
           path: List[ContextIdPathPart]
@@ -40,9 +41,6 @@ object CollectedLiveData {
 
   private implicit val instantEncoder: Encoder[Instant] = Encoder.encodeLong.contramap(_.getEpochSecond)
   private implicit val instantDecoder: Decoder[Instant] = Decoder.decodeLong.map(Instant.ofEpochSecond)
-
-  private implicit val nodeIdEncoder: Encoder[NodeId] = Encoder.encodeString.contramap(_.id)
-  private implicit val nodeIdDecoder: Decoder[NodeId] = Decoder.decodeString.map(NodeId(_))
 
   private implicit val nodeTransitionEncoder: Encoder[NodeTransition] = deriveEncoder
   private implicit val nodeTransitionDecoder: Decoder[NodeTransition] = deriveDecoder
@@ -171,4 +169,4 @@ case class LiveDataSample(
     variables: Map[String, Json],
 )
 
-final case class NodeTransition(sourceNodeId: String, destinationNodeId: Option[String])
+final case class NodeTransition(sourceNodeId: NodeId, destinationNodeId: Option[NodeId])

--- a/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListener.scala
+++ b/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListener.scala
@@ -28,14 +28,14 @@ class LiveDataCollectingListener private[livedata] (
   private val variableEncoder: Any => io.circe.Json = TestInterpreterRunner.testResultsVariableEncoder
 
   override def nodeEntered(
-      nodeId: String,
+      nodeId: NodeId,
       context: Context,
       processMetaData: MetaData,
   ): Unit = ()
 
   override def transitionToNextNode(
-      nodeId: String,
-      nextNodeId: String,
+      nodeId: NodeId,
+      nextNodeId: NodeId,
       context: Context,
       processMetaData: MetaData,
   ): Unit = performStorageOperation {
@@ -46,7 +46,7 @@ class LiveDataCollectingListener private[livedata] (
   }
 
   override def processingFinishedInNode(
-      nodeId: String,
+      nodeId: NodeId,
       context: Context,
       processMetaData: MetaData,
   ): Unit = performStorageOperation {
@@ -57,20 +57,20 @@ class LiveDataCollectingListener private[livedata] (
   }
 
   override def endEncountered(
-      nodeId: String,
+      nodeId: NodeId,
       ref: String,
       context: Context,
       processMetaData: MetaData,
   ): Unit = ()
 
   override def deadEndEncountered(
-      lastNodeId: String,
+      lastNodeId: NodeId,
       context: Context,
       processMetaData: MetaData,
   ): Unit = ()
 
   override def expressionEvaluated(
-      nodeId: String,
+      nodeId: NodeId,
       expressionId: String,
       expression: String,
       context: Context,
@@ -78,20 +78,20 @@ class LiveDataCollectingListener private[livedata] (
       result: Any,
   ): Unit = performStorageOperation {
     _.addExpressionEvaluation(
-      NodeId(nodeId),
+      nodeId,
       InvocationResult(context.id, Instant.now(), expressionId, encode(result)),
     )
   }
 
   override def serviceInvoked(
-      nodeId: String,
+      nodeId: NodeId,
       id: String,
       context: Context,
       processMetaData: MetaData,
       result: Try[Any],
   ): Unit = performStorageOperation {
     _.addExternalInvocation(
-      NodeId(nodeId),
+      nodeId,
       InvocationResult(context.id, Instant.now(), id, result.map(encode).getOrElse(Json.Null)),
     )
   }
@@ -103,7 +103,7 @@ class LiveDataCollectingListener private[livedata] (
       case Some(nodeComponentInfo) =>
         performStorageOperation {
           _.addException(
-            NodeId(nodeComponentInfo.nodeId),
+            nodeComponentInfo.nodeId,
             ExceptionResult(
               exceptionInfo.context.id,
               Instant.now(),

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/MissingSinkHandler.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/MissingSinkHandler.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.engine.canonize
 
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.graph.node
 
 // This trait and its 2 implementation encapsulate the logic of handling scenarios that do not end with sink
@@ -8,7 +9,7 @@ import pl.touk.nussknacker.engine.graph.node
 sealed trait MissingSinkHandler {
 
   def handleMissingSink(
-      previousNodeId: String,
+      previousNodeId: NodeId,
       nodeOnMissingSink: Option[node.SubsequentNode],
   ): MaybeArtificial[Option[node.SubsequentNode]]
 
@@ -19,7 +20,7 @@ object MissingSinkHandler {
   object AllowMissingSinkHandler extends MissingSinkHandler {
 
     override def handleMissingSink(
-        previousNodeId: String,
+        previousNodeId: NodeId,
         nodeOnMissingSink: Option[node.SubsequentNode],
     ): MaybeArtificial[Option[node.SubsequentNode]] =
       new MaybeArtificial(nodeOnMissingSink, Nil)
@@ -29,7 +30,7 @@ object MissingSinkHandler {
   object DoNotAllowMissingSinkHandler extends MissingSinkHandler {
 
     override def handleMissingSink(
-        previousNodeId: String,
+        previousNodeId: NodeId,
         nodeOnMissingSink: Option[node.SubsequentNode],
     ): MaybeArtificial[Option[node.SubsequentNode]] =
       new MaybeArtificial(nodeOnMissingSink, InvalidTailOfBranch(previousNodeId) :: Nil)

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/ProcessCanonizer.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/ProcessCanonizer.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.canonize
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.instances.list._
 import cats.syntax.traverse._
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.canonicalgraph._
 import pl.touk.nussknacker.engine.graph._
 import pl.touk.nussknacker.engine.graph.node.{BranchEnd, BranchEndData}
@@ -46,7 +47,7 @@ object ProcessCanonizer {
       case (a @ canonicalnode.FlatNode(data: node.StartingNodeData)) :: tail =>
         uncanonize(a, tail).map(node.SourceNode(data, _))
       case other :: _ =>
-        MaybeArtificial.artificialSource(InvalidRootNode(other.id))
+        MaybeArtificial.artificialSource(InvalidRootNode(NodeId(other.id)))
 
       case _ =>
         MaybeArtificial.artificialSource(EmptyProcess)
@@ -96,7 +97,7 @@ object ProcessCanonizer {
         }
 
       case canonicalnode.SplitNode(bare, Nil) :: Nil =>
-        missingSinkHandler.handleMissingSink(bare.id, Some(node.SplitNode(bare, List.empty)))
+        missingSinkHandler.handleMissingSink(NodeId(bare.id), Some(node.SplitNode(bare, List.empty)))
 
       case (a @ canonicalnode.SplitNode(bare, nexts)) :: Nil =>
         nexts
@@ -107,10 +108,10 @@ object ProcessCanonizer {
           }
 
       case invalidHead :: _ =>
-        MaybeArtificial.missingSinkError(InvalidTailOfBranch(invalidHead.id))
+        MaybeArtificial.missingSinkError(InvalidTailOfBranch(NodeId(invalidHead.id)))
 
       case Nil =>
-        missingSinkHandler.handleMissingSink(previous.id, None)
+        missingSinkHandler.handleMissingSink(NodeId(previous.id), None)
     }
 
 }

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/ProcessUncanonizationError.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonize/ProcessUncanonizationError.scala
@@ -1,13 +1,15 @@
 package pl.touk.nussknacker.engine.canonize
 
+import pl.touk.nussknacker.engine.api.NodeId
+
 sealed trait ProcessUncanonizationError
 
 object EmptyProcess extends ProcessUncanonizationError
 
 sealed trait ProcessUncanonizationNodeError extends ProcessUncanonizationError {
-  def nodeId: String
+  def nodeId: NodeId
 }
 
-case class InvalidRootNode(nodeId: String) extends ProcessUncanonizationNodeError
+case class InvalidRootNode(nodeId: NodeId) extends ProcessUncanonizationNodeError
 
-case class InvalidTailOfBranch(nodeId: String) extends ProcessUncanonizationNodeError
+case class InvalidTailOfBranch(nodeId: NodeId) extends ProcessUncanonizationNodeError

--- a/scenario-api/src/test/scala/pl/touk/nussknacker/engine/marshall/ProcessMarshallerSpec.scala
+++ b/scenario-api/src/test/scala/pl/touk/nussknacker/engine/marshall/ProcessMarshallerSpec.scala
@@ -230,7 +230,7 @@ class ProcessMarshallerSpec
           CanonicalProcess(MetaData("1", StreamMetaData()), nodes.toList, List.empty),
           DoNotAllowMissingSinkHandler,
         )
-      ) { case Invalid(NonEmptyList(canonize.InvalidTailOfBranch(id), Nil)) =>
+      ) { case Invalid(NonEmptyList(canonize.InvalidTailOfBranch(NodeId(id)), Nil)) =>
         id shouldBe expectedBadNodeId
       }
     }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/Interpreter.scala
@@ -54,15 +54,15 @@ private class InterpreterInternal[F[_]: Monad](
     NuExceptionInfo(Some(NodeComponentInfoExtractor.fromCompiledNode(node)), _, ctx)
   }
 
-  private def onTransitionToNextNode(nodeId: String, nextNode: Next, ctx: Context): Unit = {
+  private def onTransitionToNextNode(nodeId: NodeId, nextNode: Next, ctx: Context): Unit = {
     val nextNodeId = nextNode match {
       case NextNode(BranchEnd(definition)) => definition.joinId
       case other                           => other.id
     }
-    listeners.foreach(_.transitionToNextNode(nodeId, nextNodeId, ctx, jobData.metaData))
+    listeners.foreach(_.transitionToNextNode(nodeId, NodeId(nextNodeId), ctx, jobData.metaData))
   }
 
-  private def onProcessingFinishedInNode(nodeId: String, ctx: Context): Unit = {
+  private def onProcessingFinishedInNode(nodeId: NodeId, ctx: Context): Unit = {
     listeners.foreach(_.processingFinishedInNode(nodeId, ctx, jobData.metaData))
   }
 
@@ -73,7 +73,7 @@ private class InterpreterInternal[F[_]: Monad](
       // We do not invoke listener 'nodeEntered' here for nodes which are wrapped in PartRef by ProcessSplitter.
       // These are handled in interpretNext method
       case CustomNode(_, _, _) | EndingCustomNode(_, _) | Sink(_, _, _) | FragmentOutput(_, _, _) =>
-      case _ => listeners.foreach(_.nodeEntered(node.id, ctx, jobData.metaData))
+      case _ => listeners.foreach(_.nodeEntered(NodeId(node.id), ctx, jobData.metaData))
     }
     node match {
       case Source(_, _, next) =>
@@ -82,7 +82,7 @@ private class InterpreterInternal[F[_]: Monad](
         val variable = createOrUpdateVariable(ctx, varName, fields)
         interpretOptionalNext(node, next, variable)
       case VariableBuilder(_, varName, Left(expression), next) =>
-        val valueWithModifiedContext = expressionEvaluator.evaluate[Any](expression, varName, node.id, ctx)
+        val valueWithModifiedContext = expressionEvaluator.evaluate[Any](expression, varName, NodeId(node.id), ctx)
         interpretOptionalNext(node, next, ctx.withVariable(varName, valueWithModifiedContext.value))
       case FragmentUsageStart(_, params, next) =>
         val (newCtx, vars) = expressionEvaluator.evaluateParameters(params, ctx)
@@ -106,8 +106,8 @@ private class InterpreterInternal[F[_]: Monad](
         // - the `interpretOptionalNext` method triggers only reporting of the transition between the last node of the fragment graph and the next node
         // - we have to also report the transition between the single node representing the entire fragment and the next node
         next match {
-          case Some(next) => onTransitionToNextNode(fragmentUsageStartNodeId, next, newParentContext)
-          case None       => onProcessingFinishedInNode(fragmentUsageStartNodeId, newParentContext)
+          case Some(next) => onTransitionToNextNode(NodeId(fragmentUsageStartNodeId), next, newParentContext)
+          case None       => onProcessingFinishedInNode(NodeId(fragmentUsageStartNodeId), newParentContext)
         }
         interpretOptionalNext(node, next, newParentContext)
       case Processor(_, ref, next, false) =>
@@ -121,7 +121,7 @@ private class InterpreterInternal[F[_]: Monad](
       case Processor(_, _, next, true) =>
         interpretOptionalNext(node, next, ctx)
       case EndingProcessor(id, ref, false) =>
-        listeners.foreach(_.endEncountered(id, ref.id, ctx, jobData.metaData))
+        listeners.foreach(_.endEncountered(NodeId(id), ref.id, ctx, jobData.metaData))
         invokeWrappedInInterpreterShape(ref, ctx).map {
           // for Processor the result is null/BoxedUnit/Void etc. so we ignore it
           case Left(ValueWithContext(_, newCtx)) =>
@@ -136,23 +136,23 @@ private class InterpreterInternal[F[_]: Monad](
         fieldsWithExpression.toList
           .traverse(a =>
             Either
-              .catchNonFatal(a._1 -> expressionEvaluator.evaluate(a._2.expression, a._1, id, ctx).value)
+              .catchNonFatal(a._1 -> expressionEvaluator.evaluate(a._2.expression, a._1, NodeId(id), ctx).value)
               .toValidatedNel
           )
           .map(_.toMap)
           .fold(
             exceptions => {
-              listeners.foreach(_.nodeEntered(node.id, ctx, jobData.metaData))
+              listeners.foreach(_.nodeEntered(NodeId(node.id), ctx, jobData.metaData))
               Monad[F].pure(exceptions.toList.map(exc => Right(handleError(node, ctx)(exc))))
             },
             fields => {
               val newCtx = ctx.withVariables(fields)
-              listeners.foreach(_.nodeEntered(node.id, newCtx, jobData.metaData))
+              listeners.foreach(_.nodeEntered(NodeId(node.id), newCtx, jobData.metaData))
               interpretationResult(node, FragmentEndReference(id, fields), newCtx)
             }
           )
       case Enricher(_, _, outName, next, Some(mockedOutput)) if runtimeMode == Test =>
-        val valueWithModifiedContext = expressionEvaluator.evaluate[Any](mockedOutput, outName, node.id, ctx)
+        val valueWithModifiedContext = expressionEvaluator.evaluate[Any](mockedOutput, outName, NodeId(node.id), ctx)
         interpretOptionalNext(node, next, ctx.withVariable(outName, valueWithModifiedContext.value))
       case Enricher(_, ref, outName, next, _) =>
         invokeWrappedInInterpreterShape(ref, ctx).flatMap {
@@ -196,22 +196,22 @@ private class InterpreterInternal[F[_]: Monad](
       case Sink(id, _, true) =>
         sinkInterpretationResult(EndReference(id), ctx)
       case Sink(id, ref, false) =>
-        listeners.foreach(_.endEncountered(id, ref, ctx, jobData.metaData))
+        listeners.foreach(_.endEncountered(NodeId(id), ref, ctx, jobData.metaData))
         sinkInterpretationResult(EndReference(id), ctx)
       case BranchEnd(e) =>
         Monad[F].pure(List(Left(InterpretationResult(e.joinReference, ctx))))
       case CustomNode(_, _, next) =>
         interpretOptionalNext(node, next, ctx)
       case EndingCustomNode(id, ref) =>
-        listeners.foreach(_.endEncountered(id, ref, ctx, jobData.metaData))
+        listeners.foreach(_.endEncountered(NodeId(id), ref, ctx, jobData.metaData))
         interpretationResult(node, EndReference(id), ctx)
       case SplitNode(_, Nil) =>
-        onProcessingFinishedInNode(node.id, ctx)
+        onProcessingFinishedInNode(NodeId(node.id), ctx)
         Applicative[F].pure(List.empty)
       case SplitNode(_, nexts) =>
         import cats.implicits._
         nexts
-          .map(next => interpretNext(node, next, ctx.withContextIdPathPart(node.id, next.id)))
+          .map(next => interpretNext(node, next, ctx.withContextIdPathPart(NodeId(node.id), next.id)))
           .sequence
           .map(_.flatten)
     }
@@ -229,7 +229,7 @@ private class InterpreterInternal[F[_]: Monad](
       reference: PartReference,
       ctx: Context
   ): FF[List[Result[InterpretationResult]]] = {
-    onProcessingFinishedInNode(node.id, ctx)
+    onProcessingFinishedInNode(NodeId(node.id), ctx)
     Applicative[FF].pure(List(Left(InterpretationResult(reference, ctx))))
   }
 
@@ -245,7 +245,7 @@ private class InterpreterInternal[F[_]: Monad](
         // todo: perhaps we should refactor the way DeadEndingData is used, all nodes can be dead ends now
         node match {
           case Filter(_, _, _, _, _) | Switch(_, _, _, _) =>
-            listeners.foreach(_.deadEndEncountered(node.id, ctx, jobData.metaData))
+            listeners.foreach(_.deadEndEncountered(NodeId(node.id), ctx, jobData.metaData))
           case _ =>
             ()
         }
@@ -254,12 +254,12 @@ private class InterpreterInternal[F[_]: Monad](
   }
 
   private def interpretNext(node: Node, next: Next, ctx: Context): F[List[Result[InterpretationResult]]] = {
-    onTransitionToNextNode(node.id, next, ctx)
+    onTransitionToNextNode(NodeId(node.id), next, ctx)
     next match {
       case NextNode(node) =>
         interpret(node, ctx)
       case pr @ PartRef(ref) =>
-        listeners.foreach(_.nodeEntered(pr.id, ctx, jobData.metaData))
+        listeners.foreach(_.nodeEntered(NodeId(pr.id), ctx, jobData.metaData))
         Monad[F].pure(List(Left(InterpretationResult(NextPartReference(ref), ctx))))
     }
   }
@@ -271,7 +271,7 @@ private class InterpreterInternal[F[_]: Monad](
       ctx.modifyOptionalVariable[java.util.Map[String, Any]](varName, _.getOrElse(new java.util.HashMap[String, Any]()))
 
     fields.foldLeft(contextWithInitialVariable) { case (context, field) =>
-      val valueWithContext = expressionEvaluator.evaluate[Any](field.expression, field.name, node.id, context)
+      val valueWithContext = expressionEvaluator.evaluate[Any](field.expression, field.name, NodeId(node.id), context)
       valueWithContext.context.modifyVariable[java.util.Map[String, Any]](
         varName,
         { m =>
@@ -290,7 +290,9 @@ private class InterpreterInternal[F[_]: Monad](
     {
       import scala.jdk.CollectionConverters._
       val fieldsMap = fields
-        .map(field => (field.name, expressionEvaluator.evaluate[Any](field.expression, field.name, node.id, ctx).value))
+        .map(field =>
+          (field.name, expressionEvaluator.evaluate[Any](field.expression, field.name, NodeId(node.id), ctx).value)
+        )
         .toMap
         .asJava
 
@@ -315,7 +317,7 @@ private class InterpreterInternal[F[_]: Monad](
     val resultFuture                                      = ref.invoke(ctx, serviceExecutionContext)
     import SynchronousExecutionContextAndIORuntime.syncEc
     resultFuture.onComplete { result =>
-      listeners.foreach(_.serviceInvoked(node.id, ref.id, ctx, jobData.metaData, result))
+      listeners.foreach(_.serviceInvoked(NodeId(node.id), ref.id, ctx, jobData.metaData, result))
     }
     resultFuture.map(ValueWithContext(_, ctx))
   }
@@ -323,7 +325,7 @@ private class InterpreterInternal[F[_]: Monad](
   private def evaluateExpression[R](expr: CompiledExpression, ctx: Context, name: String)(
       implicit node: Node
   ): ValueWithContext[R] = {
-    expressionEvaluator.evaluate(expr, name, node.id, ctx)
+    expressionEvaluator.evaluate(expr, name, NodeId(node.id), ctx)
   }
 
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/CompilationResult.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/CompilationResult.scala
@@ -6,6 +6,7 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.instances.map._
 import cats.kernel.Semigroup
 import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ProcessUncanonizationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{
   EmptyProcess,
@@ -84,7 +85,7 @@ object CompilationResult extends Applicative[CompilationResult] {
     def mergeErrors[T <: ProcessUncanonizationError: ClassTag](
         collectedSoFar: NonEmptyList[ProcessUncanonizationError],
         error: ProcessUncanonizationNodeError,
-        create: Set[String] => T
+        create: Set[NodeId] => T
     ): NonEmptyList[ProcessUncanonizationError] = {
       val (matching, nonMatching) = collectedSoFar.toList.partition {
         case _: T => true

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
@@ -208,7 +208,7 @@ class ExpressionCompiler(
       parameterByName <- nodeParameters
         .map(param => (param.name, param))
         .toMapCheckingDuplicates
-        .leftMap(duplicatedKeys => NonEmptyList.of(DuplicatedParameters(duplicatedKeys.toList.toSet, nodeId.id)))
+        .leftMap(duplicatedKeys => NonEmptyList.of(DuplicatedParameters(duplicatedKeys.toList.toSet, nodeId)))
         .toIor
       compiledParams <- compileParameters(parameterByName).toIor
       paramValidatorsMap     = parameterValidatorsMap(parameterDefinitions, inputContext.globalVariables)
@@ -276,7 +276,7 @@ class ExpressionCompiler(
     def substitute(dictId: String) = {
       DictKeyWithLabelExpressionParser
         .parseDictKeyWithLabelExpression(expression.expression)
-        .leftMap(errs => errs.map(_.toProcessCompilationError(nodeId.id, paramName)))
+        .leftMap(errs => errs.map(_.toProcessCompilationError(nodeId, paramName)))
         .andThen(expr =>
           dictRegistry match {
             case _: EngineDictRegistry =>
@@ -285,10 +285,10 @@ class ExpressionCompiler(
             case _ =>
               dictRegistry
                 .labelByKey(dictId, expr.key)
-                .leftMap(e => NonEmptyList.of(e.toPartSubGraphCompilationError(nodeId.id, paramName)))
+                .leftMap(e => NonEmptyList.of(e.toPartSubGraphCompilationError(nodeId, paramName)))
                 .andThen {
                   case Some(label) => Valid(Expression.dictKeyWithLabel(expr.key, Some(label)))
-                  case None        => invalidNel(DictLabelByKeyResolutionFailed(dictId, expr.key, nodeId.id, paramName))
+                  case None        => invalidNel(DictLabelByKeyResolutionFailed(dictId, expr.key, nodeId, paramName))
                 }
           }
         )
@@ -298,7 +298,7 @@ class ExpressionCompiler(
       expression.language == DictKeyWithLabel
 
     val incompatibleChangeToParameterDefinitionDetected: ValidatedNel[PartSubGraphCompilationError, Expression] =
-      invalidNel(IncompatibleParameterDefinitionModification(paramName, expression.language, editors, nodeId.id))
+      invalidNel(IncompatibleParameterDefinitionModification(paramName, expression.language, editors, nodeId))
 
     def validateAndSubstitute(expression: Expression): ValidatedNel[PartSubGraphCompilationError, Expression] = {
       editors match {
@@ -355,7 +355,7 @@ class ExpressionCompiler(
       case e: ExpressionParserCompilationError =>
         InvalidValidationExpression(
           e.message,
-          nodeId.id,
+          nodeId,
           paramName,
           e.originalExpr
         )
@@ -366,7 +366,7 @@ class ExpressionCompiler(
           invalidNel(
             InvalidValidationExpression(
               "Validation expression cannot be blank",
-              nodeId.id,
+              nodeId,
               paramName,
               toCompileValidator.validationExpression.expression
             )

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/FragmentResolver.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/FragmentResolver.scala
@@ -65,10 +65,10 @@ case class FragmentResolver(fragments: ProcessName => Option[CanonicalProcess]) 
       {
         case canonicalnode.Fragment(FragmentInput(dataId, _, _, Some(true), _), nextNodes)
             if nextNodes.values.size > 1 =>
-          invalidBranches(DisablingManyOutputsFragment(dataId))
+          invalidBranches(DisablingManyOutputsFragment(NodeId(dataId)))
         case canonicalnode.Fragment(FragmentInput(dataId, _, _, Some(true), _), nextNodes)
             if nextNodes.values.isEmpty =>
-          invalidBranches(DisablingNoOutputsFragment(dataId))
+          invalidBranches(DisablingNoOutputsFragment(NodeId(dataId)))
         case canonicalnode.Fragment(data @ FragmentInput(_, _, _, Some(true), _), nextNodesMap) =>
           // TODO: disabling nodes should be in one place
           val output = nextNodesMap.keys.head
@@ -132,11 +132,11 @@ case class FragmentResolver(fragments: ProcessName => Option[CanonicalProcess]) 
     fragments
       .apply(ProcessName(fragmentInput.ref.id))
       .map(valid)
-      .getOrElse(invalidNel(UnknownFragment(id = fragmentInput.ref.id, nodeId = nodeId.id)))
+      .getOrElse(invalidNel(UnknownFragment(id = fragmentInput.ref.id, nodeId = nodeId)))
       .andThen { fragment =>
         FragmentGraphDefinitionExtractor
           .extractFragmentGraphDefinition(fragment)
-          .leftMap(_ => InvalidFragment(id = fragmentInput.ref.id, nodeId = nodeId.id))
+          .leftMap(_ => InvalidFragment(id = fragmentInput.ref.id, nodeId = nodeId))
           .toValidatedNel
       }
   }
@@ -163,7 +163,7 @@ case class FragmentResolver(fragments: ProcessName => Option[CanonicalProcess]) 
                   FragmentUsageOutput(id, parentId, name, Some(FragmentOutputVarDefinition(outputName, fields)), add)
                 ) :: nodes
               )
-            case _ => invalidBranches(FragmentOutputNotDefined(name, Set(id, parentId)))
+            case _ => invalidBranches(FragmentOutputNotDefined(name, Set(NodeId(id), NodeId(parentId))))
           }
         }
       },

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/FragmentValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/FragmentValidator.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.compile
 import cats.data.Validated.{invalidNel, valid}
 import cats.data.ValidatedNel
 import cats.implicits._
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.DuplicateFragmentOutputNamesInFragment
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -20,7 +21,7 @@ object FragmentValidator {
       val duplicatedOutputNamesWithNodeIds = fragmentOutputNodes
         .groupBy(_.outputName)
         .collect {
-          case (name, nodes) if nodes.size > 1 => name -> nodes.map(_.id).toSet
+          case (name, nodes) if nodes.size > 1 => name -> nodes.map(n => NodeId(n.id)).toSet
         }
       duplicatedOutputNamesWithNodeIds
         .map(n => invalidNel(DuplicateFragmentOutputNamesInFragment(n._1, n._2)))

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/IdValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/IdValidator.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.compile
 import cats.data.Validated.{invalidNel, valid}
 import cats.data.ValidatedNel
 import cats.implicits._
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.process.ProcessName
@@ -16,7 +17,7 @@ object IdValidator {
   def validate(process: CanonicalProcess, isFragment: Boolean): ValidatedNel[ProcessCompilationError, Unit] = {
     val scenarioIdValidationResult = validateScenarioName(process.name, isFragment)
     val nodesIdValidationResult = process.nodes
-      .map(node => validateNodeId(node.data.id))
+      .map(node => validateNodeId(NodeId(node.data.id)))
       .combineAll
 
     scenarioIdValidationResult.combine(nodesIdValidationResult)
@@ -28,8 +29,8 @@ object IdValidator {
   ): ValidatedNel[ProcessCompilationError, Unit] =
     validateId(scenarioName.value).leftMap(_.map(ScenarioNameError(_, scenarioName, isFragment)))
 
-  def validateNodeId(nodeId: String): ValidatedNel[ProcessCompilationError, Unit] =
-    validateId(nodeId, nodeIdIllegalCharacters, nodeIdIllegalCharactersReadable)
+  def validateNodeId(nodeId: NodeId): ValidatedNel[ProcessCompilationError, Unit] =
+    validateId(nodeId.id, nodeIdIllegalCharacters, nodeIdIllegalCharactersReadable)
       .leftMap(_.map(NodeIdValidationError(_, nodeId)))
 
   private def validateId(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/NodeValidationExceptionHandler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/NodeValidationExceptionHandler.scala
@@ -30,7 +30,7 @@ object NodeValidationExceptionHandler extends LazyLogging {
       f
     } catch {
       case MissingOutputVariableException =>
-        Validated.invalidNel(MissingParameters(Set(ParameterName("OutputVariable")), nodeId.id))
+        Validated.invalidNel(MissingParameters(Set(ParameterName("OutputVariable")), nodeId))
       case exc: CustomNodeValidationException =>
         Validated.invalidNel(CustomNodeError(exc.message, exc.paramName))
       case NonFatal(e) =>
@@ -38,7 +38,7 @@ object NodeValidationExceptionHandler extends LazyLogging {
           s"Exception during validation handling of node '${nodeId.id}' in scenario ${metaData.name.value}",
           e
         )
-        Validated.invalidNel(CannotCreateObjectError(e, nodeId.id))
+        Validated.invalidNel(CannotCreateObjectError(e, nodeId))
     }
   }
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -151,7 +151,7 @@ class PartSubGraphCompiler(nodeCompiler: NodeCompiler) {
 
       // probably this shouldn't occur - otherwise we'd have empty fragment?
       case FragmentInput(id, _, _, _, _) =>
-        toCompilationResult(Invalid(NonEmptyList.of(UnresolvedFragment(id))), Map.empty, None)
+        toCompilationResult(Invalid(NonEmptyList.of(UnresolvedFragment(NodeId(id)))), Map.empty, None)
 
       case FragmentOutputDefinition(id, _, Nil, _) =>
         // TODO: should we validate it's process?

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
@@ -4,7 +4,7 @@ import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.data.Validated._
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine._
-import pl.touk.nussknacker.engine.api.JobData
+import pl.touk.nussknacker.engine.api.{JobData, NodeId}
 import pl.touk.nussknacker.engine.api.component.NodesDeploymentData
 import pl.touk.nussknacker.engine.api.context._
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
@@ -167,7 +167,7 @@ protected trait ProcessCompilerBase {
   private def findDuplicates(parts: NonEmptyList[SourcePart]): Validated[ProcessCompilationError, Unit] = {
     val allNodes = NodesCollector.collectNodesInAllParts(parts)
     val duplicatedIds =
-      allNodes.map(_.id).groupBy(identity).collect {
+      allNodes.map(n => NodeId(n.id)).groupBy(identity).collect {
         case (id, grouped) if grouped.size > 1 =>
           id
       }
@@ -199,7 +199,7 @@ protected trait ProcessCompilerBase {
         partInputContexts
           .get(p.id)
           .map(compileSubsequentPart(p, _))
-          .getOrElse(CompilationResult(Invalid(NonEmptyList.of[ProcessCompilationError](MissingPart(p.id)))))
+          .getOrElse(CompilationResult(Invalid(NonEmptyList.of[ProcessCompilationError](MissingPart(NodeId(p.id))))))
       )
       .sequence
   }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/FragmentParameterValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/FragmentParameterValidator.scala
@@ -58,7 +58,7 @@ case class FragmentParameterValidator(classDefinitions: ClassDefinitionSet) {
       initialValue: Option[FixedExpressionValue],
       refClazz: FragmentClazzRef,
       paramName: ParameterName,
-      nodeIds: Set[String]
+      nodeIds: Set[NodeId]
   ): ValidatedNel[PartSubGraphCompilationError, NonEmptyList[ParameterEditor]] = {
     validateValueEditorSupportedType(valueEditor, refClazz, paramName, nodeIds)
       .andThen(_ =>
@@ -75,7 +75,7 @@ case class FragmentParameterValidator(classDefinitions: ClassDefinitionSet) {
       valueEditor: ParameterValueInput,
       refClazz: FragmentClazzRef,
       paramName: ParameterName,
-      nodeIds: Set[String]
+      nodeIds: Set[NodeId]
   ): ValidatedNel[PartSubGraphCompilationError, Unit] = {
     if (permittedTypesForEditors.contains(refClazz))
       Valid(())
@@ -106,7 +106,7 @@ case class FragmentParameterValidator(classDefinitions: ClassDefinitionSet) {
               else
                 DictKeyWithLabelExpressionParser
                   .parseDictKeyWithLabelExpression(fixedExpressionValue.expression)
-                  .leftMap(errs => errs.map(_.toProcessCompilationError(nodeId.id, fragmentParameter.name)))
+                  .leftMap(errs => errs.map(_.toProcessCompilationError(nodeId, fragmentParameter.name)))
                   .andThen(e => valid(Expression.dictKeyWithLabel(e.key, e.label)))
             case _ => valid(Expression.spel(fixedExpressionValue.expression))
           }
@@ -126,7 +126,7 @@ case class FragmentParameterValidator(classDefinitions: ClassDefinitionSet) {
           case e: ExpressionParserCompilationError =>
             ExpressionParserCompilationErrorInFragmentDefinition(
               message = e.message,
-              nodeId = nodeId.id,
+              nodeId = nodeId,
               paramName = fragmentParameter.name,
               subFieldName = subFieldName,
               originalExpr = e.originalExpr
@@ -179,7 +179,7 @@ case class FragmentParameterValidator(classDefinitions: ClassDefinitionSet) {
                     dictId,
                     dictValueType,
                     fragmentParameterTypingResult,
-                    nodeId.id,
+                    nodeId,
                     qualifiedParamFieldName(fragmentParameter.name, Some(DictIdFieldName))
                   )
                 )
@@ -188,7 +188,7 @@ case class FragmentParameterValidator(classDefinitions: ClassDefinitionSet) {
               invalidNel(
                 DictNotDeclared(
                   dictId,
-                  nodeId.id,
+                  nodeId,
                   qualifiedParamFieldName(fragmentParameter.name, Some(DictIdFieldName))
                 )
               )
@@ -202,7 +202,7 @@ case class FragmentParameterValidator(classDefinitions: ClassDefinitionSet) {
     if (dictId.isBlank)
       invalidNel(
         EmptyMandatoryField(
-          nodeId.id,
+          nodeId,
           qualifiedParamFieldName(parameterName, Some(DictIdFieldName))
         )
       )
@@ -217,7 +217,7 @@ case class FragmentParameterValidator(classDefinitions: ClassDefinitionSet) {
       .groupBy(identity)
       .foldLeft(valid(()): ValidatedNel[ProcessCompilationError, Unit]) { case (acc, (paramName, group)) =>
         val duplicationError = if (group.size > 1) {
-          invalid(DuplicateFragmentInputParameter(paramName, nodeId.toString)).toValidatedNel
+          invalid(DuplicateFragmentInputParameter(paramName, nodeId)).toValidatedNel
         } else valid(())
         val validIdentifierError = validateVariableName(
           paramName.value,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
@@ -293,7 +293,7 @@ class NodeCompiler(
           if customNodeIsEndingNode.contains(
             true
           ) && !scenarioIsAllowedToEndWithoutSink && !componentDefinition.componentTypeSpecificData.asCustomComponentData.canBeEnding =>
-        val error = Invalid(NonEmptyList.of(InvalidTailOfBranch(Set(nodeId.id))))
+        val error = Invalid(NonEmptyList.of(InvalidTailOfBranch(Set(nodeId))))
         NodeCompilationResult(Map.empty, None, defaultCtxToUse, error)
       case Some(componentDefinition) =>
         compileComponentWithContextTransformation[AnyRef]( // For custom nodes, we don't have a base class yet

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeDataValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeDataValidator.scala
@@ -142,7 +142,7 @@ class NodeDataValidator(modelData: ModelData) {
           ValidationNotPerformed
       }
 
-      val nodeIdErrors = IdValidator.validateNodeId(nodeData.id) match {
+      val nodeIdErrors = IdValidator.validateNodeId(NodeId(nodeData.id)) match {
         case Validated.Valid(_)   => List.empty
         case Validated.Invalid(e) => e.toList
       }
@@ -171,7 +171,10 @@ class NodeDataValidator(modelData: ModelData) {
               .map { output =>
                 val maybeOutputName: Option[String] = a.ref.outputVariableNames.get(output)
                 val outputName =
-                  Validated.fromOption(maybeOutputName, NonEmptyList.one(UnknownFragmentOutput(output, Set(a.id))))
+                  Validated.fromOption(
+                    maybeOutputName,
+                    NonEmptyList.one(UnknownFragmentOutput(output, Set(NodeId(a.id))))
+                  )
                 outputName.andThen(name =>
                   inputContext.validationContext.withVariable(OutputVar.fragmentOutput(output, name), Unknown)
                 )
@@ -181,7 +184,7 @@ class NodeDataValidator(modelData: ModelData) {
             val outgoingEdgesValidated = outputs
               .map {
                 case Output(name, _) if !outgoingEdges.exists(_.edgeType.contains(EdgeType.FragmentOutput(name))) =>
-                  invalidNel(FragmentOutputNotDefined(name, Set(a.id)))
+                  invalidNel(FragmentOutputNotDefined(name, Set(NodeId(a.id))))
                 case _ =>
                   valid(())
               }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/RecordValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/RecordValidator.scala
@@ -68,7 +68,7 @@ object RecordValidator {
             "The key of a record has to be unique",
             "Record key not unique",
             ParameterName(fieldName),
-            nodeId.id
+            nodeId
           )
         )
       }.toValidatedNel

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/ValueEditorValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/ValueEditorValidator.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.compile.nodecompilation
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.data.Validated.{invalidNel, Valid}
 import cats.implicits.toTraverseOps
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.PartSubGraphCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.definition.{
@@ -29,7 +30,7 @@ object ValueEditorValidator {
       valueEditor: ParameterValueInput,
       initialValue: Option[FixedExpressionValue],
       paramName: ParameterName,
-      nodeIds: Set[String]
+      nodeIds: Set[NodeId]
   ): ValidatedNel[PartSubGraphCompilationError, NonEmptyList[ParameterEditor]] = {
     val validatedInnerEditor = valueEditor match {
       case ValueInputWithFixedValuesProvided(fixedValuesList, allowOtherValue) =>
@@ -53,7 +54,7 @@ object ValueEditorValidator {
       allowOtherValue: Boolean,
       initialValue: Option[FixedExpressionValue],
       paramName: ParameterName,
-      nodeIds: Set[String]
+      nodeIds: Set[NodeId]
   ): ValidatedNel[PartSubGraphCompilationError, Unit] =
     if (!allowOtherValue) {
       List(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/validator/ValidationExpressionParameterValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/validator/ValidationExpressionParameterValidator.scala
@@ -39,7 +39,7 @@ case class ValidationExpressionParameterValidator(
     val context = Context(ContextId.dummy, Map(variableName -> value), None)
 
     Try(
-      expressionEvaluator.evaluate[java.lang.Boolean](validationExpression, "validationExpression", nodeId.id, context)(
+      expressionEvaluator.evaluate[java.lang.Boolean](validationExpression, "validationExpression", nodeId, context)(
         jobData
       )
     ).fold(
@@ -51,14 +51,14 @@ case class ValidationExpressionParameterValidator(
             description =
               s"Please provide value that satisfies the validation expression '${validationExpression.original}'",
             paramName = paramName,
-            nodeId = nodeId.id
+            nodeId = nodeId
           )
         ),
-      result => if (result.value) valid(()) else invalid(error(paramName, nodeId.id))
+      result => if (result.value) valid(()) else invalid(error(paramName, nodeId))
     )
   }
 
-  private def error(paramName: ParameterName, nodeId: String): CustomParameterValidationError =
+  private def error(paramName: ParameterName, nodeId: NodeId): CustomParameterValidationError =
     CustomParameterValidationError(
       validationFailedMessage.getOrElse(
         s"This field has to satisfy the validation expression '${validationExpression.original}'"

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/fragment/FragmentGraphDefinition.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/fragment/FragmentGraphDefinition.scala
@@ -18,7 +18,7 @@ class FragmentGraphDefinition(
 
   def validOutputs(implicit nodeId: NodeId): ValidatedNel[ProcessCompilationError, Set[Output]] = {
     NonEmptyList.fromList(allOutputs.groupBy(_.name).filter(_._2.size > 1).toList) match {
-      case Some(groups) => invalid(groups.map(gr => DuplicateFragmentOutputNamesInScenario(gr._1, nodeId.id)))
+      case Some(groups) => invalid(groups.map(gr => DuplicateFragmentOutputNamesInScenario(gr._1, nodeId)))
       case None         => valid(allOutputs.toSet)
     }
   }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/fragment/FragmentParametersDefinitionExtractor.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/fragment/FragmentParametersDefinitionExtractor.scala
@@ -86,7 +86,7 @@ class FragmentParametersDefinitionExtractor(
           initialValue = fragmentParameter.initialValue,
           refClazz = fragmentParameter.typ,
           paramName = fragmentParameter.name,
-          nodeIds = Set(nodeId.id)
+          nodeIds = Set(nodeId)
         ) match {
           case Valid(editors) => (editors, List.empty)
           case Invalid(e)     => (NonEmptyList.one(SpelParameterEditor), e.toList)
@@ -149,7 +149,7 @@ class FragmentParametersDefinitionExtractor(
         Writer
           .value[List[PartSubGraphCompilationError], TypingResult](Unknown)
           .tell(
-            List(FragmentParamClassLoadError(fragmentParameter.name, fragmentParameter.typ.refClazzName, nodeId.id))
+            List(FragmentParamClassLoadError(fragmentParameter.name, fragmentParameter.typ.refClazzName, nodeId))
           )
       )
   }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/dict/DictKeyParameterAdapter.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/dict/DictKeyParameterAdapter.scala
@@ -21,7 +21,7 @@ object DictKeyParameterAdapter extends LazyLogging {
   ): CanonicalProcess = {
     val rewriter = ProcessNodesRewriter.rewritingAllExpressions { exprIdWithMetadata => original =>
       val parameterToAdaptForExpressionOpt = parametersToAdapt.find { error =>
-        error.nodeId == exprIdWithMetadata.expressionId.nodeId.id &&
+        error.nodeId == exprIdWithMetadata.expressionId.nodeId &&
         exprIdWithMetadata.parameterName.contains(error.paramName)
       }
       parameterToAdaptForExpressionOpt match {
@@ -62,7 +62,7 @@ object DictKeyParameterAdapter extends LazyLogging {
       implicit nodeId: NodeId
   ): ValidatedNel[PartSubGraphCompilationError, Expression] = {
     val incompatibleChangeToParameterDefinitionDetected: ValidatedNel[PartSubGraphCompilationError, Expression] =
-      invalidNel(IncompatibleParameterDefinitionModification(paramName, expression.language, editors, nodeId.id))
+      invalidNel(IncompatibleParameterDefinitionModification(paramName, expression.language, editors, nodeId))
 
     def adaptToSpel(
         expression: Expression
@@ -167,7 +167,7 @@ object DictKeyParameterAdapter extends LazyLogging {
   }
 
   final case class ParameterToAdapt(
-      nodeId: String,
+      nodeId: NodeId,
       paramName: ParameterName,
       parameterEditors: List[ParameterEditor],
   )

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
@@ -65,7 +65,7 @@ class ExpressionEvaluator(
       ctx: Context
   )(implicit nodeId: NodeId, jobData: JobData): ValueWithContext[AnyRef] = {
     try {
-      val valueWithModifiedContext = evaluate[AnyRef](param.expression, param.name.value, nodeId.id, ctx)
+      val valueWithModifiedContext = evaluate[AnyRef](param.expression, param.name.value, nodeId, ctx)
       valueWithModifiedContext.map { evaluatedValue =>
         if (param.shouldBeWrappedWithScalaOption)
           Option(evaluatedValue)
@@ -79,7 +79,7 @@ class ExpressionEvaluator(
     }
   }
 
-  def evaluate[R](expr: CompiledExpression, expressionId: String, nodeId: String, ctx: Context)(
+  def evaluate[R](expr: CompiledExpression, expressionId: String, nodeId: NodeId, ctx: Context)(
       implicit jobData: JobData
   ): ValueWithContext[R] = {
     val globalVariables = if (cacheGlobalVariables) {

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/dictWithLabel/DictKeyWithLabelExpressionParser.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/language/dictWithLabel/DictKeyWithLabelExpressionParser.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.language.dictWithLabel
 import cats.data.{NonEmptyList, Validated}
 import cats.data.Validated.{invalidNel, Valid}
 import io.circe.parser
-import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.{Context, NodeId}
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.definition.{AdditionalVariable => _}
 import pl.touk.nussknacker.engine.api.expression.ExpressionTypingInfo
@@ -86,7 +86,7 @@ object DictKeyWithLabelExpressionParser extends ExpressionParser {
   case class KeyWithLabelExpressionParsingError(keyWithLabel: String, message: String) extends ExpressionParseError {
 
     def toProcessCompilationError(
-        nodeId: String,
+        nodeId: NodeId,
         paramName: ParameterName
     ): ProcessCompilationError.KeyWithLabelExpressionParsingError =
       ProcessCompilationError.KeyWithLabelExpressionParsingError(keyWithLabel, message, paramName, nodeId)

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/node/NodeComponentInfoExtractor.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/node/NodeComponentInfoExtractor.scala
@@ -1,5 +1,6 @@
 package pl.touk.nussknacker.engine.node
 
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.NodeComponentInfo
 import pl.touk.nussknacker.engine.compiledgraph.{node => compilednode}
 import pl.touk.nussknacker.engine.graph.{node => scenarionode}
@@ -8,12 +9,12 @@ object NodeComponentInfoExtractor {
 
   def fromCompiledNode(node: compilednode.Node): NodeComponentInfo = {
     val componentId = ComponentIdExtractor.fromCompiledNode(node)
-    NodeComponentInfo(node.id, componentId)
+    NodeComponentInfo(NodeId(node.id), componentId)
   }
 
   def fromScenarioNode(nodeData: scenarionode.NodeData): NodeComponentInfo = {
     val componentId = ComponentIdExtractor.fromScenarioNode(nodeData)
-    NodeComponentInfo(nodeData.id, componentId)
+    NodeComponentInfo(NodeId(nodeData.id), componentId)
   }
 
 }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testmode/ResultsCollectingListener.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testmode/ResultsCollectingListener.scala
@@ -41,13 +41,13 @@ private case class ResultsCollectingListenerImpl[T](holderClass: String, runId: 
 
   override def clean(): Unit = ResultsCollectingListenerHolder.cleanResult(runId)
 
-  override def nodeEntered(nodeId: String, context: Context, processMetaData: MetaData): Unit = {
+  override def nodeEntered(nodeId: NodeId, context: Context, processMetaData: MetaData): Unit = {
     updateResults(_.updateNodeResult(nodeId, context, variableEncoder))
   }
 
   override def transitionToNextNode(
-      nodeId: String,
-      nextNodeId: String,
+      nodeId: NodeId,
+      nextNodeId: NodeId,
       context: Context,
       processMetaData: MetaData,
   ): Unit = {
@@ -55,7 +55,7 @@ private case class ResultsCollectingListenerImpl[T](holderClass: String, runId: 
   }
 
   override def processingFinishedInNode(
-      nodeId: String,
+      nodeId: NodeId,
       context: Context,
       processMetaData: MetaData,
   ): Unit = {
@@ -63,20 +63,20 @@ private case class ResultsCollectingListenerImpl[T](holderClass: String, runId: 
   }
 
   override def endEncountered(
-      nodeId: String,
+      nodeId: NodeId,
       ref: String,
       context: Context,
       processMetaData: MetaData
   ): Unit = {}
 
   override def deadEndEncountered(
-      lastNodeId: String,
+      lastNodeId: NodeId,
       context: Context,
       processMetaData: MetaData
   ): Unit = {}
 
   override def expressionEvaluated(
-      nodeId: String,
+      nodeId: NodeId,
       expressionId: String,
       expression: String,
       context: Context,
@@ -87,7 +87,7 @@ private case class ResultsCollectingListenerImpl[T](holderClass: String, runId: 
   }
 
   override def serviceInvoked(
-      nodeId: String,
+      nodeId: NodeId,
       id: String,
       context: Context,
       processMetaData: MetaData,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testmode/TestServiceInvocationCollector.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testmode/TestServiceInvocationCollector.scala
@@ -23,7 +23,7 @@ class TestServiceInvocationCollector(resultsCollectingListener: ResultsCollectin
       case Some(mockVal) =>
         resultsCollectingListener.updateResults(
           _.updateExternalInvocationResult(
-            nodeId.id,
+            nodeId,
             contextId,
             serviceRef,
             request,
@@ -36,7 +36,7 @@ class TestServiceInvocationCollector(resultsCollectingListener: ResultsCollectin
           val invocationResult = Map("request" -> request, "response" -> resultToCollect())
           resultsCollectingListener.updateResults(
             _.updateExternalInvocationResult(
-              nodeId.id,
+              nodeId,
               contextId,
               serviceRef,
               invocationResult,
@@ -48,7 +48,7 @@ class TestServiceInvocationCollector(resultsCollectingListener: ResultsCollectin
     }
   }
 
-  def createSinkInvocationCollector(nodeId: String, ref: String): SinkInvocationCollector =
+  def createSinkInvocationCollector(nodeId: NodeId, ref: String): SinkInvocationCollector =
     new SinkInvocationCollector(resultsCollectingListener, nodeId, ref)
 
 }
@@ -56,7 +56,7 @@ class TestServiceInvocationCollector(resultsCollectingListener: ResultsCollectin
 //TODO: this should be somehow expressed via ResultCollector/TestServiceInvocationCollector
 final class SinkInvocationCollector(
     resultsCollectingListener: ResultsCollectingListener[_],
-    nodeId: String,
+    nodeId: NodeId,
     ref: String
 ) extends Serializable {
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
@@ -444,44 +444,44 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
 
   test("invoke listeners") {
 
-    var nodeResults = List[String]()
+    var nodeResults = List[NodeId]()
 
     var serviceResults = Map[String, Any]()
 
     val listener = new ProcessListener {
 
-      override def nodeEntered(nodeId: String, context: Context, processMetaData: MetaData): Unit = {
+      override def nodeEntered(nodeId: NodeId, context: Context, processMetaData: MetaData): Unit = {
         nodeResults = nodeResults :+ nodeId
       }
 
       override def transitionToNextNode(
-          nodeId: String,
-          nextNodeId: String,
+          nodeId: NodeId,
+          nextNodeId: NodeId,
           context: Context,
           processMetaData: MetaData
       ): Unit = ()
 
       override def processingFinishedInNode(
-          nodeId: String,
+          nodeId: NodeId,
           context: Context,
           processMetaData: MetaData
       ): Unit = ()
 
       override def endEncountered(
-          nodeId: String,
+          nodeId: NodeId,
           ref: String,
           context: Context,
           processMetaData: MetaData
       ): Unit = {}
 
       override def deadEndEncountered(
-          lastNodeId: String,
+          lastNodeId: NodeId,
           context: Context,
           processMetaData: MetaData
       ): Unit = {}
 
       override def serviceInvoked(
-          nodeId: String,
+          nodeId: NodeId,
           id: String,
           context: Context,
           processMetaData: MetaData,
@@ -491,7 +491,7 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
       }
 
       override def expressionEvaluated(
-          nodeId: String,
+          nodeId: NodeId,
           expressionId: String,
           expression: String,
           context: Context,
@@ -518,18 +518,18 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
       .emptySink("end", "dummySink")
 
     interpretProcess(process1, Transaction(), listeners = listenersDef(Some(listener)))
-    nodeResults should equal(List("start", "enrich", "end"))
+    nodeResults should equal(List(NodeId("start"), NodeId("enrich"), NodeId("end")))
     serviceResults should equal(
       Map("accountService" -> Success(Account(marketingAgreement1 = false, "zielonka", "bordo")))
     )
 
     nodeResults = List()
     interpretProcess(process2, Transaction(), listeners = listenersDef(Some(listener)))
-    nodeResults should equal(List("start", "filter", "end"))
+    nodeResults should equal(List(NodeId("start"), NodeId("filter"), NodeId("end")))
 
     nodeResults = List()
     interpretProcess(process2, Transaction(accountId = "333"), listeners = listenersDef(Some(listener)))
-    nodeResults should equal(List("start", "filter", "falseEnd"))
+    nodeResults should equal(List(NodeId("start"), NodeId("filter"), NodeId("falseEnd")))
 
   }
 
@@ -622,7 +622,7 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
 
     val resolved = FragmentResolver(List(emptyFragment)).resolve(process)
 
-    resolved should matchPattern { case Invalid(NonEmptyList(InvalidFragment("fragment1", "sub"), Nil)) =>
+    resolved should matchPattern { case Invalid(NonEmptyList(InvalidFragment("fragment1", NodeId("sub")), Nil)) =>
     }
   }
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/CustomNodeValidationSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/CustomNodeValidationSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.{CustomProcessValidatorLoader, ScenarioCompilationDependencies}
 import pl.touk.nussknacker.engine.ModelConfig.GlobalParametersConfig
-import pl.touk.nussknacker.engine.api.{JobData, ProcessVersion}
+import pl.touk.nussknacker.engine.api.{JobData, NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.component.{ComponentDefinition, DesignerWideComponentId}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.definition.EngineScenarioCompilationDependencies
@@ -168,7 +168,7 @@ class CustomNodeValidationSpec extends AnyFunSuite with Matchers with OptionValu
       )
 
     validate(invalidProcess).result should matchPattern {
-      case Invalid(NonEmptyList(InvalidTailOfBranch(nodeIds), _)) if nodeIds == Set("custom1") =>
+      case Invalid(NonEmptyList(InvalidTailOfBranch(nodeIds), _)) if nodeIds == Set(NodeId("custom1")) =>
     }
   }
 
@@ -182,7 +182,7 @@ class CustomNodeValidationSpec extends AnyFunSuite with Matchers with OptionValu
       )
 
     validate(invalidProcess).result should matchPattern {
-      case Invalid(NonEmptyList(InvalidTailOfBranch(nodeIds), _)) if nodeIds == Set("custom1") =>
+      case Invalid(NonEmptyList(InvalidTailOfBranch(nodeIds), _)) if nodeIds == Set(NodeId("custom1")) =>
     }
   }
 
@@ -196,7 +196,7 @@ class CustomNodeValidationSpec extends AnyFunSuite with Matchers with OptionValu
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Unresolved reference 'nonExisitngVar'",
-                "custom1",
+                NodeId("custom1"),
                 Some(ParameterName("stringVal")),
                 "#nonExisitngVar",
                 _
@@ -216,7 +216,13 @@ class CustomNodeValidationSpec extends AnyFunSuite with Matchers with OptionValu
     validate(invalidProcess).result should matchPattern {
       case Invalid(
             NonEmptyList(
-              ExpressionParserCompilationError(`expectedMsg`, "custom1", Some(ParameterName("stringVal")), "42", _),
+              ExpressionParserCompilationError(
+                `expectedMsg`,
+                NodeId("custom1"),
+                Some(ParameterName("stringVal")),
+                "42",
+                _
+              ),
               _
             )
           ) =>
@@ -312,7 +318,7 @@ class CustomNodeValidationSpec extends AnyFunSuite with Matchers with OptionValu
     errors.head should matchPattern {
       case ExpressionParserCompilationError(
             "Bad expression type, expected: String, found: Integer",
-            "stringService",
+            NodeId("stringService"),
             Some(ParameterName("stringParam")),
             _,
             _
@@ -353,7 +359,7 @@ class CustomNodeValidationSpec extends AnyFunSuite with Matchers with OptionValu
       Map("branch1" -> Typed[String])
     )
     val errors = validationResult.result.swap.toList.flatMap(_.toList).map(_.nodeIds)
-    errors shouldBe List(Set("invalidFilter"))
+    errors shouldBe List(Set(NodeId("invalidFilter")))
 
   }
 
@@ -471,7 +477,7 @@ class CustomNodeValidationSpec extends AnyFunSuite with Matchers with OptionValu
             NonEmptyList(
               ExpressionParserCompilationError(
                 `expectedMsg`,
-                "join1",
+                NodeId("join1"),
                 Some(ParameterName("key for branch branch2")),
                 "123",
                 _
@@ -513,7 +519,7 @@ class CustomNodeValidationSpec extends AnyFunSuite with Matchers with OptionValu
           "This field value is required and can not be blank",
           "Please fill field value for this parameter",
           ParameterName("key for branch branch1"),
-          "join1"
+          NodeId("join1")
         ),
         Nil
       )
@@ -653,7 +659,7 @@ class CustomNodeValidationSpec extends AnyFunSuite with Matchers with OptionValu
     val validationResult = validate(process)
 
     validationResult.result shouldBe Validated
-      .invalid(CustomNodeError("join1", "Validation contexts do not match", Option.empty))
+      .invalid(CustomNodeError(NodeId("join1"), "Validation contexts do not match", Option.empty))
       .toValidatedNel
   }
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/FragmentResolverSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/FragmentResolverSpec.scala
@@ -5,7 +5,7 @@ import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.Inside
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.{FragmentSpecificData, MetaData}
+import pl.touk.nussknacker.engine.api.{FragmentSpecificData, MetaData, NodeId}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
@@ -132,7 +132,9 @@ class FragmentResolverSpec extends AnyFunSuite with Matchers with Inside {
 
     val resolvedValidated = FragmentResolver(List(fragment)).resolve(process)
 
-    resolvedValidated shouldBe Invalid(NonEmptyList.of(FragmentOutputNotDefined("badoutput", Set("sub-out1", "sub"))))
+    resolvedValidated shouldBe Invalid(
+      NonEmptyList.of(FragmentOutputNotDefined("badoutput", Set(NodeId("sub-out1"), NodeId("sub"))))
+    )
 
   }
 
@@ -171,7 +173,7 @@ class FragmentResolverSpec extends AnyFunSuite with Matchers with Inside {
 
     val resolvedValidated = FragmentResolver(List(fragment)).resolve(process)
 
-    resolvedValidated shouldBe Invalid(NonEmptyList.of(DisablingManyOutputsFragment("sub")))
+    resolvedValidated shouldBe Invalid(NonEmptyList.of(DisablingManyOutputsFragment(NodeId("sub"))))
 
   }
 
@@ -196,7 +198,7 @@ class FragmentResolverSpec extends AnyFunSuite with Matchers with Inside {
 
     val resolvedValidated = FragmentResolver(List(fragment)).resolve(process)
 
-    resolvedValidated shouldBe Invalid(NonEmptyList.of(DisablingNoOutputsFragment("sub")))
+    resolvedValidated shouldBe Invalid(NonEmptyList.of(DisablingNoOutputsFragment(NodeId("sub"))))
 
   }
 
@@ -298,7 +300,9 @@ class FragmentResolverSpec extends AnyFunSuite with Matchers with Inside {
 
     val resolvedValidated = FragmentResolver(List.empty).resolve(process)
 
-    resolvedValidated shouldBe Invalid(NonEmptyList.of(UnknownFragment(id = "fragmentId", nodeId = "nodeFragmentId")))
+    resolvedValidated shouldBe Invalid(
+      NonEmptyList.of(UnknownFragment(id = "fragmentId", nodeId = NodeId("nodeFragmentId")))
+    )
   }
 
   test("should resolve diamond fragments") {
@@ -384,7 +388,9 @@ class FragmentResolverSpec extends AnyFunSuite with Matchers with Inside {
       .emptySink("id1", "sink")
 
     val resolvedValidated = FragmentResolver(List(fragment)).resolve(scenario)
-    resolvedValidated shouldBe Invalid(NonEmptyList.of(DuplicateFragmentOutputNamesInScenario("output1", "fragment")))
+    resolvedValidated shouldBe Invalid(
+      NonEmptyList.of(DuplicateFragmentOutputNamesInScenario("output1", NodeId("fragment")))
+    )
 
   }
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/GenericTransformationValidationSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/GenericTransformationValidationSpec.scala
@@ -251,7 +251,7 @@ class GenericTransformationValidationSpec
       )
     )
     result.result should matchPattern {
-      case Invalid(NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName("val2"), "end"), Nil)) =>
+      case Invalid(NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName("val2"), NodeId("end")), Nil)) =>
     }
 
     val parameters = result.parametersInNodes("end")
@@ -290,7 +290,7 @@ class GenericTransformationValidationSpec
         .emptySink("end", "dummySink")
     )
     result.result.invalidValue.toList should matchPattern {
-      case ExpressionParserCompilationError(message, "generic", Some(ParameterName("par1")), "12", _) :: Nil
+      case ExpressionParserCompilationError(message, NodeId("generic"), Some(ParameterName("par1")), "12", _) :: Nil
           if message == s"Bad expression type, expected: String, found: ${Typed.fromInstance(12).display}" =>
     }
     val info1 = result.typing("end")
@@ -314,7 +314,7 @@ class GenericTransformationValidationSpec
         .emptySink("end", "dummySink")
     )
     result.result should matchPattern {
-      case Invalid(NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName("val2"), "generic"), Nil)) =>
+      case Invalid(NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName("val2"), NodeId("generic")), Nil)) =>
     }
 
     val info1 = result.typing("end")
@@ -362,7 +362,7 @@ class GenericTransformationValidationSpec
         .emptySink("end", "dummySink")
     )
     result.result.invalidValue.toList should matchPattern {
-      case ExpressionParserCompilationError(message, "generic", Some(ParameterName("par1")), "12", _) :: Nil
+      case ExpressionParserCompilationError(message, NodeId("generic"), Some(ParameterName("par1")), "12", _) :: Nil
           if message == s"Bad expression type, expected: String, found: ${Typed.fromInstance(12).display}" =>
     }
     val info1 = result.typing("end")

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/IdValidatorTest.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/IdValidatorTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks.{forAll, Table}
 import org.scalatest.prop.TableFor2
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.process.ProcessName
@@ -60,7 +61,7 @@ class IdValidatorTest extends AnyFunSuite with Matchers {
       case Validated.Invalid(errors) =>
         errors.toList should contain theSameElementsAs List(
           ScenarioNameError(EmptyValue, ProcessName(""), isFragment = false),
-          NodeIdValidationError(EmptyValue, "")
+          NodeIdValidationError(EmptyValue, NodeId(""))
         )
       case Validated.Valid(_) =>
         fail("Validation succeeded, but was expected to fail")
@@ -83,15 +84,15 @@ object IdValidationTestData {
   val nodeIdErrorCases: TableFor2[String, List[IdError]] = Table(
     ("nodeId", "errors"),
     ("validId", List.empty),
-    ("", List(NodeIdValidationError(EmptyValue, ""))),
-    (" ", List(NodeIdValidationError(BlankId, " "))),
-    ("trailingSpace ", List(NodeIdValidationError(TrailingSpacesId, "trailingSpace "))),
-    (" leadingSpace", List(NodeIdValidationError(LeadingSpacesId, " leadingSpace"))),
+    ("", List(NodeIdValidationError(EmptyValue, NodeId("")))),
+    (" ", List(NodeIdValidationError(BlankId, NodeId(" ")))),
+    ("trailingSpace ", List(NodeIdValidationError(TrailingSpacesId, NodeId("trailingSpace ")))),
+    (" leadingSpace", List(NodeIdValidationError(LeadingSpacesId, NodeId(" leadingSpace")))),
     (
       " leadingAndTrailingSpace ",
       List(
-        NodeIdValidationError(LeadingSpacesId, " leadingAndTrailingSpace "),
-        NodeIdValidationError(TrailingSpacesId, " leadingAndTrailingSpace ")
+        NodeIdValidationError(LeadingSpacesId, NodeId(" leadingAndTrailingSpace ")),
+        NodeIdValidationError(TrailingSpacesId, NodeId(" leadingAndTrailingSpace "))
       )
     ),
   )

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/NodeDataValidatorSpec.scala
@@ -201,7 +201,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
                   "This field is required and can not be null",
                   _,
                   NodeExpressionId.DefaultExpressionIdParamName,
-                  "filter"
+                  NodeId("filter")
                 )
               ) :: Nil,
               _,
@@ -276,7 +276,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
         Map("input" -> Typed[String])
       )
     ) {
-      case ValidationPerformed(CannotCreateObjectError("Some exception", "tst1", _) :: Nil, parameters, _)
+      case ValidationPerformed(CannotCreateObjectError("Some exception", NodeId("tst1"), _) :: Nil, parameters, _)
           if parameters.nonEmpty =>
     }
   }
@@ -314,7 +314,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
                   "Field: $expression is mandatory and can not be empty",
                   _,
                   NodeExpressionId.DefaultExpressionIdParamName,
-                  "var1"
+                  NodeId("var1")
                 )
               ) :: Nil,
               _,
@@ -338,13 +338,13 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
         Variable("var1", "var1", "42L".spel, None),
         Map("var1" -> typing.Unknown)
       )
-    ) { case ValidationPerformed(OverwrittenVariable("var1", "var1", _) :: Nil, None, _) =>
+    ) { case ValidationPerformed(OverwrittenVariable("var1", NodeId("var1"), _) :: Nil, None, _) =>
     }
   }
 
   test("should not allow to use special chars in variable name") {
     inside(validate(Variable("var1", "var@ 2", "42L".spel, None), Map.empty)) {
-      case ValidationPerformed(InvalidVariableName("var@ 2", "var1", _) :: Nil, None, _) =>
+      case ValidationPerformed(InvalidVariableName("var@ 2", NodeId("var1"), _) :: Nil, None, _) =>
     }
   }
 
@@ -372,7 +372,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
         VariableBuilder("var1", "var1", Nil, None),
         Map("var1" -> typing.Unknown)
       )
-    ) { case ValidationPerformed(OverwrittenVariable("var1", "var1", _) :: Nil, None, _) =>
+    ) { case ValidationPerformed(OverwrittenVariable("var1", NodeId("var1"), _) :: Nil, None, _) =>
     }
   }
 
@@ -388,12 +388,12 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
               "The key of a record has to be unique",
               _,
               ParameterName("$fields-0-$key"),
-              "recordVariable"
+              NodeId("recordVariable")
             ) :: CustomParameterValidationError(
               "The key of a record has to be unique",
               _,
               ParameterName("$fields-1-$key"),
-              "recordVariable"
+              NodeId("recordVariable")
             ) :: Nil,
             None,
             _
@@ -415,7 +415,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
       case ValidationPerformed(
             ExpressionParserCompilationError(
               "Non reference 'unresolvedReference' occurred. Maybe you missed '#' in front of it?",
-              "recordVariable",
+              NodeId("recordVariable"),
               Some(ParameterName("$fields-0-$value")),
               "unresolvedReference",
               _
@@ -424,12 +424,12 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
               "The key of a record has to be unique",
               _,
               ParameterName("$fields-0-$key"),
-              "recordVariable"
+              NodeId("recordVariable")
             ) :: CustomParameterValidationError(
               "The key of a record has to be unique",
               _,
               ParameterName("$fields-1-$key"),
-              "recordVariable"
+              NodeId("recordVariable")
             ) :: Nil,
             _,
             _
@@ -450,12 +450,12 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
                 "Field: $fields-0-$value is mandatory and can not be empty",
                 _,
                 ParameterName("$fields-0-$value"),
-                "recordVariable"
+                NodeId("recordVariable")
               ) :: EmptyMandatoryParameter(
                 "Field: $fields-1-$value is mandatory and can not be empty",
                 _,
                 ParameterName("$fields-1-$value"),
-                "recordVariable"
+                NodeId("recordVariable")
               ) :: Nil,
               None,
               _
@@ -511,7 +511,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
       outgoingEdges = List(OutgoingEdge("any", Some(FragmentOutput("out1"))))
     ) should matchPattern {
       case ValidationPerformed(
-            List(UnknownFragment("non-existing-fragment", "frInput")),
+            List(UnknownFragment("non-existing-fragment", NodeId("frInput"))),
             None,
             None
           ) =>
@@ -530,7 +530,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
       )
     ) {
       case ValidationPerformed(
-            List(ExpressionParserCompilationError(message, "frInput", Some(ParameterName("param1")), "145", _)),
+            List(ExpressionParserCompilationError(message, NodeId("frInput"), Some(ParameterName("param1")), "145", _)),
             None,
             None
           ) =>
@@ -602,7 +602,11 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
         aModelData = getModelData(configWithValidators)
       )
     ) {
-      case ValidationPerformed(List(EmptyMandatoryParameter(_, _, ParameterName("P1"), returnedNodeId)), None, None) =>
+      case ValidationPerformed(
+            List(EmptyMandatoryParameter(_, _, ParameterName("P1"), NodeId(returnedNodeId))),
+            None,
+            None
+          ) =>
         returnedNodeId shouldBe nodeId
     }
   }
@@ -658,8 +662,8 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
     ) should matchPattern {
       case ValidationPerformed(
             List(
-              EmptyMandatoryParameter(_, _, ParameterName("P1"), "nameOfTheNode"),
-              EmptyMandatoryParameter(_, _, ParameterName("P2"), "nameOfTheNode")
+              EmptyMandatoryParameter(_, _, ParameterName("P1"), NodeId("nameOfTheNode")),
+              EmptyMandatoryParameter(_, _, ParameterName("P2"), NodeId("nameOfTheNode"))
             ),
             None,
             None
@@ -682,7 +686,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
       outgoingEdges = defaultFragmentOutgoingEdges
     ) should matchPattern {
       case ValidationPerformed(
-            List(EmptyMandatoryParameter(_, _, ParameterName("optionalParam"), "enricherNodeId")),
+            List(EmptyMandatoryParameter(_, _, ParameterName("optionalParam"), NodeId("enricherNodeId"))),
             None,
             None
           ) =>
@@ -707,7 +711,11 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
     ) {
       case ValidationPerformed(
             List(
-              InvalidVariableName("very bad var name", "frInput", Some(ParameterName("ref.outputVariableNames.out1")))
+              InvalidVariableName(
+                "very bad var name",
+                NodeId("frInput"),
+                Some(ParameterName("ref.outputVariableNames.out1"))
+              )
             ),
             None,
             None
@@ -730,7 +738,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
       )
     ) {
       case ValidationPerformed(
-            List(OverwrittenVariable("var1", "frInput", Some(ParameterName("ref.outputVariableNames.out1")))),
+            List(OverwrittenVariable("var1", NodeId("frInput"), Some(ParameterName("ref.outputVariableNames.out1")))),
             None,
             None
           ) =>
@@ -752,7 +760,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
         Map.empty
       )
     ) { case ValidationPerformed(List(FragmentOutputNotDefined("out1", nodes)), None, None) =>
-      nodes shouldBe Set(nodeId)
+      nodes shouldBe Set(NodeId(nodeId))
     }
 
   }
@@ -770,14 +778,14 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
             List(
               ExpressionParserCompilationError(
                 "Non reference 'input' occurred. Maybe you missed '#' in front of it?",
-                "switchId",
+                NodeId("switchId"),
                 Some(ParameterName("$expression")),
                 "input",
                 _
               ),
               ExpressionParserCompilationError(
                 "Non reference 'notExist' occurred. Maybe you missed '#' in front of it?",
-                "switchId",
+                NodeId("switchId"),
                 Some(ParameterName("caseTarget1")),
                 "notExist",
                 _
@@ -804,7 +812,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
                 "This field is required and can not be null",
                 _,
                 ParameterName("caseTarget"),
-                "switchId"
+                NodeId("switchId")
               ) :: Nil,
               None,
               None
@@ -856,7 +864,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
             None,
             None
           ) =>
-        nodes shouldBe Set(nodeId)
+        nodes shouldBe Set(NodeId(nodeId))
     }
   }
 
@@ -894,7 +902,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
             None,
             None
           ) =>
-        nodes shouldBe Set(nodeId)
+        nodes shouldBe Set(NodeId(nodeId))
     }
   }
 
@@ -1118,7 +1126,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
     ) { case ValidationPerformed((error: FragmentParamClassLoadError) :: _, None, None) =>
       error.paramName shouldBe paramName
       error.refClazzName shouldBe invalidType
-      error.nodeIds shouldBe Set(nodeId)
+      error.nodeIds shouldBe Set(NodeId(nodeId))
     }
   }
 
@@ -1207,7 +1215,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
         FragmentParamClassLoadError(
           ParameterName("param1"),
           "Map[List[Integer], Map[String, Map[Double, List[Integer]]]]]",
-          "in"
+          NodeId("in")
         )
       )
     }
@@ -1239,7 +1247,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
         outgoingEdges = List(OutgoingEdge("any", Some(FragmentOutput("out1"))))
       )
     ) { case ValidationPerformed(errors, None, None) =>
-      errors shouldBe List(FragmentParamClassLoadError(ParameterName("param1"), "Map[String, Foo]", "in"))
+      errors shouldBe List(FragmentParamClassLoadError(ParameterName("param1"), "Map[String, Foo]", NodeId("in")))
     }
   }
 
@@ -1323,7 +1331,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
             List(
               InvalidValidationExpression(
                 "Validation expression cannot be blank",
-                "in",
+                NodeId("in"),
                 ParameterName("param1"),
                 expr
               )
@@ -1364,7 +1372,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
             List(
               InvalidValidationExpression(
                 "Unresolved reference 'invalidReference'",
-                "in",
+                NodeId("in"),
                 ParameterName("param1"),
                 expr
               )
@@ -1409,7 +1417,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
             List(
               InvalidValidationExpression(
                 "Wrong part types",
-                "in",
+                NodeId("in"),
                 ParameterName("param1"),
                 expr
               )
@@ -1450,7 +1458,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
             List(
               InvalidValidationExpression(
                 "Bad expression type, expected: Boolean, found: String(ab)",
-                "in",
+                NodeId("in"),
                 ParameterName("param1"),
                 expr
               )
@@ -1482,7 +1490,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
             List(
               InvalidVariableName(
                 "1",
-                "in",
+                NodeId("in"),
                 Some(ParameterName("$param.1.$name"))
               )
             ),
@@ -1512,7 +1520,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
     ) {
       case ValidationPerformed(
             List(
-              DuplicateFragmentInputParameter(ParameterName("paramName"), "in")
+              DuplicateFragmentInputParameter(ParameterName("paramName"), NodeId("in"))
             ),
             None,
             None
@@ -1551,7 +1559,7 @@ class NodeDataValidatorSpec extends AnyFunSuite with Matchers with Inside with T
     ) {
       case ValidationPerformed(
             List(
-              DuplicateFragmentInputParameter(ParameterName("paramName"), "in")
+              DuplicateFragmentInputParameter(ParameterName("paramName"), NodeId("in"))
             ),
             None,
             None

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -200,7 +200,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Property access on Unknown is not allowed",
-                "filter1",
+                NodeId("filter1"),
                 Some(DefaultExpressionIdParamName),
                 _,
                 _
@@ -250,7 +250,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Unknown method 'copyValueOf' in String",
-                "filter1",
+                NodeId("filter1"),
                 Some(DefaultExpressionIdParamName),
                 "T(String).copyValueOf('test')",
                 _
@@ -281,7 +281,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "class java.lang.System is not allowed to be passed as TypeReference",
-                "filter1",
+                NodeId("filter1"),
                 Some(DefaultExpressionIdParamName),
                 "T(System).exit()",
                 _
@@ -325,7 +325,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Dynamic property access is not allowed",
-                "filter1",
+                NodeId("filter1"),
                 Some(DefaultExpressionIdParamName),
                 _,
                 _
@@ -541,7 +541,9 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
         .emptySink("emptySink", "sink")
 
     validate(processWithInvalidExpression, baseDefinition).result should matchPattern {
-      case Invalid(NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName("mandatoryParam"), "customNodeId"), _)) =>
+      case Invalid(
+            NonEmptyList(EmptyMandatoryParameter(_, _, ParameterName("mandatoryParam"), NodeId("customNodeId")), _)
+          ) =>
     }
   }
 
@@ -560,11 +562,11 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
     validate(processWithInvalidExpression, baseDefinition).result should matchPattern {
       case Invalid(
             NonEmptyList(
-              BlankParameter(_, _, ParameterName("notBlankParam"), "customNodeId1"),
+              BlankParameter(_, _, ParameterName("notBlankParam"), NodeId("customNodeId1")),
               List(
-                BlankParameter(_, _, ParameterName("notBlankParam"), "customNodeId2"),
-                BlankParameter(_, _, ParameterName("notBlankParam"), "customNodeId3"),
-                BlankParameter(_, _, ParameterName("notBlankParam"), "customNodeId4")
+                BlankParameter(_, _, ParameterName("notBlankParam"), NodeId("customNodeId2")),
+                BlankParameter(_, _, ParameterName("notBlankParam"), NodeId("customNodeId3")),
+                BlankParameter(_, _, ParameterName("notBlankParam"), NodeId("customNodeId4"))
               )
             )
           ) =>
@@ -629,7 +631,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 _,
-                "customNodeId",
+                NodeId("customNodeId"),
                 Some(ParameterName("nullableLiteralIntegerParam")),
                 "as",
                 _
@@ -637,7 +639,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
               List(
                 ExpressionParserCompilationError(
                   _,
-                  "customNodeId2",
+                  NodeId("customNodeId2"),
                   Some(ParameterName("nullableLiteralIntegerParam")),
                   "1.23",
                   _
@@ -660,7 +662,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
     validate(processWithInvalidExpression, baseDefinition).result should matchPattern {
       case Invalid(
             NonEmptyList(
-              ExpressionParserCompilationError(_, "customNodeId", Some(ParameterName("regExpParam")), "as", _),
+              ExpressionParserCompilationError(_, NodeId("customNodeId"), Some(ParameterName("regExpParam")), "as", _),
               _
             )
           ) =>
@@ -698,11 +700,11 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
     validate(processWithInvalidExpression, baseDefinition).result should matchPattern {
       case Invalid(
             NonEmptyList(
-              JsonRequiredParameter(_, _, ParameterName("jsonParam"), "customNodeId"),
+              JsonRequiredParameter(_, _, ParameterName("jsonParam"), NodeId("customNodeId")),
               List(
-                JsonRequiredParameter(_, _, ParameterName("jsonParam"), "customNodeId2"),
-                JsonRequiredParameter(_, _, ParameterName("jsonParam"), "customNodeId3"),
-                JsonRequiredParameter(_, _, ParameterName("jsonParam"), "customNodeId4")
+                JsonRequiredParameter(_, _, ParameterName("jsonParam"), NodeId("customNodeId2")),
+                JsonRequiredParameter(_, _, ParameterName("jsonParam"), NodeId("customNodeId3")),
+                JsonRequiredParameter(_, _, ParameterName("jsonParam"), NodeId("customNodeId4"))
               )
             )
           ) =>
@@ -748,7 +750,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
     val definition = ModelDefinitionBuilder.empty.withService(serviceId, Parameter[String](ParameterName("foo"))).build
     val compilationResult = validate(processWithRefToMissingService, definition)
     compilationResult.result should matchPattern {
-      case Invalid(NonEmptyList(MissingSourceFactory("source", "id1"), Nil)) =>
+      case Invalid(NonEmptyList(MissingSourceFactory("source", NodeId("id1")), Nil)) =>
     }
     compilationResult.variablesInNodes("id2") shouldBe Map(
       "input"     -> Unknown,
@@ -767,7 +769,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
         .emptySink("id2", "sink")
 
     validate(processWithRefToMissingService, baseDefinition).result should matchPattern {
-      case Invalid(NonEmptyList(MissingCustomNodeExecutor("notExisting", "custom"), Nil)) =>
+      case Invalid(NonEmptyList(MissingCustomNodeExecutor("notExisting", NodeId("custom")), Nil)) =>
     }
   }
 
@@ -783,7 +785,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Unresolved reference 'doesNotExist1'",
-                "sampleFilter",
+                NodeId("sampleFilter"),
                 Some(DefaultExpressionIdParamName),
                 _,
                 _
@@ -791,7 +793,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
               List(
                 ExpressionParserCompilationError(
                   "Unresolved reference 'doesNotExist2'",
-                  "sampleFilter",
+                  NodeId("sampleFilter"),
                   Some(DefaultExpressionIdParamName),
                   _,
                   _
@@ -814,7 +816,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Non reference 'input' occurred. Maybe you missed '#' in front of it?",
-                "sampleFilter2",
+                NodeId("sampleFilter2"),
                 Some(DefaultExpressionIdParamName),
                 _,
                 _
@@ -837,7 +839,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "There is no property 'value3' in type: AnotherSimpleRecord",
-                "sampleFilter2",
+                NodeId("sampleFilter2"),
                 Some(DefaultExpressionIdParamName),
                 _,
                 _
@@ -862,7 +864,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "There is no property 'value3' in type: AnotherSimpleRecord",
-                "sampleFilter2",
+                NodeId("sampleFilter2"),
                 Some(DefaultExpressionIdParamName),
                 _,
                 _
@@ -891,7 +893,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "There is no property 'value3' in type: AnotherSimpleRecord",
-                "sampleFilter2",
+                NodeId("sampleFilter2"),
                 Some(DefaultExpressionIdParamName),
                 _,
                 _
@@ -928,7 +930,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "There is no property 'terefere' in type: AnotherSimpleRecord",
-                "sampleFilter2",
+                NodeId("sampleFilter2"),
                 Some(DefaultExpressionIdParamName),
                 "#out1.terefere",
                 _
@@ -952,7 +954,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Unresolved reference 'strangeVar'",
-                "cNode1",
+                NodeId("cNode1"),
                 Some(ParameterName("par1")),
                 "#strangeVar",
                 _
@@ -991,7 +993,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Bad expression type, expected: Record{someInt: Integer, someString: String}, found: Record{someString: String(abc)}",
-                "enricher1",
+                NodeId("enricher1"),
                 Some(NodeCompiler.MockExpressionParameterName),
                 _,
                 _
@@ -1019,7 +1021,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Bad expression type, expected: Record{someInt: Integer, someString: String}, found: Record{someString: String}",
-                "enricher1",
+                NodeId("enricher1"),
                 Some(NodeCompiler.MockExpressionParameterName),
                 _,
                 _
@@ -1041,7 +1043,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "There is no property 'terefere' in type: BigDecimal",
-                "sampleFilter1",
+                NodeId("sampleFilter1"),
                 Some(DefaultExpressionIdParamName),
                 _,
                 _
@@ -1071,7 +1073,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Unexpectedly ran out of input",
-                "c1",
+                NodeId("c1"),
                 Some(ParameterName("par1")),
                 _,
                 _
@@ -1079,14 +1081,14 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
               List(
                 ExpressionParserCompilationError(
                   "Unresolved reference 'terefere'",
-                  "p1",
+                  NodeId("p1"),
                   Some(ParameterName("par1")),
                   _,
                   _
                 ),
                 ExpressionParserCompilationError(
                   "Unresolved reference 'terefere22'",
-                  "v1",
+                  NodeId("v1"),
                   Some(ParameterName("$fields-0-$value")),
                   _,
                   _
@@ -1106,7 +1108,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
       .emptySink("id2", "sink")
     val compilationResult = validate(process, definitionWithTypedSource)
     compilationResult.result should matchPattern {
-      case Invalid(NonEmptyList(OverwrittenVariable("var1", "var1overwrite", _), _)) =>
+      case Invalid(NonEmptyList(OverwrittenVariable("var1", NodeId("var1overwrite"), _), _)) =>
     }
     compilationResult.variablesInNodes("id2") shouldBe Map(
       "input"         -> Typed[SimpleRecord],
@@ -1124,7 +1126,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
       .switch("var1overwrite", "''".spel, "var1", GraphBuilder.emptySink("id2", "sink"))
 
     validate(process, definitionWithTypedSource).result should matchPattern {
-      case Invalid(NonEmptyList(OverwrittenVariable("var1", "var1overwrite", _), _)) =>
+      case Invalid(NonEmptyList(OverwrittenVariable("var1", NodeId("var1overwrite"), _), _)) =>
     }
   }
 
@@ -1137,7 +1139,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
       .emptySink("id2", "sink")
 
     validate(process, definitionWithTypedSource).result should matchPattern {
-      case Invalid(NonEmptyList(OverwrittenVariable("var1", "var1overwrite", _), _)) =>
+      case Invalid(NonEmptyList(OverwrittenVariable("var1", NodeId("var1overwrite"), _), _)) =>
     }
   }
 
@@ -1149,7 +1151,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
       .buildVariable("var1overwrite", "var1", "a" -> "''".spel)
       .emptySink("id2", "sink")
     validate(process, definitionWithTypedSource).result should matchPattern {
-      case Invalid(NonEmptyList(OverwrittenVariable("var1", "var1overwrite", _), _)) =>
+      case Invalid(NonEmptyList(OverwrittenVariable("var1", NodeId("var1overwrite"), _), _)) =>
     }
   }
 
@@ -1167,7 +1169,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Wrong part types",
-                "notWorking",
+                NodeId("notWorking"),
                 Some(DefaultExpressionIdParamName),
                 "#var1.a > 10",
                 _
@@ -1187,7 +1189,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
       .emptySink("id2", "sink")
 
     validate(process, definitionWithTypedSourceAndTransformNode.build).result should matchPattern {
-      case Invalid(NonEmptyList(OverwrittenVariable("var1", "var1overwrite", _), _)) =>
+      case Invalid(NonEmptyList(OverwrittenVariable("var1", NodeId("var1overwrite"), _), _)) =>
     }
   }
 
@@ -1242,7 +1244,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Unresolved reference 'var3'",
-                "id3",
+                NodeId("id3"),
                 Some(DefaultExpressionIdParamName),
                 "#var3",
                 _
@@ -1264,7 +1266,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Unresolved reference 'notExist'",
-                "switch",
+                NodeId("switch"),
                 Some(ParameterName("end1")),
                 "#notExist",
                 _
@@ -1297,7 +1299,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
         .emptySink("end-id2", "sink")
 
     validate(processWithInvalidExpresssion, baseDefinition).result should matchPattern {
-      case Invalid(NonEmptyList(MissingParameters(vars, "custom"), Nil))
+      case Invalid(NonEmptyList(MissingParameters(vars, NodeId("custom")), Nil))
           if vars == Set(ParameterName("OutputVariable")) =>
     }
   }
@@ -1352,7 +1354,10 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
 
     validate(processWithInvalidExpresssion, failingDefinition).result should matchPattern {
       case Invalid(
-            NonEmptyList(CannotCreateObjectError("You passed incorrect parameter, cannot proceed", "id1", _), Nil)
+            NonEmptyList(
+              CannotCreateObjectError("You passed incorrect parameter, cannot proceed", NodeId("id1"), _),
+              Nil
+            )
           ) =>
     }
 
@@ -1441,8 +1446,8 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
 
     result.result shouldBe Invalid(
       NonEmptyList.of(
-        CustomNodeError("service-1", "Too young", Some(ParameterName("age"))),
-        CustomNodeError("service-2", "Service is invalid", None),
+        CustomNodeError(NodeId("service-1"), "Too young", Some(ParameterName("age"))),
+        CustomNodeError(NodeId("service-2"), "Service is invalid", None),
       )
     )
   }
@@ -1464,7 +1469,9 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
         .emptySink("id2", "sink")
 
     validate(processWithLocalVarInEagerParam, baseDefinition).result shouldBe
-      Invalid(NonEmptyList.of(DuplicatedParameters(Set(ParameterName("par1"), ParameterName("par2")), "custom")))
+      Invalid(
+        NonEmptyList.of(DuplicatedParameters(Set(ParameterName("par1"), ParameterName("par2")), NodeId("custom")))
+      )
   }
 
   test("not allows local variables in eager custom node parameter") {
@@ -1480,7 +1487,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Unresolved reference 'input'",
-                "custom",
+                NodeId("custom"),
                 Some(ParameterName("par1")),
                 "#input.toString()",
                 _
@@ -1700,7 +1707,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
     validate(processWithInvalidExpression, baseDefinition).result should matchPattern {
       case Invalid(
             NonEmptyList(
-              CustomParameterValidationError(_, _, ParameterName("param"), "customNodeId2"),
+              CustomParameterValidationError(_, _, ParameterName("param"), NodeId("customNodeId2")),
               Nil
             )
           ) =>
@@ -1732,7 +1739,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
             NonEmptyList(
               ExpressionParserCompilationError(
                 "Unresolved reference 'input'",
-                "customNodeId",
+                NodeId("customNodeId"),
                 Some(ParameterName("param")),
                 _,
                 _
@@ -1766,7 +1773,10 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
 
     withUsed should matchPattern {
       case Invalid(
-            NonEmptyList(OverwrittenVariable(`usedVarName`, "sample-out", Some(ParameterName(`errorFieldName`))), Nil)
+            NonEmptyList(
+              OverwrittenVariable(`usedVarName`, NodeId("sample-out"), Some(ParameterName(`errorFieldName`))),
+              Nil
+            )
           ) =>
     }
   }
@@ -1795,8 +1805,8 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
     inside(validate(scenarioWith, baseDefinition).result) { case Invalid(errors) =>
       errors.toList should contain theSameElementsAs
         List(
-          InvalidRootNode(Set(variableName1, variableName2)),
-          InvalidTailOfBranch(Set(sourceName1, sourceName2)),
+          InvalidRootNode(Set(NodeId(variableName1), NodeId(variableName2))),
+          InvalidTailOfBranch(Set(NodeId(sourceName1), NodeId(sourceName2))),
           EmptyProcess
         )
     }
@@ -1990,7 +2000,7 @@ class StartingWithACustomValidator extends CustomParameterValidator {
             message = s"Value $value does not starts with 'A'",
             description = "Value does not starts with 'A'",
             paramName = paramName,
-            nodeId = nodeId.id
+            nodeId = nodeId
           )
         )
     }

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/nodecompilation/FragmentParameterValidatorTest.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/nodecompilation/FragmentParameterValidatorTest.scala
@@ -5,6 +5,7 @@ import cats.data.Validated.{invalidNel, Valid}
 import org.scalatest.Inspectors.forAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{
   UnsupportedDictParameterEditorType,
   UnsupportedFixedValuesType
@@ -31,7 +32,7 @@ class FragmentParameterValidatorTest extends AnyFunSuite with Matchers with Vali
           initialValue = None,
           refClazz = fragmentParameterType,
           paramName = ParameterName("someParamName"),
-          nodeIds = Set("someNodeId")
+          nodeIds = Set(NodeId("someNodeId"))
         )
         result.validValue shouldBe NonEmptyList.one(DictParameterEditor(dictId))
       }
@@ -47,7 +48,7 @@ class FragmentParameterValidatorTest extends AnyFunSuite with Matchers with Vali
           initialValue = None,
           refClazz = fragmentParameterType,
           paramName = ParameterName("someParamName"),
-          nodeIds = Set("someNodeId")
+          nodeIds = Set(NodeId("someNodeId"))
         )
         result.validValue shouldBe NonEmptyList.one(
           FixedValuesParameterEditor(FixedExpressionValue.nullFixedValue +: fixedValuesList)
@@ -59,7 +60,7 @@ class FragmentParameterValidatorTest extends AnyFunSuite with Matchers with Vali
   test("should not be valid when validating with not permitted type for value input with dict editor") {
     val paramName            = ParameterName("someParamName")
     val invalidParameterType = FragmentClazzRef[java.lang.Double]
-    val nodeIds              = Set("someNodeId")
+    val nodeIds              = Set(NodeId("someNodeId"))
     val result = FragmentParameterValidator(emptyClassDefinitionSet).validateAgainstClazzRefAndGetEditor(
       valueEditor = ValueInputWithDictEditor("someDictId", allowOtherValue = false),
       initialValue = None,
@@ -75,7 +76,7 @@ class FragmentParameterValidatorTest extends AnyFunSuite with Matchers with Vali
   test("should not be valid when validating with not permitted type for value input with fixed values editor") {
     val paramName            = ParameterName("someParamName")
     val invalidParameterType = FragmentClazzRef[java.lang.Double]
-    val nodeIds              = Set("someNodeId")
+    val nodeIds              = Set(NodeId("someNodeId"))
     val result = FragmentParameterValidator(emptyClassDefinitionSet).validateAgainstClazzRefAndGetEditor(
       valueEditor = ValueInputWithFixedValuesProvided(
         List(FixedExpressionValue("someExpression", "someLabel")),

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/definition/AdditionalVariableSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/definition/AdditionalVariableSpec.scala
@@ -66,7 +66,7 @@ class AdditionalVariableSpec extends AnyFunSuite with Matchers {
     result.asInstanceOf[ValidationPerformed].errors.distinct should matchPattern {
       case CannotCreateObjectError(
             "AdditionalVariableWithFixedValue should not be used with LazyParameters",
-            "sid",
+            NodeId("sid"),
             _
           ) :: Nil =>
     }

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelConversionServiceOverrideSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelConversionServiceOverrideSpec.scala
@@ -82,7 +82,7 @@ class SpelConversionServiceOverrideSpec extends AnyFunSuite with Matchers with O
       case Invalid(
             NonEmptyList(
               NuExceptionInfo(
-                Some(NodeComponentInfo("invoke-service", Some(ComponentId(ComponentType.Service, "service")))),
+                Some(NodeComponentInfo(NodeId("invoke-service"), Some(ComponentId(ComponentType.Service, "service")))),
                 ex,
                 _,
                 _,

--- a/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/runtimecontext/TestEngineRuntimeContext.scala
+++ b/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/runtimecontext/TestEngineRuntimeContext.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.util.runtimecontext
 
-import pl.touk.nussknacker.engine.api.JobData
+import pl.touk.nussknacker.engine.api.{JobData, NodeId}
 import pl.touk.nussknacker.engine.api.runtimecontext.{ContextIdGenerator, EngineRuntimeContext, IncContextIdGenerator}
 import pl.touk.nussknacker.engine.util.metrics.{MetricsProviderForScenario, NoOpMetricsProviderForScenario}
 
@@ -8,6 +8,6 @@ case class TestEngineRuntimeContext(
     jobData: JobData,
     metricsProvider: MetricsProviderForScenario = NoOpMetricsProviderForScenario
 ) extends EngineRuntimeContext {
-  override def contextIdGenerator(nodeId: String): ContextIdGenerator =
+  override def contextIdGenerator(nodeId: NodeId): ContextIdGenerator =
     IncContextIdGenerator.withProcessIdNodeIdPrefix(jobData, nodeId, taskId = 0)
 }

--- a/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkTestScenarioRunner.scala
+++ b/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkTestScenarioRunner.scala
@@ -8,7 +8,7 @@ import org.scalatest.concurrent.ScalaFutures.{convertScalaFuture, scaled, Patien
 import org.scalatest.time.{Millis, Seconds, Span}
 import pl.touk.nussknacker.defaultmodel.DefaultConfigCreator
 import pl.touk.nussknacker.engine.RuntimeMode
-import pl.touk.nussknacker.engine.api.ProcessVersion
+import pl.touk.nussknacker.engine.api.{NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.component.{ComponentDefinition, NodesDeploymentData}
 import pl.touk.nussknacker.engine.api.process.SourceFactory
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
@@ -350,7 +350,7 @@ class FlinkTestScenarioRunner(
       testScenarioCollectorHandler: TestScenarioCollectorHandler
   ) = {
     val allSinks           = scenario.collectAllNodes.collect { case sink: node.Sink => sink }
-    def isSink(id: String) = allSinks.exists(_.id == id)
+    def isSink(id: NodeId) = allSinks.exists(_.id == id.id)
     testScenarioCollectorHandler.resultsCollectingListener.results.externalInvocationResults.flatMap {
       case (id, externalInvocationResults) if isSink(id) =>
         externalInvocationResults.map(_.value)

--- a/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonDefaultExpressionDeterminer.scala
+++ b/utils/json-utils/src/main/scala/pl/touk/nussknacker/engine/json/JsonDefaultExpressionDeterminer.scala
@@ -23,9 +23,9 @@ object JsonDefaultExpressionDeterminer {
   ): ValidatedNel[ProcessCompilationError, Option[Expression]] =
     extractorWithHandleNotSupported
       .determine(schema)
-      .leftMap(_.map(customNodeError => customNodeError.copy(nodeId = nodeId.id, paramName = paramName)))
+      .leftMap(_.map(customNodeError => customNodeError.copy(nodeId = nodeId, paramName = paramName)))
 
-  private def createCustomNodeError(errMsg: String): CustomNodeError = CustomNodeError("", errMsg, None)
+  private def createCustomNodeError(errMsg: String): CustomNodeError = CustomNodeError(NodeId(""), errMsg, None)
 
   final val NullNotAllowed = createCustomNodeError("Value is not nullable")
 

--- a/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/validator/TopicsExistenceValidator.scala
+++ b/utils/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/validator/TopicsExistenceValidator.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.kafka.validator
 
 import cats.data.{NonEmptyList, Validated}
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomNodeError
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.TopicName
@@ -29,7 +30,7 @@ object TopicsExistenceValidator {
 final case class TopicExistenceValidationException[T <: TopicName](topics: NonEmptyList[T])
     extends RuntimeException(TopicExistenceValidationException.message(topics)) {
 
-  def toCustomNodeError(nodeId: String, paramName: Option[ParameterName]) =
+  def toCustomNodeError(nodeId: NodeId, paramName: Option[ParameterName]) =
     new CustomNodeError(nodeId, super.getMessage, paramName)
 }
 

--- a/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaJsonExceptionSerializationSchema.scala
+++ b/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/exception/KafkaJsonExceptionSerializationSchema.scala
@@ -6,7 +6,7 @@ import io.circe.syntax.EncoderOps
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.record.DefaultRecordBatch
 import org.apache.kafka.common.utils.Utils
-import pl.touk.nussknacker.engine.api.MetaData
+import pl.touk.nussknacker.engine.api.{MetaData, NodeId}
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 import pl.touk.nussknacker.engine.api.json.encoders.ToJsonEncoder
 import pl.touk.nussknacker.engine.api.process.ProcessName
@@ -161,7 +161,7 @@ class KafkaJsonExceptionSerializationSchema(metaData: MetaData, consumerConfig: 
 
 @JsonCodec case class KafkaExceptionInfo(
     processName: ProcessName,
-    nodeId: Option[String],
+    nodeId: Option[NodeId],
     message: Option[String],
     exceptionInput: Option[String],
     inputEvent: Option[Json],

--- a/utils/lite-components-testkit/src/test/scala/pl/touk/nussknacker/engine/lite/util/test/RequestResponseTestScenarioRunnerSpec.scala
+++ b/utils/lite-components-testkit/src/test/scala/pl/touk/nussknacker/engine/lite/util/test/RequestResponseTestScenarioRunnerSpec.scala
@@ -4,7 +4,7 @@ import io.circe.syntax.EncoderOps
 import org.apache.pekko.http.scaladsl.model.{HttpMethods, HttpRequest}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.{MethodToInvoke, ParamName, Service}
+import pl.touk.nussknacker.engine.api.{MethodToInvoke, NodeId, ParamName, Service}
 import pl.touk.nussknacker.engine.api.component.{ComponentDefinition, ComponentId, ComponentType, NodeComponentInfo}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.lite.util.test.RequestResponseTestScenarioRunner._
@@ -62,7 +62,7 @@ class RequestResponseTestScenarioRunnerSpec extends AnyFunSuite with Matchers {
       ).swap.toOption.get.head
 
       firstError.nodeComponentInfo shouldBe Some(
-        NodeComponentInfo("fail", Some(ComponentId(ComponentType.Service, failingComponent)))
+        NodeComponentInfo(NodeId("fail"), Some(ComponentId(ComponentType.Service, failingComponent)))
       )
       firstError.throwable.getMessage shouldBe FailingService.failMessage
 

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaUniversalComponentTransformer.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/KafkaUniversalComponentTransformer.scala
@@ -185,7 +185,7 @@ abstract class KafkaUniversalComponentTransformer[T, TN <: TopicName: TopicValid
           .validateTopic(preparedTopic.prepared)
           .swap
           .toList
-          .map(_.toCustomNodeError(nodeId.id, Some(topicParamName)))
+          .map(_.toCustomNodeError(nodeId, Some(topicParamName)))
       NextParameters(
         versionOrContentTypeParam.value.createParameter() :: nextParams,
         errors = versionOrContentTypeParam.written ++ topicValidationErrors

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/AvroSinkValueParameterTest.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/AvroSinkValueParameterTest.scala
@@ -128,7 +128,7 @@ class AvroSchemaBasedParameterTest extends AnyFunSuite with Matchers {
     result shouldBe Invalid(
       NonEmptyList.one(
         CustomNodeError(
-          nodeId.id,
+          nodeId,
           s"""Record field name is restricted. Restricted names are Schema version, Key, Value validation mode, Topic""",
           None
         )

--- a/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/LoggingListener.scala
+++ b/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/LoggingListener.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.engine.util
 
 import org.slf4j.Logger
-import pl.touk.nussknacker.engine.api.{Context, MetaData, ProcessListener}
+import pl.touk.nussknacker.engine.api.{Context, MetaData, NodeId, ProcessListener}
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 
 import java.util.concurrent.ConcurrentHashMap
@@ -36,38 +36,38 @@ object LoggingListener extends ProcessListener with Serializable {
     }
   }
 
-  override def nodeEntered(nodeId: String, context: Context, metadata: MetaData): Unit = {
-    debug(List(metadata.name.value, nodeId), s"Node entered. Context: $context")
+  override def nodeEntered(nodeId: NodeId, context: Context, metadata: MetaData): Unit = {
+    debug(List(metadata.name.value, nodeId.id), s"Node entered. Context: $context")
   }
 
   override def transitionToNextNode(
-      nodeId: String,
-      nextNodeId: String,
+      nodeId: NodeId,
+      nextNodeId: NodeId,
       context: Context,
       processMetaData: MetaData
   ): Unit = ()
 
   override def processingFinishedInNode(
-      nodeId: String,
+      nodeId: NodeId,
       context: Context,
       processMetaData: MetaData,
   ): Unit = ()
 
   override def endEncountered(
-      nodeId: String,
+      nodeId: NodeId,
       ref: String,
       context: Context,
       metadata: MetaData
   ): Unit = {
-    debug(List(metadata.name.value, nodeId, "end", ref), s"End encountered. Context: $context")
+    debug(List(metadata.name.value, nodeId.id, "end", ref), s"End encountered. Context: $context")
   }
 
-  override def deadEndEncountered(lastNodeId: String, context: Context, metadata: MetaData): Unit = {
-    debug(List(metadata.name.value, lastNodeId, "deadEnd"), s"Dead end encountered. Context: $context")
+  override def deadEndEncountered(lastNodeId: NodeId, context: Context, metadata: MetaData): Unit = {
+    debug(List(metadata.name.value, lastNodeId.id, "deadEnd"), s"Dead end encountered. Context: $context")
   }
 
   override def expressionEvaluated(
-      nodeId: String,
+      nodeId: NodeId,
       expressionId: String,
       expr: String,
       context: Context,
@@ -75,20 +75,20 @@ object LoggingListener extends ProcessListener with Serializable {
       result: Any
   ): Unit = {
     debug(
-      List(metadata.name.value, nodeId, "expression"),
+      List(metadata.name.value, nodeId.id, "expression"),
       s"invoked expression: $expr with result $result. Context: $context"
     )
   }
 
   override def serviceInvoked(
-      nodeId: String,
+      nodeId: NodeId,
       id: String,
       context: Context,
       metadata: MetaData,
       result: Try[Any]
   ): Unit = {
     debug(
-      List(metadata.name.value, nodeId, "service", id),
+      List(metadata.name.value, nodeId.id, "service", id),
       s"Invocation ended-up with result: $result. Context: $context"
     )
   }

--- a/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/exception/ExceptionRateMeter.scala
+++ b/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/exception/ExceptionRateMeter.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.util.exception
 
 import cats.data.NonEmptyList
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
 import pl.touk.nussknacker.engine.util.metrics.{MetricIdentifier, MetricsProviderForScenario, RateMeter}
 import pl.touk.nussknacker.engine.util.metrics.common.naming.nodeIdTag
@@ -11,17 +12,17 @@ class ExceptionRateMeter(metricsProvider: MetricsProviderForScenario) {
     metricsProvider.instantRateMeterWithCount(MetricIdentifier(NonEmptyList.of("error", "instantRate"), Map.empty))
 
   // This meter will not be eagerly initialized
-  private val nodeErrorsMeterMap = collection.concurrent.TrieMap[String, RateMeter]()
+  private val nodeErrorsMeterMap = collection.concurrent.TrieMap[NodeId, RateMeter]()
 
   def markException(exceptionInfo: NuExceptionInfo): Unit = {
     allErrorsMeter.mark()
-    getMeterForNode(exceptionInfo.nodeComponentInfo.map(_.nodeId).getOrElse("unknown")).mark()
+    getMeterForNode(exceptionInfo.nodeComponentInfo.map(_.nodeId).getOrElse(NodeId("unknown"))).mark()
   }
 
-  private def getMeterForNode(nodeId: String): RateMeter = nodeErrorsMeterMap.getOrElseUpdate(
+  private def getMeterForNode(nodeId: NodeId): RateMeter = nodeErrorsMeterMap.getOrElseUpdate(
     nodeId,
     metricsProvider.instantRateMeterWithCount(
-      MetricIdentifier(NonEmptyList.of("error", "instantRateByNode"), Map(nodeIdTag -> nodeId))
+      MetricIdentifier(NonEmptyList.of("error", "instantRateByNode"), Map(nodeIdTag -> nodeId.id))
     )
   )
 

--- a/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/metrics/common/EndCountingListener.scala
+++ b/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/metrics/common/EndCountingListener.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.engine.util.metrics.common
 
 import cats.data.NonEmptyList
-import pl.touk.nussknacker.engine.api.{Context, EmptyProcessListener, MetaData}
+import pl.touk.nussknacker.engine.api.{Context, EmptyProcessListener, MetaData, NodeId}
 import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
 import pl.touk.nussknacker.engine.graph.node.{DeadEndingData, EndingNodeData, NodeData}
 import pl.touk.nussknacker.engine.util.metrics.{MetricIdentifier, RateMeter, WithMetrics}
@@ -30,20 +30,20 @@ private[engine] class EndCountingListener(allNodes: Iterable[NodeData]) extends 
   }
 
   override def deadEndEncountered(
-      lastNodeId: String,
+      lastNodeId: NodeId,
       context: Context,
       processMetaData: MetaData
   ): Unit = {
-    deadEndRateMeters.mark(lastNodeId)
+    deadEndRateMeters.mark(lastNodeId.id)
   }
 
   override def endEncountered(
-      nodeId: String,
+      nodeId: NodeId,
       ref: String,
       context: Context,
       processMetaData: MetaData
   ): Unit = {
-    endRateMeters.mark(nodeId)
+    endRateMeters.mark(nodeId.id)
   }
 
   private class Meters(name: String, nodeIds: PartialFunction[NodeData, String]) {

--- a/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/metrics/common/NodeCountingListener.scala
+++ b/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/metrics/common/NodeCountingListener.scala
@@ -1,25 +1,25 @@
 package pl.touk.nussknacker.engine.util.metrics.common
 
 import cats.data.NonEmptyList
-import pl.touk.nussknacker.engine.api.{Context, EmptyProcessListener, MetaData}
+import pl.touk.nussknacker.engine.api.{Context, EmptyProcessListener, MetaData, NodeId}
 import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
 import pl.touk.nussknacker.engine.util.metrics.{Counter, MetricIdentifier, WithMetrics}
 import pl.touk.nussknacker.engine.util.metrics.common.naming.nodeIdTag
 
-private[engine] class NodeCountingListener(nodeIds: Iterable[String]) extends EmptyProcessListener with WithMetrics {
+private[engine] class NodeCountingListener(nodeIds: Iterable[NodeId]) extends EmptyProcessListener with WithMetrics {
 
-  private var counters: Map[String, Counter] = null
+  private var counters: Map[NodeId, Counter] = null
 
   override def open(context: EngineRuntimeContext): Unit = {
     super.open(context)
     counters = nodeIds
       .map(nodeId =>
-        nodeId -> metricsProvider.counter(MetricIdentifier(NonEmptyList.of("nodeCount"), Map(nodeIdTag -> nodeId)))
+        nodeId -> metricsProvider.counter(MetricIdentifier(NonEmptyList.of("nodeCount"), Map(nodeIdTag -> nodeId.id)))
       )
       .toMap
   }
 
-  override def nodeEntered(nodeId: String, context: Context, processMetaData: MetaData): Unit = {
+  override def nodeEntered(nodeId: NodeId, context: Context, processMetaData: MetaData): Unit = {
     val counter = counters
       .getOrElse(nodeId, throw new RuntimeException(s"Unexpected node: ${nodeId}, known nodes: ${counters.keySet}"))
     counter.update(1)


### PR DESCRIPTION
## Describe your changes

After this change, the last missing place where we have `String` -> `NodeId` conversion is the scenario api.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
