### PR TITLE
Run off schedule button fixes

### DIFF
--- a/designer/client/src/reducers/scenarioState.ts
+++ b/designer/client/src/reducers/scenarioState.ts
@@ -1,5 +1,4 @@
 import { produce } from "immer";
-import { merge } from "lodash";
 
 import type { Reducer } from "../actions/reduxTypes";
 import type { ProcessStateType } from "../components/Process/types";
@@ -11,8 +10,7 @@ export const reducer: Reducer<ProcessStateType> = produce((draft, action) => {
             // Since scenario endpoint doesn't return null attributes the state will be undefined for fragments.
             // Redux and Immer does not allow to return undefined values so in that case we return null explicitly.
             if (action.scenario.state) {
-                merge(draft, action.scenario.state);
-                return draft;
+                return action.scenario.state;
             }
             return null;
         }
@@ -28,8 +26,7 @@ export const reducer: Reducer<ProcessStateType> = produce((draft, action) => {
             return draft;
         }
         case "PROCESS_STATE_LOADED": {
-            merge(draft, action.processState);
-            return draft;
+            return action.processState;
         }
         case "CLEAR_PROCESS": {
             return {} as ProcessStateType;

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/exception/ProcessIllegalAction.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/exception/ProcessIllegalAction.scala
@@ -4,6 +4,7 @@ import pl.touk.nussknacker.engine.api.deployment.{ScenarioActionName, StateStatu
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.ui.IllegalOperationError
 import pl.touk.nussknacker.ui.process.deployment.scenariostatus.ScenarioStatusWithAllowedActions
+import pl.touk.nussknacker.ui.process.periodic.PeriodicProcessService.PeriodicScenarioStatus
 
 final case class ProcessIllegalAction(message: String) extends IllegalOperationError(message, details = "")
 
@@ -13,12 +14,17 @@ object ProcessIllegalAction {
       actionName: ScenarioActionName,
       processName: ProcessName,
       ScenarioStatusWithAllowedActions: ScenarioStatusWithAllowedActions
-  ): ProcessIllegalAction =
+  ): ProcessIllegalAction = {
+    val scenarioStatusName = ScenarioStatusWithAllowedActions.scenarioStatus match {
+      case status: PeriodicScenarioStatus => status.mergedStatus.name
+      case other                          => other.name
+    }
     ProcessIllegalAction(
-      s"Action: $actionName is not allowed in scenario ($processName) state: ${ScenarioStatusWithAllowedActions.scenarioStatus}, allowed actions: ${ScenarioStatusWithAllowedActions.allowedActions
+      s"Action: $actionName is not allowed, because scenario $processName is in state $scenarioStatusName, allowed actions: ${ScenarioStatusWithAllowedActions.allowedActions
           .map(_.value)
           .mkString(",")}."
     )
+  }
 
   def archived(actionName: ScenarioActionName, processName: ProcessName): ProcessIllegalAction =
     ProcessIllegalAction(s"Forbidden action: $actionName for archived scenario: $processName.")

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicStateStatus.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicStateStatus.scala
@@ -92,7 +92,9 @@ object PeriodicStateStatus {
           ScenarioActionName.RunOffSchedule -> s"Version ${print(input.deployedVersionId)} is deployed, but different version ${print(input.currentlyPresentedVersionId)} is displayed"
         )
       case other =>
-        Map(ScenarioActionName.RunOffSchedule -> s"Disabled for ${other.name} status.")
+        Map(
+          ScenarioActionName.RunOffSchedule -> s"Cannot run off schedule, because scenario is in ${other.name} state."
+        )
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/PeriodicProcessStateDefinitionManagerTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/PeriodicProcessStateDefinitionManagerTest.scala
@@ -103,7 +103,7 @@ class PeriodicProcessStateDefinitionManagerTest extends AnyFunSuite with Matcher
         currentlyPresentedVersionId = Some(VersionId(5)),
       )
     ) shouldEqual Map(
-      ScenarioActionName.RunOffSchedule -> "Disabled for CANCELED status."
+      ScenarioActionName.RunOffSchedule -> "Cannot run off schedule, because scenario is in CANCELED state."
     )
   }
 


### PR DESCRIPTION
## Describe your changes

There was a bug in scenario state handling on FE side. The state was refreshed, but the new state was merged with old state, instead of replacing it. As a result, maps and arrays inside the state representation were not correctly updated. (For example, the "Run off schedule" button was not disabled when scenario state changed - it was not removed from the list of allowed actions, because the new list of allowed actions was merged with older one instead of replacing it, same with custom tooltips).

Additionally, updated error messages and tooltips for "run now" button.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
