### PR TITLE
[NU-2190] LiveDataProvider: returing upstreamTimestamp

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/livedata/LiveDataProvider.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/livedata/LiveDataProvider.scala
@@ -2,6 +2,8 @@ package pl.touk.nussknacker.engine.api.livedata
 
 import pl.touk.nussknacker.engine.api.process.Source
 
+import java.time.Instant
+
 trait LiveDataProvider { self: Source =>
 
   def fetchLiveData(maxNumberOfRecords: Int): DataRecords
@@ -12,5 +14,8 @@ final case class DataRecords(records: List[DataRecord])
 
 /**
  * @param variables should contain variables matching types declared in `ValidationContext`
+ * @param upstreamTimestamp should contain the timestamp provided by the upstream source which is used
+ *                          before we initiate the context and extract the even timestamp using user-provided parameter;
+ *                          this is a second parameter (recordTimestamp) in TimestampAssigner.extractTimestamp
  */
-final case class DataRecord(variables: Map[String, Any], timestamp: Option[Long])
+final case class DataRecord(variables: Map[String, Any], upstreamTimestamp: Option[Instant])

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecords.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecords.scala
@@ -6,23 +6,24 @@ import io.circe.DecodingFailure.Reason.CustomReason
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import pl.touk.nussknacker.engine.api.NodeId
 
+import java.time.Instant
+
 case class PreliminaryScenarioRecords(records: NonEmptyList[PreliminaryScenarioRecord])
 
 sealed trait PreliminaryScenarioRecord {
   def sourceId: NodeId
-  def timestamp: Option[Long]
 }
 
 final case class SourceSpecificFormatPreliminaryScenarioRecord(
     override val sourceId: NodeId,
     record: Json,
-    override val timestamp: Option[Long]
+    timestamp: Option[Long]
 ) extends PreliminaryScenarioRecord
 
 final case class CommonFormatPreliminaryScenarioRecord(
     override val sourceId: NodeId,
     variables: Map[String, Json],
-    override val timestamp: Option[Long]
+    upstreamTimestamp: Option[Instant]
 ) extends PreliminaryScenarioRecord
 
 object PreliminaryScenarioRecord {
@@ -56,6 +57,14 @@ object PreliminaryScenarioRecord {
           cursor
         )
       )
+  }
+
+  implicit val ordering: Ordering[PreliminaryScenarioRecord] = Ordering.by[PreliminaryScenarioRecord, Long] {
+    case SourceSpecificFormatPreliminaryScenarioRecord(_, _, Some(timestamp)) => timestamp
+    case CommonFormatPreliminaryScenarioRecord(_, _, Some(timestamp))         => timestamp.toEpochMilli
+    case SourceSpecificFormatPreliminaryScenarioRecord(_, _, None) |
+        CommonFormatPreliminaryScenarioRecord(_, _, None) =>
+      Long.MaxValue
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
@@ -165,8 +165,10 @@ class ScenarioTestService(
         )
 
         mergedLivedData = ListUtil
-          .mergeLists(fetchedLiveDataForSourcesNel.toList, maxNumberOfRecords)
-          .sortBy(_.timestamp.getOrElse(Long.MaxValue))
+          // We sort firstly in case if returner by the source records are not sorted
+          // and then sort at the end after we merge elements from each list in round-robin manner
+          .mergeListsRoundRobin(fetchedLiveDataForSourcesNel.toList.map(_.sorted), maxNumberOfRecords)
+          .sorted
 
         fetchedLiveDataNel <- NonEmptyList
           .fromList(mergedLivedData)
@@ -201,6 +203,7 @@ class ScenarioTestService(
         fetchedLiveData <- testDataFormatHandler
           .fetchLiveData(nodeId, compiledSource, maxNumberOfRecords)
           .leftMap(_ => FetchLiveDataError.LiveDataFetchingNotSupportedError)
+          .map(_.sorted)
 
         fetchedLiveDataNel <- NonEmptyList
           .fromList(fetchedLiveData)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testdataformat/CommonDataFormatHandler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testdataformat/CommonDataFormatHandler.scala
@@ -58,7 +58,7 @@ class CommonDataFormatHandler(modelData: ModelData) extends TestDataFormatHandle
           sourceRecords
             .map { record =>
               val variablesAsJson = record.variables.mapValuesNow(toJsonEncoder.encodeUnsafe)
-              CommonFormatPreliminaryScenarioRecord(sourceId, variablesAsJson, record.timestamp)
+              CommonFormatPreliminaryScenarioRecord(sourceId, variablesAsJson, record.upstreamTimestamp)
             }
         }
         Right(records)
@@ -105,7 +105,7 @@ class CommonDataFormatHandler(modelData: ModelData) extends TestDataFormatHandle
         .leftMap(_.message)
         .leftMap(InputVariablesExpressionDecodingError)
       // Timestamp handling is supported only during testing using test data in the json format
-      singleRecord = ScenarioTestCommonFormatJsonRecord(NodeId(sourceId), validVariablesMap, timestamp = None)
+      singleRecord = ScenarioTestCommonFormatJsonRecord(NodeId(sourceId), validVariablesMap, upstreamTimestamp = None)
     } yield ScenarioTestData(List(singleRecord))
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/GenericSourceWithCustomTestingSupportTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/GenericSourceWithCustomTestingSupportTestingApiHttpServiceSpec.scala
@@ -29,9 +29,9 @@ class GenericSourceWithCustomTestingSupportTestingApiHttpServiceSpec
 
   override protected def expectedTestDataJson: String =
     s"""[
-       |  {"sourceId":"sourceId","variables":{"input": "test-0"},"timestamp":123},
-       |  {"sourceId":"sourceId","variables":{"input": "test-1"},"timestamp":123},
-       |  {"sourceId":"sourceId","variables":{"input": "test-2"},"timestamp":123}
+       |  {"sourceId":"sourceId","variables":{"input": "test-0"},"upstreamTimestamp":"1970-01-01T00:00:00.123Z"},
+       |  {"sourceId":"sourceId","variables":{"input": "test-1"},"upstreamTimestamp":"1970-01-01T00:00:00.123Z"},
+       |  {"sourceId":"sourceId","variables":{"input": "test-2"},"upstreamTimestamp":"1970-01-01T00:00:00.123Z"}
        |]""".stripMargin
 
   override protected def validParameters: TestSourceParameters =

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/ScenarioTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/ScenarioTestingApiHttpServiceSpec.scala
@@ -220,7 +220,7 @@ trait ScenarioTestingApiHttpServiceSpec
       createSavedScenario(exampleScenario)
 
       val response = runTestsFromFile(s"""[
-          |  {"sourceId":"$exampleScenarioSourceId","variables":{"nonExistingVariable": 123},"timestamp":123}
+          |  {"sourceId":"$exampleScenarioSourceId","variables":{"nonExistingVariable": 123},"upstreamTimestamp":"1970-01-01T00:00:00.123Z"}
           |]""".stripMargin)
 
       response.code shouldEqual StatusCode.BadRequest
@@ -231,7 +231,7 @@ trait ScenarioTestingApiHttpServiceSpec
       createSavedScenario(exampleScenario)
 
       val response = runTestsFromFile(s"""[
-                                         |  {"sourceId":"$exampleScenarioSourceId","variables":{"input":$inputValueNotMatchingExpectedType},"timestamp":123}
+                                         |  {"sourceId":"$exampleScenarioSourceId","variables":{"input":$inputValueNotMatchingExpectedType},"upstreamTimestamp":"1970-01-01T00:00:00.123Z"}
                                          |]""".stripMargin)
 
       response.code shouldEqual StatusCode.BadRequest

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/SchemedKafkaTestingApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/testing/SchemedKafkaTestingApiHttpServiceSpec.scala
@@ -33,6 +33,7 @@ import pl.touk.nussknacker.test.processes.WithScenarioActivitySpecAsserts.UsersB
 import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.TestSourceParameters
 import pl.touk.nussknacker.ui.process.test.testdataformat.CommonDataFormatHandler.InputVariablesParameterName
 
+import java.time.Instant
 import scala.jdk.CollectionConverters._
 
 class SchemedKafkaTestingApiHttpServiceSpec
@@ -143,7 +144,7 @@ class SchemedKafkaTestingApiHttpServiceSpec
       |        "headers": {}
       |      }
       |    },
-      |    "timestamp": $givenTimestamp
+      |    "upstreamTimestamp": "${Instant.ofEpochMilli(givenTimestamp)}"
       |  }
       |]""".stripMargin
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecordTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecordTest.scala
@@ -8,6 +8,8 @@ import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
 
+import java.time.Instant
+
 class PreliminaryScenarioRecordTest extends AnyFunSuite with Matchers with EitherValuesDetailedMessage {
 
   test("should encode and decode source-specific format record") {
@@ -26,9 +28,10 @@ class PreliminaryScenarioRecordTest extends AnyFunSuite with Matchers with Eithe
     val inputRecord: PreliminaryScenarioRecord = CommonFormatPreliminaryScenarioRecord(
       sourceId = NodeId("source 1"),
       variables = Map("input" -> Json.obj("f1" -> Json.fromLong(42), "f2" -> Json.fromString("str"))),
-      timestamp = Some(159L)
+      upstreamTimestamp = Some(Instant.ofEpochMilli(159L))
     )
-    val recordJsonString = """{"sourceId":"source 1","variables":{"input":{"f1":42,"f2":"str"}},"timestamp":159}"""
+    val recordJsonString =
+      """{"sourceId":"source 1","variables":{"input":{"f1":42,"f2":"str"}},"upstreamTimestamp":"1970-01-01T00:00:00.159Z"}"""
 
     inputRecord.asJson.noSpaces shouldBe recordJsonString
     decode[PreliminaryScenarioRecord](recordJsonString).rightValue shouldBe inputRecord

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecordsSerDeTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/PreliminaryScenarioRecordsSerDeTest.scala
@@ -10,7 +10,8 @@ import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
 import pl.touk.nussknacker.ui.api.TestDataFormat
 import pl.touk.nussknacker.ui.process.test.PreliminaryScenarioRecordsSerDe.{DeserializationError, SerializationError}
-import pl.touk.nussknacker.ui.process.test.testdataformat.TestDataFormatSerDe
+
+import java.time.Instant
 
 class PreliminaryScenarioRecordsSerDeTest extends AnyFunSuite with Matchers with EitherValuesDetailedMessage {
 
@@ -40,11 +41,11 @@ class PreliminaryScenarioRecordsSerDeTest extends AnyFunSuite with Matchers with
         "f2" -> Json.fromLong(42L)
       )
     ),
-    timestamp = Some(24L)
+    upstreamTimestamp = Some(Instant.parse("2025-01-01T02:03:04.005Z"))
   )
 
   private val serializedCommonFormatRecord =
-    """[{"sourceId":"source1","variables":{"input":{"f1":"field value","f2":42}},"timestamp":24}]""".stripMargin
+    """[{"sourceId":"source1","variables":{"input":{"f1":"field value","f2":42}},"upstreamTimestamp":"2025-01-01T02:03:04.005Z"}]""".stripMargin
 
   test("should serialize scenario test data") {
     forAll(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
@@ -34,6 +34,8 @@ import pl.touk.nussknacker.ui.process.test.ScenarioTestService.TestingCapabiliti
 import pl.touk.nussknacker.ui.process.test.testdataformat.CommonDataFormatHandler.InputVariablesParameterName
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
+import java.time.Instant
+
 class ScenarioTestServiceSpec
     extends AnyFunSuite
     with Matchers
@@ -75,7 +77,7 @@ class ScenarioTestServiceSpec
 
         override def fetchLiveData(maxNumberOfRecords: Int): DataRecords = DataRecords((for {
           number <- 1 to maxNumberOfRecords
-          record = DataRecord(Map("input" -> s"record $number"), timestamp = None)
+          record = DataRecord(Map("input" -> s"record $number"), upstreamTimestamp = None)
         } yield record).toList)
 
       }
@@ -276,17 +278,17 @@ class ScenarioTestServiceSpec
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source1"),
               Map("input" -> Json.fromString("record 1")),
-              timestamp = Some(1)
+              upstreamTimestamp = Some(Instant.ofEpochMilli(1))
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source1"),
               Map("input" -> Json.fromString("record 2")),
-              timestamp = Some(2)
+              upstreamTimestamp = Some(Instant.ofEpochMilli(2))
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source1"),
               Map("input" -> Json.fromString("record 3")),
-              timestamp = Some(3)
+              upstreamTimestamp = Some(Instant.ofEpochMilli(3))
             ),
           )
       }
@@ -329,17 +331,17 @@ class ScenarioTestServiceSpec
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source1"),
               Map("input" -> Json.fromString("record 1")),
-              timestamp = None
+              upstreamTimestamp = None
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source1"),
               Map("input" -> Json.fromString("record 2")),
-              timestamp = None
+              upstreamTimestamp = None
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source1"),
               Map("input" -> Json.fromString("record 3")),
-              timestamp = None
+              upstreamTimestamp = None
             ),
           )
       }
@@ -439,42 +441,42 @@ class ScenarioTestServiceSpec
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source1"),
               Map("input" -> Json.fromString("record 1")),
-              timestamp = Some(1)
+              upstreamTimestamp = Some(Instant.ofEpochMilli(1))
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source3"),
               Map("input" -> Json.fromString("record 1")),
-              timestamp = Some(1)
+              upstreamTimestamp = Some(Instant.ofEpochMilli(1))
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source1"),
               Map("input" -> Json.fromString("record 2")),
-              timestamp = Some(2)
+              upstreamTimestamp = Some(Instant.ofEpochMilli(2))
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source3"),
               Map("input" -> Json.fromString("record 2")),
-              timestamp = Some(2)
+              upstreamTimestamp = Some(Instant.ofEpochMilli(2))
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source1"),
               Map("input" -> Json.fromString("record 3")),
-              timestamp = Some(3)
+              upstreamTimestamp = Some(Instant.ofEpochMilli(3))
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source2"),
               Map("input" -> Json.fromString("record 1")),
-              timestamp = None
+              upstreamTimestamp = None
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source2"),
               Map("input" -> Json.fromString("record 2")),
-              timestamp = None
+              upstreamTimestamp = None
             ),
             CommonFormatPreliminaryScenarioRecord(
               NodeId("source2"),
               Map("input" -> Json.fromString("record 3")),
-              timestamp = None
+              upstreamTimestamp = None
             ),
           )
       }
@@ -569,12 +571,12 @@ class ScenarioTestServiceSpec
         CommonFormatPreliminaryScenarioRecord(
           sourceId = NodeId("source1"),
           variables = Map("input" -> Json.fromString("record 1")),
-          timestamp = Some(1)
+          upstreamTimestamp = Some(Instant.ofEpochMilli(1))
         ),
         CommonFormatPreliminaryScenarioRecord(
           sourceId = NodeId("source2"),
           variables = Map("input" -> Json.fromString("record 2")),
-          timestamp = None
+          upstreamTimestamp = None
         ) :: Nil,
       )
     )
@@ -586,12 +588,12 @@ class ScenarioTestServiceSpec
       ScenarioTestCommonFormatJsonRecord(
         NodeId("source1"),
         Map("input" -> Json.fromString("record 1")),
-        timestamp = Some(1L)
+        upstreamTimestamp = Some(Instant.ofEpochMilli(1))
       ),
       ScenarioTestCommonFormatJsonRecord(
         NodeId("source2"),
         Map("input" -> Json.fromString("record 2")),
-        timestamp = None
+        upstreamTimestamp = None
       ),
     )
   }
@@ -628,17 +630,17 @@ class ScenarioTestServiceSpec
                 CommonFormatPreliminaryScenarioRecord(
                   sourceId = NodeId("source1"),
                   variables = Map("input" -> Json.fromString("record 1")),
-                  timestamp = None
+                  upstreamTimestamp = None
                 ),
                 CommonFormatPreliminaryScenarioRecord(
                   sourceId = NodeId("non-existing source"),
                   variables = Map("input" -> Json.fromString("record 2")),
-                  timestamp = None
+                  upstreamTimestamp = None
                 ) ::
                   CommonFormatPreliminaryScenarioRecord(
                     sourceId = NodeId("non-existing source 2"),
                     variables = Map("input" -> Json.fromString("record 3")),
-                    timestamp = None
+                    upstreamTimestamp = None
                   ) :: Nil
               )
             )

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/watermarkstrategy/FlinkWatermarkStrategyRuntimeHandler.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/watermarkstrategy/FlinkWatermarkStrategyRuntimeHandler.scala
@@ -90,7 +90,6 @@ object FlinkWatermarkStrategyRuntimeHandler {
     )
   }
 
-  // TODO: use this WatermarkStrategy also in scenario testing mechanism, when common format is used
   def watermarkStrategy(watermarkStrategyOptions: WatermarkStrategyOptions): WatermarkStrategy[ContextWithEventTime] = {
     val strategyWithLateness =
       WatermarkStrategy.forBoundedOutOfOrderness[ContextWithEventTime](
@@ -108,9 +107,10 @@ object FlinkWatermarkStrategyRuntimeHandler {
     override def extractTimestamp(context: ContextWithEventTime, recordTimestamp: Long): Long =
       context.eventTime
         .map(_.toEpochMilli)
-        // MinValue means that even time is not configured in upstream
+        // MinValue means that event time is not configured in upstream
         .orElse(Option(recordTimestamp).filterNot(_ == Long.MinValue))
-        // It is better produce watermarks in streaming than not. Thanks to that things such as aggregations will work
+        // It is better to produce watermarks based on current time in streaming than not produce at all.
+        // Thanks to that things such as aggregations will work somehow
         .getOrElse(System.currentTimeMillis())
 
   }

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/sink/TableFileSinkTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/sink/TableFileSinkTest.scala
@@ -221,7 +221,7 @@ class TableFileSinkTest
        |""".stripMargin)
 
   private lazy val tableComponents: List[ComponentDefinition] =
-    new FlinkTableDataSourceComponentProvider().create(tableComponentsConfig)
+    FlinkTableDataSourceComponentProvider.create(tableComponentsConfig)
 
   private lazy val flinkMiniClusterWithServices = FlinkMiniClusterFactory.createUnitTestsMiniClusterWithServices()
 

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSinkParametersTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/sink/TableSinkParametersTest.scala
@@ -94,7 +94,7 @@ class TableSinkParametersTest
   )
 
   private lazy val tableComponents: List[ComponentDefinition] =
-    new FlinkTableDataSourceComponentProvider().create(tableComponentsConfig)
+    FlinkTableDataSourceComponentProvider.create(tableComponentsConfig)
 
   private lazy val flinkMiniClusterWithServices = FlinkMiniClusterFactory.createUnitTestsMiniClusterWithServices()
 

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/source/TableSourceLiveDataFetchingTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/source/TableSourceLiveDataFetchingTest.scala
@@ -1,0 +1,136 @@
+package pl.touk.nussknacker.engine.flink.table.source
+
+import com.typesafe.config.ConfigFactory
+import io.circe.Json
+import org.apache.commons.io.FileUtils
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.LoneElement.convertToCollectionLoneElementWrapper
+import org.scalatest.OptionValues.convertOptionToValuable
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.api.livedata.LiveDataProvider
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.flink.minicluster.FlinkMiniClusterFactory
+import pl.touk.nussknacker.engine.flink.table.FlinkTableDataSourceComponentProvider
+import pl.touk.nussknacker.engine.flink.util.test.FlinkNodeCompiler.FlinkNodeCompilerExt
+import pl.touk.nussknacker.engine.graph.evaluatedparam.Parameter
+import pl.touk.nussknacker.engine.graph.node
+import pl.touk.nussknacker.engine.graph.source.SourceRef
+import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
+import pl.touk.nussknacker.engine.util.test.TestNodeCompiler
+import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage.convertValidatedToValuable
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.time.Instant
+
+class TableSourceLiveDataFetchingTest extends AnyFunSuite with BeforeAndAfterAll with Matchers {
+
+  private val miniClusterWithServices =
+    FlinkMiniClusterFactory.createUnitTestsMiniClusterWithServices()
+
+  private val configuredEventTimeTimestampTableName = "configured_event_time_timestamp_table"
+
+  private val configuredEventTimeTimestampLtzTableName = "configured_event_time_timestamp_ltz_table"
+
+  private val configuredEventTimeTimestampDirectory =
+    Files.createTempDirectory(s"nusssknacker-${getClass.getSimpleName}-$configuredEventTimeTimestampTableName")
+
+  private val configuredEventTimeTimestampLtzDirectory =
+    Files.createTempDirectory(s"nusssknacker-${getClass.getSimpleName}-$configuredEventTimeTimestampLtzTableName")
+
+  private val nodeCompiler = TestNodeCompiler
+    .flinkBased(ConfigFactory.empty())
+    .withFlinkMiniCluster(miniClusterWithServices)
+    .withExtraComponents(
+      FlinkTableDataSourceComponentProvider.create(
+        ConfigFactory.parseString(
+          s"""tableDefinition: \"\"\"
+             |CREATE TABLE $configuredEventTimeTimestampTableName(
+             |  event_timestamp TIMESTAMP(3),
+             |  another_timestamp_column TIMESTAMP(3),
+             |  WATERMARK FOR event_timestamp AS event_timestamp - INTERVAL '1' MINUTE
+             |) WITH (
+             |  'connector' = 'filesystem',
+             |  'path' = 'file:///$configuredEventTimeTimestampDirectory',
+             |  'format' = 'json'
+             |);
+             |CREATE TABLE $configuredEventTimeTimestampLtzTableName(
+             |  event_timestamp TIMESTAMP_LTZ(3),
+             |  another_timestamp_column TIMESTAMP_LTZ(3),
+             |  WATERMARK FOR event_timestamp AS event_timestamp - INTERVAL '1' MINUTE
+             |) WITH (
+             |  'connector' = 'filesystem',
+             |  'path' = 'file:///$configuredEventTimeTimestampLtzDirectory',
+             |  'format' = 'json'
+             |);
+             |\"\"\"
+             """.stripMargin
+        )
+      )
+    )
+    .build()
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    miniClusterWithServices.close()
+    FileUtils.deleteQuietly(configuredEventTimeTimestampDirectory.toFile)
+    FileUtils.deleteQuietly(configuredEventTimeTimestampLtzDirectory.toFile)
+  }
+
+  test("should return timestamp based on upstream event time configured as TIMESTAMP_LTZ") {
+    val inputContent = Json
+      .fromFields(
+        List(
+          "event_timestamp"          -> Json.fromString("2025-01-01 12:01:02.003Z"),
+          "another_timestamp_column" -> Json.fromString("2025-12-30 00:00:00Z"),
+        )
+      )
+      .noSpaces
+
+    Files.writeString(
+      configuredEventTimeTimestampLtzDirectory.resolve("file.json"),
+      inputContent,
+      StandardCharsets.UTF_8
+    )
+    val record = getLoneLiveDataRecord(configuredEventTimeTimestampLtzTableName)
+
+    record.upstreamTimestamp.value shouldBe Instant.parse("2025-01-01T12:01:02.003Z")
+  }
+
+  test("should return no timestamp if the rowtime is configured as timestamp without time zone (TIMESTAMP)") {
+    val inputContent = Json
+      .fromFields(
+        List(
+          "event_timestamp"          -> Json.fromString("2025-01-01 12:01:02.003"),
+          "another_timestamp_column" -> Json.fromString("2025-12-30 00:00:00"),
+        )
+      )
+      .noSpaces
+
+    Files.writeString(configuredEventTimeTimestampDirectory.resolve("file.json"), inputContent, StandardCharsets.UTF_8)
+    val record = getLoneLiveDataRecord(configuredEventTimeTimestampTableName)
+
+    record.upstreamTimestamp shouldBe None
+  }
+
+  private def getLoneLiveDataRecord(tableName: String) = {
+    val liveDataProvider = nodeCompiler
+      .compileNode(
+        node.Source(
+          "source",
+          SourceRef(
+            "table",
+            List(
+              Parameter(ParameterName("Table"), s"'`default_catalog`.`default_database`.`$tableName`'".spel)
+            )
+          )
+        )
+      )
+      .compiledObject
+      .validValue
+      .asInstanceOf[LiveDataProvider]
+    liveDataProvider.fetchLiveData(1).records.loneElement
+  }
+
+}

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/source/TableSourceTest.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/table/source/TableSourceTest.scala
@@ -44,7 +44,7 @@ class TableSourceTest
   )
 
   private lazy val tableComponents: List[ComponentDefinition] =
-    new FlinkTableDataSourceComponentProvider().create(tableComponentsConfig)
+    FlinkTableDataSourceComponentProvider.create(tableComponentsConfig)
 
   private lazy val flinkMiniClusterWithServices = FlinkMiniClusterFactory.createUnitTestsMiniClusterWithServices()
 
@@ -118,7 +118,7 @@ class TableSourceTest
     )
 
     val tableComponentsBasedOnCatalogConfiguration: List[ComponentDefinition] =
-      new FlinkTableDataSourceComponentProvider().create(configWithCatalogConfiguration)
+      FlinkTableDataSourceComponentProvider.create(configWithCatalogConfiguration)
 
     val runnerWithCatalogConfiguration: FlinkTestScenarioRunner = TestScenarioRunner
       .flinkBased(ConfigFactory.empty(), flinkMiniClusterWithServices)

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/EventGeneratorSourceFactory.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/EventGeneratorSourceFactory.scala
@@ -111,10 +111,10 @@ object EventGeneratorSourceFactory
           _
         ) =>
       val outputValidationContext = prepareOutputValidationContext(inputContext, valueType)
-      NextParameters(prepareWatermarkStrategyParameters(outputValidationContext))
+      NextParameters(
+        prepareWatermarkStrategyParameters(outputValidationContext, eventTimeDefaultValueExpression = "#DATE.now".spel)
+      )
   }
-
-  override protected def eventTimeDefaultValueExpression: Expression = "#DATE.now".spel
 
   override def contextTransformation(inputContext: ValidationContext, dependencies: List[NodeDependencyValue])(
       implicit nodeId: NodeId
@@ -220,7 +220,7 @@ object EventGeneratorSourceFactory
           DataRecord(
             variables = Map(VariableConstants.InputVariableName -> record),
             // TODO: Respect Event time parameter
-            timestamp = None
+            upstreamTimestamp = None
           )
         })
       }

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/FlinkTableDataSourceComponentProvider.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/FlinkTableDataSourceComponentProvider.scala
@@ -20,7 +20,6 @@ import scala.jdk.CollectionConverters._
 class FlinkTableDataSourceComponentProvider extends ComponentProvider with LazyLogging {
 
   override def providerName: String = "flinkTableDataSource"
-  private val tableComponentName    = "table"
 
   override def resolveConfigForExecution(config: Config): Config = config
 
@@ -28,10 +27,20 @@ class FlinkTableDataSourceComponentProvider extends ComponentProvider with LazyL
       componentProviderConfig: Config,
       componentDependencies: ComponentDependencies
   ): List[ComponentDefinition] = {
-    create(componentProviderConfig)
+    FlinkTableDataSourceComponentProvider.create(componentProviderConfig)
   }
 
-  private[nussknacker] def create(componentProviderConfig: Config) = {
+  override def isCompatible(version: NussknackerVersion): Boolean = true
+
+  override def isAutoLoaded: Boolean = false
+
+}
+
+object FlinkTableDataSourceComponentProvider {
+
+  private val tableComponentName = "table"
+
+  private[nussknacker] def create(componentProviderConfig: Config): List[ComponentDefinition] = {
     val parsedConfig                    = TableComponentProviderConfig.parse(componentProviderConfig)
     val testDataGenerationModeOrDefault = parsedConfig.testDataGenerationMode.getOrElse(TestDataGenerationMode.default)
     val sqlStatements                   = parsedConfig.tableDefinition
@@ -53,10 +62,6 @@ class FlinkTableDataSourceComponentProvider extends ComponentProvider with LazyL
       )
     )
   }
-
-  override def isCompatible(version: NussknackerVersion): Boolean = true
-
-  override def isAutoLoaded: Boolean = false
 
 }
 

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/TableDefinition.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/TableDefinition.scala
@@ -1,15 +1,45 @@
 package pl.touk.nussknacker.engine.flink.table
 
-import org.apache.flink.table.catalog.{ObjectIdentifier, ResolvedSchema}
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.flink.table.catalog.{Column, ObjectIdentifier, ResolvedSchema}
 import org.apache.flink.table.types.DataType
+import org.apache.flink.table.types.logical.{LocalZonedTimestampType, TimestampKind, ZonedTimestampType}
+
+import scala.jdk.CollectionConverters._
 
 // We need to use ResolvedSchema instead of (unresolved) Schema because we need to know the type
 // of computed columns in sources. UnresolvedComputedColumn holds unresolved Expression which unknown type.
 // After expression resolution, the type is determined.
-final case class TableDefinition(tableId: ObjectIdentifier, schema: ResolvedSchema) {
+final case class TableDefinition(tableId: ObjectIdentifier, schema: ResolvedSchema) extends LazyLogging {
 
   lazy val sourceRowDataType: DataType = schema.toSourceRowDataType
 
   lazy val sinkRowDataType: DataType = schema.toSinkRowDataType
+
+  lazy val singleColumnWithTimezoneAwareRowtime: Option[Column] = schema.getColumns.asScala.toList.filter { column =>
+    column.getDataType.getLogicalType match {
+      case zoned: LocalZonedTimestampType => zoned.getKind == TimestampKind.ROWTIME
+      // This is not tested because TIMESTAMP WITH TIME ZONE is not supported by flink sql https://issues.apache.org/jira/browse/FLINK-20869
+      case zoned: ZonedTimestampType => zoned.getKind == TimestampKind.ROWTIME
+      case _                         => false
+    }
+  } match {
+    case one :: Nil =>
+      logger.debug(
+        s"Column [$one] is a rowtime column in $tableId table. It will be used as a timestamp field"
+      )
+      Some(one)
+    case Nil =>
+      logger.debug(
+        s"No rowtime column found in $tableId table"
+      )
+      None
+    case moreThanOne =>
+      logger.warn(
+        s"More than one rowtime column found in $tableId table [${moreThanOne.mkString(", ")}]. " +
+          s"This construction is not supported, timestamp field will be skipped"
+      )
+      None
+  }
 
 }

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/source/TableSource.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/source/TableSource.scala
@@ -11,20 +11,14 @@ import pl.touk.nussknacker.engine.api.{Context, VariableConstants}
 import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.livedata.{DataRecord, DataRecords, LiveDataProvider}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
-import pl.touk.nussknacker.engine.api.process.{
-  BasicContextInitializer,
-  ContextInitializer,
-  TestDataGenerator,
-  TestWithParametersSupport
-}
+import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.test.{TestData, TestRecord, TestRecordParser}
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process.{
   CustomizableContextInitializerSource,
   FlinkCustomNodeContext,
   FlinkSource,
-  FlinkSourceTestSupport,
-  StandardFlinkSource
+  FlinkSourceTestSupport
 }
 import pl.touk.nussknacker.engine.flink.api.timestampwatermark.TimestampWatermarkHandler
 import pl.touk.nussknacker.engine.flink.table.TableComponentProviderConfig.TestDataGenerationMode
@@ -45,6 +39,7 @@ import pl.touk.nussknacker.engine.flink.watermarkstrategy.FlinkWatermarkStrategy
 }
 import pl.touk.nussknacker.engine.util.watermarkstrategy.{WatermarkStrategyOptions, WithWatermarkStrategyOptions}
 
+import java.time.{Instant, OffsetDateTime}
 import scala.jdk.CollectionConverters._
 
 class TableSource(
@@ -172,9 +167,28 @@ class TableSource(
       .asScala
       .toList
       .map { row =>
-        DataRecord(Map(VariableConstants.InputVariableName -> row), timestamp = None)
+        DataRecord(
+          Map(VariableConstants.InputVariableName -> row),
+          upstreamTimestamp = extractTimezoneAwareRowtime(row)
+        )
       }
     DataRecords(records)
+  }
+
+  private def extractTimezoneAwareRowtime(row: Row) = {
+    tableDefinition.singleColumnWithTimezoneAwareRowtime.map(_.getName).map(row.getField).flatMap {
+      case instant: Instant =>
+        Some(instant)
+      // This is not tested because TIMESTAMP WITH TIME ZONE is not supported by flink sql https://issues.apache.org/jira/browse/FLINK-20869
+      case offsetDateTime: OffsetDateTime =>
+        Some(offsetDateTime.toInstant)
+      case other =>
+        logger.warn(
+          s"For ${tableDefinition.singleColumnWithTimezoneAwareRowtime.map(_.getName).getOrElse("<unknown>")} column in ${tableDefinition.tableId}: " +
+            s"timestamp of ${other.getClass.getName} type is not supported. Timestamp field will be omitted from returned live data"
+        )
+        None
+    }
   }
 
   // We don't want to generate data for computed columns - they will be added during parsing of test data

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/source/TableSourceFactory.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/source/TableSourceFactory.scala
@@ -85,23 +85,24 @@ class TableSourceFactory(
       )
     case TransformationStep(
           (`tableNameParamName`, DefinedEagerParameter(tableName: String, _)) :: Nil,
-          state @ Some(AvailableTables(tableDefinitions, _))
+          Some(AvailableTables(tableDefinitions, env))
         ) =>
       val selectedTable = getSelectedTableUnsafe(tableName, tableDefinitions)
       val initializer = new BasicContextInitializer(
         selectedTable.schema.toSourceRowDataType.getLogicalType.toTypingResult
       )
+      val nextState = Some(SelectedTable(selectedTable, env))
       NextParameters(
         prepareWatermarkStrategyParameters(
-          initializer.validationContext(inputContext).getOrElse(ValidationContext.empty)
+          initializer.validationContext(inputContext).getOrElse(ValidationContext.empty),
+          selectedTable.singleColumnWithTimezoneAwareRowtime
+            .map(_.getName)
+            .map(c => s"#input['$c']".spel)
+            .getOrElse("".spel)
         ),
-        state = state
+        state = nextState
       )
   }
-
-  // The null expression means that it will be used the default logic that uses upstream even time if is defined or
-  // System.currentTimeMills otherwise.
-  override protected def eventTimeDefaultValueExpression: Expression = "".spel
 
   override protected def resultAfterWatermarkStrategyParameters(
       inputContext: ValidationContext,
@@ -109,29 +110,19 @@ class TableSourceFactory(
       parameters: List[(ParameterName, DefinedSingleParameter)],
       state: Option[TableSourceFactoryState]
   )(implicit nodeId: NodeId): TransformationStepResult = {
-    val tableName = parameters
-      .collectFirst { case (`tableNameParamName`, DefinedEagerParameter(value: String, _)) =>
-        value
-      }
-      .getOrElse {
-        throw new IllegalStateException(
-          s"[$tableNameParamName] parameter is missing from parameters [$parameters] after watermark strategy parameters step"
-        )
-      }
-    val availableTables = state match {
-      case Some(availableTables: AvailableTables) =>
-        availableTables
+    val selectedTableStateValue = state match {
+      case Some(selectedTableState: SelectedTable) =>
+        selectedTableState
       case other =>
         throw new IllegalStateException(s"Unexpected state [$other] after watermark strategy parameters step")
     }
-    val selectedTable = getSelectedTableUnsafe(tableName, availableTables.tableDefinitions)
     val initializer = new BasicContextInitializer(
-      selectedTable.schema.toSourceRowDataType.getLogicalType.toTypingResult
+      selectedTableStateValue.tableDefinition.schema.toSourceRowDataType.getLogicalType.toTypingResult
     )
     FinalResults.forValidation(
       inputContext,
       errors = Nil,
-      state = Some(SelectedTable(selectedTable, availableTables.env))
+      state = Some(selectedTableStateValue)
     )(
       initializer.validationContext
     )

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/scenariotesting/CommonTestDataFormatStubbedSourcePreparer.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/scenariotesting/CommonTestDataFormatStubbedSourcePreparer.scala
@@ -26,9 +26,9 @@ object CommonTestDataFormatStubbedSourcePreparer {
     val decodedRecords = testRecords
       .map { case (record, testRecordIndex) =>
         val decodedVariables = decoder.decode(record.variables, testRecordIndex)
-        DataRecord(decodedVariables, record.timestamp)
+        DataRecord(decodedVariables, record.upstreamTimestamp)
       }
-      .sortBy(_.timestamp)
+      .sortBy(_.upstreamTimestamp)
 
     new DataRecordsSource(decodedRecords, outputValidationContextWithRecordsAsMaps, watermarkStrategyOptions)
   }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/scenariotesting/DataRecordsSource.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/scenariotesting/DataRecordsSource.scala
@@ -86,7 +86,7 @@ class DataRecordsSource(
   private lazy val dataRecordTypeInformation: TypeInformation[DataRecord] =
     ConcreteCaseClassTypeInfo[DataRecord](
       ("variables", TypeInformationDetection.instance.forVariables(sourceOutputValidationContext.localVariables)),
-      ("timestamp", new OptionTypeInfo[Long, Option[Long]](TypeInformation.of(classOf[Long])))
+      ("upstreamTimestamp", new OptionTypeInfo[Instant, Option[Instant]](TypeInformation.of(classOf[Instant])))
     )
 
 }
@@ -117,10 +117,12 @@ class DataRecordContextInitializingFunction(
     val initialContext = Context(contextIdGenerator.nextContextId())
     collectHandlingErrors(initialContext, out) {
       val contextWithSourceOutputVariables = initialContext.withVariables(input.variables)
+      // We simulate behaviour of FlinkWatermarkStrategyRuntimeHandler.EventTimeTimestampAssigner which
+      // use upstream timestamp as a fallback if user haven't specified the Event time parameter
       val eventTimeValue =
         eventTimeFun
           .flatMap(fun => Option(fun(contextWithSourceOutputVariables)))
-          .orElse(input.timestamp.map(Instant.ofEpochMilli))
+          .orElse(input.upstreamTimestamp)
       ContextWithEventTime(contextWithSourceOutputVariables, eventTimeValue)
     }
   }

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/flink/KafkaLiveDataProvider.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/flink/KafkaLiveDataProvider.scala
@@ -8,6 +8,8 @@ import pl.touk.nussknacker.engine.api.process.{ContextInitializer, Source, Topic
 import pl.touk.nussknacker.engine.kafka.{serialization, KafkaComponentsConfig}
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.UniversalToJsonFormatter
 
+import java.time.Instant
+
 trait KafkaLiveDataProvider[K, V] extends LiveDataProvider { self: Source =>
 
   protected val topics: NonEmptyList[TopicName.ForSource]
@@ -30,9 +32,9 @@ trait KafkaLiveDataProvider[K, V] extends LiveDataProvider { self: Source =>
       .map(deserializationSchema.deserialize)
       .map { consumerRecord =>
         val variables = contextInitializer.convertToInitialVariables(consumerRecord)
-        // TODO: Respect Event time parameter
         val timestamp = Option(consumerRecord.timestamp())
           .filterNot(_ => consumerRecord.timestampType() == TimestampType.NO_TIMESTAMP_TYPE)
+          .map(Instant.ofEpochMilli)
         DataRecord(variables.variables, timestamp)
       }
     DataRecords(records)

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/CsvSource.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/CsvSource.scala
@@ -45,8 +45,8 @@ class CsvSource
 
   override def fetchLiveData(maxNumberOfRecords: Int): DataRecords = DataRecords(
     List(
-      DataRecord(Map(VariableConstants.InputVariableName -> Array("record1", "field2")), timestamp = None),
-      DataRecord(Map(VariableConstants.InputVariableName -> Array("record2", "field3")), timestamp = None)
+      DataRecord(Map(VariableConstants.InputVariableName -> Array("record1", "field2")), upstreamTimestamp = None),
+      DataRecord(Map(VariableConstants.InputVariableName -> Array("record2", "field3")), upstreamTimestamp = None)
     )
   )
 

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/GenericSourceWithCustomTestingSupport.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/GenericSourceWithCustomTestingSupport.scala
@@ -15,6 +15,7 @@ import pl.touk.nussknacker.engine.flink.api.process._
 import pl.touk.nussknacker.engine.flink.api.timestampwatermark.TimestampWatermarkHandler
 import pl.touk.nussknacker.engine.flink.util.source.CollectionSource
 
+import java.time.Instant
 import scala.jdk.CollectionConverters._
 
 object GenericSourceWithCustomTestingSupport
@@ -55,12 +56,16 @@ object GenericSourceWithCustomTestingSupport
       with FlinkSourceTestSupport[ProcessingType]
       with TestWithParametersSupport[ProcessingType]
       with LiveDataProvider {
+
       override val contextInitializer: ContextInitializer[ProcessingType] = customContextInitializer
 
       override def fetchLiveData(maxNumberOfRecords: Int): DataRecords = DataRecords(
         (0 until maxNumberOfRecords).flatMap { index =>
           elementsValue.map { el =>
-            DataRecord(variables = Map(VariableConstants.InputVariableName -> (el + s"-$index")), timestamp = Some(123))
+            DataRecord(
+              variables = Map(VariableConstants.InputVariableName -> (el + s"-$index")),
+              upstreamTimestamp = Some(Instant.ofEpochMilli(123))
+            )
           }
         }.toList
       )

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/LiteCsvSource.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/source/LiteCsvSource.scala
@@ -26,8 +26,11 @@ class LiteCsvSource(override val nodeId: NodeId)
 
   override def fetchLiveData(maxNumberOfRecords: Int): DataRecords = DataRecords(
     List(
-      DataRecord(Map(VariableConstants.InputVariableName -> List("record1", "field2").asJava), timestamp = None),
-      DataRecord(Map(VariableConstants.InputVariableName -> List("record2", "field3").asJava), timestamp = None)
+      DataRecord(
+        Map(VariableConstants.InputVariableName -> List("record1", "field2").asJava),
+        upstreamTimestamp = None
+      ),
+      DataRecord(Map(VariableConstants.InputVariableName -> List("record2", "field3").asJava), upstreamTimestamp = None)
     )
   )
 

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/CustomWatermarkStrategySpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/CustomWatermarkStrategySpec.scala
@@ -5,7 +5,6 @@ import io.circe.Json
 import org.scalatest.{LoneElement, OptionValues}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
-import pl.touk.nussknacker.engine.api.livedata.DataRecord
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.TopicName.ForSource
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
@@ -76,7 +75,7 @@ class CustomWatermarkStrategySpec extends FlinkWithKafkaSuite with OptionValues 
        |""".stripMargin
 
   override lazy val additionalComponents: List[ComponentDefinition] =
-    new FlinkTableDataSourceComponentProvider().create(ConfigFactory.parseString(kafkaTableConfig))
+    FlinkTableDataSourceComponentProvider.create(ConfigFactory.parseString(kafkaTableConfig))
 
   private val givenKey  = "foo-key"
   private val givenData = 1
@@ -127,24 +126,83 @@ class CustomWatermarkStrategySpec extends FlinkWithKafkaSuite with OptionValues 
     val testData = List(
       TestDataRecord(
         NodeId("start"),
-        DataRecord(
-          Map("input" -> prepareMapRecord(givenFirstEventTimestamp)),
-          timestamp = None
-        )
+        Map("input" -> prepareMapRecord(givenFirstEventTimestamp)),
+        upstreamTimestamp = Some(Instant.ofEpochMilli(123)) // Will be overridden by user-specified event time
       ),
       TestDataRecord(
         NodeId("start"),
-        DataRecord(
-          Map("input" -> prepareMapRecord(givenSecondEventTimestamp)),
-          timestamp = None
-        )
+        Map("input" -> prepareMapRecord(givenSecondEventTimestamp)),
+        upstreamTimestamp = Some(Instant.ofEpochMilli(123)) // Will be overridden by user-specified event time
       ),
       TestDataRecord(
         NodeId("start"),
-        DataRecord(
-          Map("input" -> prepareMapRecord(givenThirdEventTimestamp)),
-          timestamp = None
+        Map("input" -> prepareMapRecord(givenThirdEventTimestamp)),
+        upstreamTimestamp = Some(Instant.ofEpochMilli(123)) // Will be overridden by user-specified event time
+      )
+    )
+    val testResults = testScenarioRunner.runWithTestRecords(scenario, testData).validValue
+
+    testResults.successes shouldBe List(
+      givenData,
+      givenData * 2,
+      givenData
+    )
+  }
+
+  test(
+    "should user upstream timestamp if event timestamp is configured as null expression by a user during scenario testing"
+  ) {
+    val inputTopic = "input-topic-upstream-timestamp-scenario-testing"
+
+    // We create topics to skip validation problems
+    kafkaClient.createTopic(inputTopic, 1)
+    val givenFirstEventTimestamp  = 6000000000L
+    val givenSecondEventTimestamp = 6000000000L + 60 * 1000 - 1
+    val givenThirdEventTimestamp  = 6000000000L + 60 * 1000
+
+    val scenario =
+      ScenarioBuilder
+        .streaming("custom-event-time-scenario-testing")
+        .parallelism(1)
+        .source(
+          "start",
+          "kafka",
+          KafkaUniversalComponentTransformer.topicParamName.value       -> Expression.spel(s"'$inputTopic'"),
+          KafkaUniversalComponentTransformer.contentTypeParamName.value -> s"'${ContentTypes.JSON.toString}'".spel,
+          KafkaUniversalComponentTransformer.dataSampleParamName.value  -> dataSampleExpression,
+          WatermarkStrategyValidationHandler.eventTimeParamName.value -> "".spel, // null expression means upstream timestamp
         )
+        .customNode(
+          "aggregate",
+          "sum",
+          "aggregate-sliding",
+          "groupBy"      -> "#input.key".spel,
+          "aggregateBy"  -> "#input.data".spel,
+          "aggregator"   -> "#AGG.sum".spel,
+          "windowLength" -> "T(java.time.Duration).parse('PT1M')".spel,
+        )
+        .emptySink(
+          "end",
+          TestScenarioRunner.testResultSink,
+          // TODO: { timestamp: #eventTimestamp, sum: #sum } <- allow to return event timestamp as well
+          "value" -> s"#sum".spel,
+        )
+
+    val testData = List(
+      TestDataRecord(
+        NodeId("start"),
+        Map("input" -> prepareMapRecord(123)),
+        upstreamTimestamp = Some(Instant.ofEpochMilli(givenFirstEventTimestamp))
+      ),
+      TestDataRecord(
+        NodeId("start"),
+        Map("input" -> prepareMapRecord(123)),
+        upstreamTimestamp = Some(Instant.ofEpochMilli(givenSecondEventTimestamp))
+      ),
+      TestDataRecord(
+        NodeId("start"),
+        Map("input" -> prepareMapRecord(123)),
+        upstreamTimestamp = Some(Instant.ofEpochMilli(givenThirdEventTimestamp))
       )
     )
     val testResults = testScenarioRunner.runWithTestRecords(scenario, testData).validValue
@@ -158,6 +216,25 @@ class CustomWatermarkStrategySpec extends FlinkWithKafkaSuite with OptionValues 
 
   test("should use timestamp configured in table definition used by table source") {
     val outputTopic = "output-topic-event-time-table-definition"
+
+    val compilationResult = nodeCompiler.compileNode(
+      node.Source(
+        "id",
+        SourceRef(
+          "table",
+          Parameter(
+            ParameterName("Table"),
+            s"'`default_catalog`.`default_database`.`$eventTimeConfiguredInTableDefinitionTableName`'".spel
+          ) ::
+            Nil
+        )
+      )
+    )
+    compilationResult.compiledObject shouldBe Symbol("valid")
+    val dynamicParametersDefinitions = compilationResult.parameters.value
+    val eventTimeParameterDefinition =
+      dynamicParametersDefinitions.filter(_.name == WatermarkStrategyValidationHandler.eventTimeParamName).loneElement
+    eventTimeParameterDefinition.defaultValue.value shouldBe "#input['timestamp']".spel
 
     kafkaClient.createTopic(eventTimeConfiguredInTableDefinitionTopicName, 1)
     kafkaClient.createTopic(outputTopic, 1)
@@ -181,31 +258,12 @@ class CustomWatermarkStrategySpec extends FlinkWithKafkaSuite with OptionValues 
         .emptySink(
           "end",
           "kafka",
+          // null expression means that it will be used upstream Event time
           KafkaUniversalComponentTransformer.sinkKeyParamName.value     -> "".spel,
           KafkaUniversalComponentTransformer.sinkValueParamName.value   -> "foo".spelTemplate,
           KafkaUniversalComponentTransformer.topicParamName.value       -> s"'$outputTopic'".spel,
           KafkaUniversalComponentTransformer.contentTypeParamName.value -> s"'${ContentTypes.PLAIN.toString}'".spel,
         )
-
-    val compilationResult = nodeCompiler.compileNode(
-      node.Source(
-        "id",
-        SourceRef(
-          "table",
-          Parameter(
-            ParameterName("Table"),
-            s"'`default_catalog`.`default_database`.`$eventTimeConfiguredInTableDefinitionTableName`'".spel
-          ) ::
-            Nil
-        )
-      )
-    )
-    compilationResult.compiledObject shouldBe Symbol("valid")
-    val dynamicParametersDefinitions = compilationResult.parameters.value
-    val eventTimeParameterDefinition =
-      dynamicParametersDefinitions.filter(_.name == WatermarkStrategyValidationHandler.eventTimeParamName).loneElement
-    // Lack of Event time parameter will be interpreted as null expression which means that it will be used upstream Event time
-    eventTimeParameterDefinition.defaultValue.value shouldBe "".spel
 
     testScenarioRunner.withRunningScenario(scenario) { _ =>
       val records = kafkaClient.createConsumer().consumeWithConsumerRecord(outputTopic)

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/CustomWatermarkStrategySpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/CustomWatermarkStrategySpec.scala
@@ -150,7 +150,7 @@ class CustomWatermarkStrategySpec extends FlinkWithKafkaSuite with OptionValues 
   }
 
   test(
-    "should user upstream timestamp if event timestamp is configured as null expression by a user during scenario testing"
+    "should use upstream timestamp if event timestamp is configured as null expression by a user during scenario testing"
   ) {
     val inputTopic = "input-topic-upstream-timestamp-scenario-testing"
 

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/devmodel/TableKafkaPingPongTest.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/devmodel/TableKafkaPingPongTest.scala
@@ -111,7 +111,7 @@ class TableKafkaPingPongTest extends FlinkWithKafkaSuite {
   private lazy val tableKafkaComponentsConfig: Config = ConfigFactory.parseString(kafkaTableConfig)
 
   override lazy val additionalComponents: List[ComponentDefinition] =
-    new FlinkTableDataSourceComponentProvider().create(tableKafkaComponentsConfig)
+    FlinkTableDataSourceComponentProvider.create(tableKafkaComponentsConfig)
 
   test("should ping-pong with sql kafka source and DataStream kafka sink") {
     val topics = createAndRegisterTopicConfig(topicNaming1, simpleTypesSchema)

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/api/test/ScenarioTestData.scala
@@ -5,14 +5,21 @@ import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.graph.expression.Expression
 
+import java.time.Instant
+
 sealed trait ScenarioTestRecord {
   val sourceId: NodeId
 }
 
 case class ScenarioTestSourceSpecificFormatJsonRecord(sourceId: NodeId, record: Json, timestamp: Option[Long] = None)
     extends ScenarioTestRecord
-case class ScenarioTestCommonFormatJsonRecord(sourceId: NodeId, variables: Map[String, Json], timestamp: Option[Long])
-    extends ScenarioTestRecord
+
+case class ScenarioTestCommonFormatJsonRecord(
+    sourceId: NodeId,
+    variables: Map[String, Json],
+    upstreamTimestamp: Option[Instant]
+) extends ScenarioTestRecord
+
 case class ScenarioTestParametersRecord(sourceId: NodeId, parameterExpressions: Map[ParameterName, Expression])
     extends ScenarioTestRecord
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/validationHelpers.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/validationHelpers.scala
@@ -20,6 +20,7 @@ import pl.touk.nussknacker.engine.api.util.ReflectUtils
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 
+import java.time.Instant
 import javax.validation.constraints.NotBlank
 import scala.concurrent.Future
 import scala.reflect.{classTag, ClassTag}
@@ -310,7 +311,7 @@ object validationHelpers {
 
         override def fetchLiveData(maxNumberOfRecords: Int): DataRecords = DataRecords((for {
           number <- 1 to maxNumberOfRecords
-          record = DataRecord(Map("input" -> s"record $number"), timestamp = Some(number))
+          record = DataRecord(Map("input" -> s"record $number"), upstreamTimestamp = Some(Instant.ofEpochMilli(number)))
         } yield record).toList)
       }
     }

--- a/utils/components-testkit/src/main/scala/pl/touk/nussknacker/engine/util/test/TestScenarioRunner.scala
+++ b/utils/components-testkit/src/main/scala/pl/touk/nussknacker/engine/util/test/TestScenarioRunner.scala
@@ -6,7 +6,6 @@ import pl.touk.nussknacker.engine.RuntimeMode.{Live, Test}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ComponentDefinition
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
-import pl.touk.nussknacker.engine.api.livedata.DataRecord
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.resultcollector.{ProductionServiceInvocationCollector, ResultCollector}
 import pl.touk.nussknacker.engine.testmode.{
@@ -17,6 +16,7 @@ import pl.touk.nussknacker.engine.testmode.{
 import pl.touk.nussknacker.engine.testmode.TestProcess.ExceptionResult
 import pl.touk.nussknacker.engine.util.test.TestScenarioRunner.RunnerListResult
 
+import java.time.Instant
 import scala.reflect.ClassTag
 
 /**
@@ -121,4 +121,4 @@ case class RunListResult[T](errors: List[ExceptionResult[_]], successes: List[T]
 
 case class RunUnitResult(errors: List[ExceptionResult[_]]) extends RunResult
 
-case class TestDataRecord(sourceId: NodeId, record: DataRecord)
+case class TestDataRecord(sourceId: NodeId, variables: Map[String, Any], upstreamTimestamp: Option[Instant])

--- a/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/watermarkstrategy/WatermarkStrategyValidationHandler.scala
+++ b/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/watermarkstrategy/WatermarkStrategyValidationHandler.scala
@@ -9,13 +9,7 @@ import pl.touk.nussknacker.engine.api.context.transformation.{
   NodeDependencyValue,
   SingleInputDynamicComponent
 }
-import pl.touk.nussknacker.engine.api.definition.{
-  AdditionalVariableProvidedInRuntime,
-  DurationParameterEditor,
-  Parameter,
-  ParameterCategory,
-  SpelParameterEditor
-}
+import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
@@ -42,13 +36,19 @@ object WatermarkStrategyValidationHandler {
 
 trait WatermarkStrategyValidationHandler { self: SingleInputDynamicComponent[_] =>
 
-  protected def prepareWatermarkStrategyParameters(outputValidationContext: ValidationContext): List[Parameter] = {
-    val eventTimeParameter   = prepareEventTimeParameter(outputValidationContext)
+  protected def prepareWatermarkStrategyParameters(
+      outputValidationContext: ValidationContext,
+      eventTimeDefaultValueExpression: Expression
+  ): List[Parameter] = {
+    val eventTimeParameter   = prepareEventTimeParameter(outputValidationContext, eventTimeDefaultValueExpression)
     val idlenessParameterOpt = if (isIdlenessParameterAvailable) Some(idlenessParameter) else None
     eventTimeParameter :: maxOutOfOrdernessParameter :: idlenessParameterOpt.toList
   }
 
-  private def prepareEventTimeParameter(outputValidationContext: ValidationContext): Parameter =
+  private def prepareEventTimeParameter(
+      outputValidationContext: ValidationContext,
+      eventTimeDefaultValueExpression: Expression
+  ): Parameter =
     Parameter
       .optional[Instant](eventTimeParamName)
       .copy(
@@ -57,7 +57,7 @@ trait WatermarkStrategyValidationHandler { self: SingleInputDynamicComponent[_] 
           outputValidationContext.localVariables.mapValuesNow(AdditionalVariableProvidedInRuntime(_)),
         defaultValue = Some(eventTimeDefaultValueExpression),
         hintText = Some(
-          s"An expression that determines the Event Time to be used in stateful stream processing. " +
+          s"An expression that determines the Event Time to be used in stateful stream processing. If this field won't be specified, the upstream source event time will be used.  " +
             s"For more information on how Event Time is handled in Flink, and why it is important, see [Flink documentation](${FlinkDocumentationUrl.forCurrentFlinkVersion("concepts/time/#introduction")})"
         ),
         category = ParameterCategory.Advanced
@@ -96,8 +96,6 @@ trait WatermarkStrategyValidationHandler { self: SingleInputDynamicComponent[_] 
         ),
         category = ParameterCategory.Advanced
       )
-
-  protected def eventTimeDefaultValueExpression: Expression
 
   protected def maxOutOfOrdernessDefaultValueExpression: Expression = "T(java.time.Duration).parse('PT10S')".spel
 

--- a/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/watermarkstrategy/WatermarkStrategyValidationHandler.scala
+++ b/utils/components-utils/src/main/scala/pl/touk/nussknacker/engine/util/watermarkstrategy/WatermarkStrategyValidationHandler.scala
@@ -57,7 +57,7 @@ trait WatermarkStrategyValidationHandler { self: SingleInputDynamicComponent[_] 
           outputValidationContext.localVariables.mapValuesNow(AdditionalVariableProvidedInRuntime(_)),
         defaultValue = Some(eventTimeDefaultValueExpression),
         hintText = Some(
-          s"An expression that determines the Event Time to be used in stateful stream processing. If this field won't be specified, the upstream source event time will be used.  " +
+          s"An expression that determines the Event Time to be used in stateful stream processing. If this field is empty, the upstream source event time will be used.  " +
             s"For more information on how Event Time is handled in Flink, and why it is important, see [Flink documentation](${FlinkDocumentationUrl.forCurrentFlinkVersion("concepts/time/#introduction")})"
         ),
         category = ParameterCategory.Advanced

--- a/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkProcessCompilerDataFactoryWithTestComponents.scala
+++ b/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkProcessCompilerDataFactoryWithTestComponents.scala
@@ -5,6 +5,7 @@ import pl.touk.nussknacker.engine.ModelConfig.GlobalParametersConfig
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.component.{ComponentType, DesignerWideComponentId, NodesDeploymentData}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
+import pl.touk.nussknacker.engine.api.livedata.DataRecord
 import pl.touk.nussknacker.engine.api.typed.typing
 import pl.touk.nussknacker.engine.compile.nodecompilation.StaticComponentOutputValidationContextDeterminer
 import pl.touk.nussknacker.engine.definition.component.{
@@ -89,8 +90,8 @@ object FlinkProcessCompilerDataFactoryWithTestComponents {
                           val recordsForSource =
                             testRecords
                               .filter(_.sourceId == compilationDependencies.nodeId)
-                              .map(_.record)
-                              .sortBy(_.timestamp)
+                              .sortBy(_.upstreamTimestamp)
+                              .map(r => DataRecord(r.variables, r.upstreamTimestamp))
                           new DataRecordsSource(
                             recordsForSource,
                             outputValidationContextWithRecordsAsMaps,

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalToJsonFormatterFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalToJsonFormatterFactory.scala
@@ -72,8 +72,10 @@ class UniversalToJsonFormatter[K, V](
       size: Int,
       kafkaComponentsConfig: KafkaComponentsConfig
   ): TestData = {
-    val listsFromAllTopics = topics.map(KafkaUtils.readLastMessages(_, size, kafkaComponentsConfig))
-    val merged             = ListUtil.mergeLists(listsFromAllTopics.toList, size)
+    val listsFromAllTopics = topics.map(
+      KafkaUtils.readLastMessages(_, size, kafkaComponentsConfig).sorted(Ordering.by(getConsumerRecordTimestamp))
+    )
+    val merged = ListUtil.mergeListsRoundRobin(listsFromAllTopics.toList, size)
     prepareGeneratedTestData(merged)
   }
 

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/source/UniversalKafkaSourceFactory.scala
@@ -65,7 +65,7 @@ class UniversalKafkaSourceFactory(
 
   override type State = UniversalKafkaSourceFactoryState
 
-  override protected val eventTimeDefaultValueExpression: Expression = "#inputMeta.timestamp".spel
+  private val eventTimeDefaultValueExpression: Expression = "#inputMeta.timestamp".spel
 
   override protected val maxOutOfOrdernessDefaultValueExpression: Expression = {
     val seconds = kafkaComponentsConfig.defaultMaxOutOfOrdernessMillis.toSeconds
@@ -117,7 +117,10 @@ class UniversalKafkaSourceFactory(
         step.parameters
       )
       NextParameters(
-        prepareWatermarkStrategyParameters(outputValidationOrEmpty(inputContext, validFinalState)),
+        prepareWatermarkStrategyParameters(
+          outputValidationOrEmpty(inputContext, validFinalState),
+          eventTimeDefaultValueExpression
+        ),
         state = Some(
           BeforeWatermarkStrategyParametersStepKafkaSourceFactoryState(validFinalState)
         )
@@ -132,7 +135,10 @@ class UniversalKafkaSourceFactory(
       val validFinalState = prepareFinalState(preparedTopic, valueValidationResult, None, dependencies, step.parameters)
 
       NextParameters(
-        prepareWatermarkStrategyParameters(outputValidationOrEmpty(inputContext, validFinalState)),
+        prepareWatermarkStrategyParameters(
+          outputValidationOrEmpty(inputContext, validFinalState),
+          eventTimeDefaultValueExpression
+        ),
         state = Some(BeforeWatermarkStrategyParametersStepKafkaSourceFactoryState(validFinalState))
       )
     case step @ TransformationStep(
@@ -144,7 +150,10 @@ class UniversalKafkaSourceFactory(
       val valueValidationResult = Valid((Some(runtimeDataForPlainSchema), Typed[String]))
       val validFinalState = prepareFinalState(preparedTopic, valueValidationResult, None, dependencies, step.parameters)
       NextParameters(
-        prepareWatermarkStrategyParameters(outputValidationOrEmpty(inputContext, validFinalState)),
+        prepareWatermarkStrategyParameters(
+          outputValidationOrEmpty(inputContext, validFinalState),
+          eventTimeDefaultValueExpression
+        ),
         state = Some(BeforeWatermarkStrategyParametersStepKafkaSourceFactoryState(validFinalState))
       )
     case step @ TransformationStep(
@@ -168,7 +177,10 @@ class UniversalKafkaSourceFactory(
       val validFinalState = prepareFinalState(preparedTopic, valueValidationResult, None, dependencies, step.parameters)
 
       NextParameters(
-        prepareWatermarkStrategyParameters(outputValidationOrEmpty(inputContext, validFinalState)),
+        prepareWatermarkStrategyParameters(
+          outputValidationOrEmpty(inputContext, validFinalState),
+          eventTimeDefaultValueExpression
+        ),
         state = Some(BeforeWatermarkStrategyParametersStepKafkaSourceFactoryState(validFinalState))
       )
     case step @ TransformationStep((`topicParamName`, _) :: (`schemaVersionParamName`, _) :: Nil, _) =>

--- a/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/ListUtil.scala
+++ b/utils/utils/src/main/scala/pl/touk/nussknacker/engine/util/ListUtil.scala
@@ -4,15 +4,15 @@ import scala.annotation.tailrec
 
 object ListUtil {
 
-  def mergeLists[T](lists: List[List[T]], size: Int): List[T] = {
-    mergeLists(lists).take(size)
+  def mergeListsRoundRobin[T](lists: List[List[T]], size: Int): List[T] = {
+    mergeListsRoundRobin(lists).take(size)
   }
 
   @tailrec
-  private def mergeLists[T](lists: List[List[T]], acc: List[T] = List()): List[T] = lists match {
+  private def mergeListsRoundRobin[T](lists: List[List[T]], acc: List[T] = List()): List[T] = lists match {
     case Nil                         => acc
-    case Nil :: next                 => mergeLists(next, acc)
-    case (head :: rest) :: nextLists => mergeLists(nextLists :+ rest, acc :+ head)
+    case Nil :: next                 => mergeListsRoundRobin(next, acc)
+    case (head :: rest) :: nextLists => mergeListsRoundRobin(nextLists :+ rest, acc :+ head)
   }
 
 }

--- a/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/ListUtilSpec.scala
+++ b/utils/utils/src/test/scala/pl/touk/nussknacker/engine/util/ListUtilSpec.scala
@@ -6,19 +6,27 @@ import org.scalatest.matchers.should.Matchers
 class ListUtilSpec extends AnyFunSuite with Matchers {
 
   test("merges one list ") {
-    ListUtil.mergeLists(List(List("a", "b", "c", "d")), 3) shouldBe List("a", "b", "c")
+    ListUtil.mergeListsRoundRobin(List(List("a", "b", "c", "d")), 3) shouldBe List("a", "b", "c")
   }
 
-  test("merges list of same size") {
-    ListUtil.mergeLists(List(List("aa", "ab", "ac"), List("ba", "bb", "bc"), List("ca", "cb", "cc")), 3) shouldBe List(
+  test("merges in round-robin manner lists of same sizes") {
+    ListUtil.mergeListsRoundRobin(
+      List(List("aa", "ab", "ac"), List("ba", "bb", "bc"), List("ca", "cb", "cc")),
+      3
+    ) shouldBe List(
       "aa",
       "ba",
       "ca"
     )
   }
 
-  test("merges list of different size") {
-    ListUtil.mergeLists(List(List("aa", "ab", "ac"), List("ba"), List()), 5) shouldBe List("aa", "ba", "ab", "ac")
+  test("merges in round-robin manner lists of different sizes") {
+    ListUtil.mergeListsRoundRobin(List(List("aa", "ab", "ac"), List("ba"), List()), 5) shouldBe List(
+      "aa",
+      "ba",
+      "ab",
+      "ac"
+    )
   }
 
 }


### PR DESCRIPTION
## Describe your changes

Changes:
- `LiveDataProvider` returns  `upstreamTimestamp` instead of some not-well-defined `timestamp`
- Input test data for "common format" also use `upstreamTimestamp` + type was changed to `Instant`
- `table` source uses `rowtime` column in expression for `Event time`

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
