### PR TITLE
[NU-2346] Fixed issue with missing expression evaluation results in live data samples

### DIFF
--- a/designer/client/src/common/TestResultUtils.ts
+++ b/designer/client/src/common/TestResultUtils.ts
@@ -3,8 +3,8 @@ import { head, uniq, values } from "lodash";
 
 import type {
     ExceptionResultJson,
-    ExpressionInvocationResultJson,
-    ExternalInvocationResultJson,
+    ExpressionEvaluationResultJson,
+    ExternalServiceInvocationResultJson,
     ResultContextJson,
     TestResultsDto,
 } from "../http/resultsWithCountsDto";
@@ -35,8 +35,8 @@ export interface TestFormParameters {
 }
 
 export interface NodeTestResults {
-    externalInvocationResults: ExternalInvocationResultJson[];
-    invocationResults: ExpressionInvocationResultJson[];
+    externalServiceInvocationResults: ExternalServiceInvocationResultJson[];
+    expressionEvaluationResults: ExpressionEvaluationResultJson[];
     nodeResults: ResultContextJson[];
     errors: ExceptionResultJson[];
 }
@@ -48,9 +48,9 @@ export interface StateForSelectTestResults {
 
 export interface NodeResultsForContext {
     context: ResultContextJson;
-    externalInvocationResultsForEveryContext: ExternalInvocationResultJson[];
+    externalInvocationResultsForEveryContext: ExternalServiceInvocationResultJson[];
     expressionResults: Record<string, any>;
-    externalInvocationResultsForCurrentContext: ExternalInvocationResultJson[];
+    externalInvocationResultsForCurrentContext: ExternalServiceInvocationResultJson[];
     error: string;
 }
 
@@ -61,8 +61,8 @@ class TestResultUtils {
         if (nodeResults) {
             return {
                 nodeResults,
-                invocationResults: this._invocationResults(testResults, nodeId),
-                externalInvocationResults: this._externalInvocationResults(testResults, nodeId),
+                expressionEvaluationResults: this._expressionEvaluationResults(testResults, nodeId),
+                externalServiceInvocationResults: this._externalServiceInvocationResults(testResults, nodeId),
                 errors: this._errors(testResults, nodeId),
             };
         }
@@ -96,12 +96,12 @@ class TestResultUtils {
         );
     }
 
-    private _invocationResults(results: TestResultsDto, nodeId: NodeId): ExpressionInvocationResultJson[] {
-        return results?.invocationResults?.[nodeId] || [];
+    private _expressionEvaluationResults(results: TestResultsDto, nodeId: NodeId): ExpressionEvaluationResultJson[] {
+        return results?.expressionEvaluationResults?.[nodeId] || [];
     }
 
-    private _externalInvocationResults(results: TestResultsDto, nodeId: NodeId): ExternalInvocationResultJson[] {
-        return results?.externalInvocationResults?.[nodeId] || [];
+    private _externalServiceInvocationResults(results: TestResultsDto, nodeId: NodeId): ExternalServiceInvocationResultJson[] {
+        return results?.externalServiceInvocationResults?.[nodeId] || [];
     }
 
     private _errors(results: TestResultsDto, nodeId: NodeId): ExceptionResultJson[] {
@@ -118,14 +118,14 @@ class TestResultUtils {
     private nodeResultsForContext = (nodeTestResults: NodeTestResults, contextId: string): NodeResultsForContext => {
         const context = nodeTestResults.nodeResults.find((result) => result.id == contextId);
         const expressionResults = Object.fromEntries(
-            nodeTestResults.invocationResults
+            nodeTestResults.expressionEvaluationResults
                 .filter((result) => result.contextId == contextId)
                 .map((result) => [result.name, result.value]),
         );
-        const externalInvocationResultsForCurrentContext = nodeTestResults.externalInvocationResults.filter(
+        const externalInvocationResultsForCurrentContext = nodeTestResults.externalServiceInvocationResults.filter(
             (result) => result.contextId == contextId,
         );
-        const externalInvocationResultsForEveryContext = nodeTestResults.externalInvocationResults;
+        const externalInvocationResultsForEveryContext = nodeTestResults.externalServiceInvocationResults;
         const error = nodeTestResults.errors?.find((error) => error.context.id === contextId)?.throwable;
         return {
             context,

--- a/designer/client/src/http/resultsWithCountsDto.ts
+++ b/designer/client/src/http/resultsWithCountsDto.ts
@@ -11,7 +11,7 @@ export interface ResultContextJson {
     variables: Record<string, Variable>;
 }
 
-export interface ExpressionInvocationResultJson {
+export interface ExpressionEvaluationResultJson {
     contextId: ResultContextJson["id"];
     name: string;
     value: unknown;
@@ -23,7 +23,7 @@ export interface ExceptionResultJson {
     throwable;
 }
 
-export interface ExternalInvocationResultJson {
+export interface ExternalServiceInvocationResultJson {
     contextId: ResultContextJson["id"];
 }
 
@@ -39,8 +39,8 @@ export interface TestResultsDto {
     /** @deprecated Use nodeTransitionResults instead */
     nodeResults?: Record<NodeId, ResultContextJson[]> | null;
     nodeTransitionResults?: NodeTransitionResult[] | null;
-    invocationResults: Record<NodeId, ExpressionInvocationResultJson[]>;
-    externalInvocationResults: Record<NodeId, ExternalInvocationResultJson[]>;
+    expressionEvaluationResults: Record<NodeId, ExpressionEvaluationResultJson[]>;
+    externalServiceInvocationResults: Record<NodeId, ExternalServiceInvocationResultJson[]>;
     /** @deprecated Use exceptionsByNodeId instead */
     exceptions: ExceptionResultJson[];
     exceptionsByNodeId: Record<NodeId, ExceptionResultJson[]>;

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDto.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDto.scala
@@ -44,8 +44,8 @@ object ResultsWithCountsDto {
       results = TestResultsDto(
         nodeResults = Option.when(!skipResultsPerNode.value)(resultsWithCounts.results.nodeResults),
         nodeTransitionResults = Option.when(!skipResultsPerTransition.value)(nodeTransitionResults),
-        invocationResults = resultsWithCounts.results.invocationResults,
-        externalInvocationResults = resultsWithCounts.results.externalInvocationResults,
+        expressionEvaluationResults = resultsWithCounts.results.expressionEvaluationResults,
+        externalServiceInvocationResults = resultsWithCounts.results.externalServiceInvocationResults,
         exceptions = resultsWithCounts.results.exceptions,
         exceptionsByNodeId = exceptionsByNodeId,
       ),
@@ -74,11 +74,11 @@ object ResultsWithCountsDto {
             )
           }.toList
         ),
-        invocationResults = liveData.invocationResults.map { case (nodeId, results) =>
-          nodeId -> results.map(r => ExpressionInvocationResult(r.contextId, r.timestamp, r.name, r.value))
+        expressionEvaluationResults = liveData.expressionEvaluationResults.map { case (nodeId, results) =>
+          nodeId -> results.map(r => ExpressionEvaluationResult(r.contextId, r.timestamp, r.name, r.value))
         },
-        externalInvocationResults = liveData.externalInvocationResults.map { case (nodeId, results) =>
-          nodeId -> results.map(r => ExternalInvocationResult(r.contextId, r.timestamp, r.name, r.value))
+        externalServiceInvocationResults = liveData.externalServiceInvocationResults.map { case (nodeId, results) =>
+          nodeId -> results.map(r => ExternalServiceInvocationResult(r.contextId, r.timestamp, r.name, r.value))
         },
         exceptions = exceptionsByNodeId.values.toList.flatten,
         exceptionsByNodeId = exceptionsByNodeId,
@@ -94,23 +94,23 @@ object ResultsWithCountsDto {
   implicit def contextIdPathPartDtoSchema: Schema[ContextIdPathPartDto] = Schema.derived
   implicit def contextIdSchema: Schema[ContextId] =
     Schema.derived[ContextIdDto].map(_ => None)(ContextIdDto.from)
-  implicit def resultContextSchema: Schema[ResultContext[Json]]                           = Schema.derived
-  implicit def expressionInvocationResultSchema: Schema[ExpressionInvocationResult[Json]] = Schema.derived
-  implicit def externalInvocationResultSchema: Schema[ExternalInvocationResult[Json]]     = Schema.derived
-  implicit def throwableSchema: Schema[Throwable]                                         = Schema.string
-  implicit def exceptionResultSchema: Schema[ExceptionResult[Json]]                       = Schema.derived
-  implicit def nodeTransitionResultSchema: Schema[NodeTransitionResult]                   = Schema.derived
-  implicit def testResultsSchema: Schema[TestResultsDto]                                  = Schema.derived
-  implicit def nodeCountSchema: Schema[NodeCount]                                         = Schema.anyObject
-  implicit def resultsWithCountsSchema: Schema[ResultsWithCountsDto]                      = Schema.derived
+  implicit def resultContextSchema: Schema[ResultContext[Json]]                              = Schema.derived
+  implicit def expressionInvocationResultSchema: Schema[ExpressionEvaluationResult[Json]]    = Schema.derived
+  implicit def externalInvocationResultSchema: Schema[ExternalServiceInvocationResult[Json]] = Schema.derived
+  implicit def throwableSchema: Schema[Throwable]                                            = Schema.string
+  implicit def exceptionResultSchema: Schema[ExceptionResult[Json]]                          = Schema.derived
+  implicit def nodeTransitionResultSchema: Schema[NodeTransitionResult]                      = Schema.derived
+  implicit def testResultsSchema: Schema[TestResultsDto]                                     = Schema.derived
+  implicit def nodeCountSchema: Schema[NodeCount]                                            = Schema.anyObject
+  implicit def resultsWithCountsSchema: Schema[ResultsWithCountsDto]                         = Schema.derived
 
 }
 
 final case class TestResultsDto(
     nodeResults: Option[Map[NodeId, List[ResultContext[Json]]]],
     nodeTransitionResults: Option[List[NodeTransitionResult]],
-    invocationResults: Map[NodeId, List[ExpressionInvocationResult[Json]]],
-    externalInvocationResults: Map[NodeId, List[ExternalInvocationResult[Json]]],
+    expressionEvaluationResults: Map[NodeId, List[ExpressionEvaluationResult[Json]]],
+    externalServiceInvocationResults: Map[NodeId, List[ExternalServiceInvocationResult[Json]]],
     exceptions: List[ExceptionResult[Json]],
     exceptionsByNodeId: Map[NodeId, List[ExceptionResult[Json]]],
 )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDtoCodecs.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDtoCodecs.scala
@@ -6,8 +6,8 @@ import io.circe.generic.semiauto.deriveEncoder
 import pl.touk.nussknacker.engine.api.{ContextId, NodeId}
 import pl.touk.nussknacker.engine.testmode.TestProcess.{
   ExceptionResult,
-  ExpressionInvocationResult,
-  ExternalInvocationResult,
+  ExpressionEvaluationResult,
+  ExternalServiceInvocationResult,
   ResultContext
 }
 
@@ -35,14 +35,14 @@ object ResultsWithCountsDtoCodecs {
       underlying = Encoder.forProduct3("cid", "timestamp", "variables")(r => (r.id, r.timestamp, r.variables)),
     )
 
-    implicit val expressionInvocationResult: Encoder[ExpressionInvocationResult[Json]] = encoderWithLegacyContextId(
+    implicit val expressionInvocationResult: Encoder[ExpressionEvaluationResult[Json]] = encoderWithLegacyContextId(
       fieldName = "contextId",
       valueExtractor = _.contextId,
       underlying =
         Encoder.forProduct4("cid", "timestamp", "name", "value")(r => (r.contextId, r.timestamp, r.name, r.value)),
     )
 
-    implicit val externalInvocationResult: Encoder[ExternalInvocationResult[Json]] = encoderWithLegacyContextId(
+    implicit val externalInvocationResult: Encoder[ExternalServiceInvocationResult[Json]] = encoderWithLegacyContextId(
       fieldName = "contextId",
       valueExtractor = _.contextId,
       underlying =
@@ -74,8 +74,8 @@ object ResultsWithCountsDtoCodecs {
       case TestResultsDto(
             nodeResults,
             nodeTransitionResults,
-            invocationResults,
-            externalInvocationResults,
+            expressionEvaluationResults,
+            externalServiceInvocationResults,
             exceptions,
             exceptionsByNodeId,
           ) =>
@@ -87,10 +87,10 @@ object ResultsWithCountsDtoCodecs {
             .map(_.sortBy(r => (r.sourceNodeId, r.destinationNodeId)))
             .asJson
             .deepDropNullValues,
-          "invocationResults" -> invocationResults.map { case (node, list) =>
+          "expressionEvaluationResults" -> expressionEvaluationResults.map { case (node, list) =>
             node -> list.sortBy(_.contextId.legacyString)
           }.asJson,
-          "externalInvocationResults" -> externalInvocationResults.map { case (node, list) =>
+          "externalServiceInvocationResults" -> externalServiceInvocationResults.map { case (node, list) =>
             node -> list.sortBy(_.contextId.legacyString)
           }.asJson,
           "exceptions" -> exceptions.sortBy(_.context.id.legacyString).asJson,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementApiHttpServiceBusinessSpec.scala
@@ -43,8 +43,8 @@ class ManagementApiHttpServiceBusinessSpec
               exampleScenario.name.value -> TestResults(
                 nodeResults = Map.empty,
                 nodeTransitionResults = Map.empty,
-                invocationResults = Map.empty,
-                externalInvocationResults = Map.empty,
+                expressionEvaluationResults = Map.empty,
+                externalServiceInvocationResults = Map.empty,
                 exceptions = List.empty,
               )
             )
@@ -76,8 +76,8 @@ class ManagementApiHttpServiceBusinessSpec
              |  "results": {
              |    "nodeResults": {},
              |    "nodeTransitionResults": [],
-             |    "invocationResults": {},
-             |    "externalInvocationResults": {},
+             |    "expressionEvaluationResults": {},
+             |    "externalServiceInvocationResults": {},
              |    "exceptions": [],
              |    "exceptionsByNodeId": {}
              |  },

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/livedata/ScenarioLiveDataApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/livedata/ScenarioLiveDataApiHttpServiceSpec.scala
@@ -79,8 +79,8 @@ class ScenarioLiveDataApiHttpServiceSpec
              |  "results": {
              |    "nodeResults": null,
              |    "nodeTransitionResults": [],
-             |    "invocationResults": {},
-             |    "externalInvocationResults": {},
+             |    "expressionEvaluationResults": {},
+             |    "externalServiceInvocationResults": {},
              |    "exceptions": [],
              |    "exceptionsByNodeId": {}
              |  },
@@ -216,7 +216,7 @@ class ScenarioLiveDataApiHttpServiceSpec
              |        "currentThroughput": "${regexes.decimalRegex}"
              |      }
              |    ],
-             |    "invocationResults": {
+             |    "expressionEvaluationResults": {
              |      "start": [
              |        {
              |          "cid": {
@@ -235,7 +235,7 @@ class ScenarioLiveDataApiHttpServiceSpec
              |        }
              |      ]
              |    },
-             |    "externalInvocationResults": {
+             |    "externalServiceInvocationResults": {
              |      "start": [
              |        {
              |          "cid": {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/integration/BaseFlowTest.scala
@@ -468,7 +468,7 @@ class BaseFlowTest
 
     def firstInvocationResult(result: Json): Option[String] = result.hcursor
       .downField("results")
-      .downField("externalInvocationResults")
+      .downField("externalServiceInvocationResults")
       .downField("end")
       .downArray
       .downField("value")

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -5769,8 +5769,8 @@ components:
           type: string
         expression:
           type: string
-    ExpressionInvocationResult_Json:
-      title: ExpressionInvocationResult_Json
+    ExpressionEvaluationResult_Json:
+      title: ExpressionEvaluationResult_Json
       type: object
       required:
       - contextId
@@ -5830,8 +5830,8 @@ components:
           $ref: '#/components/schemas/CaretPosition2d'
         variableTypes:
           $ref: '#/components/schemas/Map_TypingResultInJson'
-    ExternalInvocationResult_Json:
-      title: ExternalInvocationResult_Json
+    ExternalServiceInvocationResult_Json:
+      title: ExternalServiceInvocationResult_Json
       type: object
       required:
       - contextId
@@ -7641,8 +7641,8 @@ components:
       title: TestResultsDto
       type: object
       required:
-      - invocationResults
-      - externalInvocationResults
+      - expressionEvaluationResults
+      - externalServiceInvocationResults
       - exceptionsByNodeId
       properties:
         nodeResults:
@@ -7655,9 +7655,9 @@ components:
           - 'null'
           items:
             $ref: '#/components/schemas/NodeTransitionResult'
-        invocationResults:
+        expressionEvaluationResults:
           $ref: '#/components/schemas/Map_NodeId_V'
-        externalInvocationResults:
+        externalServiceInvocationResults:
           $ref: '#/components/schemas/Map_NodeId_V'
         exceptions:
           type: array

--- a/e2e-tests/src/test/scala/pl/touk/nussknacker/BatchDataGenerationSpec.scala
+++ b/e2e-tests/src/test/scala/pl/touk/nussknacker/BatchDataGenerationSpec.scala
@@ -151,7 +151,7 @@ class BatchDataGenerationSpec
            |        ]
            |      }
            |    ],
-           |    "invocationResults": {
+           |    "expressionEvaluationResults": {
            |      "sourceId": [
            |        {
            |          "contextId": "E2ETest-SumTransactions-sourceId-0-0",
@@ -167,7 +167,7 @@ class BatchDataGenerationSpec
            |        }
            |      ]
            |    },
-           |    "externalInvocationResults": {},
+           |    "externalServiceInvocationResults": {},
            |    "exceptions": [],
            |    "exceptionsByNodeId": {}
            |  },
@@ -286,7 +286,7 @@ class BatchDataGenerationSpec
            |        ]
            |      }
            |    ],
-           |    "invocationResults": {
+           |    "expressionEvaluationResults": {
            |      "sourceId": [
            |        {
            |          "contextId": "E2ETest-SumTransactions-sourceId-0-0",
@@ -302,7 +302,7 @@ class BatchDataGenerationSpec
            |        }
            |      ]
            |    },
-           |    "externalInvocationResults": {},
+           |    "externalServiceInvocationResults": {},
            |    "exceptions": [],
            |    "exceptionsByNodeId": {}
            |  },

--- a/e2e-tests/src/test/scala/pl/touk/nussknacker/DetectLargeTransactionSpec.scala
+++ b/e2e-tests/src/test/scala/pl/touk/nussknacker/DetectLargeTransactionSpec.scala
@@ -536,6 +536,98 @@ class DetectLargeTransactionSpec
              |          }
              |        }
              |      ],
+             |      "send for audit": [
+             |        {
+             |          "contextId": "DetectLargeTransactions-transactions-0-3",
+             |          "cid": {
+             |            "nid": "transactions",
+             |            "tid": 0,
+             |            "idx": 3,
+             |            "path": []
+             |          },
+             |          "timestamp": "${regexes.zuluDateRegex}",
+             |          "name": "Value",
+             |          "value": {
+             |            "pretty": {
+             |              "amount": 100,
+             |              "clientId": "100",
+             |              "isLast": false
+             |            }
+             |          }
+             |        },
+             |        {
+             |          "contextId": "DetectLargeTransactions-transactions-0-3",
+             |          "cid": {
+             |            "nid": "transactions",
+             |            "tid": 0,
+             |            "idx": 3,
+             |            "path": []
+             |          },
+             |          "timestamp": "${regexes.zuluDateRegex}",
+             |          "name": "Key",
+             |          "value": null
+             |        },
+             |        {
+             |          "contextId": "DetectLargeTransactions-transactions-0-4",
+             |          "cid": {
+             |            "nid": "transactions",
+             |            "tid": 0,
+             |            "idx": 4,
+             |            "path": []
+             |          },
+             |          "timestamp": "${regexes.zuluDateRegex}",
+             |          "name": "Value",
+             |          "value": {
+             |            "pretty": {
+             |              "amount": 1000,
+             |              "clientId": "100",
+             |              "isLast": false
+             |            }
+             |          }
+             |        },
+             |        {
+             |          "contextId": "DetectLargeTransactions-transactions-0-4",
+             |          "cid": {
+             |            "nid": "transactions",
+             |            "tid": 0,
+             |            "idx": 4,
+             |            "path": []
+             |          },
+             |          "timestamp": "${regexes.zuluDateRegex}",
+             |          "name": "Key",
+             |          "value": null
+             |        },
+             |        {
+             |          "contextId": "DetectLargeTransactions-transactions-0-5",
+             |          "cid": {
+             |            "nid": "transactions",
+             |            "tid": 0,
+             |            "idx": 5,
+             |            "path": []
+             |          },
+             |          "timestamp": "${regexes.zuluDateRegex}",
+             |          "name": "Value",
+             |          "value": {
+             |            "pretty": {
+             |              "amount": 10000,
+             |              "clientId": "100",
+             |              "isLast": false
+             |            }
+             |          }
+             |        },
+             |        {
+             |          "contextId": "DetectLargeTransactions-transactions-0-5",
+             |          "cid": {
+             |            "nid": "transactions",
+             |            "tid": 0,
+             |            "idx": 5,
+             |            "path": []
+             |          },
+             |          "timestamp": "${regexes.zuluDateRegex}",
+             |          "name": "Key",
+             |          "value": null
+             |        }
+             |      ],
              |      "transactions": [
              |        {
              |          "contextId": "DetectLargeTransactions-transactions-0-0",
@@ -619,98 +711,6 @@ class DetectLargeTransactionSpec
              |          "name": "Event time",
              |          "value": {
              |            "pretty": "${regexes.zuluDateRegex}"
-             |          }
-             |        }
-             |      ],
-             |      "send for audit": [
-             |        {
-             |          "contextId": "DetectLargeTransactions-transactions-0-3",
-             |          "cid": {
-             |            "nid": "transactions",
-             |            "tid": 0,
-             |            "idx": 3,
-             |            "path": []
-             |          },
-             |          "timestamp": "${regexes.zuluDateRegex}",
-             |          "name": "Key",
-             |          "value": null
-             |        },
-             |        {
-             |          "contextId": "DetectLargeTransactions-transactions-0-3",
-             |          "cid": {
-             |            "nid": "transactions",
-             |            "tid": 0,
-             |            "idx": 3,
-             |            "path": []
-             |          },
-             |          "timestamp": "${regexes.zuluDateRegex}",
-             |          "name": "Value",
-             |          "value": {
-             |            "pretty": {
-             |              "amount": 100,
-             |              "clientId": "100",
-             |              "isLast": false
-             |            }
-             |          }
-             |        },
-             |        {
-             |          "contextId": "DetectLargeTransactions-transactions-0-4",
-             |          "cid": {
-             |            "nid": "transactions",
-             |            "tid": 0,
-             |            "idx": 4,
-             |            "path": []
-             |          },
-             |          "timestamp": "${regexes.zuluDateRegex}",
-             |          "name": "Key",
-             |          "value": null
-             |        },
-             |        {
-             |          "contextId": "DetectLargeTransactions-transactions-0-4",
-             |          "cid": {
-             |            "nid": "transactions",
-             |            "tid": 0,
-             |            "idx": 4,
-             |            "path": []
-             |          },
-             |          "timestamp": "${regexes.zuluDateRegex}",
-             |          "name": "Value",
-             |          "value": {
-             |            "pretty": {
-             |              "amount": 1000,
-             |              "clientId": "100",
-             |              "isLast": false
-             |            }
-             |          }
-             |        },
-             |        {
-             |          "contextId": "DetectLargeTransactions-transactions-0-5",
-             |          "cid": {
-             |            "nid": "transactions",
-             |            "tid": 0,
-             |            "idx": 5,
-             |            "path": []
-             |          },
-             |          "timestamp": "${regexes.zuluDateRegex}",
-             |          "name": "Key",
-             |          "value": null
-             |        },
-             |        {
-             |          "contextId": "DetectLargeTransactions-transactions-0-5",
-             |          "cid": {
-             |            "nid": "transactions",
-             |            "tid": 0,
-             |            "idx": 5,
-             |            "path": []
-             |          },
-             |          "timestamp": "${regexes.zuluDateRegex}",
-             |          "name": "Value",
-             |          "value": {
-             |            "pretty": {
-             |              "amount": 10000,
-             |              "clientId": "100",
-             |              "isLast": false
-             |            }
              |          }
              |        }
              |      ]

--- a/e2e-tests/src/test/scala/pl/touk/nussknacker/DetectLargeTransactionSpec.scala
+++ b/e2e-tests/src/test/scala/pl/touk/nussknacker/DetectLargeTransactionSpec.scala
@@ -449,7 +449,7 @@ class DetectLargeTransactionSpec
              |        "currentThroughput": "${regexes.decimalRegex}"
              |      }
              |    ],
-             |    "invocationResults": {
+             |    "expressionEvaluationResults": {
              |      "only large ones": [
              |        {
              |          "contextId": "DetectLargeTransactions-transactions-0-0",
@@ -715,7 +715,7 @@ class DetectLargeTransactionSpec
              |        }
              |      ]
              |    },
-             |    "externalInvocationResults": {},
+             |    "externalServiceInvocationResults": {},
              |    "exceptions": [],
              |    "exceptionsByNodeId": {}
              |  },

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
@@ -86,7 +86,7 @@ trait BaseFlinkDeploymentManagerSpec
     val process      = SampleProcess.prepareProcessWithEventGeneratorSource(processName)
     val deploymentId = DeploymentId("with-event-generator")
 
-    val configuredMaxNumbersOfRecords = 20
+    val configuredMaxNumbersOfRecords = 15
     LiveDataCollectingListener.createListenerFor(
       processIdWithName = ProcessIdWithName(processId, processName),
       deploymentIdOpt = None,
@@ -139,27 +139,33 @@ trait BaseFlinkDeploymentManagerSpec
           sample.variables shouldBe Map("input" -> Json.obj("pretty" -> "abrakadabra".asJson))
         }
 
-        val startInvocationResults = liveDataSamples.expressionEvaluationResults
+        val startNodeExpressionEvaluationResults = liveDataSamples.expressionEvaluationResults
           .get(NodeId("start"))
           .value
-        // We reach maxNumbersOfRecords because there are 2 samples for each transition (one for value and one for Event time
-        startInvocationResults.size shouldBe configuredMaxNumbersOfRecords
-        forAll(startInvocationResults.grouped(2).toList) { expressionEvaluationResults =>
+        val valueEvaluationResults     = startNodeExpressionEvaluationResults.filter(_.name == "value")
+        val eventTimeEvaluationResults = startNodeExpressionEvaluationResults.filter(_.name == "Event time")
+        // We can exceed `configuredMaxNumbersOfRecords`, because:
+        // - `start` node has 2 expressions: `value` and `Event time`
+        // - the limit (configuredMaxNumbersOfRecords) is applied separately for each variable
+        startNodeExpressionEvaluationResults.size shouldBe configuredMaxNumbersOfRecords * 2
+        valueEvaluationResults.size shouldBe configuredMaxNumbersOfRecords
+        eventTimeEvaluationResults.size shouldBe configuredMaxNumbersOfRecords
+
+        forAll(valueEvaluationResults) { expressionEvaluationResults =>
           inside(expressionEvaluationResults) {
-            case ExpressionEvaluationResult(valueContextId, _, "value", valueJson) :: ExpressionEvaluationResult(
-                  eventTimeContextId,
-                  _,
-                  "Event time",
-                  _
-                ) :: Nil =>
+            case ExpressionEvaluationResult(valueContextId, _, "value", valueJson) =>
               valueContextId.scenarioName shouldBe processName
               valueContextId.originatingNodeId shouldBe NodeId("start")
               valueContextId.taskId shouldBe 0
+              valueJson shouldBe Json.obj("pretty" -> "abrakadabra".asJson)
+          }
+        }
+        forAll(eventTimeEvaluationResults) { expressionEvaluationResults =>
+          inside(expressionEvaluationResults) {
+            case ExpressionEvaluationResult(eventTimeContextId, _, "Event time", _) =>
               eventTimeContextId.scenarioName shouldBe processName
               eventTimeContextId.originatingNodeId shouldBe NodeId("start")
               eventTimeContextId.taskId shouldBe 0
-              valueJson shouldBe Json.obj("pretty" -> "abrakadabra".asJson)
-
           }
         }
         val endSendInvocationResults = liveDataSamples.expressionEvaluationResults

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
@@ -139,14 +139,14 @@ trait BaseFlinkDeploymentManagerSpec
           sample.variables shouldBe Map("input" -> Json.obj("pretty" -> "abrakadabra".asJson))
         }
 
-        val startInvocationResults = liveDataSamples.invocationResults
+        val startInvocationResults = liveDataSamples.expressionEvaluationResults
           .get(NodeId("start"))
           .value
         // We reach maxNumbersOfRecords because there are 2 samples for each transition (one for value and one for Event time
         startInvocationResults.size shouldBe configuredMaxNumbersOfRecords
-        forAll(startInvocationResults.grouped(2).toList) { invocationResults =>
-          inside(invocationResults) {
-            case InvocationResult(valueContextId, _, "value", valueJson) :: InvocationResult(
+        forAll(startInvocationResults.grouped(2).toList) { expressionEvaluationResults =>
+          inside(expressionEvaluationResults) {
+            case ExpressionEvaluationResult(valueContextId, _, "value", valueJson) :: ExpressionEvaluationResult(
                   eventTimeContextId,
                   _,
                   "Event time",
@@ -162,7 +162,7 @@ trait BaseFlinkDeploymentManagerSpec
 
           }
         }
-        val endSendInvocationResults = liveDataSamples.invocationResults
+        val endSendInvocationResults = liveDataSamples.expressionEvaluationResults
           .get(NodeId("endSend"))
           .value
         endSendInvocationResults.size should be >= totalCountWaitLimit

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/FlinkMiniClusterScenarioTestRunnerSpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/FlinkMiniClusterScenarioTestRunnerSpec.scala
@@ -163,11 +163,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       nodeResults(NodeId("proc2")) shouldBe List(nodeResult(1, "input" -> input2, "variable1" -> "ala"))
       nodeResults(NodeId("out")) shouldBe List(nodeResult(1, "input" -> input2, "variable1" -> "ala"))
 
-      val invocationResults = results.invocationResults
+      val expressionEvaluationResults = results.expressionEvaluationResults
 
-      invocationResults(NodeId("proc2")).map(withMockedTimestamp) shouldBe
+      expressionEvaluationResults(NodeId("proc2")).map(withMockedTimestamp) shouldBe
         List(
-          ExpressionInvocationResult(
+          ExpressionEvaluationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -180,9 +180,9 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
         )
 
-      invocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
+      expressionEvaluationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
-          ExpressionInvocationResult(
+          ExpressionEvaluationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -195,7 +195,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
         )
 
-      results.externalInvocationResults(NodeId("proc2")).map(r => (r.contextId, r.name, r.value)) shouldBe List(
+      results.externalServiceInvocationResults(NodeId("proc2")).map(r => (r.contextId, r.name, r.value)) shouldBe List(
         (
           ContextId(
             scenarioName = scenarioName,
@@ -208,8 +208,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         )
       )
 
-      results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe List(
-        ExternalInvocationResult(
+      results.externalServiceInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe List(
+        ExternalServiceInvocationResult(
           ContextId(
             scenarioName = scenarioName,
             originatingNodeId = sourceNodeId,
@@ -222,8 +222,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         )
       )
 
-      results.externalInvocationResults(NodeId("eager1")).map(withMockedTimestamp) shouldBe List(
-        ExternalInvocationResult(
+      results.externalServiceInvocationResults(NodeId("eager1")).map(withMockedTimestamp) shouldBe List(
+        ExternalServiceInvocationResult(
           ContextId(
             scenarioName = scenarioName,
             originatingNodeId = sourceNodeId,
@@ -268,11 +268,11 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         nodeResults(sourceNodeId) shouldBe List(nodeResult(0, "input" -> input))
         nodeResults(NodeId("out")) shouldBe List(nodeResult(0, "input" -> input))
 
-        val invocationResults = results.invocationResults
+        val expressionEvaluationResults = results.expressionEvaluationResults
 
-        invocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
+        expressionEvaluationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
           List(
-            ExpressionInvocationResult(
+            ExpressionEvaluationResult(
               ContextId(
                 scenarioName = scenarioName,
                 originatingNodeId = sourceNodeId,
@@ -285,8 +285,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
             )
           )
 
-        results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe List(
-          ExternalInvocationResult(
+        results.externalServiceInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe List(
+          ExternalServiceInvocationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -362,12 +362,12 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         nodeResult(1, "input" -> input2, "out" -> aggregate2)
       )
 
-      val invocationResults = results.invocationResults
+      val expressionEvaluationResults = results.expressionEvaluationResults
 
-      invocationResults(NodeId("cid")).map(withMockedTimestamp) shouldBe
+      expressionEvaluationResults(NodeId("cid")).map(withMockedTimestamp) shouldBe
         List(
           // we record only LazyParameter execution results
-          ExpressionInvocationResult(
+          ExpressionEvaluationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -378,7 +378,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
             "groupBy",
             variable("0")
           ),
-          ExpressionInvocationResult(
+          ExpressionEvaluationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -391,9 +391,9 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
         )
 
-      invocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
+      expressionEvaluationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
-          ExpressionInvocationResult(
+          ExpressionEvaluationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -404,7 +404,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
             "Value",
             variable("1 0")
           ),
-          ExpressionInvocationResult(
+          ExpressionEvaluationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -417,9 +417,9 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
         )
 
-      results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
+      results.externalServiceInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
-          ExternalInvocationResult(
+          ExternalServiceInvocationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -430,7 +430,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
             "valueMonitor",
             variable("1 0")
           ),
-          ExternalInvocationResult(
+          ExternalServiceInvocationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -604,9 +604,9 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         prepareTestRunner(useIOMonadInInterpreter).runTests(process, testData).futureValue
 
       nodeResultsWithoutTimestamp(results)(sourceNodeId) should have size 3
-      results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
+      results.externalServiceInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
-          ExternalInvocationResult(
+          ExternalServiceInvocationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -617,7 +617,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
             "valueMonitor",
             variable(SimpleJsonRecord("1", "11"))
           ),
-          ExternalInvocationResult(
+          ExternalServiceInvocationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -628,7 +628,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
             "valueMonitor",
             variable(SimpleJsonRecord("2", "22"))
           ),
-          ExternalInvocationResult(
+          ExternalServiceInvocationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -654,9 +654,9 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         prepareTestRunner(useIOMonadInInterpreter).runTests(process, testData).futureValue
 
       nodeResultsWithoutTimestamp(results)(sourceNodeId) should have size 1
-      results.externalInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
+      results.externalServiceInvocationResults(NodeId("out")).map(withMockedTimestamp) shouldBe
         List(
-          ExternalInvocationResult(
+          ExternalServiceInvocationResult(
             ContextId(
               scenarioName = scenarioName,
               originatingNodeId = sourceNodeId,
@@ -748,7 +748,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         )
         .futureValue
 
-      results.invocationResults(NodeId("out")).map(_.value) shouldBe List(variable("abcdef"))
+      results.expressionEvaluationResults(NodeId("out")).map(_.value) shouldBe List(variable("abcdef"))
     }
 
     "using dependent services" in {
@@ -776,7 +776,9 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
           .futureValue
 
-      results.invocationResults(NodeId("out")).map(_.value) shouldBe List(variable(s"$countToPass $valueToReturn"))
+      results.expressionEvaluationResults(NodeId("out")).map(_.value) shouldBe List(
+        variable(s"$countToPass $valueToReturn")
+      )
     }
 
     "switch value should be equal to variable value" in {
@@ -802,12 +804,12 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           .runTests(process, ScenarioTestData(List(recordTrue, recordFalse)))
           .futureValue
 
-      val invocationResults = results.invocationResults
+      val expressionEvaluationResults = results.expressionEvaluationResults
 
-      invocationResults(NodeId("switch")).filter(_.name == "expression").head.value shouldBe variable(true)
-      invocationResults(NodeId("switch")).filter(_.name == "expression").last.value shouldBe variable(false)
+      expressionEvaluationResults(NodeId("switch")).filter(_.name == "expression").head.value shouldBe variable(true)
+      expressionEvaluationResults(NodeId("switch")).filter(_.name == "expression").last.value shouldBe variable(false)
       // first record was filtered out
-      invocationResults(NodeId("out")).head.contextId shouldBe ContextId(
+      expressionEvaluationResults(NodeId("out")).head.contextId shouldBe ContextId(
         scenarioName = scenarioName,
         originatingNodeId = sourceNodeId,
         taskId = firstSubtaskIndex,
@@ -848,7 +850,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           .runTests(process, ScenarioTestData(List(recA, recB, recC)))
           .futureValue
 
-      results.invocationResults(NodeId("proc2")).map(_.contextId) should contain only (
+      results.expressionEvaluationResults(NodeId("proc2")).map(_.contextId) should contain only (
         ContextId(
           scenarioName = scenarioName,
           originatingNodeId = sourceNodeId,
@@ -892,7 +894,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       )
 
       results
-        .externalInvocationResults(NodeId("proc2"))
+        .externalServiceInvocationResults(NodeId("proc2"))
         .map(_.value.asInstanceOf[Json]) should contain theSameElementsAs List(
         "b",
         "a",
@@ -966,8 +968,8 @@ class FlinkMiniClusterScenarioTestRunnerSpec
         nodeResult(2, NodeId("source2"), "end2", "input" -> recordC, "joinInput" -> recordC)
       )
 
-      results.invocationResults(NodeId("proc2")).map(withMockedTimestamp) should contain only (
-        ExpressionInvocationResult(
+      results.expressionEvaluationResults(NodeId("proc2")).map(withMockedTimestamp) should contain only (
+        ExpressionEvaluationResult(
           ContextId(
             scenarioName = scenarioName,
             originatingNodeId = NodeId("source1"),
@@ -979,7 +981,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           "all",
           variable("d")
         ),
-        ExpressionInvocationResult(
+        ExpressionEvaluationResult(
           ContextId(
             scenarioName = scenarioName,
             originatingNodeId = NodeId("source2"),
@@ -991,7 +993,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           "all",
           variable("a")
         ),
-        ExpressionInvocationResult(
+        ExpressionEvaluationResult(
           ContextId(
             scenarioName = scenarioName,
             originatingNodeId = NodeId("source2"),
@@ -1006,7 +1008,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
       )
 
       results
-        .externalInvocationResults(NodeId("proc2"))
+        .externalServiceInvocationResults(NodeId("proc2"))
         .map(_.value.asInstanceOf[Json]) should contain theSameElementsAs List("a", "c", "d")
         .map(_ + "-collectedDuringServiceInvocation")
         .map(variable)
@@ -1036,7 +1038,7 @@ class FlinkMiniClusterScenarioTestRunnerSpec
           )
           .futureValue
 
-      results.invocationResults(NodeId("out")).map(_.value) shouldBe List(
+      results.expressionEvaluationResults(NodeId("out")).map(_.value) shouldBe List(
         variable(List(ComponentUseContext.ScenarioTesting, ComponentUseContext.ScenarioTesting))
       )
     }
@@ -1202,10 +1204,10 @@ class FlinkMiniClusterScenarioTestRunnerSpec
   private def nodeResultsWithoutTimestamp[T](results: TestProcess.TestResults[T]) =
     results.nodeResults.map { case (key, values) => (key, values.map(v => (v.id, v.variables))) }
 
-  private def withMockedTimestamp(result: ExpressionInvocationResult[Json]) =
+  private def withMockedTimestamp(result: ExpressionEvaluationResult[Json]) =
     result.copy(timestamp = mockedTimestamp)
 
-  private def withMockedTimestamp(result: ExternalInvocationResult[Json]) =
+  private def withMockedTimestamp(result: ExternalServiceInvocationResult[Json]) =
     result.copy(timestamp = mockedTimestamp)
 
 }

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
@@ -183,7 +183,7 @@ class SchemedKafkaScenarioTestingSpec
 
     val results = testRunner.runTests(process, scenarioTestData).futureValue
     results
-      .invocationResults(NodeId("end"))
+      .expressionEvaluationResults(NodeId("end"))
       .head
       .value
       .hcursor
@@ -232,9 +232,9 @@ class SchemedKafkaScenarioTestingSpec
 
     val mockedTimestamp = Instant.now()
     results
-      .invocationResults(NodeId("fragmentEnd"))
+      .expressionEvaluationResults(NodeId("fragmentEnd"))
       .loneElement
-      .copy(timestamp = mockedTimestamp) shouldBe ExpressionInvocationResult(
+      .copy(timestamp = mockedTimestamp) shouldBe ExpressionEvaluationResult(
       ContextId(
         scenarioName = ProcessName("fragment1"),
         originatingNodeId = NodeId("fragment1"),

--- a/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
+++ b/engine/lite/embeddedDeploymentManager/src/test/scala/pl/touk/nussknacker/streaming/embedded/StreamingEmbeddedDeploymentManagerTest.scala
@@ -16,7 +16,7 @@ import pl.touk.nussknacker.engine.kafka.consumerrecord.SerializableConsumerRecor
 import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransformer
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.formatter.SchemaBasedSerializableConsumerRecord
 import pl.touk.nussknacker.engine.spel.SpelExtension._
-import pl.touk.nussknacker.engine.testmode.TestProcess.ExpressionInvocationResult
+import pl.touk.nussknacker.engine.testmode.TestProcess.ExpressionEvaluationResult
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
 
@@ -249,20 +249,20 @@ class StreamingEmbeddedDeploymentManagerTest
     }
     results.nodeResults(NodeId("sink")) should have length 2
     val idGenerator = IncContextIdGenerator.withProcessIdNodeIdPrefix(scenario.metaData, NodeId("source"), taskId = 0)
-    val invocationResults = results.invocationResults(NodeId("sink"))
-    val id1               = idGenerator.nextContextId()
-    val id2               = idGenerator.nextContextId()
+    val expressionEvaluationResults = results.expressionEvaluationResults(NodeId("sink"))
+    val id1                         = idGenerator.nextContextId()
+    val id2                         = idGenerator.nextContextId()
 
-    invocationResults.toSet.map(withMockedTimestamp) shouldBe Set(
-      ExpressionInvocationResult(id1, mockedTimestamp, "Key", Json.Null),
-      ExpressionInvocationResult(
+    expressionEvaluationResults.toSet.map(withMockedTimestamp) shouldBe Set(
+      ExpressionEvaluationResult(id1, mockedTimestamp, "Key", Json.Null),
+      ExpressionEvaluationResult(
         id1,
         mockedTimestamp,
         sinkValueParamName.value,
         variable(Map("message" -> "1", "other" -> "1"))
       ),
-      ExpressionInvocationResult(id2, mockedTimestamp, "Key", Json.Null),
-      ExpressionInvocationResult(
+      ExpressionEvaluationResult(id2, mockedTimestamp, "Key", Json.Null),
+      ExpressionEvaluationResult(
         id2,
         mockedTimestamp,
         sinkValueParamName.value,
@@ -275,7 +275,7 @@ class StreamingEmbeddedDeploymentManagerTest
   private def variable(value: Map[String, String]): Json =
     Json.obj("pretty" -> Json.fromFields(value.mapValuesNow(Json.fromString)))
 
-  private def withMockedTimestamp(result: ExpressionInvocationResult[Json]) =
+  private def withMockedTimestamp(result: ExpressionEvaluationResult[Json]) =
     result.copy(timestamp = mockedTimestamp)
 
 }

--- a/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
+++ b/engine/lite/request-response/runtime/src/test/scala/pl/touk/nussknacker/engine/requestresponse/test/RequestResponseTestMainSpec.scala
@@ -67,20 +67,25 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
       (secondId, Map("input" -> variable(Request1("c", "d"))))
     )
 
-    results.invocationResults(NodeId("filter1")).map(withMockedTimestamp).toSet shouldBe Set(
-      ExpressionInvocationResult(firstId, mockedTimestamp, "expression", variable(true)),
-      ExpressionInvocationResult(secondId, mockedTimestamp, "expression", variable(false))
+    results.expressionEvaluationResults(NodeId("filter1")).map(withMockedTimestamp).toSet shouldBe Set(
+      ExpressionEvaluationResult(firstId, mockedTimestamp, "expression", variable(true)),
+      ExpressionEvaluationResult(secondId, mockedTimestamp, "expression", variable(false))
     )
 
-    results.externalInvocationResults(NodeId("processor")).map(withMockedTimestamp).toSet shouldBe Set(
-      ExternalInvocationResult(firstId, mockedTimestamp, "processorService", variable("processor service invoked"))
+    results.externalServiceInvocationResults(NodeId("processor")).map(withMockedTimestamp).toSet shouldBe Set(
+      ExternalServiceInvocationResult(
+        firstId,
+        mockedTimestamp,
+        "processorService",
+        variable("processor service invoked")
+      )
     )
-    results.externalInvocationResults(NodeId("eagerProcessor")).map(withMockedTimestamp).toSet shouldBe Set(
-      ExternalInvocationResult(firstId, mockedTimestamp, "collectingEager", variable("static-s-dynamic-a"))
+    results.externalServiceInvocationResults(NodeId("eagerProcessor")).map(withMockedTimestamp).toSet shouldBe Set(
+      ExternalServiceInvocationResult(firstId, mockedTimestamp, "collectingEager", variable("static-s-dynamic-a"))
     )
 
-    results.externalInvocationResults(NodeId("endNodeIID")).map(withMockedTimestamp).toSet shouldBe Set(
-      ExternalInvocationResult(firstId, mockedTimestamp, "endNodeIID", variable(Response(s"alamakota-$firstId")))
+    results.externalServiceInvocationResults(NodeId("endNodeIID")).map(withMockedTimestamp).toSet shouldBe Set(
+      ExternalServiceInvocationResult(firstId, mockedTimestamp, "endNodeIID", variable(Response(s"alamakota-$firstId")))
     )
 
     RequestResponseSampleComponents.processorService.get().invocationsCount.get shouldBe 0
@@ -105,8 +110,8 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
 
     val results = runTest(process, scenarioTestData)
 
-    results.invocationResults(NodeId("occasionallyThrowFilter")).map(withMockedTimestamp).toSet shouldBe Set(
-      ExpressionInvocationResult(secondId, mockedTimestamp, "expression", variable(true))
+    results.expressionEvaluationResults(NodeId("occasionallyThrowFilter")).map(withMockedTimestamp).toSet shouldBe Set(
+      ExpressionEvaluationResult(secondId, mockedTimestamp, "expression", variable(true))
     )
 
     results.exceptions should have size 1
@@ -139,8 +144,8 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
       (firstId, Map("input" -> variable(Request1("a", "b"))))
     )
 
-    results.externalInvocationResults(NodeId("endNodeIID")).map(withMockedTimestamp).toSet shouldBe Set(
-      ExternalInvocationResult(firstId, mockedTimestamp, "endNodeIID", variable("a withRandomString"))
+    results.externalServiceInvocationResults(NodeId("endNodeIID")).map(withMockedTimestamp).toSet shouldBe Set(
+      ExternalServiceInvocationResult(firstId, mockedTimestamp, "endNodeIID", variable("a withRandomString"))
     )
 
   }
@@ -196,7 +201,7 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
     unionContextIds should contain theSameElementsAs unionContextIds.toSet
     nodeResults(results, "union1") shouldBe nodeResults(results, "collect1")
 
-    val endNodeIdInvocationResult = results.externalInvocationResults(NodeId("endNodeIID")).loneElement
+    val endNodeIdInvocationResult = results.externalServiceInvocationResults(NodeId("endNodeIID")).loneElement
     endNodeIdInvocationResult.contextId shouldBe contextIdGenForNodeId(process, NodeId("collect1")).nextContextId()
 
     endNodeIdInvocationResult.value shouldBe variable(List("aa", "bb"))
@@ -241,10 +246,10 @@ class RequestResponseTestMainSpec extends AnyFunSuite with Matchers with BeforeA
   private def nodeResults[T](results: TestProcess.TestResults[T], nodeId: String) =
     results.nodeResults(NodeId(nodeId)).map(r => (r.id, r.variables))
 
-  private def withMockedTimestamp(result: ExpressionInvocationResult[Json]) =
+  private def withMockedTimestamp(result: ExpressionEvaluationResult[Json]) =
     result.copy(timestamp = mockedTimestamp)
 
-  private def withMockedTimestamp(result: ExternalInvocationResult[Json]) =
+  private def withMockedTimestamp(result: ExternalServiceInvocationResult[Json]) =
     result.copy(timestamp = mockedTimestamp)
 
 }

--- a/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/InterpreterTestRunnerTest.scala
+++ b/engine/lite/runtime/src/test/scala/pl/touk/nussknacker/engine/lite/InterpreterTestRunnerTest.scala
@@ -14,7 +14,7 @@ import pl.touk.nussknacker.engine.graph.expression.Expression.Language
 import pl.touk.nussknacker.engine.lite.sample.SampleInputWithListAndMap
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.testmode.TestProcess
-import pl.touk.nussknacker.engine.testmode.TestProcess.{ExpressionInvocationResult, ExternalInvocationResult}
+import pl.touk.nussknacker.engine.testmode.TestProcess.{ExpressionEvaluationResult, ExternalServiceInvocationResult}
 
 import java.time.Instant
 import scala.jdk.CollectionConverters._
@@ -61,19 +61,24 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
       (ContextId(ProcessName("C"), NodeId(""), 0, 0), Map("input" -> 3, "out1" -> 3, "sum" -> 5).mapValuesNow(variable))
     )
 
-    results.invocationResults(NodeId("sum")).map(withMockedTimestamp) shouldBe List(
-      ExpressionInvocationResult(ContextId(ProcessName("A"), NodeId(""), 0, 0), mockedTimestamp, "value", variable(2)),
-      ExpressionInvocationResult(ContextId(ProcessName("C"), NodeId(""), 0, 0), mockedTimestamp, "value", variable(3))
+    results.expressionEvaluationResults(NodeId("sum")).map(withMockedTimestamp) shouldBe List(
+      ExpressionEvaluationResult(ContextId(ProcessName("A"), NodeId(""), 0, 0), mockedTimestamp, "value", variable(2)),
+      ExpressionEvaluationResult(ContextId(ProcessName("C"), NodeId(""), 0, 0), mockedTimestamp, "value", variable(3))
     )
 
-    results.externalInvocationResults(NodeId("end")).map(withMockedTimestamp) shouldBe List(
-      ExternalInvocationResult(
+    results.externalServiceInvocationResults(NodeId("end")).map(withMockedTimestamp) shouldBe List(
+      ExternalServiceInvocationResult(
         ContextId(ProcessName("A"), NodeId(""), 0, 0),
         mockedTimestamp,
         "end",
         variable("2:2.0")
       ),
-      ExternalInvocationResult(ContextId(ProcessName("C"), NodeId(""), 0, 0), mockedTimestamp, "end", variable("3:5.0"))
+      ExternalServiceInvocationResult(
+        ContextId(ProcessName("C"), NodeId(""), 0, 0),
+        mockedTimestamp,
+        "end",
+        variable("3:5.0")
+      )
     )
   }
 
@@ -102,12 +107,27 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
       (ContextId(ProcessName("C"), NodeId(""), 0, 0), Map("input" -> variable(3)))
     )
 
-    results.externalInvocationResults(NodeId("end1")).map(withMockedTimestamp) shouldBe List(
-      ExternalInvocationResult(ContextId(ProcessName("A"), NodeId(""), 0, 0), mockedTimestamp, "end1", variable(1)),
-      ExternalInvocationResult(ContextId(ProcessName("B"), NodeId(""), 0, 0), mockedTimestamp, "end1", variable(2))
+    results.externalServiceInvocationResults(NodeId("end1")).map(withMockedTimestamp) shouldBe List(
+      ExternalServiceInvocationResult(
+        ContextId(ProcessName("A"), NodeId(""), 0, 0),
+        mockedTimestamp,
+        "end1",
+        variable(1)
+      ),
+      ExternalServiceInvocationResult(
+        ContextId(ProcessName("B"), NodeId(""), 0, 0),
+        mockedTimestamp,
+        "end1",
+        variable(2)
+      )
     )
-    results.externalInvocationResults(NodeId("end2")).map(withMockedTimestamp) shouldBe List(
-      ExternalInvocationResult(ContextId(ProcessName("C"), NodeId(""), 0, 0), mockedTimestamp, "end2", variable(3))
+    results.externalServiceInvocationResults(NodeId("end2")).map(withMockedTimestamp) shouldBe List(
+      ExternalServiceInvocationResult(
+        ContextId(ProcessName("C"), NodeId(""), 0, 0),
+        mockedTimestamp,
+        "end2",
+        variable(3)
+      )
     )
   }
 
@@ -174,8 +194,8 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
       )
     )
 
-    results.invocationResults(NodeId("sumNumbers")).map(withMockedTimestamp) shouldBe List(
-      ExpressionInvocationResult(
+    results.expressionEvaluationResults(NodeId("sumNumbers")).map(withMockedTimestamp) shouldBe List(
+      ExpressionEvaluationResult(
         ContextId(ProcessName("some-ctx-id"), NodeId(""), 0, 0),
         mockedTimestamp,
         "value",
@@ -183,8 +203,8 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
       )
     )
 
-    results.externalInvocationResults(NodeId("end")).map(withMockedTimestamp) shouldBe List(
-      ExternalInvocationResult(
+    results.externalServiceInvocationResults(NodeId("end")).map(withMockedTimestamp) shouldBe List(
+      ExternalServiceInvocationResult(
         ContextId(ProcessName("some-ctx-id"), NodeId(""), 0, 0),
         mockedTimestamp,
         "end",
@@ -214,8 +234,8 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
         Map("in" -> variable("some-text-id"), "out" -> variable("some-text-id"))
       )
     )
-    results.invocationResults(NodeId("fragmentEnd")).map(withMockedTimestamp) shouldBe List(
-      ExpressionInvocationResult(
+    results.expressionEvaluationResults(NodeId("fragmentEnd")).map(withMockedTimestamp) shouldBe List(
+      ExpressionEvaluationResult(
         ContextId(ProcessName("fragment1"), NodeId("fragment1"), 0, 0),
         mockedTimestamp,
         "out",
@@ -275,10 +295,10 @@ class InterpreterTestRunnerTest extends AnyFunSuite with Matchers {
   private def nodeResults[T](results: TestProcess.TestResults[T], key: String) =
     results.nodeResults(NodeId(key)).map(r => (r.id, r.variables))
 
-  private def withMockedTimestamp(result: ExpressionInvocationResult[Json]) =
+  private def withMockedTimestamp(result: ExpressionEvaluationResult[Json]) =
     result.copy(timestamp = mockedTimestamp)
 
-  private def withMockedTimestamp(result: ExternalInvocationResult[Json]) =
+  private def withMockedTimestamp(result: ExternalServiceInvocationResult[Json]) =
     result.copy(timestamp = mockedTimestamp)
 
 }

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/testmode/TestProcess.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/testmode/TestProcess.scala
@@ -10,8 +10,8 @@ object TestProcess {
   case class TestResults[T](
       nodeResults: Map[NodeId, List[ResultContext[T]]],
       nodeTransitionResults: Map[NodeTransition, List[ResultContext[T]]],
-      invocationResults: Map[NodeId, List[ExpressionInvocationResult[T]]],
-      externalInvocationResults: Map[NodeId, List[ExternalInvocationResult[T]]],
+      expressionEvaluationResults: Map[NodeId, List[ExpressionEvaluationResult[T]]],
+      externalServiceInvocationResults: Map[NodeId, List[ExternalServiceInvocationResult[T]]],
       exceptions: List[ExceptionResult[T]]
   ) {
 
@@ -42,9 +42,12 @@ object TestProcess {
         result: Any,
         variableEncoder: Any => T
     ): TestResults[T] = {
-      val invocationResult = ExpressionInvocationResult(context.id, Instant.now(), name, variableEncoder(result))
-      copy(invocationResults =
-        invocationResults + (nodeId -> addResults(invocationResult, invocationResults.getOrElse(nodeId, List())))
+      val invocationResult = ExpressionEvaluationResult(context.id, Instant.now(), name, variableEncoder(result))
+      copy(expressionEvaluationResults =
+        expressionEvaluationResults + (nodeId -> addResults(
+          invocationResult,
+          expressionEvaluationResults.getOrElse(nodeId, List())
+        ))
       )
     }
 
@@ -55,9 +58,10 @@ object TestProcess {
         result: Any,
         variableEncoder: Any => T
     ): TestResults[T] = {
-      val invocation = ExternalInvocationResult(contextId, Instant.now(), name, variableEncoder(result))
-      copy(externalInvocationResults =
-        externalInvocationResults + (nodeId -> (externalInvocationResults.getOrElse(nodeId, List()) :+ invocation))
+      val invocation = ExternalServiceInvocationResult(contextId, Instant.now(), name, variableEncoder(result))
+      copy(externalServiceInvocationResults =
+        externalServiceInvocationResults + (nodeId -> (externalServiceInvocationResults
+          .getOrElse(nodeId, List()) :+ invocation))
       )
     }
 
@@ -72,9 +76,9 @@ object TestProcess {
     // when evaluating e.g. keyBy expression can be invoked more than once...
     // TODO: is it the best way to handle it??
     private def addResults(
-        invocationResult: ExpressionInvocationResult[T],
-        resultsSoFar: List[ExpressionInvocationResult[T]]
-    ): List[ExpressionInvocationResult[T]] = resultsSoFar.filterNot(res =>
+        invocationResult: ExpressionEvaluationResult[T],
+        resultsSoFar: List[ExpressionEvaluationResult[T]]
+    ): List[ExpressionEvaluationResult[T]] = resultsSoFar.filterNot(res =>
       res.contextId == invocationResult.contextId && res.name == invocationResult.name
     ) :+ invocationResult
 
@@ -88,8 +92,8 @@ object TestProcess {
       TestResults[T](
         nodeResults = mergeMaps(testResults.map(_.nodeResults)),
         nodeTransitionResults = mergeMaps(testResults.map(_.nodeTransitionResults)),
-        invocationResults = mergeMaps(testResults.map(_.invocationResults)),
-        externalInvocationResults = mergeMaps(testResults.map(_.externalInvocationResults)),
+        expressionEvaluationResults = mergeMaps(testResults.map(_.expressionEvaluationResults)),
+        externalServiceInvocationResults = mergeMaps(testResults.map(_.externalServiceInvocationResults)),
         exceptions = testResults.flatMap(_.exceptions).toList,
       )
     }
@@ -106,9 +110,9 @@ object TestProcess {
 
   final case class NodeTransition(sourceNodeId: NodeId, destinationNodeId: Option[NodeId])
 
-  case class ExpressionInvocationResult[T](contextId: ContextId, timestamp: Instant, name: String, value: T)
+  case class ExpressionEvaluationResult[T](contextId: ContextId, timestamp: Instant, name: String, value: T)
 
-  case class ExternalInvocationResult[T](contextId: ContextId, timestamp: Instant, name: String, value: T)
+  case class ExternalServiceInvocationResult[T](contextId: ContextId, timestamp: Instant, name: String, value: T)
 
   object ExceptionResult {
 

--- a/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/CollectedLiveData.scala
+++ b/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/CollectedLiveData.scala
@@ -13,8 +13,8 @@ import java.time.Instant
 final case class CollectedLiveData(
     timestamp: Instant,
     nodeTransitions: Map[NodeTransition, LiveDataForNodeTransition],
-    invocationResults: Map[NodeId, List[InvocationResult]],
-    externalInvocationResults: Map[NodeId, List[InvocationResult]],
+    expressionEvaluationResults: Map[NodeId, List[ExpressionEvaluationResult]],
+    externalServiceInvocationResults: Map[NodeId, List[ExternalServiceInvocationResult]],
     exceptions: Map[NodeId, List[ExceptionResult]]
 )
 
@@ -51,8 +51,11 @@ object CollectedLiveData {
   private implicit val liveDataForNodeTransitionEncoder: Encoder[LiveDataForNodeTransition] = deriveEncoder
   private implicit val liveDataForNodeTransitionDecoder: Decoder[LiveDataForNodeTransition] = deriveDecoder
 
-  private implicit val invocationResultEncoder: Encoder[InvocationResult] = deriveEncoder
-  private implicit val invocationResultDecoder: Decoder[InvocationResult] = deriveDecoder
+  private implicit val expressionEvaluationResultEncoder: Encoder[ExpressionEvaluationResult] = deriveEncoder
+  private implicit val expressionEvaluationResultDecoder: Decoder[ExpressionEvaluationResult] = deriveDecoder
+
+  private implicit val externalServiceInvocationResultEncoder: Encoder[ExternalServiceInvocationResult] = deriveEncoder
+  private implicit val externalServiceInvocationResultDecoder: Decoder[ExternalServiceInvocationResult] = deriveDecoder
 
   private implicit val exceptionResultEncoder: Encoder[ExceptionResult] = deriveEncoder
   private implicit val exceptionResultDecoder: Decoder[ExceptionResult] = deriveDecoder
@@ -72,8 +75,31 @@ object CollectedLiveData {
       result.getOrElse(throw new IllegalArgumentException("Could not parse NodeTransition"))
     }
 
+  // The live data collected by standalone Flink are synchronized using `live_data` db table.
+  // They are stored in the db as CollectedLiveData encoded as Json.
+  // The already deployed processes will upload the data to the table using the old schema after Nu upgrade.
+  // This class represents old schema (with `invocationResults` and `externalInvocationResults` fields.
+  private final case class CollectedLiveDataV1(
+      timestamp: Instant,
+      nodeTransitions: Map[NodeTransition, LiveDataForNodeTransition],
+      invocationResults: Map[NodeId, List[ExpressionEvaluationResult]],
+      externalInvocationResults: Map[NodeId, List[ExternalServiceInvocationResult]],
+      exceptions: Map[NodeId, List[ExceptionResult]]
+  ) {}
+
   implicit val collectedLiveDataEncoder: Encoder[CollectedLiveData] = deriveEncoder
-  implicit val collectedLiveDataDecoder: Decoder[CollectedLiveData] = deriveDecoder
+
+  implicit val collectedLiveDataDecoder: Decoder[CollectedLiveData] =
+    deriveDecoder[CollectedLiveData]
+      .or(deriveDecoder[CollectedLiveDataV1].map { v1 =>
+        CollectedLiveData(
+          timestamp = v1.timestamp,
+          nodeTransitions = v1.nodeTransitions,
+          expressionEvaluationResults = v1.invocationResults,
+          externalServiceInvocationResults = v1.externalInvocationResults,
+          exceptions = v1.exceptions,
+        )
+      })
 
   def aggregate(
       liveData: List[CollectedLiveData],
@@ -89,13 +115,13 @@ object CollectedLiveData {
             liveDataNel.toList.map(_.nodeTransitions),
             maxNumberOfSamples
           ),
-          invocationResults = latestSamples[InvocationResult](
-            liveDataNel.toList.map(_.invocationResults),
+          expressionEvaluationResults = latestSamples[ExpressionEvaluationResult](
+            liveDataNel.toList.map(_.expressionEvaluationResults),
             maxNumberOfSamples,
             _.timestamp
           ),
-          externalInvocationResults = latestSamples[InvocationResult](
-            liveDataNel.toList.map(_.externalInvocationResults),
+          externalServiceInvocationResults = latestSamples[ExternalServiceInvocationResult](
+            liveDataNel.toList.map(_.externalServiceInvocationResults),
             maxNumberOfSamples,
             _.timestamp
           ),
@@ -150,7 +176,14 @@ final case class ExceptionResult(
     throwable: Throwable,
 )
 
-final case class InvocationResult(
+final case class ExpressionEvaluationResult(
+    contextId: ContextId,
+    timestamp: Instant,
+    name: String,
+    value: Json,
+)
+
+final case class ExternalServiceInvocationResult(
     contextId: ContextId,
     timestamp: Instant,
     name: String,

--- a/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListener.scala
+++ b/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListener.scala
@@ -79,7 +79,7 @@ class LiveDataCollectingListener private[livedata] (
   ): Unit = performStorageOperation {
     _.addExpressionEvaluationResult(
       nodeId,
-      InvocationResult(context.id, Instant.now(), expressionId, encode(result)),
+      ExpressionEvaluationResult(context.id, Instant.now(), expressionId, encode(result)),
     )
   }
 
@@ -92,7 +92,7 @@ class LiveDataCollectingListener private[livedata] (
   ): Unit = performStorageOperation {
     _.addExternalServiceInvocation(
       nodeId,
-      InvocationResult(context.id, Instant.now(), id, result.map(encode).getOrElse(Json.Null)),
+      ExternalServiceInvocationResult(context.id, Instant.now(), id, result.map(encode).getOrElse(Json.Null)),
     )
   }
 

--- a/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListener.scala
+++ b/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListener.scala
@@ -77,7 +77,7 @@ class LiveDataCollectingListener private[livedata] (
       processMetaData: MetaData,
       result: Any,
   ): Unit = performStorageOperation {
-    _.addExpressionEvaluation(
+    _.addExpressionEvaluationResult(
       nodeId,
       InvocationResult(context.id, Instant.now(), expressionId, encode(result)),
     )
@@ -90,7 +90,7 @@ class LiveDataCollectingListener private[livedata] (
       processMetaData: MetaData,
       result: Try[Any],
   ): Unit = performStorageOperation {
-    _.addExternalInvocation(
+    _.addExternalServiceInvocation(
       nodeId,
       InvocationResult(context.id, Instant.now(), id, result.map(encode).getOrElse(Json.Null)),
     )

--- a/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListenerStorage.scala
+++ b/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListenerStorage.scala
@@ -1,6 +1,7 @@
 package pl.touk.nussknacker.engine.livedata
 
 import pl.touk.nussknacker.engine.api.NodeId
+import pl.touk.nussknacker.engine.livedata.LiveDataCollectingListenerStorage.NodeParameter
 
 import java.time.{Clock, Instant}
 import java.util.concurrent.ConcurrentHashMap
@@ -16,9 +17,11 @@ private[livedata] class LiveDataCollectingListenerStorage(
 
   private val samples = new ConcurrentHashMap[NodeTransition, RingBufferWithTotalCount[LiveDataSample]]
 
-  private val invocationResults = new ConcurrentHashMap[NodeId, RingBufferWithTotalCount[InvocationResult]]
+  private val expressionEvaluationResults =
+    new ConcurrentHashMap[NodeParameter, RingBufferWithTotalCount[InvocationResult]]
 
-  private val externalInvocations = new ConcurrentHashMap[NodeId, RingBufferWithTotalCount[InvocationResult]]
+  private val externalServiceInvocationResults =
+    new ConcurrentHashMap[NodeParameter, RingBufferWithTotalCount[InvocationResult]]
 
   private val exceptions = new ConcurrentHashMap[NodeId, RingBufferWithTotalCount[ExceptionResult]]
 
@@ -37,12 +40,12 @@ private[livedata] class LiveDataCollectingListenerStorage(
           currentThroughput = transitionsSlidingWindowCounter.getThroughput.getOrElse(transition, 0)
         )
       },
-      invocationResults = invocationResults.asScala.toMap.map { case (nodeId, values) =>
-        nodeId -> values.values
-      },
-      externalInvocationResults = externalInvocations.asScala.toMap.map { case (nodeId, values) =>
-        nodeId -> values.values
-      },
+      invocationResults = expressionEvaluationResults.asScala.toMap
+        .groupBy { case (nodeExpr, _) => nodeExpr.nodeId }
+        .map { case (nodeId, matchingValuesMap) => nodeId -> matchingValuesMap.values.toList.flatMap(_.values) },
+      externalInvocationResults = externalServiceInvocationResults.asScala.toMap
+        .groupBy { case (nodeExpr, _) => nodeExpr.nodeId }
+        .map { case (nodeId, matchingValuesMap) => nodeId -> matchingValuesMap.values.toList.flatMap(_.values) },
       exceptions = exceptions.asScala.toMap.map { case (nodeId, values) =>
         nodeId -> values.values
       },
@@ -54,12 +57,12 @@ private[livedata] class LiveDataCollectingListenerStorage(
     put(samples, nodeTransition, liveDataSample)
   }
 
-  def addExpressionEvaluation(nodeId: NodeId, value: InvocationResult): Unit = {
-    put(invocationResults, nodeId, value)
+  def addExpressionEvaluationResult(nodeId: NodeId, value: InvocationResult): Unit = {
+    put(expressionEvaluationResults, NodeParameter(nodeId, value.name), value)
   }
 
-  def addExternalInvocation(nodeId: NodeId, value: InvocationResult): Unit = {
-    put(externalInvocations, nodeId, value)
+  def addExternalServiceInvocation(nodeId: NodeId, value: InvocationResult): Unit = {
+    put(externalServiceInvocationResults, NodeParameter(nodeId, value.name), value)
   }
 
   def addException(nodeId: NodeId, value: ExceptionResult): Unit = {
@@ -85,4 +88,8 @@ private[livedata] class LiveDataCollectingListenerStorage(
     )
   }
 
+}
+
+object LiveDataCollectingListenerStorage {
+  private final case class NodeParameter(nodeId: NodeId, parameterName: String)
 }

--- a/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListenerStorage.scala
+++ b/live-data-collector/src/main/scala/pl/touk/nussknacker/engine/livedata/LiveDataCollectingListenerStorage.scala
@@ -18,10 +18,10 @@ private[livedata] class LiveDataCollectingListenerStorage(
   private val samples = new ConcurrentHashMap[NodeTransition, RingBufferWithTotalCount[LiveDataSample]]
 
   private val expressionEvaluationResults =
-    new ConcurrentHashMap[NodeParameter, RingBufferWithTotalCount[InvocationResult]]
+    new ConcurrentHashMap[NodeParameter, RingBufferWithTotalCount[ExpressionEvaluationResult]]
 
   private val externalServiceInvocationResults =
-    new ConcurrentHashMap[NodeParameter, RingBufferWithTotalCount[InvocationResult]]
+    new ConcurrentHashMap[NodeParameter, RingBufferWithTotalCount[ExternalServiceInvocationResult]]
 
   private val exceptions = new ConcurrentHashMap[NodeId, RingBufferWithTotalCount[ExceptionResult]]
 
@@ -40,10 +40,10 @@ private[livedata] class LiveDataCollectingListenerStorage(
           currentThroughput = transitionsSlidingWindowCounter.getThroughput.getOrElse(transition, 0)
         )
       },
-      invocationResults = expressionEvaluationResults.asScala.toMap
+      expressionEvaluationResults = expressionEvaluationResults.asScala.toMap
         .groupBy { case (nodeExpr, _) => nodeExpr.nodeId }
         .map { case (nodeId, matchingValuesMap) => nodeId -> matchingValuesMap.values.toList.flatMap(_.values) },
-      externalInvocationResults = externalServiceInvocationResults.asScala.toMap
+      externalServiceInvocationResults = externalServiceInvocationResults.asScala.toMap
         .groupBy { case (nodeExpr, _) => nodeExpr.nodeId }
         .map { case (nodeId, matchingValuesMap) => nodeId -> matchingValuesMap.values.toList.flatMap(_.values) },
       exceptions = exceptions.asScala.toMap.map { case (nodeId, values) =>
@@ -57,11 +57,11 @@ private[livedata] class LiveDataCollectingListenerStorage(
     put(samples, nodeTransition, liveDataSample)
   }
 
-  def addExpressionEvaluationResult(nodeId: NodeId, value: InvocationResult): Unit = {
+  def addExpressionEvaluationResult(nodeId: NodeId, value: ExpressionEvaluationResult): Unit = {
     put(expressionEvaluationResults, NodeParameter(nodeId, value.name), value)
   }
 
-  def addExternalServiceInvocation(nodeId: NodeId, value: InvocationResult): Unit = {
+  def addExternalServiceInvocation(nodeId: NodeId, value: ExternalServiceInvocationResult): Unit = {
     put(externalServiceInvocationResults, NodeParameter(nodeId, value.name), value)
   }
 

--- a/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkTestScenarioRunner.scala
+++ b/utils/flink-components-testkit/src/main/scala/pl/touk/nussknacker/engine/flink/util/test/FlinkTestScenarioRunner.scala
@@ -373,9 +373,9 @@ class FlinkTestScenarioRunner(
   ) = {
     val allSinks           = scenario.collectAllNodes.collect { case sink: node.Sink => sink }
     def isSink(id: NodeId) = allSinks.exists(_.id == id.id)
-    testScenarioCollectorHandler.resultsCollectingListener.results.externalInvocationResults.flatMap {
-      case (id, externalInvocationResults) if isSink(id) =>
-        externalInvocationResults.map(_.value)
+    testScenarioCollectorHandler.resultsCollectingListener.results.externalServiceInvocationResults.flatMap {
+      case (id, externalServiceInvocationResults) if isSink(id) =>
+        externalServiceInvocationResults.map(_.value)
       case _ =>
         List.empty
     }.toList


### PR DESCRIPTION
## Describe your changes

- improved collecting live data samples - expression evaluation results are now collected separately for each expression, and not for each node, thus fixing the incomplete results issue
- refactored field names in test results and live data (from invocationResults to expressionEvaluationResults, from externalInvocationResults to externalServiceInvocationResults)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
