### PR TITLE
Handle null value for key parameter in aggregators

### DIFF
--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/keyed.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/keyed.scala
@@ -94,6 +94,10 @@ object keyed {
         options: KeyOptions
     ): Either[InterpretationError.NullKeyError, T] = {
       Either.cond(
+        // Validate the key selector before using it in a keyed transformation.
+        // Flink's keyed stateful transformations require a non-null key selector.
+        // Passing a null key selector would cause the scenario to crash.
+        // This check can be bypassed if `allowNullableKeys` is explicitly enabled.
         options.allowNullableKeys || key != null,
         key,
         InterpretationError.NullKeyError(keyParameterName)

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/keyed.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/keyed.scala
@@ -6,6 +6,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
+import pl.touk.nussknacker.engine.api.exception.NonTransientException
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.flink.api.process.{
   FlinkCustomNodeContext,
@@ -43,6 +45,8 @@ object keyed {
     )
   }
 
+  import BaseKeyedValueMapper._
+
   abstract class BaseKeyedValueMapper[OutputKey <: AnyRef: TypeTag, OutputValue <: AnyRef: TypeTag]
       extends RichFlatMapFunction[Context, ValueWithContext[KeyedValue[OutputKey, OutputValue]]]
       with LazyParameterInterpreterFunction {
@@ -50,23 +54,50 @@ object keyed {
     protected implicit def toEvaluateFunctionConverterImpl: ToEvaluateFunctionConverter = toEvaluateFunctionConverter
 
     protected def prepareInterpreter(
-        key: LazyParameter[OutputKey],
+        key: LazyParameter[Either[InterpretationError, OutputKey]],
         value: LazyParameter[OutputValue]
-    ): Context => KeyedValue[OutputKey, OutputValue] = {
+    ): Context => Either[InterpretationError, KeyedValue[OutputKey, OutputValue]] = {
       toEvaluateFunctionConverter.toEvaluateFunction(
-        key.product(value).map(tuple => KeyedValue(tuple._1, tuple._2))
+        key.product(value).map(tuple => tuple._1.map(KeyedValue(_, tuple._2)))
       )
     }
 
-    protected def interpret(ctx: Context): KeyedValue[OutputKey, OutputValue]
+    protected def interpret(ctx: Context): Either[InterpretationError, KeyedValue[OutputKey, OutputValue]]
 
     override def flatMap(
         ctx: Context,
         out: Collector[ValueWithContext[KeyedValue[OutputKey, OutputValue]]]
     ): Unit = {
       collectHandlingErrors(ctx, out) {
-        ValueWithContext(interpret(ctx), ctx)
+        interpret(ctx) match {
+          case Right(value) => ValueWithContext(value, ctx)
+          case Left(InterpretationError.NullKeyError(parameterName)) =>
+            throw new NullKeyException(parameterName.value)
+        }
       }
+    }
+
+  }
+
+  final case class KeyOptions(allowNullableKeys: Boolean)
+
+  private[keyed] object BaseKeyedValueMapper {
+    sealed trait InterpretationError
+
+    object InterpretationError {
+      final case class NullKeyError(parameterName: ParameterName) extends InterpretationError
+    }
+
+    def checkKey[T](
+        key: T,
+        keyParameterName: ParameterName,
+        options: KeyOptions
+    ): Either[InterpretationError.NullKeyError, T] = {
+      Either.cond(
+        options.allowNullableKeys || key != null,
+        key,
+        InterpretationError.NullKeyError(keyParameterName)
+      )
     }
 
   }
@@ -74,52 +105,82 @@ object keyed {
   class KeyedValueMapper(
       protected val lazyParameterHelper: FlinkLazyParameterFunctionHelper,
       key: LazyParameter[AnyRef],
+      keyParameterName: ParameterName,
+      keyOptions: KeyOptions,
       value: LazyParameter[AnyRef]
   ) extends BaseKeyedValueMapper[AnyRef, AnyRef] {
 
-    private lazy val interpreter = prepareInterpreter(key, value)
+    private lazy val interpreter = prepareInterpreter(key.map(checkKey(_, keyParameterName, keyOptions)), value)
 
-    override protected def interpret(ctx: Context): KeyedValue[AnyRef, AnyRef] = interpreter(ctx)
+    override protected def interpret(ctx: Context): Either[InterpretationError, KeyedValue[AnyRef, AnyRef]] =
+      interpreter(ctx)
 
   }
 
   class GenericKeyedValueMapper[Value <: AnyRef: TypeTag, Key <: AnyRef: TypeTag](
       protected val lazyParameterHelper: FlinkLazyParameterFunctionHelper,
       key: LazyParameter[Key],
+      keyParameterName: ParameterName,
+      keyOptions: KeyOptions,
       value: LazyParameter[Value]
   ) extends BaseKeyedValueMapper[Key, Value] {
 
-    def this(customNodeContext: FlinkCustomNodeContext, key: LazyParameter[Key], value: LazyParameter[Value]) =
-      this(customNodeContext.lazyParameterHelper, key, value)
+    def this(
+        customNodeContext: FlinkCustomNodeContext,
+        key: LazyParameter[Key],
+        keyParameterName: ParameterName,
+        keyOptions: KeyOptions,
+        value: LazyParameter[Value]
+    ) =
+      this(customNodeContext.lazyParameterHelper, key, keyParameterName, keyOptions, value)
 
-    private lazy val interpreter = prepareInterpreter(key, value)
+    private lazy val interpreter = prepareInterpreter(key.map(transformKey), value)
 
-    override protected def interpret(ctx: Context): KeyedValue[Key, Value] = interpreter(ctx)
+    override protected def interpret(ctx: Context): Either[InterpretationError, KeyedValue[Key, Value]] = interpreter(
+      ctx
+    )
+
+    private def transformKey(keyValue: Key): Either[InterpretationError, Key] = {
+      checkKey(keyValue, keyParameterName, keyOptions)
+    }
 
   }
 
   class StringKeyedValueMapper[T <: AnyRef: TypeTag](
       protected val lazyParameterHelper: FlinkLazyParameterFunctionHelper,
       key: LazyParameter[CharSequence],
+      keyParameterName: ParameterName,
+      keyOptions: KeyOptions,
       value: LazyParameter[T]
   ) extends BaseKeyedValueMapper[String, T] {
 
-    def this(customNodeContext: FlinkCustomNodeContext, key: LazyParameter[CharSequence], value: LazyParameter[T]) =
-      this(customNodeContext.lazyParameterHelper, key, value)
+    def this(
+        customNodeContext: FlinkCustomNodeContext,
+        key: LazyParameter[CharSequence],
+        keyParameterName: ParameterName,
+        keyOptions: KeyOptions,
+        value: LazyParameter[T]
+    ) =
+      this(customNodeContext.lazyParameterHelper, key, keyParameterName, keyOptions, value)
 
     private lazy val interpreter = prepareInterpreter(key.map(transformKey), value)
 
-    protected def transformKey(keyValue: CharSequence): String = {
-      Option(keyValue).map(_.toString).getOrElse("")
+    protected def transformKey(keyValue: CharSequence): Either[InterpretationError, String] = {
+      checkKey(keyValue, keyParameterName, keyOptions)
+        .map(_.toString)
     }
 
-    override protected def interpret(ctx: Context): KeyedValue[String, T] = interpreter(ctx)
+    override protected def interpret(ctx: Context): Either[InterpretationError, KeyedValue[String, T]] = interpreter(
+      ctx
+    )
 
   }
 
   class StringKeyOnlyMapper(
       protected val lazyParameterHelper: FlinkLazyParameterFunctionHelper,
-      key: LazyParameter[CharSequence]
+      key: LazyParameter[CharSequence],
+      keyParameterName: ParameterName,
+      keyOptions: KeyOptions,
   ) extends RichFlatMapFunction[Context, ValueWithContext[String]]
       with LazyParameterInterpreterFunction {
 
@@ -127,15 +188,20 @@ object keyed {
 
     private lazy val interpreter = toEvaluateFunctionConverter.toEvaluateFunction(key.map(transformKey))
 
-    protected def interpret(ctx: Context): String = interpreter(ctx)
+    protected def interpret(ctx: Context): Either[InterpretationError, String] = interpreter(ctx)
 
-    protected def transformKey(keyValue: CharSequence): String = {
-      Option(keyValue).map(_.toString).getOrElse("")
+    protected def transformKey(keyValue: CharSequence): Either[InterpretationError, String] = {
+      checkKey(keyValue, keyParameterName, keyOptions)
+        .map(_.toString)
     }
 
     override def flatMap(ctx: Context, out: Collector[ValueWithContext[String]]): Unit = {
       collectHandlingErrors(ctx, out) {
-        ValueWithContext(interpret(ctx), ctx)
+        interpret(ctx) match {
+          case Right(value) => ValueWithContext(value, ctx)
+          case Left(InterpretationError.NullKeyError(parameterName)) =>
+            throw new NullKeyException(parameterName.value)
+        }
       }
     }
 
@@ -155,5 +221,11 @@ object keyed {
       ctx.withVariableOverriden(VariableConstants.KeyVariableName, groupByReturnType, None)
 
   }
+
+  private[keyed] final class NullKeyException(parameterName: String)
+      extends NonTransientException(
+        input = "",
+        message = s"A key value derived from parameter '$parameterName' evaluated to null. Keys must not be null."
+      )
 
 }

--- a/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/richflink.scala
+++ b/engine/flink/components-utils/src/main/scala/pl/touk/nussknacker/engine/flink/util/richflink.scala
@@ -2,9 +2,10 @@ package pl.touk.nussknacker.engine.flink.util
 
 import org.apache.flink.streaming.api.datastream.{DataStream, KeyedStream, SingleOutputStreamOperator}
 import pl.touk.nussknacker.engine.api.{Context, LazyParameter, ValueWithContext}
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process.FlinkCustomNodeContext
-import pl.touk.nussknacker.engine.flink.util.keyed.{GenericKeyedValueMapper, StringKeyOnlyMapper}
+import pl.touk.nussknacker.engine.flink.util.keyed.{GenericKeyedValueMapper, KeyOptions, StringKeyOnlyMapper}
 import pl.touk.nussknacker.engine.util.KeyedValue
 
 import scala.reflect.runtime.universe.TypeTag
@@ -14,24 +15,40 @@ object richflink {
   implicit class FlinkKeyOperations(dataStream: DataStream[Context]) {
 
     def groupBy(
-        groupBy: LazyParameter[CharSequence]
+        groupBy: LazyParameter[CharSequence],
+        groupByParameterName: ParameterName
     )(implicit ctx: FlinkCustomNodeContext): KeyedStream[ValueWithContext[String], String] =
       dataStream
         .flatMap(
-          new StringKeyOnlyMapper(ctx.lazyParameterHelper, groupBy),
+          new StringKeyOnlyMapper(
+            ctx.lazyParameterHelper,
+            groupBy,
+            groupByParameterName,
+            KeyOptions(allowNullableKeys = false)
+          ),
           ctx.valueWithContextInfo.forClass[String]
         )
         .keyBy((k: ValueWithContext[String]) => k.value)
 
     def groupByWithValue[T <: AnyRef: TypeTag, K <: AnyRef: TypeTag](
         groupBy: LazyParameter[K],
+        groupByParameterName: ParameterName,
         value: LazyParameter[T]
     )(
         implicit ctx: FlinkCustomNodeContext
     ): KeyedStream[ValueWithContext[KeyedValue[K, T]], K] = {
       val typeInfo = keyed.typeInfo(ctx, groupBy, value)
       dataStream
-        .flatMap(new GenericKeyedValueMapper(ctx.lazyParameterHelper, groupBy, value), typeInfo)
+        .flatMap(
+          new GenericKeyedValueMapper(
+            ctx.lazyParameterHelper,
+            groupBy,
+            groupByParameterName,
+            KeyOptions(allowNullableKeys = false),
+            value
+          ),
+          typeInfo
+        )
         .keyBy((k: ValueWithContext[KeyedValue[K, T]]) => k.value.key)
     }
 

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/TransformStateTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/TransformStateTransformer.scala
@@ -5,6 +5,7 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.{ContextTransformation, OutputVar}
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process.{
   FlinkCustomNodeContext,
@@ -49,7 +50,7 @@ object TransformStateTransformer extends CustomStreamTransformer with ExplicitUi
           setUidToNodeIdIfNeed(
             ctx,
             stream
-              .groupBy(groupBy)
+              .groupBy(groupBy, ParameterName("groupBy"))
               .process(
                 new TransformStateFunction[String](
                   ctx.lazyParameterHelper,

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/TransformStateTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/TransformStateTransformer.scala
@@ -33,6 +33,8 @@ import scala.concurrent.duration._
   */
 object TransformStateTransformer extends CustomStreamTransformer with ExplicitUidInOperatorsSupport {
 
+  private val groupByParameterName = ParameterName("groupBy")
+
   @MethodToInvoke(returnType = classOf[AnyRef])
   def invoke(
       @ParamName("groupBy") groupBy: LazyParameter[CharSequence],
@@ -50,7 +52,7 @@ object TransformStateTransformer extends CustomStreamTransformer with ExplicitUi
           setUidToNodeIdIfNeed(
             ctx,
             stream
-              .groupBy(groupBy, ParameterName("groupBy"))
+              .groupBy(groupBy, groupByParameterName)
               .process(
                 new TransformStateFunction[String](
                   ctx.lazyParameterHelper,

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionWithMemoTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/UnionWithMemoTransformer.scala
@@ -15,6 +15,7 @@ import pl.touk.nussknacker.engine.api.context.{
   ProcessCompilationError,
   ValidationContext
 }
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.datastream.DataStreamImplicits.DataStreamExtension
@@ -24,6 +25,7 @@ import pl.touk.nussknacker.engine.flink.api.timestampwatermark.TimestampWatermar
 import pl.touk.nussknacker.engine.flink.api.typeinformation.TypeInformationDetection
 import pl.touk.nussknacker.engine.flink.typeinformation.KeyedValueType
 import pl.touk.nussknacker.engine.flink.util.keyed.{StringKeyedValue, StringKeyedValueMapper}
+import pl.touk.nussknacker.engine.flink.util.keyed.KeyOptions
 import pl.touk.nussknacker.engine.flink.util.timestamp.TimestampAssignmentHelper
 import pl.touk.nussknacker.engine.flink.util.transformer.UnionWithMemoTransformer.KeyField
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
@@ -90,7 +92,13 @@ class UnionWithMemoTransformer(
               stream
                 .map(ctx => ctx.withContextIdPathPart(context.nodeId, branchId))
                 .flatMap(
-                  new StringKeyedValueMapper(context, keyByBranchId(branchId), valueParam),
+                  new StringKeyedValueMapper(
+                    context,
+                    keyByBranchId(branchId),
+                    ParameterName(KeyField),
+                    KeyOptions(allowNullableKeys = false),
+                    valueParam
+                  ),
                   flatMapTypeInfo
                 )
                 .map(valueWithCtx =>

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
@@ -26,6 +26,8 @@ object sampleTransformers {
       with ExplicitUidInOperatorsSupport
       with Serializable {
 
+    private val groupByParameterName = ParameterName("groupBy")
+
     @MethodToInvoke(returnType = classOf[AnyRef])
     def execute(
         @ParamName("groupBy") groupBy: LazyParameter[AnyRef],
@@ -61,7 +63,7 @@ object sampleTransformers {
       val windowDuration = Duration(length.toMillis, TimeUnit.MILLISECONDS)
       transformers.slidingTransformer(
         groupBy,
-        ParameterName("groupBy"),
+        groupByParameterName,
         aggregateBy,
         aggregator,
         windowDuration,
@@ -83,6 +85,8 @@ object sampleTransformers {
       with UnboundedStreamComponent
       with ExplicitUidInOperatorsSupport
       with Serializable {
+
+    private val groupByParameterName = ParameterName("groupBy")
 
     @MethodToInvoke(returnType = classOf[AnyRef])
     def execute(
@@ -122,7 +126,7 @@ object sampleTransformers {
         .map(o => AggregateWindowsOffsetProvider.offset(windowDuration, o))
       transformers.tumblingTransformer(
         groupBy,
-        ParameterName("groupBy"),
+        groupByParameterName,
         aggregateBy,
         aggregator,
         windowDuration,
@@ -145,6 +149,8 @@ object sampleTransformers {
       with UnboundedStreamComponent
       with ExplicitUidInOperatorsSupport
       with Serializable {
+
+    private val groupByParameterName = ParameterName("groupBy")
 
     @MethodToInvoke(returnType = classOf[AnyRef])
     def execute(
@@ -184,7 +190,7 @@ object sampleTransformers {
       val sessionTimeoutDuration = Duration(sessionTimeout.toMillis, TimeUnit.MILLISECONDS)
       transformers.sessionWindowTransformer(
         groupBy,
-        ParameterName("groupBy"),
+        groupByParameterName,
         aggregateBy,
         aggregator,
         sessionTimeoutDuration,

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
@@ -6,6 +6,7 @@ import pl.touk.nussknacker.engine.api.component.Component.AllowedProcessingModes
 import pl.touk.nussknacker.engine.api.component.Component.AllowedProcessingModes.SetOf
 import pl.touk.nussknacker.engine.api.context.ContextTransformation
 import pl.touk.nussknacker.engine.api.editor._
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 
 import java.util.concurrent.TimeUnit
@@ -60,6 +61,7 @@ object sampleTransformers {
       val windowDuration = Duration(length.toMillis, TimeUnit.MILLISECONDS)
       transformers.slidingTransformer(
         groupBy,
+        ParameterName("groupBy"),
         aggregateBy,
         aggregator,
         windowDuration,
@@ -120,6 +122,7 @@ object sampleTransformers {
         .map(o => AggregateWindowsOffsetProvider.offset(windowDuration, o))
       transformers.tumblingTransformer(
         groupBy,
+        ParameterName("groupBy"),
         aggregateBy,
         aggregator,
         windowDuration,
@@ -181,6 +184,7 @@ object sampleTransformers {
       val sessionTimeoutDuration = Duration(sessionTimeout.toMillis, TimeUnit.MILLISECONDS)
       transformers.sessionWindowTransformer(
         groupBy,
+        ParameterName("groupBy"),
         aggregateBy,
         aggregator,
         sessionTimeoutDuration,

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/transformers.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/transformers.scala
@@ -9,6 +9,7 @@ import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow
 import pl.touk.nussknacker.engine.api.{Context => NkContext, _}
 import pl.touk.nussknacker.engine.api.context.ContextTransformation
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process._
 import pl.touk.nussknacker.engine.flink.api.typeinformation.TypeInformationDetection
@@ -28,6 +29,7 @@ object transformers {
 
   def slidingTransformer(
       groupBy: LazyParameter[AnyRef],
+      groupByParameterName: ParameterName,
       aggregateBy: LazyParameter[AnyRef],
       aggregator: Aggregator,
       windowLength: Duration,
@@ -62,7 +64,7 @@ object transformers {
                 fctx.convertToEngineRuntimeContext
               )
           start
-            .groupByWithValue(groupBy, aggregateBy)
+            .groupByWithValue(groupBy, groupByParameterName, aggregateBy)
             .process(aggregatorFunction, typeInfos.returnedValueTypeInfo)
             .setUidWithName(ctx, explicitUidInStatefulOperators)
         })
@@ -71,6 +73,7 @@ object transformers {
 
   def tumblingTransformer(
       groupBy: LazyParameter[AnyRef],
+      groupByParameterName: ParameterName,
       aggregateBy: LazyParameter[AnyRef],
       aggregator: Aggregator,
       windowLength: Duration,
@@ -79,6 +82,7 @@ object transformers {
   )(implicit nodeId: NodeId): ContextTransformation = {
     tumblingTransformer(
       groupBy,
+      groupByParameterName,
       aggregateBy,
       aggregator,
       windowLength,
@@ -92,6 +96,7 @@ object transformers {
   @nowarn("cat=deprecation")
   def tumblingTransformer(
       groupBy: LazyParameter[AnyRef],
+      groupByParameterName: ParameterName,
       aggregateBy: LazyParameter[AnyRef],
       aggregator: Aggregator,
       windowLength: Duration,
@@ -115,7 +120,7 @@ object transformers {
           val typeInfos                             = AggregatorTypeInformations(ctx, aggregator, aggregateBy)
 
           val keyedStream = start
-            .groupByWithValue(groupBy, aggregateBy)
+            .groupByWithValue(groupBy, groupByParameterName, aggregateBy)
           val aggregatingFunction =
             new UnwrappingAggregateFunction[AnyRef](aggregator, aggregateBy.returnType, identity)
           val offsetMillis = windowOffset.getOrElse(Duration.Zero).toMillis
@@ -158,6 +163,7 @@ object transformers {
   @nowarn("cat=deprecation")
   def sessionWindowTransformer(
       groupBy: LazyParameter[AnyRef],
+      groupByParameterName: ParameterName,
       aggregateBy: LazyParameter[AnyRef],
       aggregator: Aggregator,
       sessionTimeout: Duration,
@@ -187,7 +193,7 @@ object transformers {
           val groupByValue = aggregateBy.product(endSessionCondition)
 
           val keyedStream = start
-            .groupByWithValue(groupBy, groupByValue)
+            .groupByWithValue(groupBy, groupByParameterName, groupByValue)
           val aggregatingFunction =
             new UnwrappingAggregateFunction[(AnyRef, java.lang.Boolean)](aggregator, aggregateBy.returnType, _._1)
           val windowDefinition = EventTimeSessionWindows.withGap(Time.milliseconds(sessionTimeout.toMillis))

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/FullOuterJoinTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/FullOuterJoinTransformer.scala
@@ -1,6 +1,5 @@
 package pl.touk.nussknacker.engine.flink.util.transformer.join
 
-import cats.Id
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.implicits.toTraverseOps
 import com.typesafe.scalalogging.LazyLogging
@@ -32,6 +31,7 @@ import pl.touk.nussknacker.engine.flink.api.typeinfo.option.OptionTypeInfo
 import pl.touk.nussknacker.engine.flink.api.typeinformation.TypeInformationDetection
 import pl.touk.nussknacker.engine.flink.typeinformation.KeyedValueType
 import pl.touk.nussknacker.engine.flink.util.keyed.{StringKeyedValue, StringKeyedValueMapper}
+import pl.touk.nussknacker.engine.flink.util.keyed.KeyOptions
 import pl.touk.nussknacker.engine.flink.util.richflink._
 import pl.touk.nussknacker.engine.flink.util.timestamp.TimestampAssignmentHelper
 import pl.touk.nussknacker.engine.flink.util.transformer.aggregate.{AggregateHelper, Aggregator}
@@ -151,7 +151,13 @@ class FullOuterJoinTransformer(
 
         stream
           .flatMap(
-            new StringKeyedValueMapper(context, keyByBranchId(id), valueParameter),
+            new StringKeyedValueMapper(
+              context,
+              keyByBranchId(id),
+              KeyParamDeclaration.parameterName,
+              KeyOptions(allowNullableKeys = false),
+              valueParameter
+            ),
             branchTypeInfo
           )
           .map(_.map(_.mapValue { x =>

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/SingleSideJoinTransformer.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/join/SingleSideJoinTransformer.scala
@@ -22,6 +22,7 @@ import pl.touk.nussknacker.engine.flink.api.timestampwatermark.TimestampWatermar
 import pl.touk.nussknacker.engine.flink.api.typeinformation.TypeInformationDetection
 import pl.touk.nussknacker.engine.flink.typeinformation.KeyedValueType
 import pl.touk.nussknacker.engine.flink.util.keyed.{StringKeyedValue, StringKeyedValueMapper, StringKeyOnlyMapper}
+import pl.touk.nussknacker.engine.flink.util.keyed.KeyOptions
 import pl.touk.nussknacker.engine.flink.util.richflink._
 import pl.touk.nussknacker.engine.flink.util.timestamp.TimestampAssignmentHelper
 import pl.touk.nussknacker.engine.flink.util.transformer.aggregate.{AggregateHelper, Aggregator}
@@ -129,7 +130,12 @@ class SingleSideJoinTransformer(
 
         val keyedMainBranchStream = inputs(mainBranchId)
           .flatMap(
-            new StringKeyOnlyMapper(context.lazyParameterHelper, keyByBranchId(mainBranchId)),
+            new StringKeyOnlyMapper(
+              lazyParameterHelper = context.lazyParameterHelper,
+              key = keyByBranchId(mainBranchId),
+              keyParameterName = KeyParamDeclaration.parameterName,
+              keyOptions = KeyOptions(allowNullableKeys = false)
+            ),
             context.valueWithContextInfo.forBranch[String](mainBranchId, Typed.typedClass[String])
           )
 
@@ -143,7 +149,13 @@ class SingleSideJoinTransformer(
 
         val keyedJoinedStream = inputs(joinedBranchId)
           .flatMap(
-            new StringKeyedValueMapper(context, keyByBranchId(joinedBranchId), aggregateBy),
+            new StringKeyedValueMapper(
+              context,
+              keyByBranchId(joinedBranchId),
+              KeyParamDeclaration.parameterName,
+              KeyOptions(allowNullableKeys = false),
+              aggregateBy
+            ),
             joinedTypeInfo
           )
 

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
@@ -23,6 +23,8 @@ class DelayTransformer extends CustomStreamTransformer with ExplicitUidInOperato
 
   import pl.touk.nussknacker.engine.flink.util.richflink._
 
+  private val keyParameterName = ParameterName("key")
+
   @MethodToInvoke(returnType = classOf[Void])
   def invoke(
       @ParamName("key") @Nullable key: LazyParameter[CharSequence],
@@ -33,7 +35,7 @@ class DelayTransformer extends CustomStreamTransformer with ExplicitUidInOperato
         Option(key)
           .map { _ =>
             stream
-              .groupBy(key, ParameterName("key"))(ctx)
+              .groupBy(key, keyParameterName)(ctx)
           }
           .getOrElse {
             stream

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/DelayTransformer.scala
@@ -9,6 +9,7 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api
 import pl.touk.nussknacker.engine.api._
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkCustomStreamTransformation}
 
@@ -32,7 +33,7 @@ class DelayTransformer extends CustomStreamTransformer with ExplicitUidInOperato
         Option(key)
           .map { _ =>
             stream
-              .groupBy(key)(ctx)
+              .groupBy(key, ParameterName("key"))(ctx)
           }
           .getOrElse {
             stream

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
@@ -6,6 +6,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.api._
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.ReturningType
 import pl.touk.nussknacker.engine.flink.api.compat.ExplicitUidInOperatorsSupport
 import pl.touk.nussknacker.engine.flink.api.process._
@@ -26,7 +27,7 @@ case object PreviousValueTransformer extends CustomStreamTransformer with Explic
       setUidToNodeIdIfNeed(
         ctx,
         start
-          .groupBy(key)(ctx)
+          .groupBy(key, ParameterName("Key"))(ctx)
           .flatMap(
             new PreviousValueFunction(value, ctx.lazyParameterHelper, valueTypeInfo),
             ctx.valueWithContextInfo.forType(valueTypeInfo)

--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/PreviousValueTransformer.scala
@@ -17,6 +17,8 @@ case object PreviousValueTransformer extends CustomStreamTransformer with Explic
 
   type Value = AnyRef
 
+  private val keyParameterName = ParameterName("Key")
+
   @MethodToInvoke(returnType = classOf[Value])
   def execute(
       @ParamName("Key") key: LazyParameter[CharSequence],
@@ -27,7 +29,7 @@ case object PreviousValueTransformer extends CustomStreamTransformer with Explic
       setUidToNodeIdIfNeed(
         ctx,
         start
-          .groupBy(key, ParameterName("Key"))(ctx)
+          .groupBy(key, keyParameterName)(ctx)
           .flatMap(
             new PreviousValueFunction(value, ctx.lazyParameterHelper, valueTypeInfo),
             ctx.valueWithContextInfo.forType(valueTypeInfo)

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/LastVariableFilterTransformer.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/LastVariableFilterTransformer.scala
@@ -21,7 +21,7 @@ import pl.touk.nussknacker.engine.flink.api.process.{
   FlinkLazyParameterFunctionHelper,
   OneParamLazyParameterFunction
 }
-import pl.touk.nussknacker.engine.flink.util.keyed.{StringKeyedValue, StringKeyedValueMapper}
+import pl.touk.nussknacker.engine.flink.util.keyed.{KeyOptions, StringKeyedValue, StringKeyedValueMapper}
 
 /* This is example for GenericTransformation
    the idea is that we have two parameters:
@@ -86,7 +86,15 @@ object LastVariableFilterTransformer extends CustomStreamTransformer with Single
 
     FlinkCustomStreamTransformation((str: DataStream[Context], ctx: FlinkCustomNodeContext) => {
       str
-        .flatMap(new StringKeyedValueMapper(ctx, groupBy, value))
+        .flatMap(
+          new StringKeyedValueMapper(
+            ctx,
+            groupBy,
+            groupByParameterDeclaration.parameterName,
+            KeyOptions(allowNullableKeys = false),
+            value
+          )
+        )
         .keyBy(_.value.key)
         .process(new ConditionalUpdateFunction(condition, ctx.lazyParameterHelper))
     })

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/StatefulTransformer.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/StatefulTransformer.scala
@@ -11,6 +11,7 @@ import pl.touk.nussknacker.engine.api.{
   ParamName,
   ValueWithContext
 }
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.flink.api.datastream.DataStreamImplicits.DataStreamExtension
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkCustomStreamTransformation}
 
@@ -24,7 +25,7 @@ case object StatefulTransformer extends CustomStreamTransformer with LazyLogging
   def execute(@ParamName("groupBy") groupBy: LazyParameter[String]): FlinkCustomStreamTransformation =
     FlinkCustomStreamTransformation((start: DataStream[Context], ctx: FlinkCustomNodeContext) => {
       start
-        .groupBy(groupBy)(ctx)
+        .groupBy(groupBy, ParameterName("groupBy"))(ctx)
         .mapWithState[ValueWithContext[AnyRef], util.List[String]] {
           case (StringFromIr(ir, sr), oldState) =>
             logger.info(s"received: $sr, current state: $oldState")

--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/StatefulTransformer.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/StatefulTransformer.scala
@@ -21,11 +21,13 @@ case object StatefulTransformer extends CustomStreamTransformer with LazyLogging
 
   import pl.touk.nussknacker.engine.flink.util.richflink._
 
+  private val groupByParameterName = ParameterName("groupBy")
+
   @MethodToInvoke
   def execute(@ParamName("groupBy") groupBy: LazyParameter[String]): FlinkCustomStreamTransformation =
     FlinkCustomStreamTransformation((start: DataStream[Context], ctx: FlinkCustomNodeContext) => {
       start
-        .groupBy(groupBy, ParameterName("groupBy"))(ctx)
+        .groupBy(groupBy, groupByParameterName)(ctx)
         .mapWithState[ValueWithContext[AnyRef], util.List[String]] {
           case (StringFromIr(ir, sr), oldState) =>
             logger.info(s"received: $sr, current state: $oldState")

--- a/engine/flink/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/FlinkKafkaUniversalSink.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/FlinkKafkaUniversalSink.scala
@@ -9,13 +9,14 @@ import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import pl.touk.nussknacker.engine.api.{Context, LazyParameter, ValueWithContext}
 import pl.touk.nussknacker.engine.api.component.{ComponentType, NodeComponentInfo}
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.TopicName
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.flink.api.exception.{ExceptionHandler, WithExceptionHandler}
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkSink}
 import pl.touk.nussknacker.engine.flink.typeinformation.KeyedValueType
 import pl.touk.nussknacker.engine.flink.util.keyed
-import pl.touk.nussknacker.engine.flink.util.keyed.KeyedValueMapper
+import pl.touk.nussknacker.engine.flink.util.keyed.{KeyedValueMapper, KeyOptions}
 import pl.touk.nussknacker.engine.kafka.{KafkaComponentsConfig, PartitionByKeyFlinkKafkaProducer, PreparedKafkaTopic}
 import pl.touk.nussknacker.engine.kafka.serialization.KafkaSerializationSchema
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.UniversalSchemaSupportDispatcher
@@ -26,6 +27,7 @@ import scala.annotation.nowarn
 class FlinkKafkaUniversalSink(
     preparedTopic: PreparedKafkaTopic[TopicName.ForSink],
     key: LazyParameter[AnyRef],
+    keyParameterName: ParameterName,
     value: LazyParameter[AnyRef],
     kafkaComponentsConfig: KafkaComponentsConfig,
     serializationSchema: KafkaSerializationSchema[KeyedValue[AnyRef, AnyRef]],
@@ -64,7 +66,16 @@ class FlinkKafkaUniversalSink(
       flinkNodeContext: FlinkCustomNodeContext
   ): DataStream[ValueWithContext[Value]] = {
     val typeInfo = keyed.typeInfo(flinkNodeContext, key, value)
-    ds.flatMap(new KeyedValueMapper(flinkNodeContext.lazyParameterHelper, key, value), typeInfo)
+    ds.flatMap(
+      new KeyedValueMapper(
+        flinkNodeContext.lazyParameterHelper,
+        key,
+        keyParameterName,
+        KeyOptions(allowNullableKeys = true),
+        value
+      ),
+      typeInfo
+    )
   }
 
   @nowarn("cat=deprecation")

--- a/engine/flink/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/FlinkKafkaUniversalSinkImplFactory.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/FlinkKafkaUniversalSinkImplFactory.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.schemedkafka.sink.flink
 
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import pl.touk.nussknacker.engine.api.LazyParameter
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.{Sink, TopicName}
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.kafka.{KafkaComponentsConfig, PreparedKafkaTopic}
@@ -12,9 +13,10 @@ import pl.touk.nussknacker.engine.util.KeyedValue
 
 object FlinkKafkaUniversalSinkImplFactory extends UniversalKafkaSinkImplFactory with Serializable {
 
-  def createSink(
+  override def createSink(
       preparedTopic: PreparedKafkaTopic[TopicName.ForSink],
       key: LazyParameter[AnyRef],
+      keyParameterName: ParameterName,
       value: LazyParameter[AnyRef],
       kafkaComponentsConfig: KafkaComponentsConfig,
       serializationSchema: KafkaSerializationSchema[KeyedValue[AnyRef, AnyRef]],
@@ -25,6 +27,7 @@ object FlinkKafkaUniversalSinkImplFactory extends UniversalKafkaSinkImplFactory 
     new FlinkKafkaUniversalSink(
       preparedTopic,
       key,
+      keyParameterName,
       value,
       kafkaComponentsConfig,
       serializationSchema,

--- a/engine/lite/components/kafka/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalSinkImplFactory.scala
+++ b/engine/lite/components/kafka/src/main/scala/pl/touk/nussknacker/engine/lite/components/LiteKafkaUniversalSinkImplFactory.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.lite.components
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import org.apache.kafka.clients.producer.ProducerRecord
 import pl.touk.nussknacker.engine.api.LazyParameter
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.{Sink, TopicName}
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.kafka.{KafkaComponentsConfig, PreparedKafkaTopic}
@@ -18,6 +19,7 @@ object LiteKafkaUniversalSinkImplFactory extends UniversalKafkaSinkImplFactory {
   override def createSink(
       preparedTopic: PreparedKafkaTopic[TopicName.ForSink],
       keyParam: LazyParameter[AnyRef],
+      keyParameterName: ParameterName,
       valueParam: LazyParameter[AnyRef],
       kafkaComponentsConfig: KafkaComponentsConfig,
       serializationSchema: KafkaSerializationSchema[KeyedValue[AnyRef, AnyRef]],

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkFactory.scala
@@ -405,6 +405,7 @@ class UniversalKafkaSinkFactory(
     implProvider.createSink(
       preparedTopic,
       key,
+      sinkKeyParamName,
       valueLazyParam,
       kafkaComponentsConfig,
       serializationSchema,

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkImplFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/UniversalKafkaSinkImplFactory.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.schemedkafka.sink
 
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import pl.touk.nussknacker.engine.api.LazyParameter
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process.{Sink, TopicName}
 import pl.touk.nussknacker.engine.api.validation.ValidationMode
 import pl.touk.nussknacker.engine.kafka.{KafkaComponentsConfig, PreparedKafkaTopic}
@@ -14,6 +15,7 @@ trait UniversalKafkaSinkImplFactory {
   def createSink(
       preparedTopic: PreparedKafkaTopic[TopicName.ForSink],
       key: LazyParameter[AnyRef],
+      keyParameterName: ParameterName,
       value: LazyParameter[AnyRef],
       kafkaComponentsConfig: KafkaComponentsConfig,
       serializationSchema: KafkaSerializationSchema[KeyedValue[AnyRef, AnyRef]],


### PR DESCRIPTION
## Describe your changes

The key parameter passed to Flink's data-stream keyBy function requires a non-null key. In some places (KeyValueMappers), the null key was replaced with an empty string, which caused the data stream elements with null keys to be added to the global aggregate.  
When the null key was not replaced and was passed to the data-stream keyBy function, it caused the scenario to crash.
In this PR, the behavior changed to filter out elements with a null key, and for such an element, a dedicated NotTransientException is thrown.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
