### PR TITLE
[NU-2371] Allow to end fragment without sink

### DIFF
--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ScenarioWithoutSinksSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ScenarioWithoutSinksSpec.scala
@@ -348,6 +348,60 @@ class ScenarioWithoutSinksSpec
     )
   }
 
+  test("ending without sink is allowed - there is a fragment without sink at the end of the scenario") {
+    val scenarioWithFragment =
+      ScenarioBuilder
+        .streaming("sample-scenario-with-fragment")
+        .source("source", "start1")
+        .fragment(
+          "sub",
+          "fragment1",
+          List("fragment1_input" -> "#input".spel),
+          Map("output"           -> "fragmentResult"),
+          Map("output"           -> None)
+        )
+
+    val fragment = ScenarioBuilder
+      .fragment("fragment1", "fragment1_input" -> classOf[Int])
+      .filter("filter", "#fragment1_input != 10".spel)
+      .endWithoutSink
+
+    val scenario = FragmentResolver(List(fragment)).resolve(scenarioWithFragment).toOption.get
+
+    withCollectingTestResults(
+      scenario,
+      testResults => {
+        assertNumberOfSamplesThatFinishedInNode(testResults, "sub-filter", 4)
+        transitionVariables(testResults, "source", Some("sub")) shouldBe Set(
+          Map("input" -> 10),
+          Map("input" -> 20),
+          Map("input" -> 30),
+          Map("input" -> 40),
+        )
+        transitionVariables(testResults, "sub", Some("sub-filter")) shouldBe Set(
+          Map("fragment1_input" -> 10),
+          Map("fragment1_input" -> 20),
+          Map("fragment1_input" -> 30),
+          Map("fragment1_input" -> 40),
+        )
+        transitionVariables(testResults, "sub", Some("sub-filter")) shouldBe Set(
+          Map("fragment1_input" -> 10),
+          Map("fragment1_input" -> 20),
+          Map("fragment1_input" -> 30),
+          Map("fragment1_input" -> 40),
+        )
+        // All samples finish in the filter node, regardless of filtering, because there is no further node
+        transitionVariables(testResults, "sub-filter", None) shouldBe Set(
+          Map("fragment1_input" -> 10),
+          Map("fragment1_input" -> 20),
+          Map("fragment1_input" -> 30),
+          Map("fragment1_input" -> 40),
+        )
+      },
+      allowEndingScenarioWithoutSink = true,
+    )
+  }
+
   test("ending without sink is allowed - there is for-each node - without sink") {
     val scenario = ScenarioBuilder
       .streaming("sample-for-each")

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -122,6 +122,7 @@ class PartSubGraphCompiler(nodeCompiler: NodeCompiler) {
   )(
       implicit scenarioCompilationDependencies: ScenarioCompilationDependencies
   ): CompilationResult[compiledgraph.node.Node] = {
+    import scenarioCompilationDependencies._
     implicit val nodeId: NodeId = NodeId(data.id)
     def toCompilationResult[T](
         validated: ValidatedNel[ProcessCompilationError, T],
@@ -149,10 +150,13 @@ class PartSubGraphCompiler(nodeCompiler: NodeCompiler) {
       case CustomNode(id, _, nodeType, _, _) =>
         toCompilationResult(Valid(compiledgraph.node.EndingCustomNode(id, nodeType)), Map.empty, None)
 
-      // probably this shouldn't occur - otherwise we'd have empty fragment?
-      case FragmentInput(id, _, _, _, _) =>
-        toCompilationResult(Invalid(NonEmptyList.of(UnresolvedFragment(NodeId(id)))), Map.empty, None)
-
+      // this occurs, when we have fragment without a sink
+      case fragmentInput: FragmentInput =>
+        val NodeCompilationResult(typingInfo, parameters, _, combinedValidParams, _) =
+          nodeCompiler.compileFragmentInput(fragmentInput, inputContext)
+        toCompilationResult(combinedValidParams, typingInfo, parameters).map { params =>
+          compiledgraph.node.FragmentUsageStart(fragmentInput.id, params, None)
+        }
       case FragmentOutputDefinition(id, _, Nil, _) =>
         // TODO: should we validate it's process?
         // TODO: does it make sense to validate FragmentOutput?

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompiler.scala
@@ -134,16 +134,8 @@ protected trait ProcessCompilerBase {
   private def missingSinkHandler(
       implicit scenarioCompilationDependencies: ScenarioCompilationDependencies
   ): MissingSinkHandler = {
-    if (scenarioIsAllowedToEndWithoutSink) MissingSinkHandler.AllowMissingSinkHandler
+    if (allowEndingScenarioWithoutSink) MissingSinkHandler.AllowMissingSinkHandler
     else MissingSinkHandler.DoNotAllowMissingSinkHandler
-  }
-
-  private def scenarioIsAllowedToEndWithoutSink(
-      implicit scenarioCompilationDependencies: ScenarioCompilationDependencies
-  ) = {
-    import scenarioCompilationDependencies._
-    lazy val isFragment = metaData.typeSpecificData.isFragment
-    allowEndingScenarioWithoutSink && !isFragment
   }
 
   private def contextWithOnlyGlobalVariables(implicit jobData: JobData): ValidationContext =

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
@@ -190,10 +190,8 @@ class NodeCompiler(
   private def scenarioIsAllowedToEndWithoutSink(
       implicit scenarioCompilationDependencies: ScenarioCompilationDependencies
   ) = {
-    import scenarioCompilationDependencies._
     lazy val allowEndingScenarioWithoutSink = definitions.allowEndingScenarioWithoutSink
-    lazy val isFragment                     = metaData.typeSpecificData.isFragment
-    allowEndingScenarioWithoutSink && !isFragment
+    allowEndingScenarioWithoutSink
   }
 
   def withLabelsDictTyper: NodeCompiler = {


### PR DESCRIPTION
## Describe your changes

We already can end scenarios without sink (it is treated similarly to dead-end sink). This PR makes ti possible to end fragments without sinks too.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
