### PR TITLE
[NU-2390] Live data preview fix

### DIFF
--- a/designer/client/src/containers/Visualization.tsx
+++ b/designer/client/src/containers/Visualization.tsx
@@ -89,7 +89,12 @@ function useCountsIfNeeded() {
     const from = searchParams.get("from");
     const to = searchParams.get("to");
     const refresh = searchParams.get("refresh");
+
+    // Prevents the counts from being initialized more than once
+    const hasRunRef = useRef(false);
+
     useEffect(() => {
+        if (hasRunRef.current) return;
         if (!scenario?.name || scenario.isFragment) return;
 
         const countParams = extractCountParams({
@@ -98,7 +103,7 @@ function useCountsIfNeeded() {
             refresh,
         });
         if (!countParams) return;
-
+        hasRunRef.current = true;
         dispatch(
             fetchAndDisplayProcessCounts({
                 processName: scenario.name,


### PR DESCRIPTION
## Describe your changes

The problem appeared, when the user entered the scenario view from link, which contains query params related to counts. For example by reloading the page.
- on that page, opened from such link, the counts mechanism interfered with live data - randomly resetting and disabling it when the view was re-rendered
- the fix is to ensure, that counts are initialized from the configuration in query params only once, and not on each re-render

[Screencast from 12-04-2025 11:17:00 AM.webm](https://github.com/user-attachments/assets/b6c44f44-f765-4c52-9ca6-1706422d1ee8)


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
