### PR TITLE
Fix OpenAPI enricher config parsing

### DIFF
--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/OpenAPIComponentProvider.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/OpenAPIComponentProvider.scala
@@ -9,7 +9,6 @@ import pl.touk.nussknacker.engine.api.component.{
   NussknackerVersion
 }
 import pl.touk.nussknacker.engine.util.config.ConfigEnrichments._
-import pl.touk.nussknacker.openapi.OpenAPIServicesConfig._
 import pl.touk.nussknacker.openapi.discovery.{CachingOpenApiDefinitionDiscovery, SwaggerOpenApiDefinitionDiscovery}
 import pl.touk.nussknacker.openapi.enrichers.OpenAPIEnricherFactory
 
@@ -23,7 +22,7 @@ class OpenAPIComponentProvider extends ComponentProvider with LazyLogging {
       componentProviderConfig: Config,
       componentDependencies: ComponentDependencies
   ): List[ComponentDefinition] = {
-    val openAPIsConfig = componentProviderConfig.rootAs[OpenAPIServicesConfig]
+    val openAPIsConfig = OpenAPIServicesConfig.parse(componentProviderConfig)
     val openApiDefinitionDiscovery =
       new CachingOpenApiDefinitionDiscovery(SwaggerOpenApiDefinitionDiscovery, openAPIsConfig)
     ComponentDefinition(

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/OpenAPIServicesConfig.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/OpenAPIServicesConfig.scala
@@ -64,6 +64,7 @@ final case class HttpBasicAuthSecret(username: String, password: String) extends
 object OpenAPIServicesConfig {
 
   import net.ceedubs.ficus.Ficus._
+  import net.ceedubs.ficus.readers.ArbitraryTypeReader.arbitraryTypeValueReader
   import pl.touk.nussknacker.engine.util.config.ConfigEnrichments._
 
   import HttpClientConfig._
@@ -73,23 +74,10 @@ object OpenAPIServicesConfig {
 
   implicit val regexReader: ValueReader[Regex] = (config: Config, path: String) => new Regex(config.getString(path))
 
-  implicit val apiKeyVR: ValueReader[ApiKeySecret] = ValueReader.relative { conf =>
-    ApiKeySecret(
-      apiKeyValue = conf.as[String]("apiKeyValue")
-    )
-  }
-
-  implicit val basicAuthVR: ValueReader[HttpBasicAuthSecret] = ValueReader.relative { conf =>
-    HttpBasicAuthSecret(
-      username = conf.as[String]("username"),
-      password = conf.as[String]("password"),
-    )
-  }
-
   implicit val secretVR: ValueReader[Secret] = ValueReader.relative { conf =>
     conf.as[String]("type") match {
-      case "apiKey"    => conf.rootAs[ApiKeySecret]
-      case "basicAuth" => conf.rootAs[HttpBasicAuthSecret]
+      case "apiKey"    => conf.as[ApiKeySecret]
+      case "basicAuth" => conf.as[HttpBasicAuthSecret]
       case typ         => throw new Exception(s"Not supported swagger security type '$typ' in the configuration")
     }
   }
@@ -121,5 +109,7 @@ object OpenAPIServicesConfig {
     val baseReader = ArbitraryTypeReader.arbitraryTypeValueReader[OpenAPIServicesConfig]
     baseReader.read(config, path).copy(secrets = secrets)
   }
+
+  def parse(config: Config): OpenAPIServicesConfig = config.as[OpenAPIServicesConfig]
 
 }

--- a/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/OpenAPIServicesConfigTest.scala
+++ b/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/OpenAPIServicesConfigTest.scala
@@ -10,10 +10,6 @@ import scala.concurrent.duration.DurationInt
 
 class OpenAPIServicesConfigTest extends AnyFunSuite with Matchers with OptionValues {
 
-  import net.ceedubs.ficus.Ficus._
-
-  import OpenAPIServicesConfig._
-
   test("should parse apikey secret for each scheme") {
     val config = ConfigFactory.parseString("""url: "http://foo"
                                              |security {
@@ -27,7 +23,7 @@ class OpenAPIServicesConfigTest extends AnyFunSuite with Matchers with OptionVal
                                              |  }
                                              |}""".stripMargin)
 
-    val parsedConfig = config.as[OpenAPIServicesConfig]
+    val parsedConfig = OpenAPIServicesConfig.parse(config)
     parsedConfig.securityConfig
       .apiKeySecret(SecuritySchemeName("apikeySecurityScheme"))
       .value shouldEqual ApiKeySecret(apiKeyValue = "34534asfdasf")
@@ -43,7 +39,7 @@ class OpenAPIServicesConfigTest extends AnyFunSuite with Matchers with OptionVal
                                              |  apiKeyValue: "34534asfdasf"
                                              |}""".stripMargin)
 
-    val parsedConfig = config.as[OpenAPIServicesConfig]
+    val parsedConfig = OpenAPIServicesConfig.parse(config)
     parsedConfig.securityConfig
       .apiKeySecret(SecuritySchemeName("someScheme"))
       .value shouldEqual ApiKeySecret(apiKeyValue = "34534asfdasf")
@@ -66,7 +62,7 @@ class OpenAPIServicesConfigTest extends AnyFunSuite with Matchers with OptionVal
                                              |  }
                                              |]""".stripMargin)
 
-    val parsedConfig = config.as[OpenAPIServicesConfig]
+    val parsedConfig = OpenAPIServicesConfig.parse(config)
     parsedConfig.securityConfig
       .apiKeySecret(SecuritySchemeName("someScheme"))
       .value shouldEqual ApiKeySecret(apiKeyValue = "34534asfdasf")
@@ -88,7 +84,7 @@ class OpenAPIServicesConfigTest extends AnyFunSuite with Matchers with OptionVal
                                              |  }
                                              |]""".stripMargin)
     intercept[RuntimeException] {
-      config.as[OpenAPIServicesConfig]
+      OpenAPIServicesConfig.parse(config)
     }.getMessage shouldBe "Both 'secrets' and 'secret' fields cannot be configured at the same time"
   }
 
@@ -105,7 +101,7 @@ class OpenAPIServicesConfigTest extends AnyFunSuite with Matchers with OptionVal
                                              |  }
                                              |]""".stripMargin)
     intercept[RuntimeException] {
-      config.as[OpenAPIServicesConfig]
+      OpenAPIServicesConfig.parse(config)
     }.getMessage shouldBe "requirement failed: Only one `apiKey` common secret (with unspecified scheme name) is allowed"
   }
 
@@ -122,7 +118,7 @@ class OpenAPIServicesConfigTest extends AnyFunSuite with Matchers with OptionVal
                                              |  apiKeyValue: "234"
                                              |}""".stripMargin)
 
-    val parsedConfig = config.as[OpenAPIServicesConfig]
+    val parsedConfig = OpenAPIServicesConfig.parse(config)
     parsedConfig.securityConfig
       .apiKeySecret(SecuritySchemeName("someScheme"))
       .value shouldEqual ApiKeySecret(apiKeyValue = "123")
@@ -149,8 +145,7 @@ class OpenAPIServicesConfigTest extends AnyFunSuite with Matchers with OptionVal
                                              |}
                                              |  """.stripMargin)
 
-    val parsedConfig = config.as[OpenAPIServicesConfig]
-
+    val parsedConfig = OpenAPIServicesConfig.parse(config)
     parsedConfig.httpClientConfig shouldBe HttpClientConfig(
       timeout = Some(5 seconds),
       connectTimeout = Some(1 seconds),

--- a/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/SecurityTest.scala
+++ b/components/openapi/src/test/scala/pl/touk/nussknacker/openapi/SecurityTest.scala
@@ -195,4 +195,25 @@ class SecurityTest
       .futureValue shouldBe TypedMap(Map.empty)
   }
 
+  test(
+    "secret specified by scheme name from 'security' config field takes precedence over common secret from 'secrets' field"
+  ) {
+    stubbedSecretApiKeyCheckingLogics.foreach { config =>
+      withClue(config.operationId) {
+        val commonSecretExpectedToBeUnused = ApiKeySecret("invalid")
+        val enricherWithSingleSecurityConfig = parseToEnrichers(
+          definitionMatchingStubbedLogicOnlyApiKeySchemes,
+          backend,
+          baseConfig.copy(
+            secrets = List(commonSecretExpectedToBeUnused),
+            security = Map(config.securitySchemeName -> config.expectedSecret)
+          )
+        )
+        enricherWithSingleSecurityConfig(ServiceName(config.operationId))
+          .invoke(context)
+          .futureValue shouldBe TypedMap(Map.empty)
+      }
+    }
+  }
+
 }

--- a/docs/integration/OpenAPI.md
+++ b/docs/integration/OpenAPI.md
@@ -170,7 +170,7 @@ components {
     security {
       apiKeyInHeader {
         type: "apiKey"
-        apiKeyValue: "34534asfdasf"
+        apiKeyValue: "secretValue"
       }
     }
   }

--- a/docs/integration/OpenAPI.md
+++ b/docs/integration/OpenAPI.md
@@ -51,20 +51,20 @@ placement of `components` configuration key in the configuration file.
 
 Sample configuration:
 
-```
+```hocon
 components {
   service1: {
-      providerType: openAPI  
-      url = "http://myservice.com/swagger"
-      rootUrl = "http://myservice.com/endpoint"
-      security {
-          apikeySecuritySchema {
-              type = "apiKey"
-              apiKeyValue = "34534asfdasf"
-          }
+    providerType: "openAPI"
+    url: "http://myservice.com/swagger"
+    rootUrl: "http://myservice.com/endpoint"
+    security {
+      apiKeySecuritySchema {
+        type: "apiKey"
+        apiKeyValue: "34534asfdasf"
       }
-      namePattern: "customer.*"
-      allowedMethods: ["GET", "POST"]
+    }
+    namePattern: "customer.*"
+    allowedMethods: ["GET", "POST"]
   }
 }
 ```
@@ -75,12 +75,107 @@ components {
 | rootUrl                | false    |         | The URL of the service. If not specified, the URL of the service is taken from the *OpenAPI interface definition*.                                                                                                                                                                                                 |
 | allowedMethods         | false    | ["GET"] | Usually only GET services should be used as enrichers are meant to be idempotent and not change data                                                                                                                                                                                                               |
 | namePattern            | false    | .*      | Regexp for filtering operations by operationId or by created service name (concatenation of HTTP method, path and parameters)                                                                                                                                                                                      |
-| security               | false    |         | Configuration for [authentication](https://swagger.io/docs/specification/authentication/) for each `securitySchemas` defined in the *OpenAPI interface definition*                                                                                                                                                 |
+| security               | false    |         | Configuration for [authentication](https://swagger.io/docs/specification/authentication/) for each `securitySchemes` defined in the *OpenAPI interface definition*                                                                                                                                                 |
 | security.*.type        | false    |         | Type of security configuration for a given security schema. Currently `apiKey` and `basicAuth` are supported                                                                                                                                                                                                       |
 | security.*.apiKeyValue | false    |         | API key that will be passed into the service via header, query parameter or cookie (depending on definition provided in OpenAPI)                                                                                                                                                                                   |
 | security.*.username    | false    |         | Username used for HTTP Basic authentication when the selected security type is `basicAuth`                                                                                                                                                                                                                         |
 | security.*.password    | false    |         | Password used for HTTP Basic authentication when the selected security type is `basicAuth`                                                                                                                                                                                                                         |
 | secrets                | false    |         | Configuration for list of [authentication](https://swagger.io/docs/specification/authentication/) which matches all schemas `securitySchemas` of its type in the *OpenAPI interface definition*. This config entry expects a list with elements with the same structure as values in `security` object (see above) |
+
+### Configuring authentication
+
+Two types of authentication are supported:
+1. API key
+```hocon
+{
+  type: "apiKey"
+  apiKeyValue: "secretValue"
+}
+```
+2. Basic auth
+```hocon
+{
+  type: "basicAuth"
+  username: "myUsername"
+  password: "secretPassword"
+}
+```
+
+Authentication can be configured in two ways:
+
+1. Through the `secrets` parameter - by targeting all `securitySchemes` that match used security type (either all Basic
+   Authentication schemes or all API key schemes)
+2. Through the `security` parameter - by targeting a specific `securityScheme` by its name
+    - A matching `security` entry will take precedence over a matching `secrets` entry
+
+#### Example authentication configurations
+
+A minimal OpenAPI definition of a `GET` endpoint requiring passing `apiKey` in header may look like this:
+
+```yaml
+openapi: "3.0.0"
+info:
+  title: Example
+  version: 1.0.0
+servers:
+  - url: http://myservice.com
+paths:
+  /headerPath:
+    get:
+      security:
+        - apiKeyInHeader: [ ]
+      responses:
+        '200':
+          description: OK
+components:
+  schemas: { }
+  securitySchemes:
+    apiKeyInHeader:
+      type: apiKey
+      name: keyHeader
+      in: header
+```
+
+Let's suppose the API key is "secretValue".
+
+##### Common secret configuration
+If the definition uses only one authentication scheme of any type, the simplest configuration is through `secrets`. This
+way, the `securityScheme` name does not need to be specified.
+
+This way is also suitable if there are multiple different `apiKey` schemes, but the actual API key value is the same.
+The configured key will be used for all of them.
+
+```hocon
+components {
+  exampleService: {
+    providerType: "openAPI"
+    url: "http://myservice.com/swagger"
+    secrets: [{
+      type: "apiKey"
+      apiKeyValue: "secretValue"
+    }]
+  }
+}
+```
+
+##### Single scheme configuration 
+Configuring specific authentication per `securityScheme` requires setting under `security` the scheme name as the key
+and the type and authentication config as the value.
+
+```hocon
+components {
+  exampleService: {
+    providerType: "openAPI"
+    url: "http://myservice.com/swagger"
+    security {
+      apiKeyInHeader {
+        type: "apiKey"
+        apiKeyValue: "34534asfdasf"
+      }
+    }
+  }
+}
+```
 
 ## Operations
 


### PR DESCRIPTION
## Describe your changes
Previously there was a bug where `secret` / `secrets` fields weren't parsed at all. Tests were using different parsing method, so this behaviour wasn't visible in tests.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
