### PR TITLE
[NU-2399] Running test cases

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ManagementResources.scala
@@ -31,6 +31,7 @@ import pl.touk.nussknacker.ui.process.deployment._
 import pl.touk.nussknacker.ui.process.deployment.LoggedUserConversions.LoggedUserOps
 import pl.touk.nussknacker.ui.process.processingtype.provider.ProcessingTypeDataProvider
 import pl.touk.nussknacker.ui.process.test.{ScenarioTestService, SerializedScenarioRecordsContent}
+import pl.touk.nussknacker.ui.process.test.testcase.{ScenarioWithTestCase, TestCase}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -217,6 +218,39 @@ class ManagementResources(
                 }
               }
             }
+          }
+        } ~
+        path("testCase" / ProcessNameSegment) { processName =>
+          (post & processDetailsForName(
+            processName
+          ) & skipResultsPerTransitionQueryParam & skipResultsPerNodeQueryParam & entity(as[ScenarioWithTestCase])) {
+            (details, skipResultsPerTransition, skipResultsPerNode, scenarioWithTestCase) =>
+              canDeploy(details.idWithNameUnsafe) {
+                complete {
+                  measureTime("testCase", metricRegistry) {
+                    scenarioTestServices
+                      .forProcessingTypeUnsafe(details.processingType)
+                      .performTestCase(
+                        scenarioWithTestCase.scenario,
+                        details.processVersionUnsafe,
+                        details.isFragment,
+                        scenarioWithTestCase.testCase
+                      )
+                      .flatMap {
+                        case Left(error) =>
+                          Future.failed(PerformTestDesignerError(TestingApiErrorMessages.from(error)))
+                        case Right(value) =>
+                          mapResultsToHttpResponse(
+                            ResultsWithCountsDto.from(
+                              resultsWithCounts = value,
+                              skipResultsPerNode = SkipResultsPerNode(skipResultsPerNode),
+                              skipResultsPerTransition = SkipResultsPerTransition(skipResultsPerTransition),
+                            )
+                          )
+                      }
+                  }
+                }
+              }
           }
         } ~
         // TODO: maybe Write permission is enough here?

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
@@ -1,12 +1,17 @@
 package pl.touk.nussknacker.ui.api
 
+import cats.data.NonEmptyList
 import io.circe.{DecodingFailure, Json}
 import pl.touk.nussknacker.engine.api.NodeId
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.restmodel.validation.ValidationResults
 import pl.touk.nussknacker.ui.process.test.PreliminaryScenarioRecordsSerDe.DeserializationError
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError
+import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.ScenarioValidationError
+import pl.touk.nussknacker.ui.process.test.testcase.Assertion
 import pl.touk.nussknacker.ui.process.test.testdataformat.CommonDataFormatHandler.InputVariablesParameterName
 import pl.touk.nussknacker.ui.process.test.testdataformat.TestDataFormatHandler
 
@@ -63,6 +68,14 @@ object TestingApiErrorMessages {
         TestingApiErrorMessages.problemInSample(recordIndex).missingSource(sourceId.id)
       case PerformTestError.TestResultsSizeExceededError(approxSizeInBytes, maxBytes) =>
         TestingApiErrorMessages.testResultsSizeExceeded(approxSizeInBytes, maxBytes)
+      case ScenarioValidationError(errors) =>
+        TestingApiErrorMessages.scenarioHasValidationErrors(errors)
+      case PerformTestError.MockConfiguredForNotExistingNodesError(nodeIds) =>
+        TestingApiErrorMessages.mocksConfiguredForNotExistingNodes(nodeIds)
+      case PerformTestError.AssertionConfiguredForNotExistingNodesError(errors) =>
+        TestingApiErrorMessages.assertionsConfiguredForNotExistingNodes(errors)
+      case PerformTestError.AssertionExpressionCompilationError(errors, assertion, node) =>
+        TestingApiErrorMessages.assertionCompilationError(errors, assertion, node)
     }
   }
 
@@ -148,5 +161,21 @@ object TestingApiErrorMessages {
 
   def testResultsSizeExceeded(approxSizeInBytes: Long, maxBytes: Long) =
     s"Test results size exceeded (approximate size is $approxSizeInBytes B). The maximum permitted size is $maxBytes B. Contact the system administrator to increase this limit."
+
+  private def scenarioHasValidationErrors(errors: ValidationResults.ValidationErrors) =
+    s"Only scenario without validation errors can be tested. Errors: $errors"
+
+  private def mocksConfiguredForNotExistingNodes(notExistingNodeIds: NonEmptyList[NodeId]) =
+    s"Mocks configured for not existing nodes: ${notExistingNodeIds.toList.mkString(", ")}"
+
+  private def assertionsConfiguredForNotExistingNodes(notExistingNodeIds: NonEmptyList[NodeId]) =
+    s"Assertions configured for not existing nodes: ${notExistingNodeIds.toList.mkString(", ")}"
+
+  private def assertionCompilationError(
+      errors: NonEmptyList[ProcessCompilationError],
+      assertion: Assertion,
+      nodeId: NodeId
+  ) =
+    s"Assertion compilation error. Node: ${nodeId.id}. Assertion expression: ${assertion.expression.expression}. Errors: ${errors.toList.mkString(", ")}"
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDto.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDto.scala
@@ -10,13 +10,19 @@ import pl.touk.nussknacker.ui.api.description.scenarioTesting.ResultsWithCountsD
   ContextIdPathPartDto
 }
 import pl.touk.nussknacker.ui.process.test.ResultsWithCounts
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionResult
 import pl.touk.nussknacker.ui.processreport.NodeCount
 import sttp.tapir.Schema
 
 import java.time.Instant
 import scala.collection.compat._
 
-final case class ResultsWithCountsDto(timestamp: Instant, results: TestResultsDto, counts: Map[NodeId, NodeCount])
+final case class ResultsWithCountsDto(
+    timestamp: Instant,
+    results: TestResultsDto,
+    counts: Map[NodeId, NodeCount],
+    assertionsResults: Map[NodeId, List[AssertionResult]]
+)
 
 object ResultsWithCountsDto {
 
@@ -50,6 +56,7 @@ object ResultsWithCountsDto {
         exceptionsByNodeId = exceptionsByNodeId,
       ),
       counts = resultsWithCounts.counts,
+      assertionsResults = resultsWithCounts.assertionsResults
     )
   }
 
@@ -84,6 +91,7 @@ object ResultsWithCountsDto {
         exceptionsByNodeId = exceptionsByNodeId,
       ),
       counts = counts,
+      assertionsResults = Map.empty
     )
   }
 
@@ -102,6 +110,7 @@ object ResultsWithCountsDto {
   implicit def nodeTransitionResultSchema: Schema[NodeTransitionResult]                      = Schema.derived
   implicit def testResultsSchema: Schema[TestResultsDto]                                     = Schema.derived
   implicit def nodeCountSchema: Schema[NodeCount]                                            = Schema.anyObject
+  implicit def assertionResultsSchema: Schema[AssertionResult]                               = Schema.derived
   implicit def resultsWithCountsSchema: Schema[ResultsWithCountsDto]                         = Schema.derived
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDtoCodecs.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/scenarioTesting/ResultsWithCountsDtoCodecs.scala
@@ -10,11 +10,15 @@ import pl.touk.nussknacker.engine.testmode.TestProcess.{
   ExternalServiceInvocationResult,
   ResultContext
 }
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionResult
 
 object ResultsWithCountsDtoCodecs {
 
   import io.circe.syntax._
   import pl.touk.nussknacker.engine.api.CirceUtil._
+
+  implicit val assertionResultEncoder: Encoder[AssertionResult] =
+    deriveConfiguredEncoder
 
   implicit val resultsWithCountsEncoder: Encoder[ResultsWithCountsDto] =
     deriveConfiguredEncoder

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ResultsWithCounts.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ResultsWithCounts.scala
@@ -3,8 +3,14 @@ package pl.touk.nussknacker.ui.process.test
 import io.circe.Json
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionResult
 import pl.touk.nussknacker.ui.processreport.NodeCount
 
 import java.time.Instant
 
-final case class ResultsWithCounts(timestamp: Instant, results: TestResults[Json], counts: Map[NodeId, NodeCount])
+final case class ResultsWithCounts(
+    timestamp: Instant,
+    results: TestResults[Json],
+    counts: Map[NodeId, NodeCount],
+    assertionsResults: Map[NodeId, List[AssertionResult]] = Map.empty
+)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
@@ -23,18 +23,27 @@ import pl.touk.nussknacker.engine.api.test.{
 }
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.canonicalgraph.{CanonicalProcess, CanonicalProcessConverter}
+import pl.touk.nussknacker.engine.compile.ExpressionCompiler
 import pl.touk.nussknacker.engine.definition.action.CommonModelDataInfoProvider
 import pl.touk.nussknacker.engine.definition.component.parameter.StandardParameterEnrichment
+import pl.touk.nussknacker.engine.graph.node
 import pl.touk.nussknacker.engine.graph.node.SourceNodeData
 import pl.touk.nussknacker.engine.testmode.CommonTestDataFormatVariablesDecoder
 import pl.touk.nussknacker.engine.testmode.CommonTestDataFormatVariablesDecoder.TestRecordVariablesDecodingError
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 import pl.touk.nussknacker.engine.util.ListUtil
-import pl.touk.nussknacker.ui.api.TestDataSettings
+import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
+import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeTypingData, ValidationErrors}
+import pl.touk.nussknacker.ui.api.{TestDataFormat, TestDataSettings}
 import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.TestSourceParameters
 import pl.touk.nussknacker.ui.process.deployment.ScenarioTestExecutorService
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService._
-import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.ExpressionsToTestDataConversionError
+import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.{
+  ExpressionsToTestDataConversionError,
+  MockConfiguredForNotExistingNodesError,
+  ScenarioValidationError
+}
+import pl.touk.nussknacker.ui.process.test.testcase._
 import pl.touk.nussknacker.ui.process.test.testdataformat.TestDataFormatHandler
 import pl.touk.nussknacker.ui.processreport.{NodeCount, ProcessCounter, RawCount}
 import pl.touk.nussknacker.ui.security.api.LoggedUser
@@ -62,6 +71,18 @@ class ScenarioTestService(
     maxRecordsCount = testDataSettings.maxSamplesCount,
     testDataFormatSerDe = testDataFormatHandler.serDe
   )
+
+  // for test cases only common data format is used - can be removed if we drop source specific format support
+  private val testCasePreliminaryScenarioRecordsSerDe = new PreliminaryScenarioRecordsSerDe(
+    serializedContentMaxLength = testDataSettings.testDataMaxLength,
+    maxRecordsCount = testDataSettings.maxSamplesCount,
+    testDataFormatSerDe = TestDataFormatHandler(TestDataFormat.CommonFormat, modelData).serDe
+  )
+
+  private val expressionCompiler              = ExpressionCompiler.withoutOptimization(modelData).withLabelsDictTyper
+  private val testCaseGlobalVariablesPreparer = GlobalVariablesPreparer(modelData.modelDefinition.expressionConfig)
+  private val assertionCompiler = new AssertionsCompiler(expressionCompiler, testCaseGlobalVariablesPreparer)
+  private val assertionVerifier: AssertionVerifier = new AssertionVerifier(testCaseGlobalVariablesPreparer)
 
   def getTestingCapabilities(
       scenarioGraph: ScenarioGraph,
@@ -258,6 +279,95 @@ class ScenarioTestService(
     } yield ResultsWithCounts(Instant.now(), testResults, computeCounts(canonical, isFragment, testResults))).value
   }
 
+  def performTestCase(
+      scenarioGraph: ScenarioGraph,
+      processVersion: ProcessVersion,
+      isFragment: Boolean,
+      testCase: TestCase,
+  )(implicit ec: ExecutionContext, user: LoggedUser): Future[Either[PerformTestError, ResultsWithCounts]] = {
+    val jobData = JobData(scenarioGraph.toMetaData(processVersion.processName), processVersion)
+    (for {
+      preliminaryScenarioTestRecords <- EitherT.fromEither[Future](
+        testCasePreliminaryScenarioRecordsSerDe
+          .deserialize(SerializedScenarioRecordsContent(testCase.inputs))
+          .leftMap[PerformTestError](PerformTestError.DeserializationError)
+      )
+      graphWithSubstitutedMocks <- EitherT.fromEither[Future](validateAndSubstituteMocks(scenarioGraph, testCase.mocks))
+      scenarioWithTyping <- EitherT.fromEither[Future](
+        validateScenario(graphWithSubstitutedMocks, processVersion, isFragment)
+      )
+
+      scenarioTestData <- EitherT.fromEither[Future](
+        prepareTestData(preliminaryScenarioTestRecords, scenarioWithTyping.scenario)
+      )
+      compiledAssertions <- EitherT.fromEither[Future](
+        compileAssertions(testCase, scenarioWithTyping.nodesTyping, jobData)
+      )
+      testResults <- EitherT(
+        performTestWithDeserializedRecords(processVersion, scenarioWithTyping.scenario, scenarioTestData)
+      )
+
+      _ <- EitherT.fromEither[Future](validateTestResultsAreNotTooBig(testResults))
+    } yield ResultsWithCounts(
+      Instant.now(),
+      testResults,
+      computeCounts(scenarioWithTyping.scenario, isFragment, testResults),
+      assertionVerifier.verify(compiledAssertions, testResults.originalNodeResults, jobData)
+    )).value
+  }
+
+  private def validateAndSubstituteMocks(
+      scenarioGraph: ScenarioGraph,
+      mocks: Map[NodeId, EnricherMock]
+  ): Either[PerformTestError, ScenarioGraph] = {
+    val existingNodesId           = scenarioGraph.nodes.map(node => NodeId(node.id)).toSet
+    val mockedNodesId             = mocks.keySet
+    val notExistingNodesWithMocks = mockedNodesId.diff(existingNodesId)
+
+    if (notExistingNodesWithMocks.nonEmpty) {
+      Left(MockConfiguredForNotExistingNodesError(NonEmptyList.fromListUnsafe(notExistingNodesWithMocks.toList)))
+    } else {
+      Right(substituteMocks(scenarioGraph, mocks))
+    }
+  }
+
+  private def substituteMocks(scenarioGraph: ScenarioGraph, mocks: Map[NodeId, EnricherMock]) = {
+    val nodesWithSubstitutions = scenarioGraph.nodes.map {
+      case nodeData @ (enricher: node.Enricher) =>
+        val enricherMockOpt = mocks.get(NodeId(nodeData.id)).map(_.expression)
+        // we use provided mock or the one specified in original scenario
+        enricher.copy(mockExpression = enricherMockOpt.orElse(enricher.mockExpression))
+      case data => data
+    }
+    scenarioGraph.copy(nodes = nodesWithSubstitutions)
+  }
+
+  private def validateScenario(scenarioGraph: ScenarioGraph, processVersion: ProcessVersion, isFragment: Boolean)(
+      implicit user: LoggedUser
+  ): Either[ScenarioValidationError, ScenarioWithTyping] = {
+    val validationResult = processResolver.validateBeforeUiResolving(scenarioGraph, processVersion, isFragment)
+    val canonicalProcess =
+      processResolver.resolveExpressions(scenarioGraph, processVersion.processName, validationResult.typingInfo)
+    if (validationResult.hasErrors) {
+      Left(ScenarioValidationError(validationResult.errors))
+    } else {
+      Right(ScenarioWithTyping(canonicalProcess, validationResult.nodeResults))
+    }
+  }
+
+  private def compileAssertions(
+      test: TestCase,
+      nodesTyping: Map[String, NodeTypingData],
+      jobData: JobData
+  ): Either[PerformTestError, CompiledAssertions] = {
+    assertionCompiler
+      .compile(test, nodesTyping, jobData)
+      .fold(
+        errors => Left(errors.head),
+        Right(_)
+      ) // in case of performing test case we return errors in fail-fast fashion
+  }
+
   def performTest(
       scenarioGraph: ScenarioGraph,
       processVersion: ProcessVersion,
@@ -451,6 +561,8 @@ class ScenarioTestService(
 
 object ScenarioTestService {
 
+  private final case class ScenarioWithTyping(scenario: CanonicalProcess, nodesTyping: Map[String, NodeTypingData])
+
   sealed trait TestingCapabilitiesError
 
   object TestingCapabilitiesError {
@@ -482,10 +594,13 @@ object ScenarioTestService {
         nodesWithErrors: NonEmptyList[(NodeId, NonEmptyList[ProcessCompilationError])]
     ) extends FetchLiveDataError
 
-    final case object NoLiveDataAvailableError          extends FetchLiveDataError
+    final case object NoLiveDataAvailableError extends FetchLiveDataError
+
     final case object LiveDataFetchingNotSupportedError extends FetchLiveDataError
+
     final case class ScenarioRecordsSerializationError(cause: PreliminaryScenarioRecordsSerDe.SerializationError)
         extends FetchLiveDataError
+
     final case class TooManyRecordsRequestedError(maxRecordsCount: Int) extends FetchLiveDataError
   }
 
@@ -511,8 +626,24 @@ object ScenarioTestService {
         testRecordIndex: Int,
     ) extends PerformTestError
 
-    final case class MissingSourceError(sourceId: NodeId, recordIndex: Int)                extends PerformTestError
+    final case class MissingSourceError(sourceId: NodeId, recordIndex: Int) extends PerformTestError
+
     final case class TestResultsSizeExceededError(approxSizeInBytes: Long, maxBytes: Long) extends PerformTestError
+
+    final case class MockConfiguredForNotExistingNodesError(notExistingNodeIds: NonEmptyList[NodeId])
+        extends PerformTestError
+
+    final case class AssertionConfiguredForNotExistingNodesError(notExistingNodeIds: NonEmptyList[NodeId])
+        extends PerformTestError
+
+    final case class AssertionExpressionCompilationError(
+        errors: NonEmptyList[ProcessCompilationError],
+        assertion: Assertion,
+        nodeId: NodeId
+    ) extends PerformTestError
+
+    final case class ScenarioValidationError(errors: ValidationErrors) extends PerformTestError
+
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -1,0 +1,53 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import pl.touk.nussknacker.engine.api.{Context, ContextId, JobData, NodeId}
+import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
+import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
+import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
+
+import scala.jdk.CollectionConverters._
+
+class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
+
+  def verify(
+      testCase: CompiledAssertions,
+      results: Map[NodeId, List[ResultContext[Any]]],
+      jobData: JobData
+  ): Map[NodeId, List[AssertionResult]] = {
+    testCase.assertions.map { case (nodeId, assertions) =>
+      nodeId -> assertions.map(assertion => verifySingleAssertions(assertion, nodeId, results, jobData))
+    }
+  }
+
+  private def verifySingleAssertions(
+      assertion: CompiledAssertion,
+      nodeId: NodeId,
+      results: Map[NodeId, List[ResultContext[Any]]],
+      jobData: JobData
+  ): AssertionResult = {
+    val context = prepareEvaluationContext(nodeId, results)
+    val globalVariables = globalVariablesPreparer
+      .prepareGlobalVariables(jobData)
+      .mapValuesNow(_.obj) + ("TESTS" -> tests)
+    try {
+      assertion.expression.evaluate[AssertionResult](context, globalVariables) match {
+        case null                             => FailedAssertion("Assertion result can't be null")
+        case assertionResult: AssertionResult => assertionResult
+      }
+    } catch {
+      case e: Exception => FailedAssertion(s"Exception during assertion evaluation: ${e.getMessage}")
+    }
+  }
+
+  private def prepareEvaluationContext(
+      nodeId: NodeId,
+      results: Map[NodeId, List[ResultContext[Any]]]
+  ): Context = {
+    val resultsForNode = results
+      .getOrElse(nodeId, List.empty)
+      .map(_.variables.asJava)
+      .asJava
+    Context(ContextId.dummy, Map("contexts" -> resultsForNode))
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -1,0 +1,138 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.data.Validated.{Invalid, Valid}
+import cats.syntax.all._
+import pl.touk.nussknacker.engine.api._
+import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, ValidationContext}
+import pl.touk.nussknacker.engine.api.typed.typing.Typed
+import pl.touk.nussknacker.engine.compile.ExpressionCompiler
+import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
+import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
+import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError
+import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.{
+  AssertionConfiguredForNotExistingNodesError,
+  AssertionExpressionCompilationError
+}
+
+import java.util
+import scala.jdk.CollectionConverters._
+
+class AssertionsCompiler(expressionCompiler: ExpressionCompiler, globalVariablesPreparer: GlobalVariablesPreparer) {
+
+  def compile(
+      testCase: TestCase,
+      scenarioTypingResult: Map[String, NodeTypingData],
+      jobData: JobData
+  ): ValidatedNel[PerformTestError, CompiledAssertions] = {
+    testCase.assertions
+      .map { case (node, assertions) =>
+        compileNodeAssertions(node, assertions, scenarioTypingResult, jobData).map(node -> _)
+      }
+      .toList
+      .sequence
+      .map(assertions => CompiledAssertions(assertions.toMap))
+  }
+
+  private def compileNodeAssertions(
+      nodeId: NodeId,
+      assertions: List[Assertion],
+      nodesTyping: Map[String, NodeTypingData],
+      jobData: JobData
+  ): ValidatedNel[PerformTestError, List[CompiledAssertion]] = {
+    validateTypingExistence(nodeId, nodesTyping).andThen { typing =>
+      val ctx = globalVariablesPreparer
+        .prepareValidationContextWithGlobalVariablesOnly(jobData)
+        .withVariablesUnsafe(
+          "contexts" -> Typed.genericTypeClass(
+            classOf[java.util.List[_]],
+            List(Typed.record(typing.variableTypes))
+          ),
+          "TESTS" -> Typed.fromInstance(tests)
+        )
+      assertions.map(compileAssertionExpression(nodeId, ctx, _)).traverse(_.toValidatedNel)
+    }
+  }
+
+  private def validateTypingExistence(
+      nodeId: NodeId,
+      nodesTyping: Map[String, NodeTypingData],
+  ): Validated[NonEmptyList[PerformTestError], NodeTypingData] = {
+    nodesTyping
+      .get(nodeId.id)
+      .map(Valid(_))
+      .getOrElse(
+        Invalid(
+          NonEmptyList.one(AssertionConfiguredForNotExistingNodesError(NonEmptyList(nodeId, Nil)))
+        )
+      )
+  }
+
+  private def compileAssertionExpression(nodeId: NodeId, context: ValidationContext, assertion: Assertion) = {
+    expressionCompiler
+      .compile(
+        assertion.expression,
+        None,
+        context,
+        Typed.typedClass(classOf[AssertionResult])
+      )(nodeId)
+      .map(e => CompiledAssertion(e.expression))
+      .leftMap(mapExpressionCompilationErrors(_, assertion, nodeId))
+  }
+
+  private def mapExpressionCompilationErrors(
+      errors: NonEmptyList[PartSubGraphCompilationError],
+      assertion: Assertion,
+      nodeId: NodeId
+  ) = {
+    AssertionExpressionCompilationError(errors, assertion, nodeId)
+  }
+
+}
+
+sealed trait AssertionResult
+
+case object SuccessfulAssertion extends AssertionResult
+
+case class FailedAssertion(message: String) extends AssertionResult
+
+object tests extends TestsFunctions
+
+trait TestsFunctions extends HideToString {
+
+  @Documentation(description = "Check whether two values are equals")
+  def assertEquals(@ParamName("expected") expected: Any, @ParamName("actual") actual: Any): AssertionResult = {
+    // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
+    if (expected == actual) {
+      SuccessfulAssertion
+    } else if (checkIfSameElements(expected, actual)) {
+      SuccessfulAssertion
+    } else {
+      produceFailedAssertion(expected, actual)
+    }
+  }
+
+  // todo: should it work recursively - e.g for arrays nested in lists?
+  private def checkIfSameElements(expected: Any, actual: Any) = {
+    if ((expected.isInstanceOf[Array[_]] || expected.isInstanceOf[util.Collection[_]]) &&
+      (actual.isInstanceOf[Array[_]] || actual.isInstanceOf[util.Collection[_]])) {
+      convertToSeq(expected) == convertToSeq(actual)
+    } else {
+      false
+    }
+  }
+
+  private def convertToSeq(value: Any): Seq[_] = {
+    value match {
+      case a: Array[_]           => a.toSeq
+      case c: util.Collection[_] => c.asScala.toSeq
+    }
+  }
+
+  private def produceFailedAssertion(expected: Any, actual: Any) = {
+    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
+    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
+    FailedAssertion(s"Expected: [$expectedStr] but found [$actualStr]")
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/CompiledAssertions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/CompiledAssertions.scala
@@ -1,0 +1,8 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import pl.touk.nussknacker.engine.api.NodeId
+import pl.touk.nussknacker.engine.expression.parse.CompiledExpression
+
+final case class CompiledAssertions(assertions: Map[NodeId, List[CompiledAssertion]])
+
+final case class CompiledAssertion(expression: CompiledExpression)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/SpelValuePrettyPrinter.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/SpelValuePrettyPrinter.scala
@@ -1,0 +1,19 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import java.util.Objects
+import scala.jdk.CollectionConverters._
+
+object SpelValuePrettyPrinter {
+
+  def prettyPrintValue(value: Any): String = {
+    value match {
+      case array: Array[_]                         => array.map(prettyPrintValue).mkString("{", ", ", "}")
+      case map: java.util.Map[_, _] if map.isEmpty => "{:}"
+      case map: java.util.Map[_, _] =>
+        map.asScala.map { case (k, v) => prettyPrintValue(k) + ": " + prettyPrintValue(v) }.mkString("{", ", ", "}")
+      case collection: java.util.Collection[_] => collection.asScala.map(prettyPrintValue).mkString("{", ", ", "}")
+      case _                                   => Objects.toString(value)
+    }
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestCase.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestCase.scala
@@ -1,0 +1,24 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import io.circe.generic.JsonCodec
+import pl.touk.nussknacker.engine.api.NodeId
+import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
+import pl.touk.nussknacker.engine.graph.expression.Expression
+
+import java.util.UUID
+
+@JsonCodec final case class ScenarioWithTestCase(scenario: ScenarioGraph, testCase: TestCase)
+
+@JsonCodec final case class TestCase(
+    id: UUID,
+    name: String,
+    inputs: String,
+    mocks: Map[NodeId, EnricherMock],
+    assertions: Map[NodeId, List[Assertion]],
+)
+
+@JsonCodec final case class TestSourceInput(serializedContent: String)
+
+@JsonCodec final case class EnricherMock(expression: Expression)
+
+@JsonCodec final case class Assertion(expression: Expression)

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/NuResourcesTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/it/NuResourcesTest.scala
@@ -27,6 +27,8 @@ import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.process.VersionId.initialVersionId
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.compile.ProcessValidator
+import pl.touk.nussknacker.engine.dict.{ProcessDictSubstitutor, SimpleDictRegistry}
 import pl.touk.nussknacker.engine.util.ExecutionContextWithIORuntimeAdapter
 import pl.touk.nussknacker.restmodel.{CancelRequest, DeployRequest}
 import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
@@ -66,8 +68,10 @@ import pl.touk.nussknacker.ui.process.repository._
 import pl.touk.nussknacker.ui.process.repository.ProcessRepository.CreateProcessAction
 import pl.touk.nussknacker.ui.process.repository.activities.ScenarioActivityRepository
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService
+import pl.touk.nussknacker.ui.process.test.testcase.{ScenarioWithTestCase, TestCase}
 import pl.touk.nussknacker.ui.processreport.ProcessCounter
 import pl.touk.nussknacker.ui.security.api.{LoggedUser, RealLoggedUser}
+import pl.touk.nussknacker.ui.uiresolving.UIProcessResolver
 import pl.touk.nussknacker.ui.util.{MultipartUtils, NuPathMatchers}
 import slick.dbio.DBIOAction
 
@@ -145,12 +149,11 @@ trait NuResourcesTest
     deploymentManagersClassLoader
   )
 
-  private val modelData =
-    ModelData(
-      processingTypeConfig,
-      modelDependencies,
-      modelClassLoaderProvider.forProcessingTypeUnsafe(Streaming.stringify)
-    )
+  private val modelData = ModelData(
+    processingTypeConfig,
+    modelDependencies,
+    modelClassLoaderProvider.forProcessingTypeUnsafe(Streaming.stringify)
+  )
 
   private val deploymentData =
     new DeploymentData(
@@ -294,7 +297,10 @@ trait NuResourcesTest
       designerConfig.testDataSettings,
       modelData,
       Resource.pure(EngineScenarioCompilationDependencies.empty),
-      processResolver(),
+      new UIProcessResolver(
+        ProcessTestData.testProcessValidator(validator = ProcessValidator.default(modelData)),
+        ProcessDictSubstitutor(new SimpleDictRegistry(Map.empty))
+      ),
       new ProcessCounter(TestFactory.prepareSampleFragmentRepository()),
       new ScenarioTestExecutorServiceImpl(
         new ScenarioResolver(sampleResolver(), Streaming.stringify),
@@ -488,6 +494,22 @@ trait NuResourcesTest
       "scenarioGraph" -> scenarioGraph.asJson.noSpaces
     )()
     Post(s"/processManagement/test/${scenario.name}", multiPart) ~> withPermissions(
+      deployRoute(),
+      Permission.Deploy,
+      Permission.Read
+    )
+  }
+
+  protected def runTestCase(scenario: CanonicalProcess, testCase: TestCase): RouteTestResult = {
+    implicit val timeout: RouteTestTimeout = RouteTestTimeout(10.seconds.dilated)
+
+    val scenarioGraph = scenario.toScenarioGraph
+
+    val body = HttpEntity(
+      ContentTypes.`application/json`,
+      ScenarioWithTestCase(scenarioGraph, testCase).asJson.noSpaces
+    )
+    Post(s"/processManagement/testCase/${scenario.name}", body) ~> withPermissions(
       deployRoute(),
       Permission.Deploy,
       Permission.Read

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementApiHttpServiceBusinessSpec.scala
@@ -46,6 +46,7 @@ class ManagementApiHttpServiceBusinessSpec
                 expressionEvaluationResults = Map.empty,
                 externalServiceInvocationResults = Map.empty,
                 exceptions = List.empty,
+                originalNodeResults = Map.empty
               )
             )
           )
@@ -92,7 +93,8 @@ class ManagementApiHttpServiceBusinessSpec
              |      "errors": 0,
              |      "fragmentCounts": {}
              |    }
-             |  }
+             |  },
+             |  "assertionsResults": {}
              |}""".stripMargin
         )
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -11,12 +11,11 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, OptionValues}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.BeMatcher
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.{MetaData, StreamMetaData}
+import pl.touk.nussknacker.engine.api.{MetaData, NodeId, StreamMetaData}
 import pl.touk.nussknacker.engine.api.deployment.{ProcessAction, ScenarioActionName}
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.{ProcessName, VersionId}
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
-import pl.touk.nussknacker.engine.graph.node.SubsequentNode
 import pl.touk.nussknacker.engine.kafka.KafkaFactory
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.restmodel.DeployRequest
@@ -31,8 +30,10 @@ import pl.touk.nussknacker.ui.api.description.scenarioActivity.Dtos
 import pl.touk.nussknacker.ui.process.ScenarioQuery
 import pl.touk.nussknacker.ui.process.exception.ProcessIllegalAction
 import pl.touk.nussknacker.ui.process.periodic.flink.FlinkClientStub
+import pl.touk.nussknacker.ui.process.test.testcase.{Assertion, EnricherMock, TestCase}
 
 import java.time.Instant
+import java.util.UUID
 
 // TODO: all these tests should be migrated to ManagementApiHttpServiceBusinessSpec or ManagementApiHttpServiceSecuritySpec
 class ManagementResourcesSpec
@@ -438,6 +439,166 @@ class ManagementResourcesSpec
         .downField("pretty")
         .downN(0)
         .focus shouldBe Some(Json.fromString("ala"))
+    }
+  }
+
+  test("run test case") {
+    val testDataContent =
+      """[
+        |  {"sourceId":"startProcess","variables":{"input":["ala"]}},
+        |  {"sourceId":"startProcess","variables":{"input":["bela"]}}
+        |]""".stripMargin
+    saveCanonicalProcessAndAssertSuccess(ProcessTestData.sampleScenario)
+
+    val testCase = TestCase(
+      UUID.randomUUID(),
+      "dummy",
+      testDataContent,
+      Map.empty,
+      Map(
+        NodeId("endsuffix") -> List(
+          Assertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
+          Assertion("#TESTS.assertEquals('ala', #contexts[1].input[0])".spel),
+        )
+      )
+    )
+    runTestCase(ProcessTestData.sampleScenario, testCase) ~> check {
+      status shouldEqual StatusCodes.OK
+
+      val responseJson = responseAs[Json]
+      responseJson.hcursor
+        .downField("assertionsResults")
+        .downField("endsuffix")
+        .downN(0)
+        .downField("type")
+        .focus shouldBe Some(Json.fromString("SuccessfulAssertion"))
+
+      responseJson.hcursor
+        .downField("assertionsResults")
+        .downField("endsuffix")
+        .downN(1)
+        .focus shouldBe Some(
+        Json.obj(
+          "type"    -> Json.fromString("FailedAssertion"),
+          "message" -> Json.fromString("Expected: [ala] but found [bela]")
+        )
+      )
+    }
+  }
+
+  test("run test case with mocked service") {
+    val testDataContent =
+      """[
+        |  {"sourceId":"startProcess","variables":{"input":["ala"]}}
+        |]""".stripMargin
+
+    val scenario = ScenarioBuilder
+      .streaming(ProcessTestData.sampleProcessName.value)
+      .parallelism(1)
+      .source("startProcess", "csv-source")
+      .enricher("someEnricher", "out1", "paramService", "param" -> "'a'".spel)
+      .filter("input", "#input != null".spel)
+      .to(
+        GraphBuilder
+          .buildVariable("message" + "suffix", "output", "message" -> "'message'".spel)
+          .emptySink(
+            "end" + "suffix",
+            "kafka-string",
+            TopicParamName.value     -> "'end.topic'".spel,
+            SinkValueParamName.value -> "#output".spel
+          )
+      )
+
+    saveCanonicalProcessAndAssertSuccess(scenario)
+
+    val testCase = TestCase(
+      UUID.randomUUID(),
+      "dummy",
+      testDataContent,
+      mocks = Map(
+        NodeId("someEnricher") -> EnricherMock("'b'".spel)
+      ),
+      assertions = Map(
+        NodeId("endsuffix") -> List(
+          Assertion("#TESTS.assertEquals('b', #contexts[0].out1)".spel),
+        )
+      )
+    )
+    runTestCase(scenario, testCase) ~> check {
+      status shouldEqual StatusCodes.OK
+
+      val responseJson = responseAs[Json]
+      responseJson.hcursor
+        .downField("assertionsResults")
+        .downField("endsuffix")
+        .downN(0)
+        .downField("type")
+        .focus shouldBe Some(Json.fromString("SuccessfulAssertion"))
+    }
+  }
+
+  test("assertion on not existing node should return bad request") {
+    val testDataContent =
+      """[
+        |  {"sourceId":"startProcess","variables":{"input":["ala"]}},
+        |  {"sourceId":"startProcess","variables":{"input":["bela"]}}
+        |]""".stripMargin
+    saveCanonicalProcessAndAssertSuccess(ProcessTestData.sampleScenario)
+
+    val invalidTestCase = TestCase(
+      UUID.randomUUID(),
+      "dummy",
+      testDataContent,
+      mocks = Map.empty,
+      assertions = Map(
+        NodeId("someNotExistingNode") -> List(
+          Assertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
+        )
+      )
+    )
+    runTestCase(ProcessTestData.sampleScenario, invalidTestCase) ~> check {
+      status shouldEqual StatusCodes.BadRequest
+      responseAs[String] shouldBe "Assertions configured for not existing nodes: someNotExistingNode"
+    }
+  }
+
+  test("mock on not existing node should return bad request") {
+    val testDataContent =
+      """[
+        |  {"sourceId":"startProcess","variables":{"input":["ala"]}},
+        |  {"sourceId":"startProcess","variables":{"input":["bela"]}}
+        |]""".stripMargin
+    saveCanonicalProcessAndAssertSuccess(ProcessTestData.sampleScenario)
+
+    val invalidTestCase = TestCase(
+      UUID.randomUUID(),
+      "dummy",
+      testDataContent,
+      mocks = Map(
+        NodeId("notExistingEnricher") -> EnricherMock("'b'".spel)
+      ),
+      assertions = Map.empty
+    )
+    runTestCase(ProcessTestData.sampleScenario, invalidTestCase) ~> check {
+      status shouldEqual StatusCodes.BadRequest
+      responseAs[String] shouldBe "Mocks configured for not existing nodes: notExistingEnricher"
+    }
+  }
+
+  test("running test case with invalid scenario should return bad request") {
+    val testDataContent =
+      """[
+        |  {"sourceId":"source","variables":{"input":["ala"]}},
+        |  {"sourceId":"source","variables":{"input":["bela"]}}
+        |]""".stripMargin
+    saveCanonicalProcessAndAssertSuccess(ProcessTestData.invalidProcess)
+
+    val testCase = TestCase(UUID.randomUUID(), "dummy", testDataContent, Map.empty, Map.empty)
+    runTestCase(ProcessTestData.invalidProcess, testCase) ~> check {
+      status shouldEqual StatusCodes.BadRequest
+      val responseAsString = responseAs[String]
+      // todo: should we return something more structured than toString of errors?
+      responseAsString.startsWith("Only scenario without validation errors can be tested. Errors: ") shouldBe true
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/livedata/ScenarioLiveDataApiHttpServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/livedata/ScenarioLiveDataApiHttpServiceSpec.scala
@@ -96,7 +96,8 @@ class ScenarioLiveDataApiHttpServiceSpec
              |      "errors": 0,
              |      "fragmentCounts": {}
              |    }
-             |  }
+             |  },
+             |  "assertionsResults": {}
              |}""".stripMargin
         )
     }
@@ -337,7 +338,8 @@ class ScenarioLiveDataApiHttpServiceSpec
              |      "fragmentCounts": {
              |      }
              |    }
-             |  }
+             |  },
+             |  "assertionsResults": {}
              |}""".stripMargin
         )
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
@@ -17,24 +17,32 @@ import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.test._
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
-import pl.touk.nussknacker.engine.compile.validationHelpers.{
-  GenericParametersSource,
-  GenericParametersSourceNoGenerate,
-  GenericParametersSourceNoTestSupport,
-  SourceWithTestParameters
-}
+import pl.touk.nussknacker.engine.compile.ProcessValidator
+import pl.touk.nussknacker.engine.compile.validationHelpers._
+import pl.touk.nussknacker.engine.dict.{ProcessDictSubstitutor, SimpleDictRegistry}
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.testing.LocalModelData
+import pl.touk.nussknacker.engine.testmode.TestProcess
+import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.test.EitherValuesDetailedMessage
-import pl.touk.nussknacker.test.utils.domain.TestFactory
+import pl.touk.nussknacker.test.mock.{StubFragmentRepository, StubModelDataWithModelDefinition}
+import pl.touk.nussknacker.test.utils.domain.{ProcessTestData, TestFactory}
 import pl.touk.nussknacker.ui.api.{TestDataFormat, TestDataSettings}
+import pl.touk.nussknacker.ui.process.deployment.ScenarioTestExecutorService
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.MissingSourceError
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService.TestingCapabilitiesError.NoSourcesError
+import pl.touk.nussknacker.ui.process.test.testcase.{Assertion, FailedAssertion, SuccessfulAssertion, TestCase}
 import pl.touk.nussknacker.ui.process.test.testdataformat.CommonDataFormatHandler.InputVariablesParameterName
+import pl.touk.nussknacker.ui.process.test.testdataformat.CommonDataFormatSerDe
+import pl.touk.nussknacker.ui.processreport.ProcessCounter
 import pl.touk.nussknacker.ui.security.api.LoggedUser
+import pl.touk.nussknacker.ui.uiresolving.UIProcessResolver
 
 import java.time.Instant
+import java.util.UUID
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 
 class ScenarioTestServiceSpec
     extends AnyFunSuite
@@ -54,6 +62,7 @@ class ScenarioTestServiceSpec
       ComponentDefinition("genericSourceWithTestParameters", new SourceWithTestParameters),
       ComponentDefinition("sourceEmptyTimestamp", SourceGeneratingEmptyTimestamp),
       ComponentDefinition("sourceGeneratingEmptyData", SourceGeneratingEmptyData),
+      ComponentDefinition("genericParametersSink", GenericParametersSink),
     )
   )
 
@@ -703,6 +712,113 @@ class ScenarioTestServiceSpec
     }
   }
 
+  test("should run test case") {
+    import scala.concurrent.ExecutionContext.Implicits._
+    import scala.concurrent.duration._
+    val now = Instant.now()
+
+    val mockedTestExecutorService = new ScenarioTestExecutorService() {
+      override def testProcess(
+          processVersion: ProcessVersion,
+          canonicalProcess: CanonicalProcess,
+          scenarioTestData: ScenarioTestData
+      )(implicit loggedUser: LoggedUser, ec: ExecutionContext): Future[TestProcess.TestResults[Json]] = {
+        scenarioTestData.commonFormatRecords(NodeId("source1")) shouldBe List(
+          (ScenarioTestCommonFormatJsonRecord(NodeId("source1"), Map("input" -> Json.fromString("record 1")), None), 0),
+          (ScenarioTestCommonFormatJsonRecord(NodeId("source1"), Map("input" -> Json.fromString("record 2")), None), 1),
+        )
+        Future.successful(
+          TestProcess.TestResults
+            .empty[Json]
+            .copy(
+              originalNodeResults = Map(
+                NodeId("end") -> (
+                  ResultContext[Any](ContextId.dummy, now, Map("otherNameThanInput" -> Map("a" -> "foo").asJava)) ::
+                    ResultContext[Any](ContextId.dummy, now, Map("otherNameThanInput" -> Map("a" -> "bar").asJava)) ::
+                    Nil
+                )
+              )
+            )
+        )
+      }
+    }
+
+    val testService = new ScenarioTestService(
+      TestDataSettings(
+        maxSamplesCount = None,
+        testDataMaxLength = None,
+        resultsMaxBytes = None,
+        TestDataFormat.CommonFormat,
+      ),
+      modelData,
+      Resource.pure(EngineScenarioCompilationDependencies.empty),
+      new UIProcessResolver(
+        ProcessTestData.testProcessValidator(validator =
+          ProcessValidator.default(new StubModelDataWithModelDefinition(modelData.modelDefinition))
+        ),
+        ProcessDictSubstitutor(new SimpleDictRegistry(Map.empty))
+      ),
+      processCounter = new ProcessCounter(new StubFragmentRepository(Map.empty)),
+      testExecutorService = mockedTestExecutorService
+    )
+
+    val scenarioRecords = PreliminaryScenarioRecords(
+      NonEmptyList(
+        CommonFormatPreliminaryScenarioRecord(
+          sourceId = NodeId("source1"),
+          variables = Map("input" -> Json.fromString("record 1")),
+          upstreamTimestamp = None
+        ),
+        CommonFormatPreliminaryScenarioRecord(
+          sourceId = NodeId("source1"),
+          variables = Map("input" -> Json.fromString("record 2")),
+          upstreamTimestamp = None
+        ) :: Nil,
+      )
+    )
+
+    val serializedRecords: SerializedScenarioRecordsContent =
+      new PreliminaryScenarioRecordsSerDe(None, None, CommonDataFormatSerDe)
+        .serialize(scenarioRecords)
+        .getOrElse(throw new RuntimeException("Error during records serialization"))
+
+    val scenario =
+      ScenarioBuilder
+        .streaming("single source scenario")
+        .source("source1", "genericSource", "par1" -> "'a'".spel, "a" -> "42".spel)
+        .emptySink("end", "genericParametersSink", "par1" -> "'dummy'".spel, "dummy" -> "1L".spel)
+
+    val testCase = TestCase(
+      UUID.randomUUID(),
+      "someTest",
+      serializedRecords.content,
+      Map.empty,
+      Map(
+        NodeId("end") -> List(
+          Assertion("#TESTS.assertEquals(#contexts[0].otherNameThanInput.a, 'foo')".spel),
+          Assertion("#TESTS.assertEquals(#contexts[1].otherNameThanInput.a, 'foo')".spel)
+        )
+      )
+    )
+
+    val result = Await
+      .result(
+        testService.performTestCase(
+          scenario.toScenarioGraph,
+          processVersionFor(scenario),
+          isFragment = false,
+          testCase
+        ),
+        20 seconds
+      )
+      .fold(e => throw new RuntimeException(s"Error during performing test: $e"), identity)
+
+    result.assertionsResults(NodeId("end")) shouldBe List(
+      SuccessfulAssertion,
+      FailedAssertion("Expected: [bar] but found [foo]")
+    )
+  }
+
   private def prepareScenarioTestService(testDataFormat: TestDataFormat.Value): ScenarioTestService =
     new ScenarioTestService(
       TestDataSettings(
@@ -716,7 +832,7 @@ class ScenarioTestServiceSpec
       TestFactory.processResolver(),
       // These dependencies are needed for test execution which is not tested here
       processCounter = null,
-      testExecutorService = null,
+      testExecutorService = null
     )
 
   private def createScenarioWithSingleSource(sourceComponentId: String = "genericSource"): CanonicalProcess = {

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -1,0 +1,169 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks._
+import org.scalatest.prop.Tables.Table
+import pl.touk.nussknacker.engine.api.{ContextId, JobData, MetaData, NodeId, ProcessVersion, StreamMetaData}
+import pl.touk.nussknacker.engine.api.definition.Parameter
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, Unknown}
+import pl.touk.nussknacker.engine.compile.ExpressionCompiler
+import pl.touk.nussknacker.engine.definition.model.ModelDefinitionWithClasses
+import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
+import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
+import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
+import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
+import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
+import pl.touk.nussknacker.engine.util.functions.conversion
+import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
+import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
+
+import java.time.Instant
+import java.util
+import java.util.UUID
+
+class AssertionVerifierSpec extends AnyFunSuite with Matchers {
+
+  private val baseDefinition = ModelDefinitionBuilder.empty
+    .withUnboundedStreamSource("sourceWithUnknown", Some(Unknown))
+    .withService("enricher1", Some(Typed[String]), Parameter[String](ParameterName("par1")))
+    .withSink("sink")
+    .withGlobalVariable("CONV", conversion)
+    .build
+
+  private val modelDefinitionWithClasses = ModelDefinitionWithClasses(baseDefinition)
+
+  private val expressionCompiler = ExpressionCompiler.withOptimization(
+    getClass.getClassLoader,
+    new SimpleDictRegistry(Map.empty),
+    modelDefinitionWithClasses.modelDefinition.expressionConfig,
+    modelDefinitionWithClasses.classDefinitions,
+    ExpressionEvaluator.unOptimizedEvaluator(
+      GlobalVariablesPreparer.apply(modelDefinitionWithClasses.modelDefinition.expressionConfig)
+    )
+  )
+
+  private val testCaseGlobalVariablesPreparer = GlobalVariablesPreparer(
+    modelDefinitionWithClasses.modelDefinition.expressionConfig
+  )
+
+  private val testCompiler = new AssertionsCompiler(expressionCompiler, testCaseGlobalVariablesPreparer)
+  private val verifier     = new AssertionVerifier(testCaseGlobalVariablesPreparer)
+
+  private val scenarioTyping: Map[String, NodeTypingData] = Map(
+    "someNode" -> NodeTypingData(
+      Map(
+        "someVariable" -> Typed.fromInstance("bar"),
+        "someJavaList" -> Typed.fromInstance(new util.ArrayList[String]()),
+        "someArray"    -> Typed.fromInstance(new Array[String](1))
+      ),
+      None,
+      Map.empty
+    )
+  )
+
+  test("should run assertions on test nodes results and return assertion result for each assertion") {
+    val testCase = TestCase(
+      UUID.randomUUID(),
+      "dummy",
+      "dummy",
+      Map.empty,
+      Map(
+        NodeId("someNode") -> List(
+          Assertion("#TESTS.assertEquals('valid', #contexts[0].someVariable)".spel),
+          Assertion("#TESTS.assertEquals('valid', #contexts[1].someVariable)".spel),
+        )
+      )
+    )
+
+    val nodesResultsAfterTestRun: Map[NodeId, List[ResultContext[Any]]] = Map(
+      NodeId("someNode") -> List(
+        ResultContext[Any](ContextId.dummy, Instant.now(), Map("someVariable" -> "valid")),
+        ResultContext[Any](ContextId.dummy, Instant.now(), Map("someVariable" -> "invalid")),
+      )
+    )
+
+    val results = verifyForTestCase(
+      testCase,
+      nodesResultsAfterTestRun
+    )
+
+    results.toList shouldBe List(
+      NodeId("someNode") -> List(SuccessfulAssertion, FailedAssertion("Expected: [valid] but found [invalid]"))
+    )
+  }
+
+  test("should properly compare various types used in SpEL") {
+    forAll(
+      Table(
+        ("assertion", "result"),
+        ("#TESTS.assertEquals('valid', 'valid')", SuccessfulAssertion),
+        ("#TESTS.assertEquals({}, {})", SuccessfulAssertion),
+        ("#TESTS.assertEquals({:}, {:})", SuccessfulAssertion),
+        ("#TESTS.assertEquals(#CONV.toAny('abc'), 'abc')", SuccessfulAssertion),
+        ("#TESTS.assertEquals({'foo'}, #contexts[0].someJavaList)", SuccessfulAssertion),
+        ("#TESTS.assertEquals({'foo'}, {'foo'})", SuccessfulAssertion),
+        ("#TESTS.assertEquals({'foo': 'bar'}, {'foo': 'bar'})", SuccessfulAssertion),
+        ("#TESTS.assertEquals(1, 1L)", SuccessfulAssertion),
+        ("#TESTS.assertEquals(null, null)", SuccessfulAssertion),
+        ("#TESTS.assertEquals({'foo'}, {})", FailedAssertion("Expected: [{foo}] but found [{}]")),
+        ("#TESTS.assertEquals('1,2,3'.split(','), '1,2,3'.split(','))", SuccessfulAssertion), // comparing arrays
+        (
+          "#TESTS.assertEquals('1,2'.split(','), '1,2,3'.split(','))",
+          FailedAssertion("Expected: [{1, 2}] but found [{1, 2, 3}]")
+        ),
+        (
+          "#TESTS.assertEquals({'1','2','3'}, '1,2,3'.split(','))",
+          SuccessfulAssertion
+        ), // comparing arrays with SpEL inline lists
+        ("#TESTS.assertEquals({'a': 1}, {:})", FailedAssertion("Expected: [{a: 1}] but found [{:}]")),
+        // ("#TESTS.assertEquals({'1,2'.split(',')}, {'1,2'.split(',')})", SuccessfulAssertion), //todo: to be discussed whether it should work for nested structures
+      )
+    ) { (assertion, result) =>
+      val testCase = TestCase(
+        UUID.randomUUID(),
+        "dummy",
+        "dummy",
+        Map.empty,
+        Map(
+          NodeId("someNode") -> List(
+            Assertion(assertion.spel),
+          )
+        )
+      )
+      val nodesResultsAfterTestRun: Map[NodeId, List[ResultContext[Any]]] = Map(
+        NodeId("someNode") -> List(
+          ResultContext[Any](
+            ContextId.dummy,
+            Instant.now(),
+            Map(
+              "someJavaList" -> createSingletonArrayList("foo"),
+            )
+          ),
+        )
+      )
+
+      verifyForTestCase(testCase, nodesResultsAfterTestRun).toList shouldBe List(NodeId("someNode") -> List(result))
+    }
+  }
+
+  private def verifyForTestCase(testCase: TestCase, nodesResultsAfterTestRun: Map[NodeId, List[ResultContext[Any]]]) = {
+    val jobData = JobData(MetaData("someScenario", StreamMetaData()), ProcessVersion.empty)
+    val compiledTestCase = testCompiler
+      .compile(testCase, scenarioTyping, jobData)
+      .fold(errors => throw new IllegalStateException(s"Test compilation errors: $errors"), identity)
+    verifier.verify(
+      compiledTestCase,
+      nodesResultsAfterTestRun,
+      jobData
+    )
+  }
+
+  private def createSingletonArrayList[T](element: T): java.util.ArrayList[T] = {
+    val list = new util.ArrayList[T]()
+    list.add(element)
+    list
+  }
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -1,0 +1,190 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import cats.data.{NonEmptyList, Validated}
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.Inside
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.{CustomProcessValidatorLoader, ScenarioCompilationDependencies}
+import pl.touk.nussknacker.engine.api._
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.ExpressionParserCompilationError
+import pl.touk.nussknacker.engine.api.definition.{EngineScenarioCompilationDependencies, Parameter}
+import pl.touk.nussknacker.engine.api.generics.ExpressionParseError.{CoordinatesBasedTextRange, TextCoordinates}
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, Unknown}
+import pl.touk.nussknacker.engine.build.ScenarioBuilder
+import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
+import pl.touk.nussknacker.engine.compile.{ExpressionCompiler, NodeTypingInfo, ProcessCompiler, ProcessValidator}
+import pl.touk.nussknacker.engine.definition.model.ModelDefinitionWithClasses
+import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
+import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
+import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
+import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
+import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
+import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
+import pl.touk.nussknacker.ui.definition.DefinitionsService
+import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.{
+  AssertionConfiguredForNotExistingNodesError,
+  AssertionExpressionCompilationError
+}
+
+import java.util.UUID
+
+class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
+
+  import pl.touk.nussknacker.engine.util.Implicits._
+
+  private val baseDefinition = ModelDefinitionBuilder.empty
+    .withUnboundedStreamSource("sourceWithUnknown", Some(Unknown))
+    .withService("enricher1", Some(Typed[String]), Parameter[String](ParameterName("par1")))
+    .withSink("sink")
+    .build
+
+  private val modelDefinitionWithClasses = ModelDefinitionWithClasses(baseDefinition)
+
+  private val assertionsCompiler: AssertionsCompiler = {
+    val globalVariablesPreparer =
+      GlobalVariablesPreparer.apply(modelDefinitionWithClasses.modelDefinition.expressionConfig)
+    val expressionCompiler = ExpressionCompiler.withOptimization(
+      getClass.getClassLoader,
+      new SimpleDictRegistry(Map.empty),
+      modelDefinitionWithClasses.modelDefinition.expressionConfig,
+      modelDefinitionWithClasses.classDefinitions,
+      ExpressionEvaluator.unOptimizedEvaluator(
+        globalVariablesPreparer
+      )
+    )
+    new AssertionsCompiler(expressionCompiler, globalVariablesPreparer)
+  }
+
+  test("should compile valid assertions for scenario") {
+    val scenario = ScenarioBuilder
+      .streaming("process1")
+      .source("id1", "sourceWithUnknown")
+      .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
+      .buildSimpleVariable("result-id2", "result", "#input".spel)
+      .emptySink("sink1", "sink")
+
+    val test = TestCase(
+      UUID.randomUUID(),
+      "someTest",
+      inputs = "",
+      mocks = Map.empty,
+      assertions = Map(NodeId("sink1") -> List(Assertion("#TESTS.assertEquals(#contexts.size, 1)".spel)))
+    )
+
+    val testCompilationResult = compileScenarioWithAssertions(scenario, test)
+    inside(testCompilationResult) { case Valid(compiledAssertions) =>
+      compiledAssertions.assertions.size shouldBe 1
+      compiledAssertions.assertions(NodeId("sink1")).size shouldBe 1
+      compiledAssertions
+        .assertions(NodeId("sink1"))
+        .head
+        .expression
+        .original shouldBe "#TESTS.assertEquals(#contexts.size, 1)"
+    }
+  }
+
+  test("should produce errors for assertions on missing nodes") {
+    val scenario = ScenarioBuilder
+      .streaming("process1")
+      .source("id1", "sourceWithUnknown")
+      .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
+      .buildSimpleVariable("result-id2", "result", "#input".spel)
+      .emptySink("sink1", "sink")
+    val test = TestCase(
+      UUID.randomUUID(),
+      "someTest",
+      inputs = "",
+      mocks = Map.empty,
+      assertions = Map(NodeId("notExistingSink") -> List(Assertion("#TESTS.assertEquals(#contexts.size, 1)".spel)))
+    )
+
+    val testCompilationResult = compileScenarioWithAssertions(scenario, test)
+
+    inside(testCompilationResult) { case Invalid(errors) =>
+      errors.toList shouldBe List(
+        AssertionConfiguredForNotExistingNodesError(
+          NonEmptyList.one(NodeId("notExistingSink"))
+        )
+      )
+    }
+  }
+
+  test("should produce errors for assertions with syntax errors") {
+    val scenario = ScenarioBuilder
+      .streaming("process1")
+      .source("id1", "sourceWithUnknown")
+      .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
+      .buildSimpleVariable("result-id2", "result", "#input".spel)
+      .emptySink("sink1", "sink")
+    val nodeId           = NodeId("sink1")
+    val invalidAssertion = Assertion("#TESTS.assertEquals(#contexts.size,".spel)
+
+    val test = TestCase(
+      UUID.randomUUID(),
+      "someTest",
+      inputs = "",
+      mocks = Map.empty,
+      assertions = Map(nodeId -> List(invalidAssertion))
+    )
+
+    val testCompilationResult = compileScenarioWithAssertions(scenario, test)
+    inside(testCompilationResult) { case Invalid(errors) =>
+      errors.size shouldBe 1
+      errors.head shouldBe AssertionExpressionCompilationError(
+        NonEmptyList.one(
+          ExpressionParserCompilationError(
+            "Unexpectedly ran out of arguments",
+            nodeId,
+            None,
+            "#TESTS.assertEquals(#contexts.size,",
+            Some(CoordinatesBasedTextRange(TextCoordinates(19, 0), TextCoordinates(20, 0)))
+          )
+        ),
+        invalidAssertion,
+        nodeId
+      )
+    }
+  }
+
+  private def compileScenarioWithAssertions(scenario: CanonicalProcess, test: TestCase) = {
+    val typing  = compileScenarioForTyping(scenario)
+    val jobData = JobData(MetaData("someScenario", StreamMetaData()), ProcessVersion.empty)
+
+    val assertionCompilationResult = assertionsCompiler.compile(
+      test,
+      typing,
+      jobData
+    )
+    assertionCompilationResult
+  }
+
+  private def compileScenarioForTyping(scenario: CanonicalProcess): Map[String, NodeTypingData] = {
+    val jobData: JobData = JobData(scenario.metaData, ProcessVersion.empty.copy(processName = scenario.metaData.name))
+    implicit val scenarioCompilationDependencies: ScenarioCompilationDependencies =
+      new ScenarioCompilationDependencies(jobData, EngineScenarioCompilationDependencies.empty)
+
+    val compilationResult = ProcessValidator
+      .default(
+        modelDefinitionWithClasses,
+        new SimpleDictRegistry(Map.empty),
+        CustomProcessValidatorLoader.emptyCustomProcessValidator,
+      )
+      .asInstanceOf[ProcessCompiler]
+      .compile(scenario)
+
+    compilationResult.result match {
+      case Validated.Valid(_) => compilationResult.typing.mapValuesNow(nodeInfoToResult).toMap
+      case Validated.Invalid(errors) =>
+        throw new IllegalStateException(s"Process compilation ended with errors: $errors")
+    }
+  }
+
+  private def nodeInfoToResult(typingInfo: NodeTypingInfo) = NodeTypingData(
+    typingInfo.inputValidationContext.localVariables,
+    typingInfo.parameters.map(_.map(DefinitionsService.createUIParameter)),
+    typingInfo.expressionsTypingInfo
+  )
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/SpelValuePrettyPrinterSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/SpelValuePrettyPrinterSpec.scala
@@ -1,0 +1,29 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks._
+import pl.touk.nussknacker.ui.process.test.testcase.SpelValuePrettyPrinter.prettyPrintValue
+
+class SpelValuePrettyPrinterSpec extends AnyFunSuite with Matchers {
+
+  test("print like a SpEL literal values") {
+    forAll(
+      Table(
+        ("valueToPrint", "expectedOutput"),
+        (java.util.List.of("a", "b", "c"), "{a, b, c}"),
+        (java.util.List.of[java.util.List[String]](java.util.List.of[String]("a")), "{{a}}"),
+        (java.util.List.of(), "{}"),
+        (java.util.Map.of("a", 1234), "{a: 1234}"),
+        (java.util.Map.of("a", java.util.Map.of("b", 1234)), "{a: {b: 1234}}"),
+        (java.util.Map.of(), "{:}"),
+        (Array("a", "b", "c"), "{a, b, c}"), // in spel there is no array literal so we print it as a list literal,
+        (Array(Array("a")), "{{a}}"),
+        (Array[String](), "{}"),
+      )
+    ) { (valueToPrint, expectedOutput) =>
+      prettyPrintValue(valueToPrint) shouldBe expectedOutput
+    }
+  }
+
+}

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -5256,6 +5256,11 @@ components:
         version:
           type: integer
           format: int32
+    AssertionResult:
+      title: AssertionResult
+      oneOf:
+      - $ref: '#/components/schemas/FailedAssertion'
+      - $ref: '#/components/schemas/SuccessfulAssertion'
     Attachment:
       title: Attachment
       type: object
@@ -5847,6 +5852,14 @@ components:
         name:
           type: string
         value: {}
+    FailedAssertion:
+      title: FailedAssertion
+      type: object
+      required:
+      - message
+      properties:
+        message:
+          type: string
     FetchSourcesLiveDataRequest:
       title: FetchSourcesLiveDataRequest
       type: object
@@ -7164,6 +7177,7 @@ components:
       - timestamp
       - results
       - counts
+      - assertionsResults
       properties:
         timestamp:
           type: string
@@ -7171,6 +7185,8 @@ components:
         results:
           $ref: '#/components/schemas/TestResultsDto'
         counts:
+          $ref: '#/components/schemas/Map_NodeId_V'
+        assertionsResults:
           $ref: '#/components/schemas/Map_NodeId_V'
     RunDeploymentRequest:
       title: RunDeploymentRequest
@@ -7647,6 +7663,9 @@ components:
       type: string
       enum:
       - ERROR
+    SuccessfulAssertion:
+      title: SuccessfulAssertion
+      type: object
     SwitchDefault:
       title: SwitchDefault
       type: object

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -310,6 +310,7 @@ description: Stay informed with detailed changelogs covering new features, impro
 * [#8803](https://github.com/TouK/nussknacker/pull/8803) Nussknacker is now built only against Scala 2.13, removed Scala 2.12 cross-compile
 * [#8815](https://github.com/TouK/nussknacker/pull/8815) Fix: In Flink's serialization was used a result type of expression
   before final implicit conversion instead of after it. It sometimes caused "AAA cannot be cast to class BBB" in runtime.
+* [#8806](https://github.com/TouK/nussknacker/pull/8806) Test case running implementation
 
 ## 1.18
 

--- a/e2e-tests/src/test/scala/pl/touk/nussknacker/BatchDataGenerationSpec.scala
+++ b/e2e-tests/src/test/scala/pl/touk/nussknacker/BatchDataGenerationSpec.scala
@@ -182,7 +182,8 @@ class BatchDataGenerationSpec
            |        "errors": 0,
            |        "fragmentCounts": {}
            |      }
-           |  }
+           |  },
+           |  "assertionsResults": {}
            |}""".stripMargin
       )
   }
@@ -317,7 +318,8 @@ class BatchDataGenerationSpec
            |        "errors": 0,
            |        "fragmentCounts": {}
            |      }
-           |  }
+           |  },
+           |  "assertionsResults": {}
            |}""".stripMargin
       )
   }

--- a/e2e-tests/src/test/scala/pl/touk/nussknacker/DetectLargeTransactionSpec.scala
+++ b/e2e-tests/src/test/scala/pl/touk/nussknacker/DetectLargeTransactionSpec.scala
@@ -737,7 +737,8 @@ class DetectLargeTransactionSpec
              |      "errors": 0,
              |      "fragmentCounts": {}
              |    }
-             |  }
+             |  },
+             |  "assertionsResults": {}
              |}""".stripMargin
         )
     }

--- a/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ResultCollectingListenerSpec.scala
+++ b/engine/flink/components/base-tests/src/test/scala/pl/touk/nussknacker/engine/flink/ResultCollectingListenerSpec.scala
@@ -12,8 +12,6 @@ import pl.touk.nussknacker.engine.flink.test.FlinkSpec
 import pl.touk.nussknacker.engine.graph.node.Case
 import pl.touk.nussknacker.test.VeryPatientScalaFutures
 
-import scala.collection.JavaConverters._
-
 class ResultCollectingListenerSpec
     extends AnyFunSuite
     with BeforeAndAfterAll

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
@@ -7,6 +7,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.Json
 import io.circe.Json._
 import org.apache.avro.Schema
+import org.apache.kafka.common.record.TimestampType
 import org.scalatest.{BeforeAndAfterAll, LoneElement, OptionValues}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -23,7 +24,9 @@ import pl.touk.nussknacker.engine.flink.minicluster.scenariotesting.schemedkafka
 import pl.touk.nussknacker.engine.flink.minicluster.util.DurationToRetryPolicyConverter
 import pl.touk.nussknacker.engine.flink.util.sink.SingleValueSinkFactory.SingleValueParamName
 import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.graph.expression.Expression.Language.JsonTemplate
 import pl.touk.nussknacker.engine.kafka.UnspecializedTopicName
+import pl.touk.nussknacker.engine.kafka.source.InputMeta
 import pl.touk.nussknacker.engine.process.helpers.TestResultsHolder
 import pl.touk.nussknacker.engine.schemedkafka.KafkaAvroIntegrationMockSchemaRegistry.schemaRegistryMockClient
 import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransformer.{
@@ -40,8 +43,10 @@ import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.testmode.TestProcess
 import pl.touk.nussknacker.engine.testmode.TestProcess._
 import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, KafkaConfigProperties, VeryPatientScalaFutures}
+import pl.touk.nussknacker.ui.process.test.testcase.{TestCase, TestSourceInput}
 
 import java.time.Instant
+import java.util.Collections
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
 

--- a/extensions-api/src/main/scala/pl/touk/nussknacker/engine/testmode/TestProcess.scala
+++ b/extensions-api/src/main/scala/pl/touk/nussknacker/engine/testmode/TestProcess.scala
@@ -12,14 +12,22 @@ object TestProcess {
       nodeTransitionResults: Map[NodeTransition, List[ResultContext[T]]],
       expressionEvaluationResults: Map[NodeId, List[ExpressionEvaluationResult[T]]],
       externalServiceInvocationResults: Map[NodeId, List[ExternalServiceInvocationResult[T]]],
-      exceptions: List[ExceptionResult[T]]
+      exceptions: List[ExceptionResult[T]],
+      originalNodeResults: Map[NodeId, List[
+        ResultContext[Any]
+      ]],
   ) {
 
-    def updateNodeResult(nodeId: NodeId, context: Context, variableEncoder: Any => T): TestResults[T] =
-      copy(nodeResults =
-        nodeResults + (nodeId -> (nodeResults.getOrElse(nodeId, List()) :+ ResultContext
-          .fromContext(context, Instant.now(), variableEncoder)))
+    def updateNodeResult(nodeId: NodeId, context: Context, variableEncoder: Any => T): TestResults[T] = {
+      val instantNow = Instant.now()
+      copy(
+        nodeResults = nodeResults + (nodeId -> (nodeResults.getOrElse(nodeId, List()) :+ ResultContext
+          .fromContext(context, instantNow, variableEncoder))),
+        originalNodeResults =
+          originalNodeResults + (nodeId -> (originalNodeResults.getOrElse(nodeId, List()) :+ ResultContext
+            .fromContext(context, instantNow, identity))),
       )
+    }
 
     def updateNodeOutputResult(
         nodeId: NodeId,
@@ -86,7 +94,8 @@ object TestProcess {
 
   object TestResults {
 
-    def empty[T]: TestResults[T] = TestResults[T](Map.empty, Map.empty, Map.empty, Map.empty, List.empty)
+    def empty[T]: TestResults[T] =
+      TestResults[T](Map.empty, Map.empty, Map.empty, Map.empty, List.empty, Map.empty)
 
     def aggregate[T](testResults: Iterable[TestResults[T]]): TestResults[T] = {
       TestResults[T](
@@ -95,6 +104,7 @@ object TestProcess {
         expressionEvaluationResults = mergeMaps(testResults.map(_.expressionEvaluationResults)),
         externalServiceInvocationResults = mergeMaps(testResults.map(_.externalServiceInvocationResults)),
         exceptions = testResults.flatMap(_.exceptions).toList,
+        originalNodeResults = mergeMaps(testResults.map(_.originalNodeResults)),
       )
     }
 

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/CanonicalProcess.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/canonicalgraph/CanonicalProcess.scala
@@ -83,7 +83,7 @@ case class CanonicalProcess(
     // DON'T use these fields, rely on allStartNodes or mapAllNodes instead.
     nodes: List[CanonicalNode],
     additionalBranches: List[List[CanonicalNode]] = List.empty,
-    stickyNotes: List[StickyNote] = List.empty,
+    stickyNotes: List[StickyNote] = List.empty
 ) extends CanonicalTreeNode {
 
   import CanonicalProcess._

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/PartSubGraphCompiler.scala
@@ -1,14 +1,13 @@
 package pl.touk.nussknacker.engine.compile
 
 import cats.Applicative
-import cats.data.{NonEmptyList, ValidatedNel}
 import cats.data.Validated._
+import cats.data.ValidatedNel
 import cats.instances.list._
 import cats.instances.option._
 import pl.touk.nussknacker.engine.{compiledgraph, ScenarioCompilationDependencies}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.{OutputVar, ProcessCompilationError}
-import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
 import pl.touk.nussknacker.engine.api.definition.Parameter
 import pl.touk.nussknacker.engine.api.expression.ExpressionTypingInfo
 import pl.touk.nussknacker.engine.api.typed.typing.Unknown

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testmode/ResultsCollectingListener.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/testmode/ResultsCollectingListener.scala
@@ -106,7 +106,7 @@ private case class ResultsCollectingListenerImpl[T](holderClass: String, runId: 
 
 private object NoopResultsCollectingListener extends ResultsCollectingListener[Any] with EmptyProcessListener {
   override def results: TestResults[Any] =
-    TestResults(Map.empty, Map.empty, Map.empty, Map.empty, List.empty)
+    TestResults(Map.empty, Map.empty, Map.empty, Map.empty, List.empty, Map.empty)
 
   override def clean(): Unit = {}
 
@@ -147,7 +147,7 @@ object ResultsCollectingListenerHolder {
 
   private def registerListener[T](variableEncoder: Any => T): ResultsCollectingListener[T] = {
     val runId = TestRunId.generate
-    results.put(runId, TestResults(Map(), Map(), Map(), Map(), List()))
+    results.put(runId, TestResults(Map(), Map(), Map(), Map(), List(), Map()))
     ResultsCollectingListenerImpl(getClass.getCanonicalName, runId, variableEncoder)
   }
 


### PR DESCRIPTION
#### As part of this PR is implemented:
* Running a TestCase on a scenario (endpoint).
  * The scenario must already exist, but you can run a test case on a draft — it is passed as a graph.
* Using the input data defined in the test case (we enforce a common format for them).
* Replacing mocks in the provided scenario based on the mocks defined in the test case.
* Validating assertion expressions defined in the test case, based on the typing derived from the compiled scenario.
* Passing the scenario with substituted mocks to the DM for execution.
* Verifying per-node assertions based on TestResults (which has been extended to include a non-serialized version of originalNodeResults).
* A basic assertEquals assertion that performs light type alignment (e.g., normalizes array vs. list to a common type), but only on the first level (no nested structures yet — TBD), and returns differences as SpEL literals (`SpelValuePrettyPrinter.prettyPrintValue`).

#### Side notes
* Thanks to preparing test data/mocks and verifying assertions using TestResults, executing a test case is independent of the DMs (the existing logic is sufficient), which is IMO a significant advantage (no lite/flink/RR specific logic).
* This may be insufficient if the DM runs tests on remote environments (e.g., a Flink-based DM executing tests on a remote cluster).
* In that case, we would need proper serialization of TestResults.originalNodeResults or move assertion verification from ScenarioTestService to the execution environment.
* TestCase has the same limitations as the existing tests — it runs during an HTTP request and must finish before that request’s read timeout triggers.
An alternative approach would be submitting tests and polling (or using WebSockets) for results.
* Missing: persistence & validation flow.