### PR TITLE
testcontainers core bump to 1.21.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -281,7 +281,7 @@ val configV                 = "1.4.4"
 val dropWizardV             = "5.0.0-rc15"
 val scalaCollectionsCompatV = "2.13.0"
 val testContainersScalaV    = "0.43.0"
-val testContainersJavaV     = "1.21.3"
+val testContainersJavaV     = "1.21.4"
 val nettyV                  = "4.1.123.Final"
 val nettyReactiveStreamsV   = "2.0.12"
 


### PR DESCRIPTION
Fixes issue with incompatibility with newer docker engines (https://github.com/testcontainers/testcontainers-java/pull/11346) which caused `Could not find a valid Docker environment` in e2eTests when run on latest docker desktop version (e.g. v4.55.0)