### PR TITLE
[NU-2438] Work around for invalid status presentation

### DIFF
--- a/designer/client/src/reducers/scenarioState.ts
+++ b/designer/client/src/reducers/scenarioState.ts
@@ -16,11 +16,19 @@ export const reducer: Reducer<ProcessStateType> = produce((draft, action) => {
         }
         case "PENDING_SCENARIO_ACTION": {
             switch (action.action) {
+                // We have to keep it synchronized with SimpleStateStatus.scala on BE side and it introduces a glitch when response from BE is quick
+                // TODO: replace this by some other way of signaling that current status is outdate and will be validated soon
                 case PredefinedActionName.Deploy:
                     draft.status.name = KnownStatusName.Deploying;
+                    draft.description = "The scenario is being deployed.";
+                    draft.tooltip = "The scenario has been already started and currently is being deployed.";
+                    draft.icon = "/assets/states/deploy-running-animated.svg";
                     break;
                 case PredefinedActionName.Redeploy:
                     draft.status.name = KnownStatusName.Redeploying;
+                    draft.description = "The scenario is being redeployed.";
+                    draft.tooltip = "The scenario has been already started and currently is being redeployed.";
+                    draft.icon = "/assets/states/deploy-running-animated.svg";
                     break;
             }
             return draft;


### PR DESCRIPTION
## Describe your changes

Video demonstrates that this solution is still not perfect - the icon is not changed correctly.

Uploading Screencast 2025-12-22 17:11:56.mp4…


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
