### PR TITLE
Reconfigure bool parameters editors

### DIFF
--- a/engine/common/components/src/main/scala/pl/touk/nussknacker/engine/common/components/DecisionTable.scala
+++ b/engine/common/components/src/main/scala/pl/touk/nussknacker/engine/common/components/DecisionTable.scala
@@ -45,8 +45,9 @@ object DecisionTable extends EagerService with SingleInputDynamicComponent {
         .lazyMandatory[java.lang.Boolean](name)
         .withAdvancedCreator[Iterable[Column.Definition]](
           create = columnDefinitions =>
-            _.copy(additionalVariables =
-              Map(
+            _.copy(
+              editors = List(SpelParameterEditor),
+              additionalVariables = Map(
                 decisionTableRowRuntimeVariableName -> AdditionalVariableProvidedInRuntime(
                   rowDataTypingResult(columnDefinitions)
                 )

--- a/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
+++ b/engine/flink/components/base-unbounded/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/aggregate/sampleTransformers.scala
@@ -169,7 +169,8 @@ object sampleTransformers {
         @Editor(`type` = EditorType.SPEL_EDITOR)
         aggregator: Aggregator,
         @ParamName("aggregateBy") aggregateBy: LazyParameter[AnyRef],
-        @ParamName("endSessionCondition") @DefaultValue("false") endSessionCondition: LazyParameter[java.lang.Boolean],
+        @ParamName("endSessionCondition") @DefaultValue("false")
+        @Editor(`type` = EditorType.SPEL_EDITOR) endSessionCondition: LazyParameter[java.lang.Boolean],
         @ParamName("sessionTimeout") @DefaultValue(
           "T(java.time.Duration).parse('PT1H')"
         ) sessionTimeout: java.time.Duration,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/editor/ParameterTypeEditorDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/editor/ParameterTypeEditorDeterminer.scala
@@ -30,9 +30,11 @@ class ParameterTypeEditorDeterminer(
         case klazz if classOf[java.lang.CharSequence].isAssignableFrom(klazz) =>
           globalParametersConfig.editorsForStringType
         case `BooleanClass` =>
-          withSpelEditorAsFallbackForLazyParameter(
-            BoolParameterEditor
-          )
+          if (isLazyParameter) {
+            NonEmptyList.of(SpelParameterEditor, BoolParameterEditor)
+          } else {
+            NonEmptyList.one(BoolParameterEditor)
+          }
         case `LocalDateTimeClass` =>
           withSpelEditorAsFallbackForLazyParameter(
             DateTimeParameterEditor

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/editor/ParameterTypeEditorDeterminer.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/editor/ParameterTypeEditorDeterminer.scala
@@ -29,12 +29,8 @@ class ParameterTypeEditorDeterminer(
           )
         case klazz if classOf[java.lang.CharSequence].isAssignableFrom(klazz) =>
           globalParametersConfig.editorsForStringType
-        case `BooleanClass` =>
-          if (isLazyParameter) {
-            NonEmptyList.of(SpelParameterEditor, BoolParameterEditor)
-          } else {
-            NonEmptyList.one(BoolParameterEditor)
-          }
+        case `BooleanClass` if isLazyParameter => NonEmptyList.of(SpelParameterEditor, BoolParameterEditor)
+        case `BooleanClass`                    => NonEmptyList.one(BoolParameterEditor)
         case `LocalDateTimeClass` =>
           withSpelEditorAsFallbackForLazyParameter(
             DateTimeParameterEditor


### PR DESCRIPTION
## Describe your changes
Changes:
1. DecisionTable `matchExpression` and AggregateSession `endSessionCondition` - only expression editor (bool editor does not make sense here)
2. AggregateSliding `emitWhenEventLeft` - only bool editor
3. Fallback for other parameters without defined editors:
	1. for lazy parameters - 2 editors - expression editor as initial editor, user can switch to bool editor (previously it was bool editor initial, expression secondary)
	2. for eager parameters - only bool editor

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
