### PR TITLE
[NU-2446] revert contexts variable in assertions

### DIFF
--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
@@ -1,12 +1,16 @@
 import { Typography } from "@mui/material";
-import React, { useCallback, useState } from "react";
+import { omit } from "lodash";
+import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { setTestCaseAssertions } from "../../../../../../actions/nk/testCasesActions";
+import httpService from "../../../../../../http/HttpService/instance";
+import { getProcessingType } from "../../../../../../reducers/selectors/graph";
 import { getTestCaseAssertionsForNode } from "../../../../../../reducers/selectors/testCases";
 import { getTestAssertionResultsForNode } from "../../../../../../reducers/selectors/testing";
 import { useAppDispatch, useAppSelector } from "../../../../../../store/storeHelpers";
 import type { NodeType } from "../../../../../../types/node";
+import type { VariableTypes } from "../../../../../../types/validation";
 import { Expandable } from "../../../../../common/Expandable";
 import { withUuid } from "../../../appendUuid";
 import { NodeRowFieldsProvider } from "../../../node-row-fields-provider/NodeRowFieldsProvider";
@@ -25,7 +29,18 @@ export const Assertions = ({ node }: Props) => {
     const dispatch = useAppDispatch();
     const testCaseAssertions = useAppSelector((state) => getTestCaseAssertionsForNode(state, node.id));
     const testAssertionResults = useAppSelector((state) => getTestAssertionResultsForNode(state, node.id));
-    const variableTypes = useVariableTypes({ node });
+    const processingType = useAppSelector(getProcessingType);
+    const nodeVariableTypes = useVariableTypes({ node });
+    const [assertionVariableTypes, setAssertionVariableTypes] = useState<VariableTypes>({});
+
+    useEffect(() => {
+        const fetchAssertionVariableTypes = async () => {
+            const response = await httpService.fetchTestCaseNodeAdditionalVariables(processingType, { variableTypes: nodeVariableTypes });
+            setAssertionVariableTypes(omit(response.assertionsAdditionalVariables, "TESTS") || {});
+        };
+
+        fetchAssertionVariableTypes();
+    }, [processingType, nodeVariableTypes]);
 
     const addAssertion = useCallback(() => {
         dispatch(
@@ -52,6 +67,7 @@ export const Assertions = ({ node }: Props) => {
     return (
         <StyledStack>
             <Expandable componentId={"Assertions"} expandableTitle={"Assertions"} expanded={isExpanded} onChange={setIsExpanded}>
+                {testCaseAssertions.length === 0 && <Typography>{t("assertions.noAssertionsDefined", "No assertions defined")}</Typography>}
                 <NodeTable sx={{ mx: 0 }}>
                     <NodeRowFieldsProvider
                         path={null}
@@ -61,23 +77,17 @@ export const Assertions = ({ node }: Props) => {
                         readOnly={false}
                         errors={[]}
                     >
-                        <>
-                            {testCaseAssertions.length === 0 && (
-                                <Typography>{t("assertions.noAssertionsDefined", "No assertions defined")}</Typography>
-                            )}
-
-                            {testCaseAssertions.map(({ expression: expressionObj, uuid }, index) => (
-                                <AssertionItem
-                                    key={uuid}
-                                    uuid={uuid}
-                                    onChange={editAssertion}
-                                    expressionObj={expressionObj}
-                                    variableTypes={variableTypes}
-                                    testAssertionResult={testAssertionResults?.[index]}
-                                    index={index}
-                                />
-                            ))}
-                        </>
+                        {testCaseAssertions.map(({ expression: expressionObj, uuid }, index) => (
+                            <AssertionItem
+                                key={uuid}
+                                uuid={uuid}
+                                onChange={editAssertion}
+                                expressionObj={expressionObj}
+                                variableTypes={assertionVariableTypes}
+                                testAssertionResult={testAssertionResults?.[index]}
+                                index={index}
+                            />
+                        ))}
                     </NodeRowFieldsProvider>
                 </NodeTable>
             </Expandable>

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
@@ -67,7 +67,9 @@ export const Assertions = ({ node }: Props) => {
     return (
         <StyledStack>
             <Expandable componentId={"Assertions"} expandableTitle={"Assertions"} expanded={isExpanded} onChange={setIsExpanded}>
-                {testCaseAssertions.length === 0 && <Typography>{t("assertions.noAssertionsDefined", "No assertions defined")}</Typography>}
+                {testCaseAssertions.length === 0 && (
+                    <Typography variant={"body2"}>{t("assertions.noAssertionsDefined", "No assertions defined")}</Typography>
+                )}
                 <NodeTable sx={{ mx: 0 }}>
                     <NodeRowFieldsProvider
                         path={null}


### PR DESCRIPTION
## Describe your changes
- Revert `#contexts` variable in assertions (`#TESTS` is still removed)
<img width="1882" height="986" alt="image" src="https://github.com/user-attachments/assets/5ef9cc69-3d41-4c75-b3e1-e009a1937def" />
<img width="1723" height="976" alt="image" src="https://github.com/user-attachments/assets/3c02f171-2831-447c-943e-bc3a2a45400c" />
-Adjust "No assertions defined" message position
<img width="1851" height="988" alt="image" src="https://github.com/user-attachments/assets/41ec06af-8ac7-453f-af65-17e6c154428b" />




## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
