### PR TITLE
[NU-2399] Define assertions without #TESTS helper

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1603,7 +1603,9 @@ lazy val scenarioApi = (project in file("scenario-api"))
   .settings(
     name := "nussknacker-scenario-api",
     libraryDependencies ++= Seq(
-      "org.apache.commons" % "commons-lang3" % flinkCommonsLang3V,
+      "org.apache.commons" % "commons-lang3"    % flinkCommonsLang3V,
+      "com.beachape"      %% "enumeratum"       % enumeratumV,
+      "com.beachape"      %% "enumeratum-circe" % enumeratumV,
     )
   )
   .dependsOn(commonApi, testUtils % Test)

--- a/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/testcase/package.scala
+++ b/designer/restmodel/src/main/scala/pl/touk/nussknacker/restmodel/validation/testcase/package.scala
@@ -34,6 +34,7 @@ package object testcase {
       message: String,
       description: String,
       details: Option[ErrorDetails],
+      fieldName: Option[String],
   )
 
   object ScenarioTestCasesValidationErrors {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
@@ -7,6 +7,7 @@ import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
 import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.test.testcase.Assertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.restmodel.validation.ValidationResults
 import pl.touk.nussknacker.ui.process.test.PreliminaryScenarioRecordsSerDe.DeserializationError
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService
@@ -176,6 +177,6 @@ object TestingApiErrorMessages {
       assertion: Assertion,
       nodeId: NodeId
   ) =
-    s"Assertion compilation error. Node: ${nodeId.id}. Assertion expression: ${assertion.expression.expression}. Errors: ${errors.toList.mkString(", ")}"
+    s"Assertion compilation error. Node: ${nodeId.id}. Assertion expression: ${assertion.asInstanceOf[ExpressionAssertion].expression.expression}. Errors: ${errors.toList.mkString(", ")}"
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
@@ -13,6 +13,12 @@ import pl.touk.nussknacker.ui.process.test.PreliminaryScenarioRecordsSerDe.Deser
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.ScenarioValidationError
+import pl.touk.nussknacker.ui.process.test.testcase.{AssertionCompilationError, AssertionValidationError}
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.{
+  ExpressionAssertionCompilationError,
+  PredicateAssertionCompilationError
+}
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionValidationError.AssertionConfiguredForNotExistingNodesError
 import pl.touk.nussknacker.ui.process.test.testdataformat.CommonDataFormatHandler.InputVariablesParameterName
 import pl.touk.nussknacker.ui.process.test.testdataformat.TestDataFormatHandler
 
@@ -73,10 +79,16 @@ object TestingApiErrorMessages {
         TestingApiErrorMessages.scenarioHasValidationErrors(errors)
       case PerformTestError.MockConfiguredForNotExistingNodesError(nodeIds) =>
         TestingApiErrorMessages.mocksConfiguredForNotExistingNodes(nodeIds)
-      case PerformTestError.AssertionConfiguredForNotExistingNodesError(errors) =>
-        TestingApiErrorMessages.assertionsConfiguredForNotExistingNodes(errors)
-      case PerformTestError.AssertionExpressionCompilationError(errors, assertion, node) =>
-        TestingApiErrorMessages.assertionCompilationError(errors, assertion, node)
+      case PerformTestError.AssertionErrors(errors) =>
+        // in case of performing test case we return errors in fail-fast fashion
+        errors.head match {
+          case AssertionConfiguredForNotExistingNodesError(notExistingNodeIds) =>
+            TestingApiErrorMessages.assertionsConfiguredForNotExistingNodes(notExistingNodeIds)
+          case ExpressionAssertionCompilationError(errors, assertion, nodeId) =>
+            TestingApiErrorMessages.assertionCompilationError(errors, assertion, nodeId)
+          case PredicateAssertionCompilationError(errors, assertion, _, nodeId) =>
+            TestingApiErrorMessages.assertionCompilationError(errors, assertion, nodeId)
+        }
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
@@ -195,7 +195,7 @@ object TestingApiErrorMessages {
     assertion match {
       case ExpressionAssertion(expression) => s"Assertion expression: ${expression.expression}')"
       case Assertion.PredicateAssertion(operator, expected, actual) =>
-        s"Assertion: '${operator.name}' , expected: ${expected.expression}, actual: ${actual.expression}"
+        s"Assertion: '${operator.entryName}' , expected: ${expected.expression}, actual: ${actual.expression}"
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
@@ -189,6 +189,14 @@ object TestingApiErrorMessages {
       assertion: Assertion,
       nodeId: NodeId
   ) =
-    s"Assertion compilation error. Node: ${nodeId.id}. Assertion expression: ${assertion.asInstanceOf[ExpressionAssertion].expression.expression}. Errors: ${errors.toList.mkString(", ")}"
+    s"Assertion compilation error. Node: ${nodeId.id}. ${prettyPrintAssertion(assertion)}. Errors: ${errors.toList.mkString(", ")}"
+
+  private def prettyPrintAssertion(assertion: Assertion): String = {
+    assertion match {
+      case ExpressionAssertion(expression) => s"Assertion expression: ${expression.expression}')"
+      case Assertion.PredicateAssertion(operator, expected, actual) =>
+        s"Assertion: '${operator.name}' , expected: ${expected.expression}, actual: ${actual.expression}"
+    }
+  }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
@@ -51,6 +51,7 @@ import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.graph.variable.Field
 import pl.touk.nussknacker.engine.spel.ExpressionSuggestion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, EnricherMock, TestCaseId, TestCaseName}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.engine.util.CaretPosition2d
 import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions
 import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions.SecuredEndpoint
@@ -248,14 +249,16 @@ class NodesApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseEndpoi
                       "test-case-1" -> NodeTestCase(
                         enricherMock = Some(EnricherMock(Expression.spel("42"))),
                         assertions = List(
-                          Assertion(Expression.spel("#TESTS.assertEquals(#contexts.size, 1)'")),
+                          ExpressionAssertion(Expression.spel("#TESTS.assertEquals(#contexts.size, 1)'")),
                         ),
                       ),
                       "test-case-2" -> NodeTestCase(
                         enricherMock = Some(EnricherMock(Expression.spel("'sample value'"))),
                         assertions = List(
-                          Assertion(Expression.spel("#TESTS.assertEquals(#contexts.size, 1)'")),
-                          Assertion(Expression.spel("#TESTS.assertEquals(#contexts[0].doesNotExist, 'expected')")),
+                          ExpressionAssertion(Expression.spel("#TESTS.assertEquals(#contexts.size, 1)'")),
+                          ExpressionAssertion(
+                            Expression.spel("#TESTS.assertEquals(#contexts[0].doesNotExist, 'expected')")
+                          ),
                         ),
                       )
                     )
@@ -1613,7 +1616,29 @@ object NodesApiEndpoints {
     )
 
     implicit val enricherMockSchema: Schema[EnricherMock] = Schema.derived
-    implicit val assertionSchema: Schema[Assertion]       = Schema.derived
+
+    implicit val expressionAssertionSchema: Schema[Assertion.ExpressionAssertion] =
+      Schema.derived[Assertion.ExpressionAssertion]
+    implicit val operatorAssertionSchema: Schema[Assertion.AssertionOperator] =
+      Schema.derivedEnumeration[Assertion.AssertionOperator](encode = Some(v => v.name))
+    implicit val predicateAssertionSchema: Schema[Assertion.PredicateAssertion] =
+      Schema.derived[Assertion.PredicateAssertion]
+
+    implicit val assertionSchema: Schema[Assertion] = {
+      Schema(
+        SchemaType.SCoproduct(
+          List(
+            expressionAssertionSchema.title("ExpressionAssertion"),
+            predicateAssertionSchema.title("PredicateAssertion")
+          ),
+          discriminator = None
+        ) {
+          case expr: Assertion.ExpressionAssertion => Some(SchemaWithValue(expressionAssertionSchema, expr))
+          case pred: Assertion.PredicateAssertion  => Some(SchemaWithValue(predicateAssertionSchema, pred))
+        },
+        Some(SName("Assertion"))
+      )
+    }
 
     implicit val enricherMockValidationErrorSchema: Schema[EnricherMockValidationError] =
       Schema.derived[EnricherMockValidationError]

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
@@ -51,7 +51,7 @@ import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.graph.variable.Field
 import pl.touk.nussknacker.engine.spel.ExpressionSuggestion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, EnricherMock, TestCaseId, TestCaseName}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion.{AssertionOperator, PredicateAssertion}
 import pl.touk.nussknacker.engine.util.CaretPosition2d
 import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions
 import pl.touk.nussknacker.restmodel.BaseEndpointDefinitions.SecuredEndpoint
@@ -249,15 +249,25 @@ class NodesApiEndpoints(auth: EndpointInput[AuthCredentials]) extends BaseEndpoi
                       "test-case-1" -> NodeTestCase(
                         enricherMock = Some(EnricherMock(Expression.spel("42"))),
                         assertions = List(
-                          ExpressionAssertion(Expression.spel("#TESTS.assertEquals(#contexts.size, 1)'")),
+                          PredicateAssertion(
+                            operator = AssertionOperator.Equals,
+                            actual = Expression.spel("#contexts.size"),
+                            expected = Expression.spel("1")
+                          ),
                         ),
                       ),
                       "test-case-2" -> NodeTestCase(
                         enricherMock = Some(EnricherMock(Expression.spel("'sample value'"))),
                         assertions = List(
-                          ExpressionAssertion(Expression.spel("#TESTS.assertEquals(#contexts.size, 1)'")),
-                          ExpressionAssertion(
-                            Expression.spel("#TESTS.assertEquals(#contexts[0].doesNotExist, 'expected')")
+                          PredicateAssertion(
+                            operator = AssertionOperator.Equals,
+                            actual = Expression.spel("#contexts.size"),
+                            expected = Expression.spel("1")
+                          ),
+                          PredicateAssertion(
+                            operator = AssertionOperator.Equals,
+                            actual = Expression.spel("#contexts[0].doesNotExist"),
+                            expected = Expression.spel("'expected'")
                           ),
                         ),
                       )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/description/NodesApiEndpoints.scala
@@ -1630,7 +1630,7 @@ object NodesApiEndpoints {
     implicit val expressionAssertionSchema: Schema[Assertion.ExpressionAssertion] =
       Schema.derived[Assertion.ExpressionAssertion]
     implicit val operatorAssertionSchema: Schema[Assertion.AssertionOperator] =
-      Schema.derivedEnumeration[Assertion.AssertionOperator](encode = Some(v => v.name))
+      Schema.derivedEnumeration[Assertion.AssertionOperator](encode = Some(v => v.entryName))
     implicit val predicateAssertionSchema: Schema[Assertion.PredicateAssertion] =
       Schema.derived[Assertion.PredicateAssertion]
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
@@ -28,7 +28,7 @@ import pl.touk.nussknacker.engine.definition.action.CommonModelDataInfoProvider
 import pl.touk.nussknacker.engine.definition.component.parameter.StandardParameterEnrichment
 import pl.touk.nussknacker.engine.graph.node
 import pl.touk.nussknacker.engine.graph.node.SourceNodeData
-import pl.touk.nussknacker.engine.test.testcase.{Assertion, EnricherMock, TestCase}
+import pl.touk.nussknacker.engine.test.testcase.{EnricherMock, TestCase}
 import pl.touk.nussknacker.engine.testmode.CommonTestDataFormatVariablesDecoder
 import pl.touk.nussknacker.engine.testmode.CommonTestDataFormatVariablesDecoder.TestRecordVariablesDecodingError
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
@@ -40,6 +40,7 @@ import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.TestSourceP
 import pl.touk.nussknacker.ui.process.deployment.ScenarioTestExecutorService
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService._
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.{
+  AssertionErrors,
   ExpressionsToTestDataConversionError,
   MockConfiguredForNotExistingNodesError,
   ScenarioValidationError
@@ -366,9 +367,9 @@ class ScenarioTestService(
     assertionCompiler
       .compile(test, nodesTyping, jobData)
       .fold(
-        errors => Left(errors.head),
+        errors => Left(AssertionErrors(errors)),
         Right(_)
-      ) // in case of performing test case we return errors in fail-fast fashion
+      )
   }
 
   def performTest(
@@ -633,17 +634,10 @@ object ScenarioTestService {
 
     final case class TestResultsSizeExceededError(approxSizeInBytes: Long, maxBytes: Long) extends PerformTestError
 
+    final case class AssertionErrors(errors: NonEmptyList[testcase.AssertionError]) extends PerformTestError
+
     final case class MockConfiguredForNotExistingNodesError(notExistingNodeIds: NonEmptyList[NodeId])
         extends PerformTestError
-
-    final case class AssertionConfiguredForNotExistingNodesError(notExistingNodeIds: NonEmptyList[NodeId])
-        extends PerformTestError
-
-    final case class AssertionExpressionCompilationError(
-        errors: NonEmptyList[ProcessCompilationError],
-        assertion: Assertion,
-        nodeId: NodeId
-    ) extends PerformTestError
 
     final case class ScenarioValidationError(errors: ValidationErrors) extends PerformTestError
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -1,7 +1,5 @@
 package pl.touk.nussknacker.ui.process.test.testcase
 
-import pl.touk.nussknacker.engine.api.{Documentation, HideToString, ParamName}
-
 import java.util
 import scala.jdk.CollectionConverters._
 
@@ -11,12 +9,9 @@ case object SuccessfulAssertion extends AssertionResult
 
 case class FailedAssertion(message: String) extends AssertionResult
 
-object tests extends TestsFunctions
+object AssertionResult {
 
-trait TestsFunctions extends HideToString {
-
-  @Documentation(description = "Check whether two values are equals")
-  def assertEquals(@ParamName("expected") expected: Any, @ParamName("actual") actual: Any): AssertionResult = {
+  def assertEquals(expected: Any, actual: Any): AssertionResult = {
     // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
     if (expected == actual) {
       SuccessfulAssertion

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -22,6 +22,17 @@ object AssertionResult {
     }
   }
 
+  def assertNotEquals(expected: Any, actual: Any): AssertionResult = {
+    // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
+    if (expected == actual) {
+      produceFailedNotEqualsAssertion(expected, actual)
+    } else if (checkIfSameElements(expected, actual)) {
+      produceFailedNotEqualsAssertion(expected, actual)
+    } else {
+      SuccessfulAssertion
+    }
+  }
+
   // todo: should it work recursively - e.g for arrays nested in lists?
   private def checkIfSameElements(expected: Any, actual: Any) = {
     if ((expected.isInstanceOf[Array[_]] || expected.isInstanceOf[util.Collection[_]]) &&
@@ -43,6 +54,12 @@ object AssertionResult {
     val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
     val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
     FailedAssertion(s"Expected: [$expectedStr] but found [$actualStr]")
+  }
+
+  private def produceFailedNotEqualsAssertion(expected: Any, actual: Any) = {
+    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
+    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
+    FailedAssertion(s"Expected value different from: [$expectedStr] but found [$actualStr]")
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -25,9 +25,9 @@ object AssertionResult {
   def assertNotEquals(expected: Any, actual: Any): AssertionResult = {
     // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
     if (expected == actual) {
-      produceFailedNotEqualsAssertion(expected, actual)
+      produceFailedNotEqualsAssertion(expected)
     } else if (checkIfSameElements(expected, actual)) {
-      produceFailedNotEqualsAssertion(expected, actual)
+      produceFailedNotEqualsAssertion(expected)
     } else {
       SuccessfulAssertion
     }
@@ -56,10 +56,9 @@ object AssertionResult {
     FailedAssertion(s"Expected: [$expectedStr] but found [$actualStr]")
   }
 
-  private def produceFailedNotEqualsAssertion(expected: Any, actual: Any) = {
+  private def produceFailedNotEqualsAssertion(expected: Any) = {
     val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
-    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
-    FailedAssertion(s"Expected value different from: [$expectedStr] but found [$actualStr]")
+    FailedAssertion(s"Expected value different from: [$expectedStr]")
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -1,0 +1,53 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import pl.touk.nussknacker.engine.api.{Documentation, HideToString, ParamName}
+
+import java.util
+import scala.jdk.CollectionConverters._
+
+sealed trait AssertionResult
+
+case object SuccessfulAssertion extends AssertionResult
+
+case class FailedAssertion(message: String) extends AssertionResult
+
+object tests extends TestsFunctions
+
+trait TestsFunctions extends HideToString {
+
+  @Documentation(description = "Check whether two values are equals")
+  def assertEquals(@ParamName("expected") expected: Any, @ParamName("actual") actual: Any): AssertionResult = {
+    // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
+    if (expected == actual) {
+      SuccessfulAssertion
+    } else if (checkIfSameElements(expected, actual)) {
+      SuccessfulAssertion
+    } else {
+      produceFailedAssertion(expected, actual)
+    }
+  }
+
+  // todo: should it work recursively - e.g for arrays nested in lists?
+  private def checkIfSameElements(expected: Any, actual: Any) = {
+    if ((expected.isInstanceOf[Array[_]] || expected.isInstanceOf[util.Collection[_]]) &&
+      (actual.isInstanceOf[Array[_]] || actual.isInstanceOf[util.Collection[_]])) {
+      convertToSeq(expected) == convertToSeq(actual)
+    } else {
+      false
+    }
+  }
+
+  private def convertToSeq(value: Any): Seq[_] = {
+    value match {
+      case a: Array[_]           => a.toSeq
+      case c: util.Collection[_] => c.asScala.toSeq
+    }
+  }
+
+  private def produceFailedAssertion(expected: Any, actual: Any) = {
+    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
+    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
+    FailedAssertion(s"Expected: [$expectedStr] but found [$actualStr]")
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -4,6 +4,7 @@ import pl.touk.nussknacker.engine.api.{Context, ContextId, JobData, NodeId}
 import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
+import pl.touk.nussknacker.ui.process.test.testcase.CompiledAssertion.CompiledExpressionAssertion
 
 import scala.jdk.CollectionConverters._
 
@@ -32,7 +33,11 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
       )
       .mapValuesNow(_.obj)
     try {
-      assertion.expression.evaluate[AssertionResult](context, globalVariables) match {
+      // TODO
+      assertion
+        .asInstanceOf[CompiledExpressionAssertion]
+        .expression
+        .evaluate[AssertionResult](context, globalVariables) match {
         case null                             => FailedAssertion("Assertion result can't be null")
         case assertionResult: AssertionResult => assertionResult
       }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -78,7 +78,8 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
     val expectedValue = expected.evaluate[Any](context, globalVariables)
     val actualValue   = actual.evaluate[Any](context, globalVariables)
     operator match {
-      case AssertionOperator.Equals => AssertionResult.assertEquals(expectedValue, actualValue)
+      case AssertionOperator.Equals    => AssertionResult.assertEquals(expectedValue, actualValue)
+      case AssertionOperator.NotEquals => AssertionResult.assertNotEquals(expectedValue, actualValue)
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -6,7 +6,10 @@ import pl.touk.nussknacker.engine.test.testcase.Assertion.AssertionOperator
 import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
-import pl.touk.nussknacker.ui.process.test.testcase.CompiledAssertion.CompiledExpressionAssertion
+import pl.touk.nussknacker.ui.process.test.testcase.CompiledAssertion.{
+  CompiledExpressionAssertion,
+  CompiledPredicateAssertion
+}
 
 import scala.jdk.CollectionConverters._
 
@@ -38,7 +41,7 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
       assertion match {
         case CompiledExpressionAssertion(expression) =>
           evaluateExpressionAssertion(expression, context, globalVariables)
-        case CompiledAssertion.CompiledPredicateAssertion(operator, expected, actual) =>
+        case CompiledPredicateAssertion(operator, expected, actual) =>
           evaluatePredicateAssertion(operator, expected, actual, context, globalVariables)
       }
     } catch {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -1,6 +1,8 @@
 package pl.touk.nussknacker.ui.process.test.testcase
 
 import pl.touk.nussknacker.engine.api.{Context, ContextId, JobData, NodeId}
+import pl.touk.nussknacker.engine.expression.parse.CompiledExpression
+import pl.touk.nussknacker.engine.test.testcase.Assertion.AssertionOperator
 import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
@@ -11,11 +13,11 @@ import scala.jdk.CollectionConverters._
 class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
 
   def verify(
-      testCase: CompiledAssertions,
+      compiledAssertions: CompiledAssertions,
       results: Map[NodeId, List[ResultContext[Any]]],
       jobData: JobData
   ): Map[NodeId, List[AssertionResult]] = {
-    testCase.assertions.map { case (nodeId, assertions) =>
+    compiledAssertions.assertions.map { case (nodeId, assertions) =>
       nodeId -> assertions.map(assertion => verifySingleAssertions(assertion, nodeId, results, jobData))
     }
   }
@@ -33,13 +35,11 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
       )
       .mapValuesNow(_.obj)
     try {
-      // TODO
-      assertion
-        .asInstanceOf[CompiledExpressionAssertion]
-        .expression
-        .evaluate[AssertionResult](context, globalVariables) match {
-        case null                             => FailedAssertion("Assertion result can't be null")
-        case assertionResult: AssertionResult => assertionResult
+      assertion match {
+        case CompiledExpressionAssertion(expression) =>
+          evaluateExpressionAssertion(expression, context, globalVariables)
+        case CompiledAssertion.CompiledPredicateAssertion(operator, expected, actual) =>
+          evaluatePredicateAssertion(operator, expected, actual, context, globalVariables)
       }
     } catch {
       case e: Exception => FailedAssertion(s"Exception during assertion evaluation: ${e.getMessage}")
@@ -55,6 +55,31 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
       .map(_.variables.asJava)
       .asJava
     Context(ContextId.dummy, Map(TestCaseVariables.ContextsNodeVariableName -> resultsForNode))
+  }
+
+  private def evaluateExpressionAssertion(
+      expression: CompiledExpression,
+      context: Context,
+      globalVariables: Map[String, Any]
+  ): AssertionResult = {
+    expression.evaluate[AssertionResult](context, globalVariables) match {
+      case null                             => FailedAssertion("Assertion result can't be null")
+      case assertionResult: AssertionResult => assertionResult
+    }
+  }
+
+  private def evaluatePredicateAssertion(
+      operator: AssertionOperator,
+      expected: CompiledExpression,
+      actual: CompiledExpression,
+      context: Context,
+      globalVariables: Map[String, Any]
+  ): AssertionResult = {
+    val expectedValue = expected.evaluate[Any](context, globalVariables)
+    val actualValue   = actual.evaluate[Any](context, globalVariables)
+    operator match {
+      case AssertionOperator.Equals => AssertionResult.assertEquals(expectedValue, actualValue)
+    }
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -5,6 +5,7 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.syntax.all._
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.compile.ExpressionCompiler
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
@@ -119,7 +120,7 @@ class AssertionsCompiler(
     val compiledExpected = expressionCompiler
       .compile(
         assertion.expected,
-        paramName = None,
+        Some(ParameterName("expected")),
         context,
         Unknown // For equals, we can assume any of type of expected and actual expressions are fine, but for >=, <, etc. we could also check if both types are comparable.
       )(nodeId)
@@ -130,7 +131,7 @@ class AssertionsCompiler(
     val compiledActual = expressionCompiler
       .compile(
         assertion.actual,
-        paramName = None,
+        Some(ParameterName("actual")),
         context,
         Unknown
       )(nodeId)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -1,24 +1,25 @@
 package pl.touk.nussknacker.ui.process.test.testcase
 
-import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.data.{NonEmptyList, ValidatedNel}
 import cats.data.Validated.{Invalid, Valid}
 import cats.syntax.all._
 import pl.touk.nussknacker.engine.api._
-import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, ValidationContext}
-import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
+import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
+import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.compile.ExpressionCompiler
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion.{ExpressionAssertion, PredicateAssertion}
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
-import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError
-import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.{
-  AssertionConfiguredForNotExistingNodesError,
-  AssertionExpressionCompilationError
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.{
+  ExpressionAssertionCompilationError,
+  PredicateAssertionCompilationError
 }
-
-import java.util
-import scala.jdk.CollectionConverters._
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionValidationError.AssertionConfiguredForNotExistingNodesError
+import pl.touk.nussknacker.ui.process.test.testcase.CompiledAssertion.{
+  CompiledExpressionAssertion,
+  CompiledPredicateAssertion
+}
 
 class AssertionsCompiler(
     expressionCompiler: ExpressionCompiler,
@@ -29,43 +30,36 @@ class AssertionsCompiler(
       testCase: TestCase,
       scenarioTypingResult: Map[String, NodeTypingData],
       jobData: JobData
-  ): ValidatedNel[PerformTestError, CompiledAssertions] = {
+  ): ValidatedNel[AssertionError, CompiledAssertions] = {
     testCase.assertions
       .map { case (node, assertions) =>
-        compileNodeAssertions(node, assertions, scenarioTypingResult, jobData).map(node -> _)
+        compileNodeAssertions(node, assertions, scenarioTypingResult, jobData)
+          .tupleLeft(node)
       }
       .toList
       .sequence
       .map(assertions => CompiledAssertions(assertions.toMap))
   }
 
-  def compileForNode(
-      nodeId: NodeId,
-      assertions: List[Assertion],
-      variableTypes: Map[String, TypingResult],
-      jobData: JobData
-  ): List[Validated[AssertionExpressionCompilationError, CompiledAssertion]] = {
-    compileEachNodeAssertion(nodeId, assertions, variableTypes, jobData)
-  }
-
+  // Returns all compiled assertions or combined compilation errors. It's used to compile test case before performing it.
   private def compileNodeAssertions(
       nodeId: NodeId,
       assertions: List[Assertion],
       nodesTyping: Map[String, NodeTypingData],
       jobData: JobData
-  ): ValidatedNel[PerformTestError, List[CompiledAssertion]] = {
+  ): ValidatedNel[AssertionError, List[CompiledAssertion]] = {
     validateTypingExistence(nodeId, nodesTyping).andThen { nodeTypingData =>
-      compileEachNodeAssertion(nodeId, assertions, nodeTypingData.variableTypes, jobData)
-        .traverse(_.toValidatedNel)
+      compileForNode(nodeId, assertions, nodeTypingData.variableTypes, jobData).sequence
     }
   }
 
-  private def compileEachNodeAssertion(
+  // For each assertion, returns compiled assertion or compilation errors. We need this, to return errors by assertion.
+  def compileForNode(
       nodeId: NodeId,
       assertions: List[Assertion],
       variableTypes: Map[String, TypingResult],
       jobData: JobData
-  ): List[Validated[AssertionExpressionCompilationError, CompiledAssertion]] = {
+  ): List[ValidatedNel[AssertionCompilationError, CompiledAssertion]] = {
     val ctx = TestCaseVariables.extendNodeVariablesValidationContext(
       globalVariablesPreparer.prepareValidationContextWithGlobalVariablesOnly(jobData),
       variableTypes
@@ -76,7 +70,7 @@ class AssertionsCompiler(
   private def validateTypingExistence(
       nodeId: NodeId,
       nodesTyping: Map[String, NodeTypingData],
-  ): Validated[NonEmptyList[PerformTestError], NodeTypingData] = {
+  ): ValidatedNel[AssertionError, NodeTypingData] = {
     nodesTyping
       .get(nodeId.id)
       .map(Valid(_))
@@ -87,71 +81,100 @@ class AssertionsCompiler(
       )
   }
 
-  private def compileAssertionExpression(nodeId: NodeId, context: ValidationContext, assertion: Assertion) = {
+  private def compileAssertionExpression(
+      nodeId: NodeId,
+      context: ValidationContext,
+      assertion: Assertion
+  ): ValidatedNel[AssertionCompilationError, CompiledAssertion] = {
+    assertion match {
+      case expressionAssertion: ExpressionAssertion =>
+        compileExpressionAssertion(nodeId, context, expressionAssertion)
+      case predicateAssertion: PredicateAssertion =>
+        compilePredicateAssertion(nodeId, context, predicateAssertion)
+    }
+  }
+
+  private def compileExpressionAssertion(
+      nodeId: NodeId,
+      context: ValidationContext,
+      assertion: ExpressionAssertion,
+  ): ValidatedNel[ExpressionAssertionCompilationError, CompiledExpressionAssertion] = {
     expressionCompiler
       .compile(
-        assertion.asInstanceOf[ExpressionAssertion].expression,
-        None,
+        assertion.expression,
+        paramName = None,
         context,
         Typed.typedClass(classOf[AssertionResult])
       )(nodeId)
-      .map(e => CompiledAssertion(e.expression))
-      .leftMap(mapExpressionCompilationErrors(_, assertion, nodeId))
+      .map(e => CompiledExpressionAssertion(e.expression))
+      .leftMap(ExpressionAssertionCompilationError(_, assertion, nodeId))
+      .toValidatedNel
   }
 
-  private def mapExpressionCompilationErrors(
-      errors: NonEmptyList[PartSubGraphCompilationError],
-      assertion: Assertion,
-      nodeId: NodeId
-  ) = {
-    AssertionExpressionCompilationError(errors, assertion, nodeId)
+  private def compilePredicateAssertion(
+      nodeId: NodeId,
+      context: ValidationContext,
+      assertion: PredicateAssertion
+  ): ValidatedNel[PredicateAssertionCompilationError, CompiledPredicateAssertion] = {
+    val compiledExpected = expressionCompiler
+      .compile(
+        assertion.expected,
+        paramName = None,
+        context,
+        Unknown // For equals, we can assume any of type of expected and actual expressions are fine, but for >=, <, etc. we could also check if both types are comparable.
+      )(nodeId)
+      .leftMap(
+        PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.ExpectedField, nodeId)
+      )
+      .toValidatedNel
+    val compiledActual = expressionCompiler
+      .compile(
+        assertion.actual,
+        paramName = None,
+        context,
+        Unknown
+      )(nodeId)
+      .leftMap(PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.ActualField, nodeId))
+      .toValidatedNel
+
+    (compiledExpected, compiledActual)
+      .mapN { (expected, actual) =>
+        CompiledPredicateAssertion(assertion.operator, expected.expression, actual.expression)
+      }
   }
 
 }
 
-sealed trait AssertionResult
+sealed trait AssertionError
 
-case object SuccessfulAssertion extends AssertionResult
+sealed trait AssertionValidationError extends AssertionError
 
-case class FailedAssertion(message: String) extends AssertionResult
+object AssertionValidationError {
+  final case class AssertionConfiguredForNotExistingNodesError(notExistingNodeIds: NonEmptyList[NodeId])
+      extends AssertionValidationError
+}
 
-object tests extends TestsFunctions
+sealed trait AssertionCompilationError extends AssertionError
 
-trait TestsFunctions extends HideToString {
+object AssertionCompilationError {
 
-  @Documentation(description = "Check whether two values are equals")
-  def assertEquals(@ParamName("expected") expected: Any, @ParamName("actual") actual: Any): AssertionResult = {
-    // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
-    if (expected == actual) {
-      SuccessfulAssertion
-    } else if (checkIfSameElements(expected, actual)) {
-      SuccessfulAssertion
-    } else {
-      produceFailedAssertion(expected, actual)
-    }
-  }
+  final case class ExpressionAssertionCompilationError(
+      errors: NonEmptyList[ProcessCompilationError],
+      assertion: ExpressionAssertion,
+      nodeId: NodeId
+  ) extends AssertionCompilationError
 
-  // todo: should it work recursively - e.g for arrays nested in lists?
-  private def checkIfSameElements(expected: Any, actual: Any) = {
-    if ((expected.isInstanceOf[Array[_]] || expected.isInstanceOf[util.Collection[_]]) &&
-      (actual.isInstanceOf[Array[_]] || actual.isInstanceOf[util.Collection[_]])) {
-      convertToSeq(expected) == convertToSeq(actual)
-    } else {
-      false
-    }
-  }
+  final case class PredicateAssertionCompilationError(
+      errors: NonEmptyList[ProcessCompilationError],
+      assertion: PredicateAssertion,
+      field: PredicateAssertionCompilationError.Field,
+      nodeId: NodeId,
+  ) extends AssertionCompilationError
 
-  private def convertToSeq(value: Any): Seq[_] = {
-    value match {
-      case a: Array[_]           => a.toSeq
-      case c: util.Collection[_] => c.asScala.toSeq
-    }
-  }
-
-  private def produceFailedAssertion(expected: Any, actual: Any) = {
-    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
-    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
-    FailedAssertion(s"Expected: [$expectedStr] but found [$actualStr]")
+  object PredicateAssertionCompilationError {
+    sealed trait Field
+    case object ExpectedField extends Field
+    case object ActualField   extends Field
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -33,9 +33,9 @@ class AssertionsCompiler(
       jobData: JobData
   ): ValidatedNel[AssertionError, CompiledAssertions] = {
     testCase.assertions
-      .map { case (node, assertions) =>
-        compileNodeAssertions(node, assertions, scenarioTypingResult, jobData)
-          .tupleLeft(node)
+      .map { case (nodeId, assertions) =>
+        compileNodeAssertions(assertions, scenarioTypingResult, jobData)(nodeId)
+          .tupleLeft(nodeId)
       }
       .toList
       .sequence
@@ -44,34 +44,31 @@ class AssertionsCompiler(
 
   // Returns all compiled assertions or combined compilation errors. It's used to compile test case before performing it.
   private def compileNodeAssertions(
-      nodeId: NodeId,
       assertions: List[Assertion],
       nodesTyping: Map[String, NodeTypingData],
       jobData: JobData
-  ): ValidatedNel[AssertionError, List[CompiledAssertion]] = {
-    validateTypingExistence(nodeId, nodesTyping).andThen { nodeTypingData =>
-      compileForNode(nodeId, assertions, nodeTypingData.variableTypes, jobData).sequence
+  )(implicit nodeId: NodeId): ValidatedNel[AssertionError, List[CompiledAssertion]] = {
+    validateTypingExistence(nodesTyping).andThen { nodeTypingData =>
+      compileForNode(assertions, nodeTypingData.variableTypes, jobData).sequence
     }
   }
 
   // For each assertion, returns compiled assertion or compilation errors. We need this, to return errors by assertion.
   def compileForNode(
-      nodeId: NodeId,
       assertions: List[Assertion],
       variableTypes: Map[String, TypingResult],
       jobData: JobData
-  ): List[ValidatedNel[AssertionCompilationError, CompiledAssertion]] = {
+  )(implicit nodeId: NodeId): List[ValidatedNel[AssertionCompilationError, CompiledAssertion]] = {
     val ctx = TestCaseVariables.extendNodeVariablesValidationContext(
       globalVariablesPreparer.prepareValidationContextWithGlobalVariablesOnly(jobData),
       variableTypes
     )
-    assertions.map(compileAssertion(nodeId, ctx, _))
+    assertions.map(compileAssertion(ctx, _))
   }
 
   private def validateTypingExistence(
-      nodeId: NodeId,
       nodesTyping: Map[String, NodeTypingData],
-  ): ValidatedNel[AssertionError, NodeTypingData] = {
+  )(implicit nodeId: NodeId): ValidatedNel[AssertionError, NodeTypingData] = {
     nodesTyping
       .get(nodeId.id)
       .map(Valid(_))
@@ -83,47 +80,44 @@ class AssertionsCompiler(
   }
 
   private def compileAssertion(
-      nodeId: NodeId,
       context: ValidationContext,
       assertion: Assertion
-  ): ValidatedNel[AssertionCompilationError, CompiledAssertion] = {
+  )(implicit nodeId: NodeId): ValidatedNel[AssertionCompilationError, CompiledAssertion] = {
     assertion match {
       case expressionAssertion: ExpressionAssertion =>
-        compileExpressionAssertion(nodeId, context, expressionAssertion)
+        compileExpressionAssertion(context, expressionAssertion)
       case predicateAssertion: PredicateAssertion =>
-        compilePredicateAssertion(nodeId, context, predicateAssertion)
+        compilePredicateAssertion(context, predicateAssertion)
     }
   }
 
   private def compileExpressionAssertion(
-      nodeId: NodeId,
       context: ValidationContext,
       assertion: ExpressionAssertion,
-  ): ValidatedNel[ExpressionAssertionCompilationError, CompiledExpressionAssertion] = {
+  )(implicit nodeId: NodeId): ValidatedNel[ExpressionAssertionCompilationError, CompiledExpressionAssertion] = {
     expressionCompiler
       .compile(
         assertion.expression,
         paramName = None,
         context,
         Typed.typedClass(classOf[AssertionResult])
-      )(nodeId)
+      )
       .map(e => CompiledExpressionAssertion(e.expression))
       .leftMap(ExpressionAssertionCompilationError(_, assertion, nodeId))
       .toValidatedNel
   }
 
   private def compilePredicateAssertion(
-      nodeId: NodeId,
       context: ValidationContext,
       assertion: PredicateAssertion
-  ): ValidatedNel[PredicateAssertionCompilationError, CompiledPredicateAssertion] = {
+  )(implicit nodeId: NodeId): ValidatedNel[PredicateAssertionCompilationError, CompiledPredicateAssertion] = {
     val compiledExpected = expressionCompiler
       .compile(
         assertion.expected,
         Some(ParameterName(PredicateAssertionCompilationError.ExpectedField.name)),
         context,
         Unknown // For equals, we can assume any of type of expected and actual expressions are fine, but for >=, <, etc. we could also check if both types are comparable.
-      )(nodeId)
+      )
       .leftMap(
         PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.ExpectedField, nodeId)
       )
@@ -134,7 +128,7 @@ class AssertionsCompiler(
         Some(ParameterName(PredicateAssertionCompilationError.ActualField.name)),
         context,
         Unknown
-      )(nodeId)
+      )
       .leftMap(PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.ActualField, nodeId))
       .toValidatedNel
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -116,22 +116,24 @@ class AssertionsCompiler(
     val compiledExpected = expressionCompiler
       .compile(
         assertion.expected,
-        Some(ParameterName(PredicateAssertionCompilationError.ExpectedField.entryName)),
+        Some(ParameterName(PredicateAssertionCompilationError.Field.Expected.entryName)),
         context,
         Unknown // For equals, we can assume any of type of expected and actual expressions are fine, but for >=, <, etc. we could also check if both types are comparable.
       )
       .leftMap(
-        PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.ExpectedField, nodeId)
+        PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.Field.Expected, nodeId)
       )
       .toValidatedNel
     val compiledActual = expressionCompiler
       .compile(
         assertion.actual,
-        Some(ParameterName(PredicateAssertionCompilationError.ActualField.entryName)),
+        Some(ParameterName(PredicateAssertionCompilationError.Field.Actual.entryName)),
         context,
         Unknown
       )
-      .leftMap(PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.ActualField, nodeId))
+      .leftMap(
+        PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.Field.Actual, nodeId)
+      )
       .toValidatedNel
 
     (compiledExpected, compiledActual)
@@ -173,11 +175,12 @@ object AssertionCompilationError {
     sealed trait Field extends EnumEntry with LowerCamelcase
 
     object Field extends Enum[Field] {
+      case object Expected extends Field
+      case object Actual   extends Field
+
       override def values: IndexedSeq[Field] = findValues
     }
 
-    case object ExpectedField extends Field
-    case object ActualField   extends Field
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -3,6 +3,8 @@ package pl.touk.nussknacker.ui.process.test.testcase
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.data.Validated.{Invalid, Valid}
 import cats.syntax.all._
+import enumeratum.{Enum, EnumEntry}
+import enumeratum.EnumEntry.LowerCamelcase
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
@@ -114,7 +116,7 @@ class AssertionsCompiler(
     val compiledExpected = expressionCompiler
       .compile(
         assertion.expected,
-        Some(ParameterName(PredicateAssertionCompilationError.ExpectedField.name)),
+        Some(ParameterName(PredicateAssertionCompilationError.ExpectedField.entryName)),
         context,
         Unknown // For equals, we can assume any of type of expected and actual expressions are fine, but for >=, <, etc. we could also check if both types are comparable.
       )
@@ -125,7 +127,7 @@ class AssertionsCompiler(
     val compiledActual = expressionCompiler
       .compile(
         assertion.actual,
-        Some(ParameterName(PredicateAssertionCompilationError.ActualField.name)),
+        Some(ParameterName(PredicateAssertionCompilationError.ActualField.entryName)),
         context,
         Unknown
       )
@@ -168,13 +170,10 @@ object AssertionCompilationError {
 
   object PredicateAssertionCompilationError {
 
-    sealed trait Field {
+    sealed trait Field extends EnumEntry with LowerCamelcase
 
-      val name: String = this match {
-        case ExpectedField => "expected"
-        case ActualField   => "actual"
-      }
-
+    object Field extends Enum[Field] {
+      override def values: IndexedSeq[Field] = findValues
     }
 
     case object ExpectedField extends Field

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -120,7 +120,7 @@ class AssertionsCompiler(
     val compiledExpected = expressionCompiler
       .compile(
         assertion.expected,
-        Some(ParameterName("expected")),
+        Some(ParameterName(PredicateAssertionCompilationError.ExpectedField.name)),
         context,
         Unknown // For equals, we can assume any of type of expected and actual expressions are fine, but for >=, <, etc. we could also check if both types are comparable.
       )(nodeId)
@@ -131,7 +131,7 @@ class AssertionsCompiler(
     val compiledActual = expressionCompiler
       .compile(
         assertion.actual,
-        Some(ParameterName("actual")),
+        Some(ParameterName(PredicateAssertionCompilationError.ActualField.name)),
         context,
         Unknown
       )(nodeId)
@@ -173,7 +173,16 @@ object AssertionCompilationError {
   ) extends AssertionCompilationError
 
   object PredicateAssertionCompilationError {
-    sealed trait Field
+
+    sealed trait Field {
+
+      val name: String = this match {
+        case ExpectedField => "expected"
+        case ActualField   => "actual"
+      }
+
+    }
+
     case object ExpectedField extends Field
     case object ActualField   extends Field
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -8,6 +8,7 @@ import pl.touk.nussknacker.engine.api.context.{PartSubGraphCompilationError, Val
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult}
 import pl.touk.nussknacker.engine.compile.ExpressionCompiler
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError
@@ -89,7 +90,7 @@ class AssertionsCompiler(
   private def compileAssertionExpression(nodeId: NodeId, context: ValidationContext, assertion: Assertion) = {
     expressionCompiler
       .compile(
-        assertion.expression,
+        assertion.asInstanceOf[ExpressionAssertion].expression,
         None,
         context,
         Typed.typedClass(classOf[AssertionResult])

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -65,7 +65,7 @@ class AssertionsCompiler(
       globalVariablesPreparer.prepareValidationContextWithGlobalVariablesOnly(jobData),
       variableTypes
     )
-    assertions.map(compileAssertionExpression(nodeId, ctx, _))
+    assertions.map(compileAssertion(nodeId, ctx, _))
   }
 
   private def validateTypingExistence(
@@ -82,7 +82,7 @@ class AssertionsCompiler(
       )
   }
 
-  private def compileAssertionExpression(
+  private def compileAssertion(
       nodeId: NodeId,
       context: ValidationContext,
       assertion: Assertion

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/CompiledAssertions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/CompiledAssertions.scala
@@ -2,7 +2,20 @@ package pl.touk.nussknacker.ui.process.test.testcase
 
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.expression.parse.CompiledExpression
+import pl.touk.nussknacker.engine.test.testcase.Assertion.AssertionOperator
 
 final case class CompiledAssertions(assertions: Map[NodeId, List[CompiledAssertion]])
 
-final case class CompiledAssertion(expression: CompiledExpression)
+sealed trait CompiledAssertion
+
+object CompiledAssertion {
+
+  final case class CompiledExpressionAssertion(expression: CompiledExpression) extends CompiledAssertion
+
+  final case class CompiledPredicateAssertion(
+      operator: AssertionOperator,
+      expected: CompiledExpression,
+      actual: CompiledExpression
+  ) extends CompiledAssertion
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/SpelValuePrettyPrinter.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/SpelValuePrettyPrinter.scala
@@ -7,12 +7,22 @@ object SpelValuePrettyPrinter {
 
   def prettyPrintValue(value: Any): String = {
     value match {
-      case array: Array[_]                         => array.map(prettyPrintValue).mkString("{", ", ", "}")
-      case map: java.util.Map[_, _] if map.isEmpty => "{:}"
+      case null =>
+        "null"
+      case s: String =>
+        s"'${s.replace("'", "''")}'"
+      case l: java.lang.Long =>
+        s"${l}L"
+      case array: Array[_] =>
+        array.map(prettyPrintValue).mkString("{", ", ", "}")
+      case map: java.util.Map[_, _] if map.isEmpty =>
+        "{:}"
       case map: java.util.Map[_, _] =>
         map.asScala.map { case (k, v) => prettyPrintValue(k) + ": " + prettyPrintValue(v) }.mkString("{", ", ", "}")
-      case collection: java.util.Collection[_] => collection.asScala.map(prettyPrintValue).mkString("{", ", ", "}")
-      case _                                   => Objects.toString(value)
+      case collection: java.util.Collection[_] =>
+        collection.asScala.map(prettyPrintValue).mkString("{", ", ", "}")
+      case _ =>
+        Objects.toString(value)
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestsFunctions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestsFunctions.scala
@@ -1,0 +1,14 @@
+package pl.touk.nussknacker.ui.process.test.testcase
+
+import pl.touk.nussknacker.engine.api.{Documentation, HideToString, ParamName}
+
+object tests extends TestsFunctions
+
+trait TestsFunctions extends HideToString {
+
+  @Documentation(description = "Check whether two values are equals")
+  def assertEquals(@ParamName("expected") expected: Any, @ParamName("actual") actual: Any): AssertionResult = {
+    AssertionResult.assertEquals(expected, actual)
+  }
+
+}

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestsFunctions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestsFunctions.scala
@@ -6,9 +6,14 @@ object tests extends TestsFunctions
 
 trait TestsFunctions extends HideToString {
 
-  @Documentation(description = "Check whether two values are equals")
+  @Documentation(description = "Check whether two values are equal")
   def assertEquals(@ParamName("expected") expected: Any, @ParamName("actual") actual: Any): AssertionResult = {
     AssertionResult.assertEquals(expected, actual)
+  }
+
+  @Documentation(description = "Check whether two values are not equal")
+  def assertNotEquals(@ParamName("expected") expected: Any, @ParamName("actual") actual: Any): AssertionResult = {
+    AssertionResult.assertNotEquals(expected, actual)
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
@@ -7,8 +7,8 @@ import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.test.testcase.Assertion
 import pl.touk.nussknacker.restmodel.validation.PrettyValidationErrors
 import pl.touk.nussknacker.restmodel.validation.testcase.{AssertionIndex, AssertionValidationError}
-import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.AssertionExpressionCompilationError
-import pl.touk.nussknacker.ui.process.test.testcase.AssertionsCompiler
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.{ExpressionAssertionCompilationError, PredicateAssertionCompilationError}
+import pl.touk.nussknacker.ui.process.test.testcase.{AssertionCompilationError, AssertionsCompiler}
 
 class AssertionValidator(
     assertionsCompiler: AssertionsCompiler
@@ -24,24 +24,40 @@ class AssertionValidator(
       None
     } else {
       val compilationResults = assertionsCompiler.compileForNode(nodeId, assertions, inputVariableTypes, jobData)
-      val errorsMap = compilationResults.zipWithIndex.collect { case (Invalid(error), index) =>
-        index -> convertToAssertionErrors(error)
+      val errorsMap = compilationResults.zipWithIndex.collect { case (Invalid(errors), index) =>
+        index -> convertToAssertionErrors(errors)
       }.toMap
       Some(errorsMap).filter(_.nonEmpty)
     }
   }
 
-  private def convertToAssertionErrors(
-      error: AssertionExpressionCompilationError
-  ): NonEmptyList[AssertionValidationError] = {
-    error.errors.map { compilationError =>
-      val prettyError = PrettyValidationErrors.formatErrorMessage(compilationError)
-      AssertionValidationError(
-        typ = prettyError.typ,
-        message = prettyError.message,
-        description = prettyError.description,
-        details = prettyError.details
-      )
+  private def convertToAssertionErrors(assertionErrors: NonEmptyList[AssertionCompilationError]): NonEmptyList[AssertionValidationError] = {
+    assertionErrors.flatMap {
+      case ExpressionAssertionCompilationError(errors, _, _) =>
+        errors.map { error =>
+          val prettyError = PrettyValidationErrors.formatErrorMessage(error)
+          AssertionValidationError(
+            typ = prettyError.typ,
+            message = prettyError.message,
+            description = prettyError.description,
+            details = prettyError.details,
+            fieldName = None,
+          )
+        }
+      case AssertionCompilationError.PredicateAssertionCompilationError(errors, _, field, _) =>
+        errors.map { error =>
+          val prettyError = PrettyValidationErrors.formatErrorMessage(error)
+          AssertionValidationError(
+            typ = prettyError.typ,
+            message = prettyError.message,
+            description = prettyError.description,
+            details = prettyError.details,
+            fieldName = Some(field match {
+              case PredicateAssertionCompilationError.ExpectedField => "expected"
+              case PredicateAssertionCompilationError.ActualField   => "actual"
+            })
+          )
+        }
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
@@ -7,10 +7,10 @@ import pl.touk.nussknacker.engine.api.typed.typing.TypingResult
 import pl.touk.nussknacker.engine.test.testcase.Assertion
 import pl.touk.nussknacker.restmodel.validation.PrettyValidationErrors
 import pl.touk.nussknacker.restmodel.validation.testcase.{AssertionIndex, AssertionValidationError}
-import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.{ExpressionAssertionCompilationError, PredicateAssertionCompilationError}
 import pl.touk.nussknacker.ui.process.test.testcase.{AssertionCompilationError, AssertionsCompiler}
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.ExpressionAssertionCompilationError
 
-class AssertionValidator(
+private class AssertionValidator(
     assertionsCompiler: AssertionsCompiler
 ) {
 
@@ -31,7 +31,9 @@ class AssertionValidator(
     }
   }
 
-  private def convertToAssertionErrors(assertionErrors: NonEmptyList[AssertionCompilationError]): NonEmptyList[AssertionValidationError] = {
+  private def convertToAssertionErrors(
+      assertionErrors: NonEmptyList[AssertionCompilationError]
+  ): NonEmptyList[AssertionValidationError] = {
     assertionErrors.flatMap {
       case ExpressionAssertionCompilationError(errors, _, _) =>
         errors.map { error =>

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
@@ -15,15 +15,14 @@ private class AssertionValidator(
 ) {
 
   def validate(
-      nodeId: NodeId,
       assertions: List[Assertion],
       inputVariableTypes: Map[String, TypingResult],
       jobData: JobData
-  ): Option[Map[AssertionIndex, NonEmptyList[AssertionValidationError]]] = {
+  )(implicit nodeId: NodeId): Option[Map[AssertionIndex, NonEmptyList[AssertionValidationError]]] = {
     if (assertions.isEmpty) {
       None
     } else {
-      val compilationResults = assertionsCompiler.compileForNode(nodeId, assertions, inputVariableTypes, jobData)
+      val compilationResults = assertionsCompiler.compileForNode(assertions, inputVariableTypes, jobData)
       val errorsMap = compilationResults.zipWithIndex.collect { case (Invalid(errors), index) =>
         index -> convertToAssertionErrors(errors)
       }.toMap

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
@@ -52,10 +52,7 @@ class AssertionValidator(
             message = prettyError.message,
             description = prettyError.description,
             details = prettyError.details,
-            fieldName = Some(field match {
-              case PredicateAssertionCompilationError.ExpectedField => "expected"
-              case PredicateAssertionCompilationError.ActualField   => "actual"
-            })
+            fieldName = Some(field.name),
           )
         }
     }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
@@ -53,7 +53,7 @@ private class AssertionValidator(
             message = prettyError.message,
             description = prettyError.description,
             details = prettyError.details,
-            fieldName = Some(field.name),
+            fieldName = Some(field.entryName),
           )
         }
     }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/TestCaseValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/TestCaseValidator.scala
@@ -80,11 +80,10 @@ class TestCaseValidator(
       nodeTyping
     )
     val assertionsErrors = assertionValidator.validate(
-      NodeId(nodeData.id),
       nodeTestCase.assertions,
       nodeTyping.inputVariables,
       scenarioCompilationDependencies.jobData
-    )
+    )(NodeId(nodeData.id))
 
     (enricherMockErrors, assertionsErrors) match {
       case (None, None) => Right(())

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ExpressionSuggesterSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ExpressionSuggesterSpec.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.ui.api
 
 import org.apache.avro.generic.GenericData.EnumSymbol
-import org.scalatest.Inside
+import org.scalatest.{Inside, Inspectors}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -81,7 +81,8 @@ class ExpressionSuggesterSpec
     with Matchers
     with PatientScalaFutures
     with TableDrivenPropertyChecks
-    with Inside {
+    with Inside
+    with Inspectors {
   private val classDefinitionExtractor = ClassDefinitionTestUtils.DefaultExtractor
 
   private val dictRegistry = new SimpleDictRegistry(
@@ -970,9 +971,9 @@ class ExpressionSuggesterSpec
     )
     testCaseSuggestions(Expression.spel("#contexts[0].varS")) shouldBe List(suggestion("varString", Typed[String]))
     testCaseSuggestions(Expression.spel("#TEST")) shouldBe List(suggestion("#TESTS", testsVariableType))
-    inside(testCaseSuggestions(Expression.spel("#TESTS.as"))) {
-      case ExpressionSuggestion("assertEquals", typingResult, _, _, _) :: Nil =>
-        typingResult shouldBe Typed[testcase.AssertionResult]
+    forAll(testCaseSuggestions(Expression.spel("#TESTS.as"))) { suggestion =>
+      suggestion.methodName should startWith("assert")
+      suggestion.refClazz shouldBe Typed[testcase.AssertionResult]
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -19,6 +19,7 @@ import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.kafka.KafkaFactory
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, EnricherMock, TestCase, TestCases}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.restmodel.DeployRequest
 import pl.touk.nussknacker.restmodel.scenariodetails._
 import pl.touk.nussknacker.security.Permission
@@ -456,8 +457,8 @@ class ManagementResourcesSpec
       ),
       assertions = Map(
         NodeId("endsuffix") -> List(
-          Assertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
-          Assertion("#TESTS.assertEquals('ala', #contexts[1].input[0])".spel),
+          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
+          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[1].input[0])".spel),
         )
       )
     )
@@ -486,13 +487,13 @@ class ManagementResourcesSpec
       Map.empty,
       Map(
         NodeId("endsuffix") -> List(
-          Assertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
-          Assertion("#TESTS.assertEquals('ala', #contexts[1].input[0])".spel),
+          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
+          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[1].input[0])".spel),
           // The output variable produced by the messagesuffix node is not visible at that node, but rather at the subsequent one (endsuffix).
-          Assertion("#TESTS.assertEquals({message: 'message'}, #contexts[0].output)".spel),
+          ExpressionAssertion("#TESTS.assertEquals({message: 'message'}, #contexts[0].output)".spel),
         ),
         NodeId("messagesuffix") -> List(
-          Assertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
+          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
         )
       )
     )
@@ -568,7 +569,7 @@ class ManagementResourcesSpec
       ),
       assertions = Map(
         NodeId("endsuffix") -> List(
-          Assertion("#TESTS.assertEquals('b', #contexts[0].out1)".spel),
+          ExpressionAssertion("#TESTS.assertEquals('b', #contexts[0].out1)".spel),
         )
       )
     )
@@ -600,7 +601,7 @@ class ManagementResourcesSpec
       mocks = Map.empty,
       assertions = Map(
         NodeId("someNotExistingNode") -> List(
-          Assertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
+          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
         )
       )
     )
@@ -648,7 +649,7 @@ class ManagementResourcesSpec
       Map(
         NodeId("messagesuffix") -> List(
           // The output variable produced by the messagesuffix node is not visible at that node, but rather at the subsequent one.
-          Assertion("#TESTS.assertEquals({message: 'message'}, #contexts[0].output)".spel),
+          ExpressionAssertion("#TESTS.assertEquals({message: 'message'}, #contexts[0].output)".spel),
         )
       )
     )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -19,7 +19,7 @@ import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.kafka.KafkaFactory
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, EnricherMock, TestCase, TestCases}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion.PredicateAssertion
 import pl.touk.nussknacker.restmodel.DeployRequest
 import pl.touk.nussknacker.restmodel.scenariodetails._
 import pl.touk.nussknacker.security.Permission
@@ -457,8 +457,8 @@ class ManagementResourcesSpec
       ),
       assertions = Map(
         NodeId("endsuffix") -> List(
-          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
-          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[1].input[0])".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'ala'".spel, "#contexts[0].input[0]".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'ala'".spel, "#contexts[1].input[0]".spel),
         )
       )
     )
@@ -487,13 +487,17 @@ class ManagementResourcesSpec
       Map.empty,
       Map(
         NodeId("endsuffix") -> List(
-          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
-          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[1].input[0])".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'ala'".spel, "#contexts[0].input[0]".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'ala'".spel, "#contexts[1].input[0]".spel),
           // The output variable produced by the messagesuffix node is not visible at that node, but rather at the subsequent one (endsuffix).
-          ExpressionAssertion("#TESTS.assertEquals({message: 'message'}, #contexts[0].output)".spel),
+          PredicateAssertion(
+            Assertion.AssertionOperator.Equals,
+            "{message: 'message'}".spel,
+            "#contexts[0].output".spel
+          ),
         ),
         NodeId("messagesuffix") -> List(
-          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'ala'".spel, "#contexts[0].input[0]".spel),
         )
       )
     )
@@ -569,7 +573,7 @@ class ManagementResourcesSpec
       ),
       assertions = Map(
         NodeId("endsuffix") -> List(
-          ExpressionAssertion("#TESTS.assertEquals('b', #contexts[0].out1)".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'b'".spel, "#contexts[0].out1".spel),
         )
       )
     )
@@ -601,7 +605,7 @@ class ManagementResourcesSpec
       mocks = Map.empty,
       assertions = Map(
         NodeId("someNotExistingNode") -> List(
-          ExpressionAssertion("#TESTS.assertEquals('ala', #contexts[0].input[0])".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'ala'".spel, "#contexts[0].input[0]".spel),
         )
       )
     )
@@ -649,7 +653,11 @@ class ManagementResourcesSpec
       Map(
         NodeId("messagesuffix") -> List(
           // The output variable produced by the messagesuffix node is not visible at that node, but rather at the subsequent one.
-          ExpressionAssertion("#TESTS.assertEquals({message: 'message'}, #contexts[0].output)".spel),
+          PredicateAssertion(
+            Assertion.AssertionOperator.Equals,
+            "{message: 'message'}".spel,
+            "#contexts[0].output".spel
+          ),
         )
       )
     )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementResourcesSpec.scala
@@ -519,7 +519,7 @@ class ManagementResourcesSpec
         .focus shouldBe Some(
         Json.obj(
           "type"    -> Json.fromString("FailedAssertion"),
-          "message" -> Json.fromString("Expected: [ala] but found [bela]")
+          "message" -> Json.fromString("Expected: ['ala'] but found ['bela']")
         )
       )
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceBusinessSpec.scala
@@ -1603,7 +1603,7 @@ class NodesApiHttpServiceBusinessSpec
             |    }
             |  }
             |}
-            |""".stripMargin
+         cccc   |""".stripMargin
         )
         .when()
         .post(s"$nuDesignerHttpAddress/api/parameters/streaming/testCase/additionalVariables")

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceBusinessSpec.scala
@@ -920,7 +920,7 @@ class NodesApiHttpServiceBusinessSpec
              |          },
              |          "expected": {
              |            "language": "spel",
-             |            "expression": "'value'"
+             |            "expression": "missing quotes"
              |          }
              |        }
              |      ]
@@ -981,6 +981,23 @@ class NodesApiHttpServiceBusinessSpec
             |          }
             |        ],
             |        "2": [
+            |          {
+            |            "typ": "ExpressionParserCompilationError",
+            |            "message": "Unexpected text",
+            |            "description": "There is problem with expression in field [expected] - it could not be parsed.",
+            |            "details": {
+            |              "start": {
+            |                "column": 8,
+            |                "row": 0
+            |              },
+            |              "end": {
+            |                "column": 9,
+            |                "row": 0
+            |              },
+            |              "type": "CoordinatesBasedTextRange"
+            |            },
+            |            "fieldName": "expected"
+            |          },
             |          {
             |            "typ": "ExpressionParserCompilationError",
             |            "message": "There is no property 'doesNotExist2' in type: Record{input: String}",

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/NodesApiHttpServiceBusinessSpec.scala
@@ -620,9 +620,14 @@ class NodesApiHttpServiceBusinessSpec
              |    "test-case-1": {
              |      "assertions": [
              |        {
-             |          "expression": {
+             |          "operator": "equals",
+             |          "actual": {
              |            "language": "spel",
-             |            "expression": "#TESTS.assertEquals(#contexts.size, 5)"
+             |            "expression": "#contexts.size"
+             |          },
+             |          "expected": {
+             |            "language": "spel",
+             |            "expression": "5"
              |          }
              |        }
              |      ]
@@ -845,15 +850,25 @@ class NodesApiHttpServiceBusinessSpec
              |      },
              |      "assertions": [
              |        {
-             |          "expression": {
+             |          "operator": "equals",
+             |          "actual": {
              |            "language": "spel",
-             |            "expression": "#TESTS.assertEquals(#contexts.size, 5)"
+             |            "expression": "#contexts.size"
+             |          },
+             |          "expected": {
+             |            "language": "spel",
+             |            "expression": "5"
              |          }
              |        },
              |        {
-             |          "expression": {
+             |          "operator": "equals",
+             |          "actual": {
              |            "language": "spel",
-             |            "expression": "#TESTS.assertEquals(#contexts[0].input, 'value')"
+             |            "expression": "#contexts[0].input"
+             |          },
+             |          "expected": {
+             |            "language": "spel",
+             |            "expression": "'value'"
              |          }
              |        }
              |      ]
@@ -876,21 +891,36 @@ class NodesApiHttpServiceBusinessSpec
              |      },
              |      "assertions": [
              |        {
-             |          "expression": {
+             |          "operator": "equals",
+             |          "actual": {
              |            "language": "spel",
-             |            "expression": "#TESTS.assertEquals(#contexts[0].doesNotExist, 'value')"
+             |            "expression": "#contexts[0].doesNotExist"
+             |          },
+             |          "expected": {
+             |            "language": "spel",
+             |            "expression": "'value'"
              |          }
              |        },
              |        {
-             |          "expression": {
+             |          "operator": "equals",
+             |          "actual": {
              |            "language": "spel",
-             |            "expression": "#TESTS.assertEquals(#contexts.size, 1)"
+             |            "expression": "#contexts.size"
+             |          },
+             |          "expected": {
+             |            "language": "spel",
+             |            "expression": "1"
              |          }
              |        },
              |        {
-             |          "expression": {
+             |          "operator": "equals",
+             |          "actual": {
              |            "language": "spel",
-             |            "expression": "#TESTS.assertEquals(#contexts[0].doesNotExist, 'value')"
+             |            "expression": "#contexts[0].doesNotExist2"
+             |          },
+             |          "expected": {
+             |            "language": "spel",
+             |            "expression": "'value'"
              |          }
              |        }
              |      ]
@@ -935,36 +965,38 @@ class NodesApiHttpServiceBusinessSpec
             |          {
             |            "typ": "ExpressionParserCompilationError",
             |            "message": "There is no property 'doesNotExist' in type: Record{input: String}",
-            |            "description": "There is problem with expression in field [<missing>] - it could not be parsed.",
+            |            "description": "There is problem with expression in field [actual] - it could not be parsed.",
             |            "details": {
             |              "start": {
-            |                "column": 33,
+            |                "column": 13,
             |                "row": 0
             |              },
             |              "end": {
-            |                "column": 45,
+            |                "column": 25,
             |                "row": 0
             |              },
             |              "type": "CoordinatesBasedTextRange"
-            |            }
+            |            },
+            |            "fieldName": "actual"
             |          }
             |        ],
             |        "2": [
             |          {
             |            "typ": "ExpressionParserCompilationError",
-            |            "message": "There is no property 'doesNotExist' in type: Record{input: String}",
-            |            "description": "There is problem with expression in field [<missing>] - it could not be parsed.",
+            |            "message": "There is no property 'doesNotExist2' in type: Record{input: String}",
+            |            "description": "There is problem with expression in field [actual] - it could not be parsed.",
             |            "details": {
             |              "start": {
-            |                "column": 33,
+            |                "column": 13,
             |                "row": 0
             |              },
             |              "end": {
-            |                "column": 45,
+            |                "column": 26,
             |                "row": 0
             |              },
             |              "type": "CoordinatesBasedTextRange"
-            |            }
+            |            },
+            |            "fieldName": "actual"
             |          }
             |        ]
             |      }
@@ -1603,7 +1635,7 @@ class NodesApiHttpServiceBusinessSpec
             |    }
             |  }
             |}
-         cccc   |""".stripMargin
+            |""".stripMargin
         )
         .when()
         .post(s"$nuDesignerHttpAddress/api/parameters/streaming/testCase/additionalVariables")

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
@@ -357,10 +357,11 @@ class ValidationResourcesSpec
               Map(
                 1 -> NonEmptyList.one(
                   AssertionValidationError(
-                    "ExpressionParserCompilationError",
-                    "There is no property 'doesNotExist' in type: Record{input: Unknown}",
-                    "There is problem with expression in field [<missing>] - it could not be parsed.",
-                    Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0)))
+                    typ = "ExpressionParserCompilationError",
+                    message = "There is no property 'doesNotExist' in type: Record{input: Unknown}",
+                    description = "There is problem with expression in field [<missing>] - it could not be parsed.",
+                    details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0))),
+                    fieldName = None,
                   )
                 )
               )
@@ -372,10 +373,10 @@ class ValidationResourcesSpec
             enricherMockErrors = Some(
               NonEmptyList.one(
                 EnricherMockValidationError(
-                  "MockForNonEnricherNode",
-                  "Mock configured for non-enricher node 'sink'",
-                  "Mocks can only be configured for enricher nodes",
-                  None
+                  typ = "MockForNonEnricherNode",
+                  message = "Mock configured for non-enricher node 'sink'",
+                  description = "Mocks can only be configured for enricher nodes",
+                  details = None,
                 )
               )
             ),
@@ -383,18 +384,20 @@ class ValidationResourcesSpec
               Map(
                 0 -> NonEmptyList.one(
                   AssertionValidationError(
-                    "ExpressionParserCompilationError",
-                    "There is no property 'doesNotExist2' in type: Record{input: Unknown, output: String}",
-                    "There is problem with expression in field [<missing>] - it could not be parsed.",
-                    Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(46, 0)))
+                    typ = "ExpressionParserCompilationError",
+                    message = "There is no property 'doesNotExist2' in type: Record{input: Unknown, output: String}",
+                    description = "There is problem with expression in field [<missing>] - it could not be parsed.",
+                    details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(46, 0))),
+                    fieldName = None,
                   )
                 ),
                 2 -> NonEmptyList.one(
                   AssertionValidationError(
-                    "ExpressionParserCompilationError",
-                    "There is no property 'doesNotExist3' in type: Record{input: Unknown, output: String}",
-                    "There is problem with expression in field [<missing>] - it could not be parsed.",
-                    Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(46, 0)))
+                    typ = "ExpressionParserCompilationError",
+                    message = "There is no property 'doesNotExist3' in type: Record{input: Unknown, output: String}",
+                    description = "There is problem with expression in field [<missing>] - it could not be parsed.",
+                    details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(46, 0))),
+                    fieldName = None,
                   )
                 )
               )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
@@ -27,7 +27,7 @@ import pl.touk.nussknacker.engine.graph.sink.SinkRef
 import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.test.testcase._
-import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion.{AssertionOperator, PredicateAssertion}
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationResult
 import pl.touk.nussknacker.restmodel.validation.testcase.{
   AssertionValidationError,
@@ -273,11 +273,23 @@ class ValidationResourcesSpec
               ),
               assertions = Map(
                 NodeId("enricher") -> List(
-                  ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 3)".spel),
-                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'abc')".spel),
+                  PredicateAssertion(
+                    operator = AssertionOperator.Equals,
+                    actual = "#contexts.size".spel,
+                    expected = "3".spel
+                  ),
+                  PredicateAssertion(
+                    operator = AssertionOperator.Equals,
+                    actual = "#contexts[0].input".spel,
+                    expected = "'abc'".spel
+                  ),
                 ),
                 NodeId("sink") -> List(
-                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].output, 'def')".spel),
+                  PredicateAssertion(
+                    operator = AssertionOperator.Equals,
+                    actual = "#contexts[0].output".spel,
+                    expected = "'def'".spel
+                  ),
                 )
               )
             )
@@ -317,14 +329,38 @@ class ValidationResourcesSpec
               ),
               assertions = Map(
                 NodeId("enricher") -> List(
-                  ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 3)".spel),
-                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 'abc')".spel),
-                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'abc')".spel),
+                  PredicateAssertion(
+                    operator = AssertionOperator.Equals,
+                    actual = "#contexts.size".spel,
+                    expected = "3".spel
+                  ),
+                  PredicateAssertion(
+                    operator = AssertionOperator.Equals,
+                    actual = "#contexts[0].doesNotExist".spel,
+                    expected = "'abc'".spel
+                  ),
+                  PredicateAssertion(
+                    operator = AssertionOperator.Equals,
+                    actual = "#contexts[0].input".spel,
+                    expected = "'abc'".spel
+                  ),
                 ),
                 NodeId("sink") -> List(
-                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist2, 'def')".spel),
-                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].output, 'def')".spel),
-                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist3, 'ghi')".spel),
+                  PredicateAssertion(
+                    operator = AssertionOperator.Equals,
+                    actual = "#contexts[0].doesNotExist2".spel,
+                    expected = "'def'".spel
+                  ),
+                  PredicateAssertion(
+                    operator = AssertionOperator.Equals,
+                    actual = "#contexts[0].output".spel,
+                    expected = "'def'".spel
+                  ),
+                  PredicateAssertion(
+                    operator = AssertionOperator.Equals,
+                    actual = "#contexts[0].doesNotExist3".spel,
+                    expected = "'ghi'".spel
+                  ),
                 )
               )
             )
@@ -359,9 +395,9 @@ class ValidationResourcesSpec
                   AssertionValidationError(
                     typ = "ExpressionParserCompilationError",
                     message = "There is no property 'doesNotExist' in type: Record{input: Unknown}",
-                    description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                    details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0))),
-                    fieldName = None,
+                    description = "There is problem with expression in field [actual] - it could not be parsed.",
+                    details = Some(CoordinatesBasedTextRange(TextCoordinates(13, 0), TextCoordinates(25, 0))),
+                    fieldName = Some("actual"),
                   )
                 )
               )
@@ -386,18 +422,18 @@ class ValidationResourcesSpec
                   AssertionValidationError(
                     typ = "ExpressionParserCompilationError",
                     message = "There is no property 'doesNotExist2' in type: Record{input: Unknown, output: String}",
-                    description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                    details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(46, 0))),
-                    fieldName = None,
+                    description = "There is problem with expression in field [actual] - it could not be parsed.",
+                    details = Some(CoordinatesBasedTextRange(TextCoordinates(13, 0), TextCoordinates(26, 0))),
+                    fieldName = Some("actual"),
                   )
                 ),
                 2 -> NonEmptyList.one(
                   AssertionValidationError(
                     typ = "ExpressionParserCompilationError",
                     message = "There is no property 'doesNotExist3' in type: Record{input: Unknown, output: String}",
-                    description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                    details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(46, 0))),
-                    fieldName = None,
+                    description = "There is problem with expression in field [actual] - it could not be parsed.",
+                    details = Some(CoordinatesBasedTextRange(TextCoordinates(13, 0), TextCoordinates(26, 0))),
+                    fieldName = Some("actual"),
                   )
                 )
               )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ValidationResourcesSpec.scala
@@ -27,6 +27,7 @@ import pl.touk.nussknacker.engine.graph.sink.SinkRef
 import pl.touk.nussknacker.engine.graph.source.SourceRef
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.test.testcase._
+import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationResult
 import pl.touk.nussknacker.restmodel.validation.testcase.{
   AssertionValidationError,
@@ -272,11 +273,11 @@ class ValidationResourcesSpec
               ),
               assertions = Map(
                 NodeId("enricher") -> List(
-                  Assertion("#TESTS.assertEquals(#contexts.size, 3)".spel),
-                  Assertion("#TESTS.assertEquals(#contexts[0].input, 'abc')".spel),
+                  ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 3)".spel),
+                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'abc')".spel),
                 ),
                 NodeId("sink") -> List(
-                  Assertion("#TESTS.assertEquals(#contexts[0].output, 'def')".spel),
+                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].output, 'def')".spel),
                 )
               )
             )
@@ -316,14 +317,14 @@ class ValidationResourcesSpec
               ),
               assertions = Map(
                 NodeId("enricher") -> List(
-                  Assertion("#TESTS.assertEquals(#contexts.size, 3)".spel),
-                  Assertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 'abc')".spel),
-                  Assertion("#TESTS.assertEquals(#contexts[0].input, 'abc')".spel),
+                  ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 3)".spel),
+                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 'abc')".spel),
+                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'abc')".spel),
                 ),
                 NodeId("sink") -> List(
-                  Assertion("#TESTS.assertEquals(#contexts[0].doesNotExist2, 'def')".spel),
-                  Assertion("#TESTS.assertEquals(#contexts[0].output, 'def')".spel),
-                  Assertion("#TESTS.assertEquals(#contexts[0].doesNotExist3, 'ghi')".spel),
+                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist2, 'def')".spel),
+                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].output, 'def')".spel),
+                  ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist3, 'ghi')".spel),
                 )
               )
             )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
@@ -22,7 +22,7 @@ import pl.touk.nussknacker.engine.compile.validationHelpers._
 import pl.touk.nussknacker.engine.dict.{ProcessDictSubstitutor, SimpleDictRegistry}
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion.PredicateAssertion
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.testmode.TestProcess
 import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
@@ -797,8 +797,12 @@ class ScenarioTestServiceSpec
       Map.empty,
       Map(
         NodeId("end") -> List(
-          ExpressionAssertion("#TESTS.assertEquals(#contexts[0].otherNameThanInput.a, 'foo')".spel),
-          ExpressionAssertion("#TESTS.assertEquals(#contexts[1].otherNameThanInput.a, 'foo')".spel)
+          PredicateAssertion(
+            Assertion.AssertionOperator.Equals,
+            "#contexts[0].otherNameThanInput.a".spel,
+            "'foo'".spel
+          ),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "#contexts[1].otherNameThanInput.a".spel, "'foo'".spel)
         )
       )
     )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
@@ -799,10 +799,10 @@ class ScenarioTestServiceSpec
         NodeId("end") -> List(
           PredicateAssertion(
             Assertion.AssertionOperator.Equals,
-            "#contexts[0].otherNameThanInput.a".spel,
-            "'foo'".spel
+            "'foo'".spel,
+            "#contexts[0].otherNameThanInput.a".spel
           ),
-          PredicateAssertion(Assertion.AssertionOperator.Equals, "#contexts[1].otherNameThanInput.a".spel, "'foo'".spel)
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'foo'".spel, "#contexts[1].otherNameThanInput.a".spel)
         )
       )
     )
@@ -821,7 +821,7 @@ class ScenarioTestServiceSpec
 
     result.assertionsResults(NodeId("end")) shouldBe List(
       SuccessfulAssertion,
-      FailedAssertion("Expected: ['bar'] but found ['foo']")
+      FailedAssertion("Expected: ['foo'] but found ['bar']")
     )
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
@@ -22,6 +22,7 @@ import pl.touk.nussknacker.engine.compile.validationHelpers._
 import pl.touk.nussknacker.engine.dict.{ProcessDictSubstitutor, SimpleDictRegistry}
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.engine.testmode.TestProcess
 import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
@@ -796,8 +797,8 @@ class ScenarioTestServiceSpec
       Map.empty,
       Map(
         NodeId("end") -> List(
-          Assertion("#TESTS.assertEquals(#contexts[0].otherNameThanInput.a, 'foo')".spel),
-          Assertion("#TESTS.assertEquals(#contexts[1].otherNameThanInput.a, 'foo')".spel)
+          ExpressionAssertion("#TESTS.assertEquals(#contexts[0].otherNameThanInput.a, 'foo')".spel),
+          ExpressionAssertion("#TESTS.assertEquals(#contexts[1].otherNameThanInput.a, 'foo')".spel)
         )
       )
     )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
@@ -821,7 +821,7 @@ class ScenarioTestServiceSpec
 
     result.assertionsResults(NodeId("end")) shouldBe List(
       SuccessfulAssertion,
-      FailedAssertion("Expected: [bar] but found [foo]")
+      FailedAssertion("Expected: ['bar'] but found ['foo']")
     )
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -99,10 +99,10 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
     results.toList shouldBe List(
       NodeId("someNode") -> List(
         SuccessfulAssertion,
-        FailedAssertion("Expected: [valid] but found [invalid]"),
+        FailedAssertion("Expected: ['valid'] but found ['invalid']"),
         SuccessfulAssertion,
-        FailedAssertion("Expected: [valid] but found [invalid]"),
-        FailedAssertion("Expected value different from: [valid]"),
+        FailedAssertion("Expected: ['valid'] but found ['invalid']"),
+        FailedAssertion("Expected value different from: ['valid']"),
         SuccessfulAssertion,
       )
     )
@@ -121,11 +121,15 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
         ("{'foo': 'bar'}", "{'foo': 'bar'}", SuccessfulAssertion),
         ("1", "1L", SuccessfulAssertion),
         ("null", "null", SuccessfulAssertion),
-        ("{'foo'}", "{}", FailedAssertion("Expected: [{foo}] but found [{}]")),
+        ("{'foo'}", "{}", FailedAssertion("Expected: [{'foo'}] but found [{}]")),
         ("'1,2,3'.split(',')", "'1,2,3'.split(',')", SuccessfulAssertion), // comparing arrays
-        ("'1,2'.split(',')", "'1,2,3'.split(',')", FailedAssertion("Expected: [{1, 2}] but found [{1, 2, 3}]")),
+        (
+          "'1,2'.split(',')",
+          "'1,2,3'.split(',')",
+          FailedAssertion("Expected: [{'1', '2'}] but found [{'1', '2', '3'}]")
+        ),
         ("{'1','2','3'}", "'1,2,3'.split(',')", SuccessfulAssertion), // comparing arrays with SpEL inline lists
-        ("{'a': 1}", "{:}", FailedAssertion("Expected: [{a: 1}] but found [{:}]")),
+        ("{'a': 1}", "{:}", FailedAssertion("Expected: [{'a': 1}] but found [{:}]")),
         // ("{'1,2'.split(',')}", "{'1,2'.split(',')}", SuccessfulAssertion), //todo: to be discussed whether it should work for nested structures
       )
     ) { (expected, actual, result) =>

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -13,9 +13,8 @@ import pl.touk.nussknacker.engine.definition.model.ModelDefinitionWithClasses
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
-import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
 import pl.touk.nussknacker.engine.test.testcase.Assertion.{AssertionOperator, ExpressionAssertion, PredicateAssertion}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.AssertionOperator.Equals
+import pl.touk.nussknacker.engine.test.testcase.TestCase
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
 import pl.touk.nussknacker.engine.util.functions.conversion

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -14,7 +14,8 @@ import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion.{AssertionOperator, ExpressionAssertion, PredicateAssertion}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.AssertionOperator.Equals
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
 import pl.touk.nussknacker.engine.util.functions.conversion
@@ -75,6 +76,8 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
         NodeId("someNode") -> List(
           ExpressionAssertion("#TESTS.assertEquals('valid', #contexts[0].someVariable)".spel),
           ExpressionAssertion("#TESTS.assertEquals('valid', #contexts[1].someVariable)".spel),
+          PredicateAssertion(AssertionOperator.Equals, "'valid'".spel, "#contexts[0].someVariable".spel),
+          PredicateAssertion(AssertionOperator.Equals, "'valid'".spel, "#contexts[1].someVariable".spel),
         )
       )
     )
@@ -92,37 +95,36 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
     )
 
     results.toList shouldBe List(
-      NodeId("someNode") -> List(SuccessfulAssertion, FailedAssertion("Expected: [valid] but found [invalid]"))
+      NodeId("someNode") -> List(
+        SuccessfulAssertion,
+        FailedAssertion("Expected: [valid] but found [invalid]"),
+        SuccessfulAssertion,
+        FailedAssertion("Expected: [valid] but found [invalid]"),
+      )
     )
   }
 
   test("should properly compare various types used in SpEL") {
     forAll(
       Table(
-        ("assertion", "result"),
-        ("#TESTS.assertEquals('valid', 'valid')", SuccessfulAssertion),
-        ("#TESTS.assertEquals({}, {})", SuccessfulAssertion),
-        ("#TESTS.assertEquals({:}, {:})", SuccessfulAssertion),
-        ("#TESTS.assertEquals(#CONV.toAny('abc'), 'abc')", SuccessfulAssertion),
-        ("#TESTS.assertEquals({'foo'}, #contexts[0].someJavaList)", SuccessfulAssertion),
-        ("#TESTS.assertEquals({'foo'}, {'foo'})", SuccessfulAssertion),
-        ("#TESTS.assertEquals({'foo': 'bar'}, {'foo': 'bar'})", SuccessfulAssertion),
-        ("#TESTS.assertEquals(1, 1L)", SuccessfulAssertion),
-        ("#TESTS.assertEquals(null, null)", SuccessfulAssertion),
-        ("#TESTS.assertEquals({'foo'}, {})", FailedAssertion("Expected: [{foo}] but found [{}]")),
-        ("#TESTS.assertEquals('1,2,3'.split(','), '1,2,3'.split(','))", SuccessfulAssertion), // comparing arrays
-        (
-          "#TESTS.assertEquals('1,2'.split(','), '1,2,3'.split(','))",
-          FailedAssertion("Expected: [{1, 2}] but found [{1, 2, 3}]")
-        ),
-        (
-          "#TESTS.assertEquals({'1','2','3'}, '1,2,3'.split(','))",
-          SuccessfulAssertion
-        ), // comparing arrays with SpEL inline lists
-        ("#TESTS.assertEquals({'a': 1}, {:})", FailedAssertion("Expected: [{a: 1}] but found [{:}]")),
-        // ("#TESTS.assertEquals({'1,2'.split(',')}, {'1,2'.split(',')})", SuccessfulAssertion), //todo: to be discussed whether it should work for nested structures
+        ("expected", "actual", "result"),
+        ("'valid'", "'valid'", SuccessfulAssertion),
+        ("{}", "{}", SuccessfulAssertion),
+        ("{:}", "{:}", SuccessfulAssertion),
+        ("#CONV.toAny('abc')", "'abc'", SuccessfulAssertion),
+        ("{'foo'}", "#contexts[0].someJavaList", SuccessfulAssertion),
+        ("{'foo'}", "{'foo'}", SuccessfulAssertion),
+        ("{'foo': 'bar'}", "{'foo': 'bar'}", SuccessfulAssertion),
+        ("1", "1L", SuccessfulAssertion),
+        ("null", "null", SuccessfulAssertion),
+        ("{'foo'}", "{}", FailedAssertion("Expected: [{foo}] but found [{}]")),
+        ("'1,2,3'.split(',')", "'1,2,3'.split(',')", SuccessfulAssertion), // comparing arrays
+        ("'1,2'.split(',')", "'1,2,3'.split(',')", FailedAssertion("Expected: [{1, 2}] but found [{1, 2, 3}]")),
+        ("{'1','2','3'}", "'1,2,3'.split(',')", SuccessfulAssertion), // comparing arrays with SpEL inline lists
+        ("{'a': 1}", "{:}", FailedAssertion("Expected: [{a: 1}] but found [{:}]")),
+        // ("{'1,2'.split(',')}", "{'1,2'.split(',')}", SuccessfulAssertion), //todo: to be discussed whether it should work for nested structures
       )
-    ) { (assertion, result) =>
+    ) { (expected, actual, result) =>
       val testCase = TestCase(
         UUID.randomUUID(),
         "dummy",
@@ -130,7 +132,8 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
         Map.empty,
         Map(
           NodeId("someNode") -> List(
-            ExpressionAssertion(assertion.spel),
+            ExpressionAssertion(s"#TESTS.assertEquals($expected, $actual)".spel),
+            PredicateAssertion(AssertionOperator.Equals, expected.spel, actual.spel),
           )
         )
       )
@@ -140,13 +143,15 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
             ContextId.dummy,
             Instant.now(),
             Map(
-              "someJavaList" -> createSingletonArrayList("foo"),
+              "someJavaList" -> java.util.List.of("foo"),
             )
           ),
         )
       )
 
-      verifyForTestCase(testCase, nodesResultsAfterTestRun).toList shouldBe List(NodeId("someNode") -> List(result))
+      verifyForTestCase(testCase, nodesResultsAfterTestRun).toList shouldBe List(
+        NodeId("someNode") -> List(result, result)
+      )
     }
   }
 
@@ -160,12 +165,6 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
       nodesResultsAfterTestRun,
       jobData
     )
-  }
-
-  private def createSingletonArrayList[T](element: T): java.util.ArrayList[T] = {
-    val list = new util.ArrayList[T]()
-    list.add(element)
-    list
   }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -78,6 +78,8 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
           ExpressionAssertion("#TESTS.assertEquals('valid', #contexts[1].someVariable)".spel),
           PredicateAssertion(AssertionOperator.Equals, "'valid'".spel, "#contexts[0].someVariable".spel),
           PredicateAssertion(AssertionOperator.Equals, "'valid'".spel, "#contexts[1].someVariable".spel),
+          PredicateAssertion(AssertionOperator.NotEquals, "'valid'".spel, "#contexts[0].someVariable".spel),
+          PredicateAssertion(AssertionOperator.NotEquals, "'valid'".spel, "#contexts[1].someVariable".spel),
         )
       )
     )
@@ -100,6 +102,8 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
         FailedAssertion("Expected: [valid] but found [invalid]"),
         SuccessfulAssertion,
         FailedAssertion("Expected: [valid] but found [invalid]"),
+        FailedAssertion("Expected value different from: [valid]"),
+        SuccessfulAssertion,
       )
     )
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -14,6 +14,7 @@ import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
 import pl.touk.nussknacker.engine.util.functions.conversion
@@ -72,8 +73,8 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
       Map.empty,
       Map(
         NodeId("someNode") -> List(
-          Assertion("#TESTS.assertEquals('valid', #contexts[0].someVariable)".spel),
-          Assertion("#TESTS.assertEquals('valid', #contexts[1].someVariable)".spel),
+          ExpressionAssertion("#TESTS.assertEquals('valid', #contexts[0].someVariable)".spel),
+          ExpressionAssertion("#TESTS.assertEquals('valid', #contexts[1].someVariable)".spel),
         )
       )
     )
@@ -129,7 +130,7 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
         Map.empty,
         Map(
           NodeId("someNode") -> List(
-            Assertion(assertion.spel),
+            ExpressionAssertion(assertion.spel),
           )
         )
       )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -145,13 +145,13 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
           ExpressionParserCompilationError(
             "Unexpected text",
             nodeId,
-            Some(ParameterName(PredicateAssertionCompilationError.ActualField.entryName)),
+            Some(ParameterName(PredicateAssertionCompilationError.Field.Actual.entryName)),
             "#contexts.size,",
             Some(CoordinatesBasedTextRange(TextCoordinates(14, 0), TextCoordinates(15, 0)))
           )
         ),
         invalidAssertion,
-        PredicateAssertionCompilationError.ActualField,
+        PredicateAssertionCompilationError.Field.Actual,
         nodeId
       )
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -19,16 +19,15 @@ import pl.touk.nussknacker.engine.definition.model.ModelDefinitionWithClasses
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
-import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
 import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
+import pl.touk.nussknacker.engine.test.testcase.TestCase
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
 import pl.touk.nussknacker.ui.definition.DefinitionsService
-import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.{
-  AssertionConfiguredForNotExistingNodesError,
-  AssertionExpressionCompilationError
-}
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.ExpressionAssertionCompilationError
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionValidationError.AssertionConfiguredForNotExistingNodesError
+import pl.touk.nussknacker.ui.process.test.testcase.CompiledAssertion.CompiledExpressionAssertion
 
 import java.util.UUID
 
@@ -82,6 +81,8 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       compiledAssertions
         .assertions(NodeId("sink1"))
         .head
+        // TODO
+        .asInstanceOf[CompiledExpressionAssertion]
         .expression
         .original shouldBe "#TESTS.assertEquals(#contexts.size, 1)"
     }
@@ -135,7 +136,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
     val testCompilationResult = compileScenarioWithAssertions(scenario, test)
     inside(testCompilationResult) { case Invalid(errors) =>
       errors.size shouldBe 1
-      errors.head shouldBe AssertionExpressionCompilationError(
+      errors.head shouldBe ExpressionAssertionCompilationError(
         NonEmptyList.one(
           ExpressionParserCompilationError(
             "Unexpectedly ran out of arguments",

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -19,15 +19,16 @@ import pl.touk.nussknacker.engine.definition.model.ModelDefinitionWithClasses
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
-import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion.PredicateAssertion
 import pl.touk.nussknacker.engine.test.testcase.TestCase
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
 import pl.touk.nussknacker.ui.definition.DefinitionsService
-import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.ExpressionAssertionCompilationError
+import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.PredicateAssertionCompilationError
 import pl.touk.nussknacker.ui.process.test.testcase.AssertionValidationError.AssertionConfiguredForNotExistingNodesError
-import pl.touk.nussknacker.ui.process.test.testcase.CompiledAssertion.CompiledExpressionAssertion
+import pl.touk.nussknacker.ui.process.test.testcase.CompiledAssertion.CompiledPredicateAssertion
 
 import java.util.UUID
 
@@ -71,20 +72,20 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       "someTest",
       inputs = "",
       mocks = Map.empty,
-      assertions = Map(NodeId("sink1") -> List(ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel)))
+      assertions = Map(
+        NodeId("sink1") -> List(PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel))
+      )
     )
 
     val testCompilationResult = compileScenarioWithAssertions(scenario, test)
     inside(testCompilationResult) { case Valid(compiledAssertions) =>
       compiledAssertions.assertions.size shouldBe 1
       compiledAssertions.assertions(NodeId("sink1")).size shouldBe 1
-      compiledAssertions
-        .assertions(NodeId("sink1"))
-        .head
-        // TODO
-        .asInstanceOf[CompiledExpressionAssertion]
-        .expression
-        .original shouldBe "#TESTS.assertEquals(#contexts.size, 1)"
+      val compiledAssertion =
+        compiledAssertions.assertions(NodeId("sink1")).head.asInstanceOf[CompiledPredicateAssertion]
+      compiledAssertion.operator shouldBe Assertion.AssertionOperator.Equals
+      compiledAssertion.expected.original shouldBe "1"
+      compiledAssertion.actual.original shouldBe "#contexts.size"
     }
   }
 
@@ -100,8 +101,11 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       "someTest",
       inputs = "",
       mocks = Map.empty,
-      assertions =
-        Map(NodeId("notExistingSink") -> List(ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel)))
+      assertions = Map(
+        NodeId("notExistingSink") -> List(
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel)
+        )
+      )
     )
 
     val testCompilationResult = compileScenarioWithAssertions(scenario, test)
@@ -123,7 +127,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       .buildSimpleVariable("result-id2", "result", "#input".spel)
       .emptySink("sink1", "sink")
     val nodeId           = NodeId("sink1")
-    val invalidAssertion = ExpressionAssertion("#TESTS.assertEquals(#contexts.size,".spel)
+    val invalidAssertion = PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size,".spel)
 
     val test = TestCase(
       UUID.randomUUID(),
@@ -136,17 +140,18 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
     val testCompilationResult = compileScenarioWithAssertions(scenario, test)
     inside(testCompilationResult) { case Invalid(errors) =>
       errors.size shouldBe 1
-      errors.head shouldBe ExpressionAssertionCompilationError(
+      errors.head shouldBe PredicateAssertionCompilationError(
         NonEmptyList.one(
           ExpressionParserCompilationError(
-            "Unexpectedly ran out of arguments",
+            "Unexpected text",
             nodeId,
-            None,
-            "#TESTS.assertEquals(#contexts.size,",
-            Some(CoordinatesBasedTextRange(TextCoordinates(19, 0), TextCoordinates(20, 0)))
+            Some(ParameterName(PredicateAssertionCompilationError.ActualField.name)),
+            "#contexts.size,",
+            Some(CoordinatesBasedTextRange(TextCoordinates(14, 0), TextCoordinates(15, 0)))
           )
         ),
         invalidAssertion,
+        PredicateAssertionCompilationError.ActualField,
         nodeId
       )
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -20,6 +20,7 @@ import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
@@ -71,7 +72,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       "someTest",
       inputs = "",
       mocks = Map.empty,
-      assertions = Map(NodeId("sink1") -> List(Assertion("#TESTS.assertEquals(#contexts.size, 1)".spel)))
+      assertions = Map(NodeId("sink1") -> List(ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel)))
     )
 
     val testCompilationResult = compileScenarioWithAssertions(scenario, test)
@@ -98,7 +99,8 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       "someTest",
       inputs = "",
       mocks = Map.empty,
-      assertions = Map(NodeId("notExistingSink") -> List(Assertion("#TESTS.assertEquals(#contexts.size, 1)".spel)))
+      assertions =
+        Map(NodeId("notExistingSink") -> List(ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel)))
     )
 
     val testCompilationResult = compileScenarioWithAssertions(scenario, test)
@@ -120,7 +122,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       .buildSimpleVariable("result-id2", "result", "#input".spel)
       .emptySink("sink1", "sink")
     val nodeId           = NodeId("sink1")
-    val invalidAssertion = Assertion("#TESTS.assertEquals(#contexts.size,".spel)
+    val invalidAssertion = ExpressionAssertion("#TESTS.assertEquals(#contexts.size,".spel)
 
     val test = TestCase(
       UUID.randomUUID(),

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -145,7 +145,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
           ExpressionParserCompilationError(
             "Unexpected text",
             nodeId,
-            Some(ParameterName(PredicateAssertionCompilationError.ActualField.name)),
+            Some(ParameterName(PredicateAssertionCompilationError.ActualField.entryName)),
             "#contexts.size,",
             Some(CoordinatesBasedTextRange(TextCoordinates(14, 0), TextCoordinates(15, 0)))
           )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/SpelValuePrettyPrinterSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/SpelValuePrettyPrinterSpec.scala
@@ -8,20 +8,33 @@ import pl.touk.nussknacker.ui.process.test.testcase.SpelValuePrettyPrinter.prett
 class SpelValuePrettyPrinterSpec extends AnyFunSuite with Matchers {
 
   test("print like a SpEL literal values") {
-    forAll(
-      Table(
-        ("valueToPrint", "expectedOutput"),
-        (java.util.List.of("a", "b", "c"), "{a, b, c}"),
-        (java.util.List.of[java.util.List[String]](java.util.List.of[String]("a")), "{{a}}"),
-        (java.util.List.of(), "{}"),
-        (java.util.Map.of("a", 1234), "{a: 1234}"),
-        (java.util.Map.of("a", java.util.Map.of("b", 1234)), "{a: {b: 1234}}"),
-        (java.util.Map.of(), "{:}"),
-        (Array("a", "b", "c"), "{a, b, c}"), // in spel there is no array literal so we print it as a list literal,
-        (Array(Array("a")), "{{a}}"),
-        (Array[String](), "{}"),
-      )
-    ) { (valueToPrint, expectedOutput) =>
+    val examples = Table(
+      ("valueToPrint", "expectedOutput"),
+
+      // Primitives
+      (null, "null"),
+      ("simple string", "'simple string'"),
+      ("string with 'quote'", "'string with ''quote'''"),
+      (123, "123"),
+      (123.45, "123.45"),
+      (99L, "99L"),
+      (true, "true"),
+      (false, "false"),
+
+      // Collections
+      (java.util.List.of("a", "b", "c"), "{'a', 'b', 'c'}"),
+      (java.util.List.of(java.util.List.of("a")), "{{'a'}}"),
+      (java.util.List.of(), "{}"),
+      (java.util.Map.of("a", 1234), "{'a': 1234}"),
+      (java.util.Map.of("a", java.util.Map.of("b", 1234)), "{'a': {'b': 1234}}"),
+      (java.util.Map.of(), "{:}"),
+      (Array("a", "b", "c"), "{'a', 'b', 'c'}"),
+      (Array(Array("a")), "{{'a'}}"),
+      (Array[String](), "{}"),
+      (java.util.List.of("text", 42, true), "{'text', 42, true}")
+    )
+
+    forAll(examples) { (valueToPrint, expectedOutput) =>
       prettyPrintValue(valueToPrint) shouldBe expectedOutput
     }
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/TestCaseValidatorSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/TestCaseValidatorSpec.scala
@@ -18,6 +18,7 @@ import pl.touk.nussknacker.engine.graph.node.{Enricher, Filter}
 import pl.touk.nussknacker.engine.graph.service.ServiceRef
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, EnricherMock, TestCase}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.restmodel.validation.testcase.{
   AssertionValidationError,
@@ -64,8 +65,8 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
       "test1" -> NodeTestCase(
         enricherMock = None,
         assertions = List(
-          Assertion("#TESTS.assertEquals(#contexts[0].input, 'expected')".spel),
-          Assertion("#TESTS.assertEquals(#contexts.size, 1)".spel)
+          ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'expected')".spel),
+          ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel)
         )
       )
     )
@@ -181,7 +182,7 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
       "test1" -> NodeTestCase(
         enricherMock = None,
         assertions = List(
-          Assertion("#TESTS.doSthMagic".spel)
+          ExpressionAssertion("#TESTS.doSthMagic".spel)
         )
       )
     )
@@ -218,7 +219,7 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
     val nodeTestCases: NodeTestCases = Map(
       "validTest" -> NodeTestCase(
         enricherMock = Some(EnricherMock("'valid mock'".spel)),
-        assertions = List(Assertion("#TESTS.assertEquals(#contexts.size, 1)".spel))
+        assertions = List(ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel))
       ),
       "invalidMockTest" -> NodeTestCase(
         enricherMock = Some(EnricherMock("#invalidVar".spel)),
@@ -227,9 +228,9 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
       "invalidAssertionTest" -> NodeTestCase(
         enricherMock = None,
         assertions = List(
-          Assertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 1)".spel),
-          Assertion("#TESTS.assertEquals(#contexts.size, 1)".spel),
-          Assertion("#TESTS.assertEquals(#contexts[0].doesNotExistOther, 2)".spel),
+          ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 1)".spel),
+          ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel),
+          ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExistOther, 2)".spel),
         )
       )
     )
@@ -309,8 +310,8 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
         inputs = "{}",
         mocks = Map(NodeId(enricher.id) -> EnricherMock("'valid mock'".spel)),
         assertions = Map(
-          NodeId(enricher.id) -> List(Assertion("#TESTS.assertEquals(#contexts.size, 1)".spel)),
-          NodeId(filter.id)   -> List(Assertion("#TESTS.assertEquals(#contexts[0].input, 'test')".spel))
+          NodeId(enricher.id) -> List(ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel)),
+          NodeId(filter.id)   -> List(ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'test')".spel))
         )
       ),
       TestCase(
@@ -330,13 +331,13 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
         mocks = Map.empty,
         assertions = Map(
           NodeId(enricher.id) -> List(
-            Assertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 1)".spel),
-            Assertion("#TESTS.assertEquals(#contexts.size, 1)".spel),
-            Assertion("#TESTS.assertEquals(#contexts[0].doesNotExistOther, 2)".spel)
+            ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 1)".spel),
+            ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel),
+            ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExistOther, 2)".spel)
           ),
           NodeId(filter.id) -> List(
-            Assertion("#TESTS.assertEquals(#contexts[0].input, 'value')".spel),
-            Assertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 1)".spel),
+            ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'value')".spel),
+            ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 1)".spel),
           )
         )
       ),

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/TestCaseValidatorSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/TestCaseValidatorSpec.scala
@@ -206,7 +206,8 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doSthMagic' in type: tests",
                 description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(7, 0), TextCoordinates(17, 0)))
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(7, 0), TextCoordinates(17, 0))),
+                fieldName = None,
               )
             )
           )
@@ -267,7 +268,8 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExist' in type: Record{input: String}",
                 description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0)))
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0))),
+                fieldName = None,
               )
             ),
             2 -> NonEmptyList.one(
@@ -275,7 +277,8 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExistOther' in type: Record{input: String}",
                 description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(50, 0)))
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(50, 0))),
+                fieldName = None,
               )
             )
           )
@@ -373,7 +376,8 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExist' in type: Record{input: String}",
                 description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0)))
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0))),
+                fieldName = None,
               )
             ),
             2 -> NonEmptyList.one(
@@ -381,7 +385,8 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExistOther' in type: Record{input: String}",
                 description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(50, 0)))
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(50, 0))),
+                fieldName = None,
               )
             )
           )
@@ -411,7 +416,8 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExist' in type: Record{input: String}",
                 description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0)))
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0))),
+                fieldName = None,
               )
             )
           )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/TestCaseValidatorSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/TestCaseValidatorSpec.scala
@@ -18,7 +18,7 @@ import pl.touk.nussknacker.engine.graph.node.{Enricher, Filter}
 import pl.touk.nussknacker.engine.graph.service.ServiceRef
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, EnricherMock, TestCase}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
+import pl.touk.nussknacker.engine.test.testcase.Assertion.PredicateAssertion
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.restmodel.validation.testcase.{
   AssertionValidationError,
@@ -65,8 +65,8 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
       "test1" -> NodeTestCase(
         enricherMock = None,
         assertions = List(
-          ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'expected')".spel),
-          ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel)
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'expected'".spel, "#contexts[0].input".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel)
         )
       )
     )
@@ -182,7 +182,7 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
       "test1" -> NodeTestCase(
         enricherMock = None,
         assertions = List(
-          ExpressionAssertion("#TESTS.doSthMagic".spel)
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'value'".spel, "#doesNotExist".spel)
         )
       )
     )
@@ -204,10 +204,10 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
             0 -> NonEmptyList.one(
               AssertionValidationError(
                 typ = "ExpressionParserCompilationError",
-                message = "There is no property 'doSthMagic' in type: tests",
-                description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(7, 0), TextCoordinates(17, 0))),
-                fieldName = None,
+                message = "Unresolved reference 'doesNotExist'",
+                description = "There is problem with expression in field [actual] - it could not be parsed.",
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(0, 0), TextCoordinates(13, 0))),
+                fieldName = Some("actual"),
               )
             )
           )
@@ -220,7 +220,7 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
     val nodeTestCases: NodeTestCases = Map(
       "validTest" -> NodeTestCase(
         enricherMock = Some(EnricherMock("'valid mock'".spel)),
-        assertions = List(ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel))
+        assertions = List(PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel))
       ),
       "invalidMockTest" -> NodeTestCase(
         enricherMock = Some(EnricherMock("#invalidVar".spel)),
@@ -229,9 +229,9 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
       "invalidAssertionTest" -> NodeTestCase(
         enricherMock = None,
         assertions = List(
-          ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 1)".spel),
-          ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel),
-          ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExistOther, 2)".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts[0].doesNotExist".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel),
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "2".spel, "#contexts[0].doesNotExistOther".spel),
         )
       )
     )
@@ -267,18 +267,18 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
               AssertionValidationError(
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExist' in type: Record{input: String}",
-                description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0))),
-                fieldName = None,
+                description = "There is problem with expression in field [actual] - it could not be parsed.",
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(13, 0), TextCoordinates(25, 0))),
+                fieldName = Some("actual"),
               )
             ),
             2 -> NonEmptyList.one(
               AssertionValidationError(
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExistOther' in type: Record{input: String}",
-                description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(50, 0))),
-                fieldName = None,
+                description = "There is problem with expression in field [actual] - it could not be parsed.",
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(13, 0), TextCoordinates(30, 0))),
+                fieldName = Some("actual"),
               )
             )
           )
@@ -313,8 +313,12 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
         inputs = "{}",
         mocks = Map(NodeId(enricher.id) -> EnricherMock("'valid mock'".spel)),
         assertions = Map(
-          NodeId(enricher.id) -> List(ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel)),
-          NodeId(filter.id)   -> List(ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'test')".spel))
+          NodeId(enricher.id) -> List(
+            PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel)
+          ),
+          NodeId(filter.id) -> List(
+            PredicateAssertion(Assertion.AssertionOperator.Equals, "'test'".spel, "#contexts[0].input".spel)
+          )
         )
       ),
       TestCase(
@@ -334,13 +338,13 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
         mocks = Map.empty,
         assertions = Map(
           NodeId(enricher.id) -> List(
-            ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 1)".spel),
-            ExpressionAssertion("#TESTS.assertEquals(#contexts.size, 1)".spel),
-            ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExistOther, 2)".spel)
+            PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts[0].doesNotExist".spel),
+            PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel),
+            PredicateAssertion(Assertion.AssertionOperator.Equals, "2".spel, "#contexts[0].doesNotExistOther".spel)
           ),
           NodeId(filter.id) -> List(
-            ExpressionAssertion("#TESTS.assertEquals(#contexts[0].input, 'value')".spel),
-            ExpressionAssertion("#TESTS.assertEquals(#contexts[0].doesNotExist, 1)".spel),
+            PredicateAssertion(Assertion.AssertionOperator.Equals, "'value'".spel, "#contexts[0].input".spel),
+            PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts[0].doesNotExist".spel),
           )
         )
       ),
@@ -375,18 +379,18 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
               AssertionValidationError(
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExist' in type: Record{input: String}",
-                description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0))),
-                fieldName = None,
+                description = "There is problem with expression in field [actual] - it could not be parsed.",
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(13, 0), TextCoordinates(25, 0))),
+                fieldName = Some("actual"),
               )
             ),
             2 -> NonEmptyList.one(
               AssertionValidationError(
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExistOther' in type: Record{input: String}",
-                description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(50, 0))),
-                fieldName = None,
+                description = "There is problem with expression in field [actual] - it could not be parsed.",
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(13, 0), TextCoordinates(30, 0))),
+                fieldName = Some("actual"),
               )
             )
           )
@@ -415,9 +419,9 @@ class TestCaseValidatorSpec extends AnyFunSuite with Matchers with Inside {
               AssertionValidationError(
                 typ = "ExpressionParserCompilationError",
                 message = "There is no property 'doesNotExist' in type: Record{input: String}",
-                description = "There is problem with expression in field [<missing>] - it could not be parsed.",
-                details = Some(CoordinatesBasedTextRange(TextCoordinates(33, 0), TextCoordinates(45, 0))),
-                fieldName = None,
+                description = "There is problem with expression in field [actual] - it could not be parsed.",
+                details = Some(CoordinatesBasedTextRange(TextCoordinates(13, 0), TextCoordinates(25, 0))),
+                fieldName = Some("actual"),
               )
             )
           )

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -1626,22 +1626,33 @@ paths:
                           language: spel
                           expression: '42'
                       assertions:
-                      - expression:
+                      - operator: equals
+                        expected:
                           language: spel
-                          expression: '#TESTS.assertEquals(#contexts.size, 1)'''
+                          expression: '1'
+                        actual:
+                          language: spel
+                          expression: '#contexts.size'
                     test-case-2:
                       enricherMock:
                         expression:
                           language: spel
                           expression: '''sample value'''
                       assertions:
-                      - expression:
+                      - operator: equals
+                        expected:
                           language: spel
-                          expression: '#TESTS.assertEquals(#contexts.size, 1)'''
-                      - expression:
+                          expression: '1'
+                        actual:
                           language: spel
-                          expression: '#TESTS.assertEquals(#contexts[0].doesNotExist,
-                            ''expected'')'
+                          expression: '#contexts.size'
+                      - operator: equals
+                        expected:
+                          language: spel
+                          expression: '''expected'''
+                        actual:
+                          language: spel
+                          expression: '#contexts[0].doesNotExist'
         required: true
       responses:
         '200':
@@ -5483,12 +5494,15 @@ components:
           format: int32
     Assertion:
       title: Assertion
-      type: object
-      required:
-      - expression
-      properties:
-        expression:
-          $ref: '#/components/schemas/Expression'
+      oneOf:
+      - $ref: '#/components/schemas/ExpressionAssertion'
+      - $ref: '#/components/schemas/PredicateAssertion'
+    AssertionOperator:
+      title: AssertionOperator
+      type: string
+      enum:
+      - equals
+      - notEquals
     AssertionResult:
       title: AssertionResult
       oneOf:
@@ -5512,6 +5526,10 @@ components:
           anyOf:
           - $ref: '#/components/schemas/ErrorDetails'
           - type: 'null'
+        fieldName:
+          type:
+          - string
+          - 'null'
     Attachment:
       title: Attachment
       type: object
@@ -6051,6 +6069,14 @@ components:
           type: string
         expression:
           type: string
+    ExpressionAssertion:
+      title: ExpressionAssertion
+      type: object
+      required:
+      - expression
+      properties:
+        expression:
+          $ref: '#/components/schemas/Expression'
     ExpressionEvaluationResult_Json:
       title: ExpressionEvaluationResult_Json
       type: object
@@ -7391,6 +7417,20 @@ components:
                 type: string
               duration:
                 type: string
+    PredicateAssertion:
+      title: PredicateAssertion
+      type: object
+      required:
+      - operator
+      - expected
+      - actual
+      properties:
+        operator:
+          $ref: '#/components/schemas/AssertionOperator'
+        expected:
+          $ref: '#/components/schemas/Expression'
+        actual:
+          $ref: '#/components/schemas/Expression'
     ProcessActivity:
       title: ProcessActivity
       type: object

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.test.testcase
 
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, DecodingFailure, Encoder, Json}
 import io.circe.generic.JsonCodec
 import io.circe.syntax._
 import pl.touk.nussknacker.engine.api.NodeId
@@ -34,4 +34,44 @@ object TestCases {
 
 @JsonCodec final case class EnricherMock(expression: Expression)
 
-@JsonCodec final case class Assertion(expression: Expression)
+sealed trait Assertion
+
+object Assertion {
+
+  @JsonCodec final case class AssertionExpression(expression: Expression) extends Assertion
+
+  @JsonCodec final case class PredicateAssertion(operator: AssertionOperator, expected: Expression, actual: Expression)
+      extends Assertion
+
+  implicit val assertionEncoder: Encoder[Assertion] = Encoder.instance {
+    case expr: AssertionExpression => expr.asJson
+    case pred: PredicateAssertion  => pred.asJson
+  }
+
+  implicit val assertionDecoder: Decoder[Assertion] = Decoder.instance { cursor =>
+    if (cursor.downField("operator").failed) {
+      cursor.as[AssertionExpression]
+    } else {
+      cursor.as[PredicateAssertion]
+    }
+  }
+
+  sealed trait AssertionOperator
+
+  object AssertionOperator {
+    case object Equals extends AssertionOperator
+
+    implicit val assertionOperatorEncoder: Encoder[AssertionOperator] = Encoder.instance { case Equals =>
+      "equals".asJson
+    }
+
+    implicit val assertionOperatorDecoder: Decoder[AssertionOperator] = Decoder.instance { cursor =>
+      cursor.as[String].flatMap {
+        case "equals" => Right(AssertionOperator.Equals)
+        case other    => Left(DecodingFailure(s"Unknown AssertionOperator: $other", cursor.history))
+      }
+    }
+
+  }
+
+}

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
@@ -38,37 +38,41 @@ sealed trait Assertion
 
 object Assertion {
 
-  @JsonCodec final case class AssertionExpression(expression: Expression) extends Assertion
+  @JsonCodec final case class ExpressionAssertion(expression: Expression) extends Assertion
 
   @JsonCodec final case class PredicateAssertion(operator: AssertionOperator, expected: Expression, actual: Expression)
       extends Assertion
 
   implicit val assertionEncoder: Encoder[Assertion] = Encoder.instance {
-    case expr: AssertionExpression => expr.asJson
+    case expr: ExpressionAssertion => expr.asJson
     case pred: PredicateAssertion  => pred.asJson
   }
 
   implicit val assertionDecoder: Decoder[Assertion] = Decoder.instance { cursor =>
     if (cursor.downField("operator").failed) {
-      cursor.as[AssertionExpression]
+      cursor.as[ExpressionAssertion]
     } else {
       cursor.as[PredicateAssertion]
     }
   }
 
-  sealed trait AssertionOperator
+  sealed trait AssertionOperator {
+
+    val name: String = this match {
+      case AssertionOperator.Equals => "equals"
+    }
+
+  }
 
   object AssertionOperator {
     case object Equals extends AssertionOperator
 
-    implicit val assertionOperatorEncoder: Encoder[AssertionOperator] = Encoder.instance { case Equals =>
-      "equals".asJson
-    }
+    implicit val assertionOperatorEncoder: Encoder[AssertionOperator] = Encoder.instance(_.name.asJson)
 
     implicit val assertionOperatorDecoder: Decoder[AssertionOperator] = Decoder.instance { cursor =>
       cursor.as[String].flatMap {
-        case "equals" => Right(AssertionOperator.Equals)
-        case other    => Left(DecodingFailure(s"Unknown AssertionOperator: $other", cursor.history))
+        case AssertionOperator.Equals.name => Right(AssertionOperator.Equals)
+        case other => Left(DecodingFailure(s"Unknown AssertionOperator: $other", cursor.history))
       }
     }
 

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
@@ -1,12 +1,12 @@
 package pl.touk.nussknacker.engine.test.testcase
 
-import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+import enumeratum.{CirceEnum, Enum, EnumEntry}
+import enumeratum.EnumEntry.LowerCamelcase
+import io.circe.{Decoder, Encoder, Json}
 import io.circe.generic.JsonCodec
 import io.circe.syntax._
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.graph.expression.Expression
-
-import java.util.UUID
 
 // TODO: When adding multiple test cases variant, remember to validate ID and name uniqueness.
 sealed trait TestCases
@@ -56,29 +56,13 @@ object Assertion {
     }
   }
 
-  sealed trait AssertionOperator {
+  sealed trait AssertionOperator extends EnumEntry with LowerCamelcase
 
-    val name: String = this match {
-      case AssertionOperator.Equals    => "equals"
-      case AssertionOperator.NotEquals => "notEquals"
-    }
-
-  }
-
-  object AssertionOperator {
+  object AssertionOperator extends Enum[AssertionOperator] with CirceEnum[AssertionOperator] {
     case object Equals    extends AssertionOperator
     case object NotEquals extends AssertionOperator
 
-    implicit val assertionOperatorEncoder: Encoder[AssertionOperator] = Encoder.instance(_.name.asJson)
-
-    implicit val assertionOperatorDecoder: Decoder[AssertionOperator] = Decoder.instance { cursor =>
-      cursor.as[String].flatMap {
-        case AssertionOperator.Equals.name    => Right(AssertionOperator.Equals)
-        case AssertionOperator.NotEquals.name => Right(AssertionOperator.NotEquals)
-        case other => Left(DecodingFailure(s"Unknown AssertionOperator: $other", cursor.history))
-      }
-    }
-
+    override def values: IndexedSeq[AssertionOperator] = findValues
   }
 
 }

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
@@ -59,19 +59,22 @@ object Assertion {
   sealed trait AssertionOperator {
 
     val name: String = this match {
-      case AssertionOperator.Equals => "equals"
+      case AssertionOperator.Equals    => "equals"
+      case AssertionOperator.NotEquals => "notEquals"
     }
 
   }
 
   object AssertionOperator {
-    case object Equals extends AssertionOperator
+    case object Equals    extends AssertionOperator
+    case object NotEquals extends AssertionOperator
 
     implicit val assertionOperatorEncoder: Encoder[AssertionOperator] = Encoder.instance(_.name.asJson)
 
     implicit val assertionOperatorDecoder: Decoder[AssertionOperator] = Decoder.instance { cursor =>
       cursor.as[String].flatMap {
-        case AssertionOperator.Equals.name => Right(AssertionOperator.Equals)
+        case AssertionOperator.Equals.name    => Right(AssertionOperator.Equals)
+        case AssertionOperator.NotEquals.name => Right(AssertionOperator.NotEquals)
         case other => Left(DecodingFailure(s"Unknown AssertionOperator: $other", cursor.history))
       }
     }


### PR DESCRIPTION
## Describe your changes

Additional small improvements:
- Add `notEquals` assertion.
- Pretty print string as SpEL expression. 

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
