### PR TITLE
Update Flink to 1.20.3, Scala to 2.13.18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ import scala.util.Try
 import scala.xml.Elem
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-val scala213 = "2.13.16"
+val scala213 = "2.13.18"
 
 lazy val defaultScalaV = sys.env.get("NUSSKNACKER_SCALA_VERSION") match {
   case None | Some("2.13") => scala213
@@ -233,7 +233,7 @@ lazy val commonSettings =
 // Note: when updating check versions in 'flink*V' below, because some libraries must be fixed at versions provided
 // by Flink, or jobs may fail in runtime when Flink is run with 'classloader.resolve-order: parent-first'.
 // You can find versions provided by Flink in it's lib/flink-dist-*.jar/META-INF/DEPENDENCIES file.
-val flinkV                = "1.20.2"
+val flinkV                = "1.20.3"
 val flinkConnectorKafkaV  = "3.4.0-1.20"
 val jdbcFlinkConnectorV   = "3.3.0-1.20"
 val flinkCommonsCompressV = "1.26.0"
@@ -241,7 +241,7 @@ val flinkCommonsLang3V    = "3.12.0"
 val flinkCommonsTextV     = "1.10.0"
 val flinkCommonsIOV       = "2.15.1"
 val flinkInfluxdbJavaV    = "2.17"
-val flinkScalaV           = "1.1.5"
+val flinkScalaV           = "1.1.6"
 // keep calcite synchronized with version used by current flink-sql-parser
 val calciteV              = "1.32.0"
 val avroV                 =

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -313,6 +313,7 @@ description: Stay informed with detailed changelogs covering new features, impro
 * [#8815](https://github.com/TouK/nussknacker/pull/8815) Fix: In Flink's serialization was used a result type of expression
   before final implicit conversion instead of after it. It sometimes caused "AAA cannot be cast to class BBB" in runtime.
 * [#8806](https://github.com/TouK/nussknacker/pull/8806) Test case running implementation
+* [#8903](https://github.com/TouK/nussknacker/pull/8903) Updated Flink dependency to 1.20.3, Scala to 2.13.18
 
 ## 1.18
 

--- a/e2e-tests/src/test/resources/bootstrap-setup-scenarios.override.yml
+++ b/e2e-tests/src/test/resources/bootstrap-setup-scenarios.override.yml
@@ -4,7 +4,7 @@ x-flink-service-with-postgres-driver: &flink-with-postgres-driver
     context: ./flink/
     dockerfile: FlinkWithPostgresDriverDockerfile
     args:
-      TOUK_FLINK_VERSION: "1.1.5-flink1.20.2-scala_2.13"
+      TOUK_FLINK_VERSION: "1.1.6-flink1.20.3-scala_2.13"
 
 services:
 

--- a/engine/flink/test-utils/src/main/resources/docker/Dockerfile
+++ b/engine/flink/test-utils/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM touk/flink:1.1.5-flink1.20.2-scala_${scala.version}
+FROM touk/flink:1.1.6-flink1.20.3-scala_${scala.version}
 
 COPY entrypointWithIP.sh /
 COPY config.overrides.yml /

--- a/examples/dev/local-testing.docker-compose.yml
+++ b/examples/dev/local-testing.docker-compose.yml
@@ -141,7 +141,7 @@ services:
     build:
       context: flink/
       args:
-        TOUK_FLINK_VERSION: "1.1.5-flink1.20.2-scala_2.13"
+        TOUK_FLINK_VERSION: "1.1.6-flink1.20.3-scala_2.13"
     restart: unless-stopped
     command: jobmanager
     ports:
@@ -162,7 +162,7 @@ services:
     build:
       context: flink/
       args:
-        TOUK_FLINK_VERSION: "1.1.5-flink1.20.2-scala_2.13"
+        TOUK_FLINK_VERSION: "1.1.6-flink1.20.3-scala_2.13"
     restart: unless-stopped
     command: taskmanager
     environment:

--- a/examples/installation/docker-compose.yml
+++ b/examples/installation/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     build:
       context: ./flink/
       args:
-        TOUK_FLINK_VERSION: "1.1.5-flink1.20.2-scala_2.13"
+        TOUK_FLINK_VERSION: "1.1.6-flink1.20.3-scala_2.13"
     restart: unless-stopped
     command: jobmanager
     environment:
@@ -218,7 +218,7 @@ services:
     build:
       context: ./flink/
       args:
-        TOUK_FLINK_VERSION: "1.1.5-flink1.20.2-scala_2.13"
+        TOUK_FLINK_VERSION: "1.1.6-flink1.20.3-scala_2.13"
     restart: unless-stopped
     command: taskmanager
     environment:


### PR DESCRIPTION
## Describe your changes

Update Flink and Scala. Mainly to align scala-library to a consistent version so that sbt 1.10 (#8900) won't complain about version mismatch.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
