### PR TITLE
Properly handle InterruptedException in SyncInterpretationFunction

### DIFF
--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/AsyncInterpretationFunction.scala
@@ -8,6 +8,7 @@ import org.apache.flink.streaming.api.functions.async.{ResultFuture, RichAsyncFu
 import pl.touk.nussknacker.engine.InterpretationResult
 import pl.touk.nussknacker.engine.Interpreter.FutureShape
 import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.component.NodeComponentInfo
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.definition.EngineScenarioCompilationDependencies
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
@@ -27,6 +28,7 @@ private[registrar] class AsyncInterpretationFunction(
     val node: SplittedNode[_ <: NodeData],
     validationContext: ValidationContext,
     serviceExecutionContextPreparer: AsyncExecutionContextPreparer,
+    nodeComponentInfo: NodeComponentInfo,
     useIOMonad: Boolean
 ) extends RichAsyncFunction[Context, InterpretationResult]
     with LazyLogging
@@ -65,12 +67,12 @@ private[registrar] class AsyncInterpretationFunction(
           handleResults(collector, successes, exceptions)
         case Left(ex) =>
           logger.warn("Unexpected error", ex)
-          handleResults(collector, Nil, List(NuExceptionInfo(None, ex, input)))
+          handleResults(collector, Nil, List(NuExceptionInfo(Some(nodeComponentInfo), ex, input)))
       }
     } catch {
       case NonFatal(ex) =>
         logger.warn("Unexpected error", ex)
-        handleResults(collector, Nil, List(NuExceptionInfo(None, ex, input)))
+        handleResults(collector, Nil, List(NuExceptionInfo(Some(nodeComponentInfo), ex, input)))
     }
 
   }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/FlinkProcessRegistrar.scala
@@ -169,12 +169,13 @@ class FlinkProcessRegistrar(
       val source = part.obj.asInstanceOf[FlinkSource]
 
       val contextTypeInformation = TypeInformationDetection.instance.forContext(part.validationContext)
+      val nodeComponentInfo      = nodeComponentInfoFrom(part)
 
       val start = source
-        .contextStream(env, nodeContext(nodeComponentInfoFrom(part), Left(ValidationContext.empty)))
+        .contextStream(env, nodeContext(nodeComponentInfo, Left(ValidationContext.empty)))
         .process(new SourceMetricsFunction(part.id, compilerData.runtimeMode), contextTypeInformation)
 
-      val asyncAssigned = registerInterpretationPart(start, part, InterpretationName)
+      val asyncAssigned = registerInterpretationPart(start, part, InterpretationName, nodeComponentInfo)
 
       registerNextParts(asyncAssigned, part)
     }
@@ -202,20 +203,20 @@ class FlinkProcessRegistrar(
           throw new IllegalArgumentException(s"Unknown join node transformer: $other")
       }
 
-      val outputVar     = joinPart.node.data.outputVar.get
-      val newContextFun = (ir: ValueWithContext[_]) => ir.context.withVariable(outputVar, ir.value)
-
+      val outputVar         = joinPart.node.data.outputVar.get
+      val newContextFun     = (ir: ValueWithContext[_]) => ir.context.withVariable(outputVar, ir.value)
+      val nodeComponentInfo = nodeComponentInfoFrom(joinPart)
       val newStart = transformer
         .transform(
           inputs.mapValuesNow(_._1),
-          nodeContext(nodeComponentInfoFrom(joinPart), Right(inputs.mapValuesNow(_._2)))
+          nodeContext(nodeComponentInfo, Right(inputs.mapValuesNow(_._2)))
         )
         .map(
           (value: ValueWithContext[AnyRef]) => newContextFun(value),
           TypeInformationDetection.instance.forContext(joinPart.validationContext)
         )
 
-      val afterSplit = registerInterpretationPart(newStart, joinPart, BranchInterpretationName)
+      val afterSplit = registerInterpretationPart(newStart, joinPart, BranchInterpretationName, nodeComponentInfo)
       registerNextParts(afterSplit, joinPart)
     }
 
@@ -272,13 +273,14 @@ class FlinkProcessRegistrar(
     ): Map[BranchEndDefinition, BranchEndData] = {
       val typeInformationForIR  = InterpretationResultTypeInformation.create(contextBefore)
       val typeInformationForCtx = TypeInformationDetection.instance.forContext(contextBefore)
+      val nodeComponentInfo     = nodeComponentInfoFrom(part)
       // TODO: for sinks there are no further nodes to interpret but the function is registered to invoke listeners (e.g. to measure end metrics).
       val afterInterpretation = sideOutput(
-        registerInterpretationPart(start, part, SinkInterpretationName),
+        registerInterpretationPart(start, part, SinkInterpretationName, nodeComponentInfo),
         new OutputTag[InterpretationResult](FlinkProcessRegistrar.EndId, typeInformationForIR)
       )
         .map((value: InterpretationResult) => value.finalContext, typeInformationForCtx)
-      val customNodeContext = nodeContext(nodeComponentInfoFrom(part), Left(contextBefore))
+      val customNodeContext = nodeContext(nodeComponentInfo, Left(contextBefore))
       val withValuePrepared = sink.prepareValue(afterInterpretation, customNodeContext)
       // TODO: maybe this logic should be moved to compiler instead?
       val withSinkAdded = resultCollector match {
@@ -295,7 +297,7 @@ class FlinkProcessRegistrar(
               new CollectingSink[AnyRef](compilerDataForProcessPart(None), collectingSink, NodeId(part.id))
             )
         case _ =>
-          sink.registerSink(withValuePrepared, nodeContext(nodeComponentInfoFrom(part), Left(contextBefore)))
+          sink.registerSink(withValuePrepared, nodeContext(nodeComponentInfo, Left(contextBefore)))
       }
 
       withSinkAdded.name(operatorName(compilerData.jobData, part.node, "sink"))
@@ -311,8 +313,8 @@ class FlinkProcessRegistrar(
         case other =>
           throw new IllegalArgumentException(s"Unknown custom node transformer: $other")
       }
-
-      val customNodeContext = nodeContext(nodeComponentInfoFrom(part), Left(part.contextBefore))
+      val nodeComponentInfo = nodeComponentInfoFrom(part)
+      val customNodeContext = nodeContext(nodeComponentInfo, Left(part.contextBefore))
       val newContextFun: ValueWithContext[_] => Context = part.node.data.outputVar match {
         case Some(name) => vwc => vwc.context.withVariable(name, vwc.value)
         case None       => _.context
@@ -324,14 +326,16 @@ class FlinkProcessRegistrar(
           TypeInformationDetection.instance.forContext(part.validationContext)
         )
       // TODO: for ending custom nodes there are no further nodes to interpret but the function is registered to invoke listeners (e.g. to measure end metrics).
-      val afterInterpretation = registerInterpretationPart(transformed, part, CustomNodeInterpretationName)
+      val afterInterpretation =
+        registerInterpretationPart(transformed, part, CustomNodeInterpretationName, nodeComponentInfo)
       registerNextParts(afterInterpretation, part)
     }
 
     def registerInterpretationPart(
         stream: SingleOutputStreamOperator[Context],
         part: ProcessPart,
-        name: String
+        name: String,
+        nodeComponentInfo: NodeComponentInfo
     ): SingleOutputStreamOperator[Unit] = {
       val node              = part.node
       val validationContext = part.validationContext
@@ -355,6 +359,7 @@ class FlinkProcessRegistrar(
           node,
           validationContext,
           asyncExecutionContextPreparer,
+          nodeComponentInfo,
           useIOMonad
         )
         AsyncDataStream
@@ -373,6 +378,7 @@ class FlinkProcessRegistrar(
             compilerDataForProcessPart(Some(part)),
             node,
             validationContext,
+            nodeComponentInfo,
             useIOMonad
           ),
           ti

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
@@ -1,6 +1,9 @@
 package pl.touk.nussknacker.engine.process.registrar
 
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
 import cats.effect.IO
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.flink.api.common.functions.RichFlatMapFunction
 import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.InterpretationResult
@@ -30,7 +33,8 @@ private[registrar] class SyncInterpretationFunction(
     nodeComponentInfo: NodeComponentInfo,
     useIOMonad: Boolean
 ) extends RichFlatMapFunction[Context, InterpretationResult]
-    with ProcessPartFunction {
+    with ProcessPartFunction
+    with LazyLogging {
 
   private lazy val compiledNode =
     compilerData.compileSubPart(
@@ -48,54 +52,62 @@ private[registrar] class SyncInterpretationFunction(
     (try {
       runInterpreter(input)
     } catch {
-      case NonFatal(error) => List(Right(exceptionInfo(error, input)))
-    }).foreach {
-      case Left(ir) =>
-        collector.collect(ir)
-      case Right(info) =>
-        exceptionHandler.handle(info)
+      case NonFatal(error) => Valid(singleExceptionInfo(error, input))
+    }) match {
+      case Valid(interpretationResults) =>
+        interpretationResults.foreach {
+          case Left(ir) =>
+            collector.collect(ir)
+          case Right(info) =>
+            exceptionHandler.handle(info)
+        }
+      case Invalid(InterruptedError) =>
+        // The running scenario was canceled, causing an interruption.
+        // This is normal control flow, not an interpretation error, so it is handled silently (logged at debug level for diagnostic purposes).
+        logger.debug(s"Interpreter action was interrupted. ContextId: ${input.id.legacyString}")
     }
   }
 
   private def runInterpreter(
       input: Context
-  ): List[Either[InterpretationResult, NuExceptionInfo]] = {
+  ): Validated[InterruptedError.type, List[Either[InterpretationResult, NuExceptionInfo]]] = {
     // we leave switch to be able to return to Future if IO has some flaws...
     if (useIOMonad) {
       compilerData.interpreter
         .interpret[IO](compiledNode, compilerData.jobData, input, serviceExecutionContext)
         .unsafeRunTimedAttempt(compilerData.processTimeout) match {
         case Right(result) =>
-          result
+          Valid(result)
         case Left(Error.Interrupted) =>
-          List(
-            Right(
-              exceptionInfo(new InterruptedException(s"Interpreter action was interrupted"), input)
-            )
-          )
+          Invalid(InterruptedError)
         case Left(Error.Timeout) =>
-          List(
-            Right(
-              exceptionInfo(
-                new TimeoutException(
-                  s"Interpreter is running too long (timeout: ${compilerData.processTimeout})"
-                ),
-                input
-              )
+          Valid(
+            singleExceptionInfo(
+              new TimeoutException(
+                s"Interpreter is running too long (timeout: ${compilerData.processTimeout})"
+              ),
+              input
             )
           )
       }
     } else {
-      Await.result(
-        awaitable = compilerData.interpreter
-          .interpret[Future](compiledNode, compilerData.jobData, input, serviceExecutionContext),
-        atMost = compilerData.processTimeout
+      Valid(
+        Await.result(
+          awaitable = compilerData.interpreter
+            .interpret[Future](compiledNode, compilerData.jobData, input, serviceExecutionContext),
+          atMost = compilerData.processTimeout
+        )
       )
     }
   }
 
-  private def exceptionInfo(error: Throwable, input: Context): NuExceptionInfo = {
-    NuExceptionInfo(Some(nodeComponentInfo), error, input)
+  private def singleExceptionInfo(
+      error: Throwable,
+      input: Context
+  ): List[Either[InterpretationResult, NuExceptionInfo]] = {
+    List(Right(NuExceptionInfo(Some(nodeComponentInfo), error, input)))
   }
+
+  private case object InterruptedError
 
 }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
@@ -6,6 +6,7 @@ import org.apache.flink.util.Collector
 import pl.touk.nussknacker.engine.InterpretationResult
 import pl.touk.nussknacker.engine.Interpreter.FutureShape
 import pl.touk.nussknacker.engine.api.Context
+import pl.touk.nussknacker.engine.api.component.NodeComponentInfo
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.definition.EngineScenarioCompilationDependencies
 import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
@@ -13,6 +14,7 @@ import pl.touk.nussknacker.engine.api.process.ServiceExecutionContext
 import pl.touk.nussknacker.engine.graph.node.NodeData
 import pl.touk.nussknacker.engine.process.ProcessPartFunction
 import pl.touk.nussknacker.engine.process.compiler.FlinkProcessCompilerData
+import pl.touk.nussknacker.engine.process.util.IoUtils._
 import pl.touk.nussknacker.engine.splittedgraph.splittednode.SplittedNode
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContextAndIORuntime
 import pl.touk.nussknacker.engine.util.SynchronousExecutionContextAndIORuntime.syncEc
@@ -25,6 +27,7 @@ private[registrar] class SyncInterpretationFunction(
     val compilerDataForClassloader: ClassLoader => FlinkProcessCompilerData,
     val node: SplittedNode[_ <: NodeData],
     validationContext: ValidationContext,
+    nodeComponentInfo: NodeComponentInfo,
     useIOMonad: Boolean
 ) extends RichFlatMapFunction[Context, InterpretationResult]
     with ProcessPartFunction {
@@ -45,7 +48,7 @@ private[registrar] class SyncInterpretationFunction(
     (try {
       runInterpreter(input)
     } catch {
-      case NonFatal(error) => List(Right(NuExceptionInfo(None, error, input)))
+      case NonFatal(error) => List(Right(NuExceptionInfo(Some(nodeComponentInfo), error, input)))
     }).foreach {
       case Left(ir) =>
         collector.collect(ir)
@@ -61,9 +64,12 @@ private[registrar] class SyncInterpretationFunction(
     if (useIOMonad) {
       compilerData.interpreter
         .interpret[IO](compiledNode, compilerData.jobData, input, serviceExecutionContext)
-        .unsafeRunTimed(compilerData.processTimeout) match {
-        case Some(result) => result
-        case None =>
+        .unsafeRunTimedAttempt(compilerData.processTimeout) match {
+        case Right(result) =>
+          result
+        case Left(Error.Interrupted) =>
+          throw new RuntimeException(s"Interpreter action was interrupted")
+        case Left(Error.Timeout) =>
           throw new TimeoutException(s"Interpreter is running too long (timeout: ${compilerData.processTimeout})")
       }
     } else {

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/registrar/SyncInterpretationFunction.scala
@@ -48,7 +48,7 @@ private[registrar] class SyncInterpretationFunction(
     (try {
       runInterpreter(input)
     } catch {
-      case NonFatal(error) => List(Right(NuExceptionInfo(Some(nodeComponentInfo), error, input)))
+      case NonFatal(error) => List(Right(exceptionInfo(error, input)))
     }).foreach {
       case Left(ir) =>
         collector.collect(ir)
@@ -68,9 +68,22 @@ private[registrar] class SyncInterpretationFunction(
         case Right(result) =>
           result
         case Left(Error.Interrupted) =>
-          throw new RuntimeException(s"Interpreter action was interrupted")
+          List(
+            Right(
+              exceptionInfo(new InterruptedException(s"Interpreter action was interrupted"), input)
+            )
+          )
         case Left(Error.Timeout) =>
-          throw new TimeoutException(s"Interpreter is running too long (timeout: ${compilerData.processTimeout})")
+          List(
+            Right(
+              exceptionInfo(
+                new TimeoutException(
+                  s"Interpreter is running too long (timeout: ${compilerData.processTimeout})"
+                ),
+                input
+              )
+            )
+          )
       }
     } else {
       Await.result(
@@ -79,6 +92,10 @@ private[registrar] class SyncInterpretationFunction(
         atMost = compilerData.processTimeout
       )
     }
+  }
+
+  private def exceptionInfo(error: Throwable, input: Context): NuExceptionInfo = {
+    NuExceptionInfo(Some(nodeComponentInfo), error, input)
   }
 
 }

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/IoUtils.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/util/IoUtils.scala
@@ -1,0 +1,47 @@
+package pl.touk.nussknacker.engine.process.util
+
+import cats.effect.{unsafe, IO}
+
+import java.util.concurrent.{ArrayBlockingQueue, TimeUnit}
+import scala.concurrent.blocking
+import scala.concurrent.duration.FiniteDuration
+
+object IoUtils {
+
+  sealed trait Error
+
+  object Error {
+    case object Timeout     extends Error
+    case object Interrupted extends Error
+  }
+
+  implicit class SyncIoOps[A](val action: IO[A]) extends AnyVal {
+
+    def unsafeRunTimedAttempt(limit: FiniteDuration)(implicit runtime: unsafe.IORuntime): Either[Error, A] = {
+      unsafeRunTimed(limit)
+    }
+
+    // method based on IO.unsafeRunTimed (cats-effect 3.5.7)
+    // original method does not return the real cause of termination (it was just an Option[A])
+    // we want to have the real cause of termination - timeout or interruption
+    // keep in sync with cats-effect
+    private def unsafeRunTimed(limit: FiniteDuration)(implicit runtime: unsafe.IORuntime): Either[Error, A] = {
+      val queue = new ArrayBlockingQueue[Either[Throwable, A]](1)
+
+      action.unsafeRunAsync { r =>
+        queue.offer(r)
+        ()
+      }
+
+      try {
+        val result = blocking(queue.poll(limit.toNanos, TimeUnit.NANOSECONDS))
+        if (result eq null) Left(Error.Timeout) else result.fold(throw _, Right(_))
+      } catch {
+        case _: InterruptedException =>
+          Left(Error.Interrupted)
+      }
+    }
+
+  }
+
+}

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/util/IOUtilsTest.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/util/IOUtilsTest.scala
@@ -6,6 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.process.util.IoUtils._
 
+import java.util.concurrent.{CountDownLatch, Semaphore}
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.duration._
 
@@ -33,15 +34,19 @@ class IOUtilsTest extends AnyFunSuite with Matchers {
     val resultRef                     = new AtomicReference[Either[Error, Unit]]()
     val testIo                        = IO.never
 
+    val startedSemaphore = new Semaphore(0)
+
     val thread = new Thread(() => {
+      startedSemaphore.release()
       val result = testIo.unsafeRunTimedAttempt(timeout)
       resultRef.set(result)
     })
 
+    // wait for thread start
     thread.start()
+    startedSemaphore.acquire()
 
-    Thread.sleep(100)
-
+    // interrupt and wait for finish
     thread.interrupt()
     thread.join()
 

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/util/IOUtilsTest.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/util/IOUtilsTest.scala
@@ -1,0 +1,51 @@
+package pl.touk.nussknacker.engine.process.util
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.process.util.IoUtils._
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration._
+
+class IOUtilsTest extends AnyFunSuite with Matchers {
+
+  test("unsafeRunTimedAttempt should return value") {
+    implicit val ioRuntime: IORuntime = IORuntime.global
+    val timeout                       = 2 seconds
+    val testIo                        = IO.sleep(timeout.div(2)).map(_ => "result")
+
+    testIo.unsafeRunTimedAttempt(timeout) shouldBe Right("result")
+  }
+
+  test("unsafeRunTimedAttempt should return timeout error") {
+    implicit val ioRuntime: IORuntime = IORuntime.global
+    val timeout                       = 2 seconds
+    val testIo                        = IO.never
+
+    testIo.unsafeRunTimedAttempt(timeout) shouldBe Left(Error.Timeout)
+  }
+
+  test("unsafeRunTimedAttempt should return interrupted error") {
+    implicit val ioRuntime: IORuntime = IORuntime.global
+    val timeout                       = 10.seconds
+    val resultRef                     = new AtomicReference[Either[Error, Unit]]()
+    val testIo                        = IO.never
+
+    val thread = new Thread(() => {
+      val result = testIo.unsafeRunTimedAttempt(timeout)
+      resultRef.set(result)
+    })
+
+    thread.start()
+
+    Thread.sleep(100)
+
+    thread.interrupt()
+    thread.join()
+
+    resultRef.get() shouldBe Left(Error.Interrupted)
+  }
+
+}

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/util/IOUtilsTest.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/util/IOUtilsTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.process.util.IoUtils._
 
-import java.util.concurrent.{CountDownLatch, Semaphore}
+import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.duration._
 
@@ -32,21 +32,24 @@ class IOUtilsTest extends AnyFunSuite with Matchers {
     implicit val ioRuntime: IORuntime = IORuntime.global
     val timeout                       = 10.seconds
     val resultRef                     = new AtomicReference[Either[Error, Unit]]()
-    val testIo                        = IO.never
 
-    val startedSemaphore = new Semaphore(0)
+    val ioActionInProgressSemaphore = new Semaphore(0)
 
     val thread = new Thread(() => {
-      startedSemaphore.release()
+      val testIo =
+        IO.unit
+          .as(ioActionInProgressSemaphore.release())
+          .flatMap(_ => IO.never[Unit])
+
       val result = testIo.unsafeRunTimedAttempt(timeout)
       resultRef.set(result)
     })
 
     // wait for thread start
     thread.start()
-    startedSemaphore.acquire()
 
-    // interrupt and wait for finish
+    // make sure IO action is in progress, interrupt thread and wait for finish
+    ioActionInProgressSemaphore.acquire()
     thread.interrupt()
     thread.join()
 


### PR DESCRIPTION
## Describe your changes

This change introduces a new extension method `unsafeRunTimedAttempt` for IO, based on Cats Effect’s IO.unsafeRunTimed, but returning structured information about the reason for termination (timeout or interruption).

Previously, both timeout and thread interruption resulted in a TimeoutException with the message "Interpreter is running too long" in SyncInterpretationFunction, making it impossible to distinguish the real cause of termination.

With this change:

* SyncInterpretationFunction returns proper ExceptionInfo only for timeout error, interruption error is not propagated to the exceptionHandler
* Additional node details are now passed to NuExceptionInfo to improve error diagnostics.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
