### PR TITLE
Update sbt to 1.11.7, switch to sbt Sonatype publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,27 +57,26 @@ ThisBuild / isSnapshot := version(_ contains "-SNAPSHOT").value
 lazy val publishSettings = Seq(
   publishMavenStyle             := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  sonatypeCredentialHost        := "central.sonatype.com", // can be removed after sbt 1.11.x+ migration
+  pomIncludeRepository          := { _ => false },
   publishTo                     := {
     if (isSnapshot.value) {
-      Some("snapshots" at "https://central.sonatype.com/repository/maven-snapshots/")
+      Some("central-snapshots" at "https://central.sonatype.com/repository/maven-snapshots/")
     } else {
-      sonatypePublishToBundle.value
+      localStaging.value
     }
   },
   Test / publishArtifact        := false,
-  // We don't put scm information here, it will be added by release plugin and if scm provided here is different than the one from scm
-  // we'll end up with two scm sections and invalid pom...
-  pomExtra in Global            := {
-    <developers>
-      <developer>
-        <id>TouK</id>
-        <name>TouK</name>
-        <url>https://touk.pl</url>
-      </developer>
-    </developers>
-  },
+  developers                    := List(
+    Developer(
+      id = "TouK",
+      name = "TouK",
+      email = "",
+      url = url("https://touk.pl")
+    )
+  ),
   organization                  := "pl.touk.nussknacker",
+  organizationName              := "TouK",
+  organizationHomepage          := Some(url("https://touk.pl/")),
   homepage                      := Some(url(s"https://github.com/touk/nussknacker")),
 )
 
@@ -136,7 +135,7 @@ val ignoreExternalDepsTests = Tests.Argument(TestFrameworks.ScalaTest, "-l", "or
 lazy val commonSettings =
   publishSettings ++
     Seq(
-      licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+      licenses                         := Seq(License.Apache2),
       crossScalaVersions               := supportedScalaVersions,
       scalaVersion                     := defaultScalaV,
       resolvers ++= Seq(
@@ -463,7 +462,7 @@ lazy val distribution: Project = sbt
     },
     Universal / packageName                  := ("nussknacker" + "-" + version.value),
     Universal / mappings                     := {
-      val universalMappings = (Universal / mappings).value
+      val universalMappings                    = (Universal / mappings).value
       val universalMappingsWithDevConfigFilter =
         if (addDevArtifacts) universalMappings
         else filterDevConfigArtifacts(universalMappings)
@@ -479,7 +478,7 @@ lazy val distribution: Project = sbt
         (flinkExecutor / additionalBundledArtifacts).value
     },
     Universal / packageZipTarball / mappings := {
-      val universalMappings = (Universal / mappings).value
+      val universalMappings                    = (Universal / mappings).value
       val universalMappingsWithDevConfigFilter =
         if (addDevArtifacts) universalMappings
         else filterDevConfigArtifacts(universalMappings)
@@ -2307,7 +2306,7 @@ lazy val root = (project in file("."))
       releaseStepCommand("dist/Universal/packageZipTarball"),
       releaseStepCommandAndRemaining("+dist/Docker/publish"),
       releaseStepCommandAndRemaining("+liteEngineRuntimeApp/Docker/publish"),
-      releaseStepCommand("sonatypeBundleRelease"),
+      releaseStepCommand("sonaRelease"),
       setNextVersion,
       commitNextVersion,
       pushChanges

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,6 +16,3 @@ addSbtPlugin("com.github.sbt"     % "sbt-pgp"                % "2.3.1")
 addSbtPlugin("com.github.sbt"     % "sbt-release"            % "1.4.0")
 addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"           % "0.14.5")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"           % "2.5.6")
-// 3.12 is missing some logging when run on JDK 11
-// (and it is deprecated, publication should be done with sbt's native integration)
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"           % "3.11.3")


### PR DESCRIPTION
## Describe your changes

Updated sbt to 1.11, switched publishing to Sonatype from deprecated sbt-sonatype plugin to native Sonatype support from sbt 1.11.

I verified on preview/ branch that publication to Sonatype snapshots works, and verified that generated Maven metadata is correct.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
