### PR TITLE
[NU-2399] Compile assertion to a single expression

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ScenarioTestingApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ScenarioTestingApiHttpService.scala
@@ -242,7 +242,7 @@ class ScenarioTestingApiHttpService(
                 request.numberOfSamples
               ) match {
                 case Left(error) =>
-                  logger.error(s"Error during generation of test data: $error")
+                  logger.info(s"Could not generate test data: $error")
                   Future(Left(toDto(error)))
                 case Right(serializedLiveData) =>
                   Future(Right(serializedLiveData.content))

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -1,8 +1,5 @@
 package pl.touk.nussknacker.ui.process.test.testcase
 
-import java.util
-import scala.jdk.CollectionConverters._
-
 sealed trait AssertionResult
 
 case object SuccessfulAssertion extends AssertionResult
@@ -11,52 +8,13 @@ case class FailedAssertion(message: String) extends AssertionResult
 
 object AssertionResult {
 
-  def assertEquals(expected: Any, actual: Any): AssertionResult = {
-    // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
-    if (expected == actual) {
-      SuccessfulAssertion
-    } else if (checkIfSameElements(expected, actual)) {
-      SuccessfulAssertion
-    } else {
-      produceFailedAssertion(expected, actual)
-    }
-  }
-
-  def assertNotEquals(expected: Any, actual: Any): AssertionResult = {
-    // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
-    if (expected == actual) {
-      produceFailedNotEqualsAssertion(expected)
-    } else if (checkIfSameElements(expected, actual)) {
-      produceFailedNotEqualsAssertion(expected)
-    } else {
-      SuccessfulAssertion
-    }
-  }
-
-  // todo: should it work recursively - e.g for arrays nested in lists?
-  private def checkIfSameElements(expected: Any, actual: Any) = {
-    if ((expected.isInstanceOf[Array[_]] || expected.isInstanceOf[util.Collection[_]]) &&
-      (actual.isInstanceOf[Array[_]] || actual.isInstanceOf[util.Collection[_]])) {
-      convertToSeq(expected) == convertToSeq(actual)
-    } else {
-      false
-    }
-  }
-
-  private def convertToSeq(value: Any): Seq[_] = {
-    value match {
-      case a: Array[_]           => a.toSeq
-      case c: util.Collection[_] => c.asScala.toSeq
-    }
-  }
-
-  private def produceFailedAssertion(expected: Any, actual: Any) = {
+  def produceFailedEqualsAssertion(expected: Any, actual: Any): FailedAssertion = {
     val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
     val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
     FailedAssertion(s"Expected: [$expectedStr] but found [$actualStr]")
   }
 
-  private def produceFailedNotEqualsAssertion(expected: Any) = {
+  def produceFailedNotEqualsAssertion(expected: Any): FailedAssertion = {
     val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
     FailedAssertion(s"Expected value different from: [$expectedStr]")
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -41,8 +41,15 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
       assertion match {
         case CompiledExpressionAssertion(expression) =>
           evaluateExpressionAssertion(expression, context, globalVariables)
-        case CompiledPredicateAssertion(operator, expected, actual) =>
-          evaluatePredicateAssertion(operator, expected, actual, context, globalVariables)
+        case CompiledPredicateAssertion(operator, expectedExpression, actualExpression, comparisonExpression) =>
+          evaluatePredicateAssertion(
+            operator,
+            expectedExpression,
+            actualExpression,
+            comparisonExpression,
+            context,
+            globalVariables
+          )
       }
     } catch {
       case e: Exception => FailedAssertion(s"Exception during assertion evaluation: ${e.getMessage}")
@@ -73,16 +80,22 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
 
   private def evaluatePredicateAssertion(
       operator: AssertionOperator,
-      expected: CompiledExpression,
-      actual: CompiledExpression,
+      expectedExpression: CompiledExpression,
+      actualExpression: CompiledExpression,
+      comparisonExpression: CompiledExpression,
       context: Context,
       globalVariables: Map[String, Any]
   ): AssertionResult = {
-    val expectedValue = expected.evaluate[Any](context, globalVariables)
-    val actualValue   = actual.evaluate[Any](context, globalVariables)
-    operator match {
-      case AssertionOperator.Equals    => AssertionResult.assertEquals(expectedValue, actualValue)
-      case AssertionOperator.NotEquals => AssertionResult.assertNotEquals(expectedValue, actualValue)
+    val comparisonResult = comparisonExpression.evaluate[Boolean](context, globalVariables)
+    if (comparisonResult) {
+      SuccessfulAssertion
+    } else {
+      val expectedValue = expectedExpression.evaluate[Any](context, globalVariables)
+      val actualValue   = actualExpression.evaluate[Any](context, globalVariables)
+      operator match {
+        case AssertionOperator.Equals    => AssertionResult.produceFailedEqualsAssertion(expectedValue, actualValue)
+        case AssertionOperator.NotEquals => AssertionResult.produceFailedNotEqualsAssertion(expectedValue)
+      }
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -121,13 +121,7 @@ class AssertionsCompiler(
       assertion: PredicateAssertion
   )(implicit nodeId: NodeId): ValidatedNel[PredicateAssertionCompilationError, CompiledPredicateAssertion] = {
     val expectedCompiled = compileExpectedExpression(context, assertion)
-    val actualCompiled = compileActualExpression(
-      context,
-      assertion,
-      // If errors occur in the expected expression, we still attempt to compile the actual expression
-      // without the expected type to return errors if there are any in the expression itself.
-      expectedCompiled.map(_.returnType).getOrElse(Unknown)
-    )
+    val actualCompiled   = compileActualExpression(context, assertion)
     (expectedCompiled, actualCompiled).tupled.andThen { case (expectedExpression, actualExpression) =>
       compileComparisonExpression(context, assertion)
         .map { comparisonExpression =>
@@ -150,13 +144,13 @@ class AssertionsCompiler(
         assertion.expected,
         Some(ParameterName(PredicateAssertionCompilationError.Field.Expected.entryName)),
         context,
-        Unknown
+        expectedType = Unknown
       )
       .leftMap(
         PredicateAssertionCompilationError(
           _,
           assertion,
-          Some(PredicateAssertionCompilationError.Field.Expected),
+          PredicateAssertionCompilationError.Field.Expected,
           nodeId
         )
       )
@@ -166,17 +160,21 @@ class AssertionsCompiler(
   private def compileActualExpression(
       context: ValidationContext,
       assertion: PredicateAssertion,
-      expectedType: TypingResult
   )(implicit nodeId: NodeId): ValidatedNel[PredicateAssertionCompilationError, TypedExpression] = {
     expressionCompiler
       .compile(
         assertion.actual,
         Some(ParameterName(PredicateAssertionCompilationError.Field.Actual.entryName)),
         context,
-        expectedType
+        expectedType = Unknown
       )
       .leftMap(
-        PredicateAssertionCompilationError(_, assertion, Some(PredicateAssertionCompilationError.Field.Actual), nodeId)
+        PredicateAssertionCompilationError(
+          _,
+          assertion,
+          PredicateAssertionCompilationError.Field.Actual,
+          nodeId
+        )
       )
       .toValidatedNel
   }
@@ -187,14 +185,23 @@ class AssertionsCompiler(
   )(implicit nodeId: NodeId): ValidatedNel[PredicateAssertionCompilationError, TypedExpression] = {
     expressionCompiler
       .compile(
+        // Compiling the below expression can result in errors like: Operator '==' used with not comparable types: String and Integer
+        // If we need to report more user-friendly error (without: Operator '=='), we can use CommonSupertypeFinder here to check if types are comparable before compiling.
         s"${assertion.expected.expression} ${toComparisonOperator(assertion.operator)} ${assertion.actual.expression}".spel,
-        paramName = None,
+        // See comment below - we report errors on actual field.
+        paramName = Some(ParameterName(PredicateAssertionCompilationError.Field.Actual.entryName)),
         context,
-        Typed[java.lang.Boolean]
+        expectedType = Typed[java.lang.Boolean]
       )
-      .leftMap(
-        PredicateAssertionCompilationError(_, assertion, field = None, nodeId)
-      )
+      .leftMap { errors =>
+        PredicateAssertionCompilationError(
+          errors,
+          assertion,
+          // If comparison expression fails to compile because of uncomparable types, we report the error on actual field.
+          PredicateAssertionCompilationError.Field.Actual,
+          nodeId
+        )
+      }
       .toValidatedNel
   }
 
@@ -229,7 +236,7 @@ object AssertionCompilationError {
   final case class PredicateAssertionCompilationError(
       errors: NonEmptyList[ProcessCompilationError],
       assertion: PredicateAssertion,
-      field: Option[PredicateAssertionCompilationError.Field],
+      field: PredicateAssertionCompilationError.Field,
       nodeId: NodeId,
   ) extends AssertionCompilationError
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -13,7 +13,12 @@ import pl.touk.nussknacker.engine.compile.ExpressionCompiler
 import pl.touk.nussknacker.engine.expression.parse.{CompiledExpression, TypedExpression}
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.{AssertionOperator, ExpressionAssertion, PredicateAssertion}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.{
+  assertionDecoder,
+  AssertionOperator,
+  ExpressionAssertion,
+  PredicateAssertion
+}
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
 import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.{
@@ -115,22 +120,24 @@ class AssertionsCompiler(
       context: ValidationContext,
       assertion: PredicateAssertion
   )(implicit nodeId: NodeId): ValidatedNel[PredicateAssertionCompilationError, CompiledPredicateAssertion] = {
-    compileExpectedExpression(context, assertion)
-      .andThen { expectedExpression =>
-        compileActualExpression(context, assertion, expectedExpression.returnType)
-          .tupleLeft(expectedExpression)
-      }
-      .andThen { case (expectedExpression, actualExpression) =>
-        compileComparisonExpression(context, assertion)
-          .map { comparisonExpression =>
-            CompiledPredicateAssertion(
-              operator = assertion.operator,
-              expectedExpression = expectedExpression.expression,
-              actualExpression = actualExpression.expression,
-              comparisonExpression = comparisonExpression.expression
-            )
-          }
-      }
+    val expectedCompiled = compileExpectedExpression(context, assertion)
+    val actualCompiled = compileActualExpression(
+      context,
+      assertion,
+      // In case of errors for expected expression, we still try to compile without expected type to return potential errors
+      expectedCompiled.map(_.returnType).getOrElse(Unknown)
+    )
+    (expectedCompiled, actualCompiled).tupled.andThen { case (expectedExpression, actualExpression) =>
+      compileComparisonExpression(context, assertion)
+        .map { comparisonExpression =>
+          CompiledPredicateAssertion(
+            operator = assertion.operator,
+            expectedExpression = expectedExpression.expression,
+            actualExpression = actualExpression.expression,
+            comparisonExpression = comparisonExpression.expression
+          )
+        }
+    }
   }
 
   private def compileExpectedExpression(

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -124,7 +124,8 @@ class AssertionsCompiler(
     val actualCompiled = compileActualExpression(
       context,
       assertion,
-      // In case of errors for expected expression, we still try to compile without expected type to return potential errors
+      // If errors occur in the expected expression, we still attempt to compile the actual expression
+      // without the expected type to return errors if there are any in the expression itself.
       expectedCompiled.map(_.returnType).getOrElse(Unknown)
     )
     (expectedCompiled, actualCompiled).tupled.andThen { case (expectedExpression, actualExpression) =>

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -10,8 +10,10 @@ import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, Validati
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.compile.ExpressionCompiler
+import pl.touk.nussknacker.engine.expression.parse.{CompiledExpression, TypedExpression}
+import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.{ExpressionAssertion, PredicateAssertion}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.{AssertionOperator, ExpressionAssertion, PredicateAssertion}
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
 import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.{
@@ -113,33 +115,86 @@ class AssertionsCompiler(
       context: ValidationContext,
       assertion: PredicateAssertion
   )(implicit nodeId: NodeId): ValidatedNel[PredicateAssertionCompilationError, CompiledPredicateAssertion] = {
-    val compiledExpected = expressionCompiler
+    compileExpectedExpression(context, assertion)
+      .andThen { expectedExpression =>
+        compileActualExpression(context, assertion, expectedExpression.returnType)
+          .tupleLeft(expectedExpression)
+      }
+      .andThen { case (expectedExpression, actualExpression) =>
+        compileComparisonExpression(context, assertion)
+          .map { comparisonExpression =>
+            CompiledPredicateAssertion(
+              operator = assertion.operator,
+              expectedExpression = expectedExpression.expression,
+              actualExpression = actualExpression.expression,
+              comparisonExpression = comparisonExpression.expression
+            )
+          }
+      }
+  }
+
+  private def compileExpectedExpression(
+      context: ValidationContext,
+      assertion: PredicateAssertion
+  )(implicit nodeId: NodeId): ValidatedNel[PredicateAssertionCompilationError, TypedExpression] = {
+    expressionCompiler
       .compile(
         assertion.expected,
         Some(ParameterName(PredicateAssertionCompilationError.Field.Expected.entryName)),
         context,
-        Unknown // For equals, we can assume any of type of expected and actual expressions are fine, but for >=, <, etc. we could also check if both types are comparable.
+        Unknown
       )
       .leftMap(
-        PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.Field.Expected, nodeId)
+        PredicateAssertionCompilationError(
+          _,
+          assertion,
+          Some(PredicateAssertionCompilationError.Field.Expected),
+          nodeId
+        )
       )
       .toValidatedNel
-    val compiledActual = expressionCompiler
+  }
+
+  private def compileActualExpression(
+      context: ValidationContext,
+      assertion: PredicateAssertion,
+      expectedType: TypingResult
+  )(implicit nodeId: NodeId): ValidatedNel[PredicateAssertionCompilationError, TypedExpression] = {
+    expressionCompiler
       .compile(
         assertion.actual,
         Some(ParameterName(PredicateAssertionCompilationError.Field.Actual.entryName)),
         context,
-        Unknown
+        expectedType
       )
       .leftMap(
-        PredicateAssertionCompilationError(_, assertion, PredicateAssertionCompilationError.Field.Actual, nodeId)
+        PredicateAssertionCompilationError(_, assertion, Some(PredicateAssertionCompilationError.Field.Actual), nodeId)
       )
       .toValidatedNel
+  }
 
-    (compiledExpected, compiledActual)
-      .mapN { (expected, actual) =>
-        CompiledPredicateAssertion(assertion.operator, expected.expression, actual.expression)
-      }
+  private def compileComparisonExpression(
+      context: ValidationContext,
+      assertion: PredicateAssertion,
+  )(implicit nodeId: NodeId): ValidatedNel[PredicateAssertionCompilationError, TypedExpression] = {
+    expressionCompiler
+      .compile(
+        s"${assertion.expected.expression} ${toComparisonOperator(assertion.operator)} ${assertion.actual.expression}".spel,
+        paramName = None,
+        context,
+        Typed[java.lang.Boolean]
+      )
+      .leftMap(
+        PredicateAssertionCompilationError(_, assertion, field = None, nodeId)
+      )
+      .toValidatedNel
+  }
+
+  private def toComparisonOperator(operator: Assertion.AssertionOperator): String = {
+    operator match {
+      case AssertionOperator.Equals    => "=="
+      case AssertionOperator.NotEquals => "!="
+    }
   }
 
 }
@@ -166,7 +221,7 @@ object AssertionCompilationError {
   final case class PredicateAssertionCompilationError(
       errors: NonEmptyList[ProcessCompilationError],
       assertion: PredicateAssertion,
-      field: PredicateAssertionCompilationError.Field,
+      field: Option[PredicateAssertionCompilationError.Field],
       nodeId: NodeId,
   ) extends AssertionCompilationError
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/CompiledAssertions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/CompiledAssertions.scala
@@ -14,8 +14,9 @@ object CompiledAssertion {
 
   final case class CompiledPredicateAssertion(
       operator: AssertionOperator,
-      expected: CompiledExpression,
-      actual: CompiledExpression
+      expectedExpression: CompiledExpression,
+      actualExpression: CompiledExpression,
+      comparisonExpression: CompiledExpression
   ) extends CompiledAssertion
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestsFunctions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestsFunctions.scala
@@ -7,7 +7,8 @@ import scala.jdk.CollectionConverters._
 
 object tests extends TestsFunctions
 
-// This helper should be eventually removed because comparison logic do apply SpEL implicit conversions.
+// This helper should be eventually removed because SpEL comparison logic do apply SpEL implicit conversions
+// in contrary to this implementation which uses Scala equality semantics.
 trait TestsFunctions extends HideToString {
 
   @Documentation(description = "Check whether two values are equal")

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestsFunctions.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/TestsFunctions.scala
@@ -1,19 +1,54 @@
 package pl.touk.nussknacker.ui.process.test.testcase
 
-import pl.touk.nussknacker.engine.api.{Documentation, HideToString, ParamName}
+import pl.touk.nussknacker.engine.api.{Documentation, HideToString}
+
+import java.util
+import scala.jdk.CollectionConverters._
 
 object tests extends TestsFunctions
 
+// This helper should be eventually removed because comparison logic do apply SpEL implicit conversions.
 trait TestsFunctions extends HideToString {
 
   @Documentation(description = "Check whether two values are equal")
-  def assertEquals(@ParamName("expected") expected: Any, @ParamName("actual") actual: Any): AssertionResult = {
-    AssertionResult.assertEquals(expected, actual)
+  def assertEquals(expected: Any, actual: Any): AssertionResult = {
+    // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
+    if (expected == actual) {
+      SuccessfulAssertion
+    } else if (checkIfSameElements(expected, actual)) {
+      SuccessfulAssertion
+    } else {
+      AssertionResult.produceFailedEqualsAssertion(expected, actual)
+    }
   }
 
   @Documentation(description = "Check whether two values are not equal")
-  def assertNotEquals(@ParamName("expected") expected: Any, @ParamName("actual") actual: Any): AssertionResult = {
-    AssertionResult.assertNotEquals(expected, actual)
+  def assertNotEquals(expected: Any, actual: Any): AssertionResult = {
+    // we use scala "lenient" equals to allow to compare boxed primitives of different types - like 1L and 1
+    if (expected == actual) {
+      AssertionResult.produceFailedNotEqualsAssertion(expected)
+    } else if (checkIfSameElements(expected, actual)) {
+      AssertionResult.produceFailedNotEqualsAssertion(expected)
+    } else {
+      SuccessfulAssertion
+    }
+  }
+
+  // todo: should it work recursively - e.g for arrays nested in lists?
+  private def checkIfSameElements(expected: Any, actual: Any) = {
+    if ((expected.isInstanceOf[Array[_]] || expected.isInstanceOf[util.Collection[_]]) &&
+      (actual.isInstanceOf[Array[_]] || actual.isInstanceOf[util.Collection[_]])) {
+      convertToSeq(expected) == convertToSeq(actual)
+    } else {
+      false
+    }
+  }
+
+  private def convertToSeq(value: Any): Seq[_] = {
+    value match {
+      case a: Array[_]           => a.toSeq
+      case c: util.Collection[_] => c.asScala.toSeq
+    }
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
@@ -53,7 +53,7 @@ private class AssertionValidator(
             message = prettyError.message,
             description = prettyError.description,
             details = prettyError.details,
-            fieldName = field.map(_.entryName),
+            fieldName = Some(field.entryName),
           )
         }
     }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/validation/AssertionValidator.scala
@@ -53,7 +53,7 @@ private class AssertionValidator(
             message = prettyError.message,
             description = prettyError.description,
             details = prettyError.details,
-            fieldName = Some(field.entryName),
+            fieldName = field.map(_.entryName),
           )
         }
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestServiceSpec.scala
@@ -735,8 +735,8 @@ class ScenarioTestServiceSpec
             .copy(
               originalNodeResults = Map(
                 NodeId("end") -> (
-                  ResultContext[Any](ContextId.dummy, now, Map("otherNameThanInput" -> Map("a" -> "foo").asJava)) ::
-                    ResultContext[Any](ContextId.dummy, now, Map("otherNameThanInput" -> Map("a" -> "bar").asJava)) ::
+                  ResultContext[Any](ContextId.dummy, now, Map("otherNameThanInput" -> Map("a" -> 42).asJava)) ::
+                    ResultContext[Any](ContextId.dummy, now, Map("otherNameThanInput" -> Map("a" -> 43).asJava)) ::
                     Nil
                 )
               )
@@ -799,10 +799,14 @@ class ScenarioTestServiceSpec
         NodeId("end") -> List(
           PredicateAssertion(
             Assertion.AssertionOperator.Equals,
-            "'foo'".spel,
+            "42".spel,
             "#contexts[0].otherNameThanInput.a".spel
           ),
-          PredicateAssertion(Assertion.AssertionOperator.Equals, "'foo'".spel, "#contexts[1].otherNameThanInput.a".spel)
+          PredicateAssertion(
+            Assertion.AssertionOperator.Equals,
+            "44".spel,
+            "#contexts[1].otherNameThanInput.a".spel
+          )
         )
       )
     )
@@ -821,7 +825,7 @@ class ScenarioTestServiceSpec
 
     result.assertionsResults(NodeId("end")) shouldBe List(
       SuccessfulAssertion,
-      FailedAssertion("Expected: ['foo'] but found ['bar']")
+      FailedAssertion("Expected: [44] but found [43]")
     )
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -13,8 +13,8 @@ import pl.touk.nussknacker.engine.definition.model.ModelDefinitionWithClasses
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
+import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
 import pl.touk.nussknacker.engine.test.testcase.Assertion.{AssertionOperator, ExpressionAssertion, PredicateAssertion}
-import pl.touk.nussknacker.engine.test.testcase.TestCase
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.engine.testmode.TestProcess.ResultContext
 import pl.touk.nussknacker.engine.util.functions.conversion
@@ -65,52 +65,42 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
     )
   )
 
+  private val nodeId = NodeId("someNode")
+
   test("should run assertions on test nodes results and return assertion result for each assertion") {
-    val testCase = TestCase(
-      UUID.randomUUID(),
-      "dummy",
-      "dummy",
-      Map.empty,
-      Map(
-        NodeId("someNode") -> List(
-          ExpressionAssertion("#TESTS.assertEquals('valid', #contexts[0].someVariable)".spel),
-          ExpressionAssertion("#TESTS.assertEquals('valid', #contexts[1].someVariable)".spel),
-          PredicateAssertion(AssertionOperator.Equals, "'valid'".spel, "#contexts[0].someVariable".spel),
-          PredicateAssertion(AssertionOperator.Equals, "'valid'".spel, "#contexts[1].someVariable".spel),
-          PredicateAssertion(AssertionOperator.NotEquals, "'valid'".spel, "#contexts[0].someVariable".spel),
-          PredicateAssertion(AssertionOperator.NotEquals, "'valid'".spel, "#contexts[1].someVariable".spel),
-        )
+    val testCase = prepareTestCase(
+      List(
+        ExpressionAssertion("#TESTS.assertEquals('valid', #contexts[0].someVariable)".spel),
+        ExpressionAssertion("#TESTS.assertEquals('valid', #contexts[1].someVariable)".spel),
+        PredicateAssertion(AssertionOperator.Equals, "'valid'".spel, "#contexts[0].someVariable".spel),
+        PredicateAssertion(AssertionOperator.Equals, "'valid'".spel, "#contexts[1].someVariable".spel),
+        PredicateAssertion(AssertionOperator.NotEquals, "'valid'".spel, "#contexts[0].someVariable".spel),
+        PredicateAssertion(AssertionOperator.NotEquals, "'valid'".spel, "#contexts[1].someVariable".spel),
+      )
+    )
+    val nodesResultsAfterTestRun: Map[NodeId, List[ResultContext[Any]]] = prepareNodeResults(
+      List(
+        Map("someVariable" -> "valid"),
+        Map("someVariable" -> "invalid"),
       )
     )
 
-    val nodesResultsAfterTestRun: Map[NodeId, List[ResultContext[Any]]] = Map(
-      NodeId("someNode") -> List(
-        ResultContext[Any](ContextId.dummy, Instant.now(), Map("someVariable" -> "valid")),
-        ResultContext[Any](ContextId.dummy, Instant.now(), Map("someVariable" -> "invalid")),
-      )
-    )
+    val results = verifyForTestCase(testCase, nodesResultsAfterTestRun)
 
-    val results = verifyForTestCase(
-      testCase,
-      nodesResultsAfterTestRun
-    )
-
-    results.toList shouldBe List(
-      NodeId("someNode") -> List(
-        SuccessfulAssertion,
-        FailedAssertion("Expected: ['valid'] but found ['invalid']"),
-        SuccessfulAssertion,
-        FailedAssertion("Expected: ['valid'] but found ['invalid']"),
-        FailedAssertion("Expected value different from: ['valid']"),
-        SuccessfulAssertion,
-      )
+    results shouldBe List(
+      SuccessfulAssertion,
+      FailedAssertion("Expected: ['valid'] but found ['invalid']"),
+      SuccessfulAssertion,
+      FailedAssertion("Expected: ['valid'] but found ['invalid']"),
+      FailedAssertion("Expected value different from: ['valid']"),
+      SuccessfulAssertion,
     )
   }
 
   test("should properly compare various types used in SpEL") {
     forAll(
       Table(
-        ("expected", "actual", "result"),
+        ("expected expression", "actual expression", "expected assertion result"),
         ("'valid'", "'valid'", SuccessfulAssertion),
         ("{}", "{}", SuccessfulAssertion),
         ("{:}", "{:}", SuccessfulAssertion),
@@ -129,49 +119,54 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
         ),
         ("{'1','2','3'}", "'1,2,3'.split(',')", SuccessfulAssertion), // comparing arrays with SpEL inline lists
         ("{'a': 1}", "{:}", FailedAssertion("Expected: [{'a': 1}] but found [{:}]")),
-        // ("{'1,2'.split(',')}", "{'1,2'.split(',')}", SuccessfulAssertion), //todo: to be discussed whether it should work for nested structures
       )
-    ) { (expected, actual, result) =>
-      val testCase = TestCase(
-        UUID.randomUUID(),
-        "dummy",
-        "dummy",
-        Map.empty,
-        Map(
-          NodeId("someNode") -> List(
-            ExpressionAssertion(s"#TESTS.assertEquals($expected, $actual)".spel),
-            PredicateAssertion(AssertionOperator.Equals, expected.spel, actual.spel),
-          )
+    ) { (expectedExpression, actualExpression, expectedResult) =>
+      val testCase = prepareTestCase(
+        List(
+          ExpressionAssertion(s"#TESTS.assertEquals($expectedExpression, $actualExpression)".spel),
+          PredicateAssertion(AssertionOperator.Equals, expectedExpression.spel, actualExpression.spel),
         )
       )
-      val nodesResultsAfterTestRun: Map[NodeId, List[ResultContext[Any]]] = Map(
-        NodeId("someNode") -> List(
-          ResultContext[Any](
-            ContextId.dummy,
-            Instant.now(),
-            Map(
-              "someJavaList" -> java.util.List.of("foo"),
-            )
-          ),
+      val nodesResultsAfterTestRun = prepareNodeResults(
+        List(
+          Map("someJavaList" -> java.util.List.of("foo"))
         )
       )
 
-      verifyForTestCase(testCase, nodesResultsAfterTestRun).toList shouldBe List(
-        NodeId("someNode") -> List(result, result)
-      )
+      val results = verifyForTestCase(testCase, nodesResultsAfterTestRun)
+
+      results shouldBe List(expectedResult, expectedResult)
     }
   }
 
-  private def verifyForTestCase(testCase: TestCase, nodesResultsAfterTestRun: Map[NodeId, List[ResultContext[Any]]]) = {
+  private def verifyForTestCase(
+      testCase: TestCase,
+      nodesResultsAfterTestRun: Map[NodeId, List[ResultContext[Any]]]
+  ): List[AssertionResult] = {
     val jobData = JobData(MetaData("someScenario", StreamMetaData()), ProcessVersion.empty)
     val compiledTestCase = testCompiler
       .compile(testCase, scenarioTyping, jobData)
       .fold(errors => throw new IllegalStateException(s"Test compilation errors: $errors"), identity)
-    verifier.verify(
+    val results = verifier.verify(
       compiledTestCase,
       nodesResultsAfterTestRun,
       jobData
     )
+    results(nodeId)
+  }
+
+  private def prepareTestCase(assertions: List[Assertion]): TestCase = {
+    TestCase(
+      id = UUID.randomUUID(),
+      name = "dummy",
+      inputs = "dummy",
+      mocks = Map.empty,
+      assertions = Map(nodeId -> assertions)
+    )
+  }
+
+  private def prepareNodeResults(variablesForEachRun: List[Map[String, Any]]): Map[NodeId, List[ResultContext[Any]]] = {
+    Map(nodeId -> variablesForEachRun.map(variables => ResultContext[Any](ContextId.dummy, Instant.now(), variables)))
   }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -118,7 +118,6 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
           "'1,2,3'.split(',')",
           FailedAssertion("Expected: [{'1', '2'}] but found [{'1', '2', '3'}]")
         ),
-        ("{'1','2','3'}", "'1,2,3'.split(',')", SuccessfulAssertion), // comparing arrays with SpEL inline lists
         ("{'a': 1}", "{:}", FailedAssertion("Expected: [{'a': 1}] but found [{:}]")),
       )
     ) { (expectedExpression, actualExpression, expectedResult) =>

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -53,19 +53,20 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   private val testCompiler = new AssertionsCompiler(expressionCompiler, globalVariablesPreparer)
   private val verifier     = new AssertionVerifier(globalVariablesPreparer)
 
+  private val nodeId = NodeId("someNode")
+
   private val scenarioTyping: Map[String, NodeTypingData] = Map(
-    "someNode" -> NodeTypingData(
-      Map(
-        "someVariable" -> Typed.fromInstance("bar"),
-        "someJavaList" -> Typed.fromInstance(new util.ArrayList[String]()),
-        "someArray"    -> Typed.fromInstance(new Array[String](1))
+    nodeId.id -> NodeTypingData(
+      variableTypes = Map(
+        "someVariable"   -> Typed.fromInstance("bar"),
+        "someJavaList"   -> Typed.fromInstance(new util.ArrayList[String]()),
+        "someArray"      -> Typed.fromInstance(new Array[String](1)),
+        "someBigDecimal" -> Typed[java.math.BigDecimal],
       ),
-      None,
-      Map.empty
+      parameters = None,
+      typingInfo = Map.empty
     )
   )
-
-  private val nodeId = NodeId("someNode")
 
   test("should run assertions on test nodes results and return assertion result for each assertion") {
     val testCase = prepareTestCase(
@@ -130,6 +131,36 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
       val nodesResultsAfterTestRun = prepareNodeResults(
         List(
           Map("someJavaList" -> java.util.List.of("foo"))
+        )
+      )
+
+      val results = verifyForTestCase(testCase, nodesResultsAfterTestRun)
+
+      results shouldBe List(expectedResult, expectedResult)
+    }
+  }
+
+  test("should apply SpEL conversions") {
+    forAll(
+      Table(
+        ("expected expression", "actual expression", "expected assertion result"),
+        ("1", "#contexts[0].someBigDecimal", SuccessfulAssertion),
+        ("1L", "#contexts[0].someBigDecimal", SuccessfulAssertion),
+        ("1.0", "#contexts[0].someBigDecimal", SuccessfulAssertion),
+        ("1.0f", "#contexts[0].someBigDecimal", SuccessfulAssertion),
+        ("1", "T(java.math.BigDecimal).ONE", SuccessfulAssertion),
+        ("{'1,2'.split(',')}", "{'1,2'.split(',')}", SuccessfulAssertion),
+      )
+    ) { (expectedExpression, actualExpression, expectedResult) =>
+      val testCase = prepareTestCase(
+        List(
+          ExpressionAssertion(s"#TESTS.assertEquals($expectedExpression, $actualExpression)".spel),
+          PredicateAssertion(AssertionOperator.Equals, expectedExpression.spel, actualExpression.spel),
+        )
+      )
+      val nodesResultsAfterTestRun = prepareNodeResults(
+        List(
+          Map("someBigDecimal" -> new java.math.BigDecimal("1.0"))
         )
       )
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -50,8 +50,8 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
     modelDefinitionWithClasses.modelDefinition.expressionConfig
   )
 
-  private val testCompiler = new AssertionsCompiler(expressionCompiler, globalVariablesPreparer)
-  private val verifier     = new AssertionVerifier(globalVariablesPreparer)
+  private val assertionsCompiler = new AssertionsCompiler(expressionCompiler, globalVariablesPreparer)
+  private val assertionVerifier  = new AssertionVerifier(globalVariablesPreparer)
 
   private val nodeId = NodeId("someNode")
 
@@ -149,12 +149,12 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
         ("1.0", "#contexts[0].someBigDecimal", SuccessfulAssertion),
         ("1.0f", "#contexts[0].someBigDecimal", SuccessfulAssertion),
         ("1", "T(java.math.BigDecimal).ONE", SuccessfulAssertion),
-        ("{'1,2'.split(',')}", "{'1,2'.split(',')}", SuccessfulAssertion),
+        ("{a: 1}", """#CONV.toJson('{"a": 1}')""", SuccessfulAssertion),
+        ("{a: 1}", """#CONV.toJson('{"a": 2}')""", FailedAssertion("Expected: [{'a': 1}] but found [{'a': 2}]")),
       )
     ) { (expectedExpression, actualExpression, expectedResult) =>
       val testCase = prepareTestCase(
         List(
-          ExpressionAssertion(s"#TESTS.assertEquals($expectedExpression, $actualExpression)".spel),
           PredicateAssertion(AssertionOperator.Equals, expectedExpression.spel, actualExpression.spel),
         )
       )
@@ -166,7 +166,7 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
 
       val results = verifyForTestCase(testCase, nodesResultsAfterTestRun)
 
-      results shouldBe List(expectedResult, expectedResult)
+      results shouldBe List(expectedResult)
     }
   }
 
@@ -175,10 +175,10 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
       nodesResultsAfterTestRun: Map[NodeId, List[ResultContext[Any]]]
   ): List[AssertionResult] = {
     val jobData = JobData(MetaData("someScenario", StreamMetaData()), ProcessVersion.empty)
-    val compiledTestCase = testCompiler
+    val compiledTestCase = assertionsCompiler
       .compile(testCase, scenarioTyping, jobData)
       .fold(errors => throw new IllegalStateException(s"Test compilation errors: $errors"), identity)
-    val results = verifier.verify(
+    val results = assertionVerifier.verify(
       compiledTestCase,
       nodesResultsAfterTestRun,
       jobData

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.ui.process.test.testcase
 
 import cats.data.{NonEmptyList, Validated}
 import cats.data.Validated.{Invalid, Valid}
+import jdk.internal.net.http.common.Log.errors
 import org.scalatest.Inside
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -66,13 +67,8 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
       .buildSimpleVariable("result-id2", "result", "#input".spel)
       .emptySink("sink1", "sink")
-
-    val test = TestCase(
-      UUID.randomUUID(),
-      "someTest",
-      inputs = "",
-      mocks = Map.empty,
-      assertions = Map(
+    val test = prepareTestCase(
+      Map(
         NodeId("sink1") -> List(PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel))
       )
     )
@@ -96,12 +92,8 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
       .buildSimpleVariable("result-id2", "result", "#input".spel)
       .emptySink("sink1", "sink")
-    val test = TestCase(
-      UUID.randomUUID(),
-      "someTest",
-      inputs = "",
-      mocks = Map.empty,
-      assertions = Map(
+    val test = prepareTestCase(
+      Map(
         NodeId("notExistingSink") -> List(
           PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel)
         )
@@ -126,21 +118,26 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
       .buildSimpleVariable("result-id2", "result", "#input".spel)
       .emptySink("sink1", "sink")
-    val nodeId           = NodeId("sink1")
-    val invalidAssertion = PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size,".spel)
-
-    val test = TestCase(
-      UUID.randomUUID(),
-      "someTest",
-      inputs = "",
-      mocks = Map.empty,
-      assertions = Map(nodeId -> List(invalidAssertion))
+    val nodeId = NodeId("sink1")
+    val assertionWithUnneededComma =
+      PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size,".spel)
+    val assertionComparingUnrelatedTypes =
+      PredicateAssertion(Assertion.AssertionOperator.Equals, "'string'".spel, "123".spel)
+    val test = prepareTestCase(
+      Map(
+        nodeId -> List(
+          assertionWithUnneededComma,
+          assertionComparingUnrelatedTypes,
+        )
+      )
     )
 
     val testCompilationResult = compileScenarioWithAssertions(scenario, test)
     inside(testCompilationResult) { case Invalid(errors) =>
-      errors.size shouldBe 1
-      errors.head shouldBe PredicateAssertionCompilationError(
+      errors.size shouldBe 2
+
+      val assertionWithUnneededCommaError :: assertionComparingUnrelatedTypesError :: Nil = errors.toList
+      assertionWithUnneededCommaError shouldBe PredicateAssertionCompilationError(
         NonEmptyList.one(
           ExpressionParserCompilationError(
             "Unexpected text",
@@ -150,7 +147,22 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
             Some(CoordinatesBasedTextRange(TextCoordinates(14, 0), TextCoordinates(15, 0)))
           )
         ),
-        invalidAssertion,
+        assertionWithUnneededComma,
+        Some(PredicateAssertionCompilationError.Field.Actual),
+        nodeId
+      )
+
+      assertionComparingUnrelatedTypesError shouldBe PredicateAssertionCompilationError(
+        NonEmptyList.one(
+          ExpressionParserCompilationError(
+            "Bad expression type, expected: String(string), found: Integer(123)",
+            nodeId,
+            Some(ParameterName(PredicateAssertionCompilationError.Field.Actual.entryName)),
+            "123",
+            details = None
+          )
+        ),
+        assertionComparingUnrelatedTypes,
         Some(PredicateAssertionCompilationError.Field.Actual),
         nodeId
       )
@@ -195,5 +207,15 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
     typingInfo.parameters.map(_.map(DefinitionsService.createUIParameter)),
     typingInfo.expressionsTypingInfo
   )
+
+  private def prepareTestCase(assertions: Map[NodeId, List[Assertion]]): TestCase = {
+    TestCase(
+      id = UUID.randomUUID(),
+      name = "dummy",
+      inputs = "dummy",
+      mocks = Map.empty,
+      assertions = assertions
+    )
+  }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -1,11 +1,13 @@
 package pl.touk.nussknacker.ui.process.test.testcase
 
-import cats.data.{NonEmptyList, Validated}
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.data.Validated.{Invalid, Valid}
+import cats.syntax.functor._
 import jdk.internal.net.http.common.Log.errors
 import org.scalatest.Inside
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
 import pl.touk.nussknacker.engine.{CustomProcessValidatorLoader, ScenarioCompilationDependencies}
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.ExpressionParserCompilationError
@@ -24,6 +26,7 @@ import pl.touk.nussknacker.engine.test.testcase.Assertion
 import pl.touk.nussknacker.engine.test.testcase.Assertion.PredicateAssertion
 import pl.touk.nussknacker.engine.test.testcase.TestCase
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
+import pl.touk.nussknacker.engine.util.functions.conversion
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
 import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage
@@ -34,7 +37,12 @@ import pl.touk.nussknacker.ui.process.test.testcase.CompiledAssertion.CompiledPr
 
 import java.util.UUID
 
-class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with ValidatedValuesDetailedMessage {
+class AssertionsCompilerSpec
+    extends AnyFunSuite
+    with Matchers
+    with Inside
+    with ValidatedValuesDetailedMessage
+    with TableDrivenPropertyChecks {
 
   import pl.touk.nussknacker.engine.util.Implicits._
 
@@ -42,6 +50,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with 
     .withUnboundedStreamSource("sourceWithUnknown", Some(Unknown))
     .withService("enricher1", Some(Typed[String]), Parameter[String](ParameterName("par1")))
     .withSink("sink")
+    .withGlobalVariable("CONV", conversion)
     .build
 
   private val modelDefinitionWithClasses = ModelDefinitionWithClasses(baseDefinition)
@@ -61,13 +70,14 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with 
     new AssertionsCompiler(expressionCompiler, globalVariablesPreparer)
   }
 
+  private val scenario = ScenarioBuilder
+    .streaming("process1")
+    .source("id1", "sourceWithUnknown")
+    .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
+    .buildSimpleVariable("result-id2", "result", "#input".spel)
+    .emptySink("sink1", "sink")
+
   test("should compile valid assertions for scenario") {
-    val scenario = ScenarioBuilder
-      .streaming("process1")
-      .source("id1", "sourceWithUnknown")
-      .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
-      .buildSimpleVariable("result-id2", "result", "#input".spel)
-      .emptySink("sink1", "sink")
     val test = prepareTestCase(
       Map(
         NodeId("sink1") -> List(PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size".spel))
@@ -86,12 +96,6 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with 
   }
 
   test("should produce errors for assertions on missing nodes") {
-    val scenario = ScenarioBuilder
-      .streaming("process1")
-      .source("id1", "sourceWithUnknown")
-      .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
-      .buildSimpleVariable("result-id2", "result", "#input".spel)
-      .emptySink("sink1", "sink")
     val test = prepareTestCase(
       Map(
         NodeId("notExistingSink") -> List(
@@ -109,13 +113,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with 
     )
   }
 
-  test("should produce errors for assertions with syntax errors") {
-    val scenario = ScenarioBuilder
-      .streaming("process1")
-      .source("id1", "sourceWithUnknown")
-      .enricher("enricher1", "enricherOutput", "enricher1", "par1" -> "'abc'".spel)
-      .buildSimpleVariable("result-id2", "result", "#input".spel)
-      .emptySink("sink1", "sink")
+  test("should produce errors for multiple assertions") {
     val nodeId = NodeId("sink1")
     val assertionWithSyntaxErrorsInBothExpressions =
       PredicateAssertion(Assertion.AssertionOperator.Equals, "'123".spel, "#contexts.size,".spel)
@@ -140,7 +138,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with 
             NonEmptyList(
               ExpressionParserCompilationError(
                 message,
-                `nodeId`,
+                _,
                 Some(ParameterName(parameterName)),
                 originalExpr,
                 _
@@ -148,8 +146,8 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with 
               Nil
             ),
             assertion,
-            Some(field),
-            `nodeId`
+            field,
+            _
           ) =>
         message shouldBe "Cannot find terminating ' for string"
         parameterName shouldBe PredicateAssertionCompilationError.Field.Expected.entryName
@@ -163,7 +161,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with 
             NonEmptyList(
               ExpressionParserCompilationError(
                 message,
-                `nodeId`,
+                _,
                 Some(ParameterName(parameterName)),
                 originalExpr,
                 _
@@ -171,8 +169,8 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with 
               Nil
             ),
             assertion,
-            Some(field),
-            `nodeId`
+            field,
+            _
           ) =>
         message shouldBe "Unexpected text"
         parameterName shouldBe PredicateAssertionCompilationError.Field.Actual.entryName
@@ -194,14 +192,72 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with 
               Nil
             ),
             assertion,
-            Some(field),
+            field,
             `nodeId`
           ) =>
-        message shouldBe "Bad expression type, expected: String(string), found: Integer(123)"
+        message shouldBe "Operator '==' used with not comparable types: String and Integer"
         parameterName shouldBe PredicateAssertionCompilationError.Field.Actual.entryName
         field shouldBe PredicateAssertionCompilationError.Field.Actual
-        originalExpr shouldBe "123"
+        originalExpr shouldBe "'string' == 123"
         assertion shouldBe assertionComparingUnrelatedTypes
+    }
+  }
+
+  test("should compile assertions with various types used in SpEL") {
+    forAll(
+      Table[Assertion, ValidatedNel[String, Unit]](
+        ("assertion", "compilation result"),
+        (
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'abc'".spel, "'def'".spel),
+          Validated.unit,
+        ),
+        (
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'abc'".spel, "#CONV.toAny(123)".spel),
+          Validated.unit,
+        ),
+        (
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "'abc'".spel, "123".spel),
+          Validated.invalidNel("Operator '==' used with not comparable types: String and Integer")
+        ),
+        (
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "{'abc', 'def'}".spel, "{'xyz'}".spel),
+          Validated.unit
+        ),
+        (
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "{'abc', 'def'}".spel, "{123}".spel),
+          Validated.invalidNel("Operator '==' used with not comparable types: List[String] and List[Integer]")
+        ),
+        (
+          PredicateAssertion(Assertion.AssertionOperator.Equals, "{'abc', 'def'}".spel, "#CONV.toAny({'xyz'})".spel),
+          Validated.unit
+        ),
+      )
+    ) { (assertion, expectedCompilationResult) =>
+      val nodeId = NodeId("sink1")
+      val test = prepareTestCase(
+        Map(
+          nodeId -> List(assertion)
+        )
+      )
+
+      val compilationResult = compileScenarioWithAssertions(scenario, test)
+
+      val actualCompilationResult = compilationResult.void
+        .leftMap { errors =>
+          errors.flatMap {
+            case PredicateAssertionCompilationError(compilationErrors, _, _, _) =>
+              compilationErrors.map {
+                case ExpressionParserCompilationError(message, _, _, _, _) =>
+                  message
+                case other =>
+                  fail(s"Unexpected error: $other")
+              }
+            case other =>
+              fail(s"Unexpected error: $other")
+          }
+        }
+
+      actualCompilationResult shouldBe expectedCompilationResult
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -26,6 +26,7 @@ import pl.touk.nussknacker.engine.test.testcase.TestCase
 import pl.touk.nussknacker.engine.testing.ModelDefinitionBuilder
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
+import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage
 import pl.touk.nussknacker.ui.definition.DefinitionsService
 import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.PredicateAssertionCompilationError
 import pl.touk.nussknacker.ui.process.test.testcase.AssertionValidationError.AssertionConfiguredForNotExistingNodesError
@@ -33,7 +34,7 @@ import pl.touk.nussknacker.ui.process.test.testcase.CompiledAssertion.CompiledPr
 
 import java.util.UUID
 
-class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
+class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside with ValidatedValuesDetailedMessage {
 
   import pl.touk.nussknacker.engine.util.Implicits._
 
@@ -73,16 +74,15 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       )
     )
 
-    val testCompilationResult = compileScenarioWithAssertions(scenario, test)
-    inside(testCompilationResult) { case Valid(compiledAssertions) =>
-      compiledAssertions.assertions.size shouldBe 1
-      compiledAssertions.assertions(NodeId("sink1")).size shouldBe 1
-      val compiledAssertion =
-        compiledAssertions.assertions(NodeId("sink1")).head.asInstanceOf[CompiledPredicateAssertion]
-      compiledAssertion.operator shouldBe Assertion.AssertionOperator.Equals
-      compiledAssertion.expectedExpression.original shouldBe "1"
-      compiledAssertion.actualExpression.original shouldBe "#contexts.size"
-    }
+    val compiledAssertions = compileScenarioWithAssertions(scenario, test).validValue
+
+    compiledAssertions.assertions.size shouldBe 1
+    compiledAssertions.assertions(NodeId("sink1")).size shouldBe 1
+    val compiledAssertion =
+      compiledAssertions.assertions(NodeId("sink1")).head.asInstanceOf[CompiledPredicateAssertion]
+    compiledAssertion.operator shouldBe Assertion.AssertionOperator.Equals
+    compiledAssertion.expectedExpression.original shouldBe "1"
+    compiledAssertion.actualExpression.original shouldBe "#contexts.size"
   }
 
   test("should produce errors for assertions on missing nodes") {
@@ -100,15 +100,13 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       )
     )
 
-    val testCompilationResult = compileScenarioWithAssertions(scenario, test)
+    val errors = compileScenarioWithAssertions(scenario, test).invalidValue
 
-    inside(testCompilationResult) { case Invalid(errors) =>
-      errors.toList shouldBe List(
-        AssertionConfiguredForNotExistingNodesError(
-          NonEmptyList.one(NodeId("notExistingSink"))
-        )
+    errors.toList shouldBe List(
+      AssertionConfiguredForNotExistingNodesError(
+        NonEmptyList.one(NodeId("notExistingSink"))
       )
-    }
+    )
   }
 
   test("should produce errors for assertions with syntax errors") {
@@ -119,53 +117,91 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       .buildSimpleVariable("result-id2", "result", "#input".spel)
       .emptySink("sink1", "sink")
     val nodeId = NodeId("sink1")
-    val assertionWithUnneededComma =
-      PredicateAssertion(Assertion.AssertionOperator.Equals, "1".spel, "#contexts.size,".spel)
+    val assertionWithSyntaxErrorsInBothExpressions =
+      PredicateAssertion(Assertion.AssertionOperator.Equals, "'123".spel, "#contexts.size,".spel)
     val assertionComparingUnrelatedTypes =
       PredicateAssertion(Assertion.AssertionOperator.Equals, "'string'".spel, "123".spel)
     val test = prepareTestCase(
       Map(
         nodeId -> List(
-          assertionWithUnneededComma,
+          assertionWithSyntaxErrorsInBothExpressions,
           assertionComparingUnrelatedTypes,
         )
       )
     )
 
-    val testCompilationResult = compileScenarioWithAssertions(scenario, test)
-    inside(testCompilationResult) { case Invalid(errors) =>
-      errors.size shouldBe 2
+    val errors = compileScenarioWithAssertions(scenario, test).invalidValue
+    errors.size shouldBe 3
+    val assertionWithErrorsInBothExpressionsActualExpectedFieldError :: assertionWithErrorsInBothExpressionsActualFieldError :: assertionComparingUnrelatedTypesError :: Nil =
+      errors.toList
 
-      val assertionWithUnneededCommaError :: assertionComparingUnrelatedTypesError :: Nil = errors.toList
-      assertionWithUnneededCommaError shouldBe PredicateAssertionCompilationError(
-        NonEmptyList.one(
-          ExpressionParserCompilationError(
-            "Unexpected text",
-            nodeId,
-            Some(ParameterName(PredicateAssertionCompilationError.Field.Actual.entryName)),
-            "#contexts.size,",
-            Some(CoordinatesBasedTextRange(TextCoordinates(14, 0), TextCoordinates(15, 0)))
-          )
-        ),
-        assertionWithUnneededComma,
-        Some(PredicateAssertionCompilationError.Field.Actual),
-        nodeId
-      )
+    inside(assertionWithErrorsInBothExpressionsActualExpectedFieldError) {
+      case PredicateAssertionCompilationError(
+            NonEmptyList(
+              ExpressionParserCompilationError(
+                message,
+                `nodeId`,
+                Some(ParameterName(parameterName)),
+                originalExpr,
+                _
+              ),
+              Nil
+            ),
+            assertion,
+            Some(field),
+            `nodeId`
+          ) =>
+        message shouldBe "Cannot find terminating ' for string"
+        parameterName shouldBe PredicateAssertionCompilationError.Field.Expected.entryName
+        field shouldBe PredicateAssertionCompilationError.Field.Expected
+        originalExpr shouldBe "'123"
+        assertion shouldBe assertionWithSyntaxErrorsInBothExpressions
+    }
 
-      assertionComparingUnrelatedTypesError shouldBe PredicateAssertionCompilationError(
-        NonEmptyList.one(
-          ExpressionParserCompilationError(
-            "Bad expression type, expected: String(string), found: Integer(123)",
-            nodeId,
-            Some(ParameterName(PredicateAssertionCompilationError.Field.Actual.entryName)),
-            "123",
-            details = None
-          )
-        ),
-        assertionComparingUnrelatedTypes,
-        Some(PredicateAssertionCompilationError.Field.Actual),
-        nodeId
-      )
+    inside(assertionWithErrorsInBothExpressionsActualFieldError) {
+      case PredicateAssertionCompilationError(
+            NonEmptyList(
+              ExpressionParserCompilationError(
+                message,
+                `nodeId`,
+                Some(ParameterName(parameterName)),
+                originalExpr,
+                _
+              ),
+              Nil
+            ),
+            assertion,
+            Some(field),
+            `nodeId`
+          ) =>
+        message shouldBe "Unexpected text"
+        parameterName shouldBe PredicateAssertionCompilationError.Field.Actual.entryName
+        field shouldBe PredicateAssertionCompilationError.Field.Actual
+        originalExpr shouldBe "#contexts.size,"
+        assertion shouldBe assertionWithSyntaxErrorsInBothExpressions
+    }
+
+    inside(assertionComparingUnrelatedTypesError) {
+      case PredicateAssertionCompilationError(
+            NonEmptyList(
+              ExpressionParserCompilationError(
+                message,
+                `nodeId`,
+                Some(ParameterName(parameterName)),
+                originalExpr,
+                _
+              ),
+              Nil
+            ),
+            assertion,
+            Some(field),
+            `nodeId`
+          ) =>
+        message shouldBe "Bad expression type, expected: String(string), found: Integer(123)"
+        parameterName shouldBe PredicateAssertionCompilationError.Field.Actual.entryName
+        field shouldBe PredicateAssertionCompilationError.Field.Actual
+        originalExpr shouldBe "123"
+        assertion shouldBe assertionComparingUnrelatedTypes
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -84,8 +84,8 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
       val compiledAssertion =
         compiledAssertions.assertions(NodeId("sink1")).head.asInstanceOf[CompiledPredicateAssertion]
       compiledAssertion.operator shouldBe Assertion.AssertionOperator.Equals
-      compiledAssertion.expected.original shouldBe "1"
-      compiledAssertion.actual.original shouldBe "#contexts.size"
+      compiledAssertion.expectedExpression.original shouldBe "1"
+      compiledAssertion.actualExpression.original shouldBe "#contexts.size"
     }
   }
 
@@ -151,7 +151,7 @@ class AssertionsCompilerSpec extends AnyFunSuite with Matchers with Inside {
           )
         ),
         invalidAssertion,
-        PredicateAssertionCompilationError.Field.Actual,
+        Some(PredicateAssertionCompilationError.Field.Actual),
         nodeId
       )
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/TestCaseVariablesSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/TestCaseVariablesSpec.scala
@@ -19,6 +19,7 @@ class TestCaseVariablesSpec extends AnyFunSuite with Matchers {
     newClasses.keySet shouldBe Set(
       classOf[testcase.tests.type],
       classOf[testcase.AssertionResult],
+      classOf[testcase.FailedAssertion], // no idea why it is being pulled in
     )
     originalClasses shouldBe originalClassDefinitionSet.classDefinitionsMap
   }


### PR DESCRIPTION
## Describe your changes

Thanks to assertions being compiled to single expressions with an operator (`==` or `!=`), comparing unrelated types is detected during validation. Additionally, built-in SpEL conversions are applied when comparing values.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
