### PR TITLE
Remove triggering of nussknacker-flink-compatibility from CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -577,9 +577,6 @@ jobs:
           - repo: nussknacker-sample-components
             workflow_id: pr.yml
             ref: staging
-          - repo: nussknacker-flink-compatibility
-            workflow_id: test.yml
-            ref: staging
     steps:
       - uses: actions/github-script@v6
         with:


### PR DESCRIPTION
## Describe your changes

Remove triggering of nussknacker-flink-compatibility from CI.
We don't plan to provide backwards compatibility with older Flink versions in Nu 2.0.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
