### PR TITLE
[NU-2451] add option to change assertion operator

### DIFF
--- a/designer/client/cypress/e2e/testCases.cy.ts
+++ b/designer/client/cypress/e2e/testCases.cy.ts
@@ -24,8 +24,10 @@ describe("Test cases", () => {
         openTestingTab();
         addEmptyAssertion();
         addEmptyAssertion();
+        addEmptyAssertion();
         fillAssertion(0, "#contexts[0].input.value", "0");
         fillAssertion(1, "#contexts.size", "10");
+        fillAssertion(2, "#contexts.size", "11", "!=");
         cy.applyNodeChanges();
         cy.contains(/^save$/i).click();
         cy.contains(/^ok$/i).click();
@@ -36,12 +38,13 @@ describe("Test cases", () => {
         openTestingTab();
         checkAssertionResult(0, "Expected: [100] but found [0]");
         checkAssertionResult(1, "ok");
+        checkAssertionResult(2, "ok");
         addEmptyAssertion();
-        fillAssertion(2, "#wrongExpected", "10");
-        checkAssertionErrorVisible(2, "expected", "Unresolved reference 'wrongExpected'");
+        fillAssertion(3, "#wrongExpected", "10");
+        checkAssertionErrorVisible(3, "expected", "Unresolved reference 'wrongExpected'");
         addEmptyAssertion();
-        fillAssertion(3, "10", "#wrongActual");
-        checkAssertionErrorVisible(3, "actual", "Unresolved reference 'wrongActual'");
+        fillAssertion(4, "10", "#wrongActual");
+        checkAssertionErrorVisible(4, "actual", "Unresolved reference 'wrongActual'");
     });
 });
 
@@ -57,9 +60,14 @@ const addEmptyAssertion = () => {
     });
 };
 
-const fillAssertion = (assertionNumber: number, expected: string, actual: string) => {
-    cy.get(`[data-testid="assertion-expected-${assertionNumber}"]`).find("textarea").type(expected, { force: true });
-    cy.get(`[data-testid="assertion-actual-${assertionNumber}"]`).find("textarea").type(actual, { force: true });
+const fillAssertion = (assertionNumber: number, expected: string, actual: string, operator?: "==" | "!=") => {
+    if (operator) {
+        cy.get(`[data-testid="assertion-operator-${assertionNumber}"]`).click();
+        cy.get("[id*='option-']").should("exist").contains(operator).click({ force: true });
+    }
+
+    cy.get(`[data-testid="assertion-expected-${assertionNumber}"]`).find("textarea").type(expected, { force: true }).click({ force: true });
+    cy.get(`[data-testid="assertion-actual-${assertionNumber}"]`).find("textarea").type(actual, { force: true }).click({ force: true });
 };
 
 const appendFromLiveDataClick = () => {

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -8,21 +8,15 @@ import { RowFieldLabel } from "../../../aggregate/rowFieldLabel";
 import { EditableEditor } from "../../../editors/EditableEditor";
 import type { ExpressionObj } from "../../../editors/expression/types";
 import { EditorType, ExpressionLang } from "../../../editors/expression/types";
-import Input from "../../../editors/field/Input";
-import { EMPTY_REQUIRED_ERROR } from "../../../editors/Validators";
 import { FieldsRow } from "../../../fragment-input-definition/FieldsRow";
+import { TypeSelect } from "../../../fragment-input-definition/TypeSelect";
+import type { Option } from "../../../fragment-input-definition/TypeSelect";
 import { AssertionStatus } from "./AssertionStatus";
 
-const ASSERTION_SYMBOLS: Record<string, string> = {
+export const ASSERTION_SYMBOLS: Record<string, string> = {
     equals: "==",
     notEquals: "!=",
 };
-
-const centeredInputStyle = css({
-    "& input": {
-        textAlign: "center",
-    },
-});
 
 const gridContainerStyle = css({
     "&&&&": {
@@ -75,9 +69,14 @@ const AssertionItemComponent = ({
         [onChange, uuid],
     );
 
-    const assertionSymbol = useMemo(() => {
-        return ASSERTION_SYMBOLS[operator] ?? "";
-    }, [operator]);
+    const assertionOptions: Option[] = useMemo(() => Object.entries(ASSERTION_SYMBOLS).map(([value, label]) => ({ value, label })), []);
+
+    const handleOperatorChange = useCallback(
+        (value: string) => {
+            onChange(uuid, { operator: value as "equals" | "notEquals" });
+        },
+        [onChange, uuid],
+    );
 
     const expectedErrors = useMemo(() => {
         return errors.filter((error) => error.fieldName === "expected") || [];
@@ -101,8 +100,12 @@ const AssertionItemComponent = ({
                         fieldErrors={expectedErrors}
                     />
                 </RowFieldLabel>
-                <RowFieldLabel showLabel={isFirstRow} label="Assertion">
-                    <Input value={assertionSymbol} disabled={true} className={centeredInputStyle} />
+                <RowFieldLabel showLabel={isFirstRow} label="Assertion" data-testid={`assertion-operator-${index}`}>
+                    <TypeSelect
+                        value={assertionOptions.find((o) => o.value === operator)}
+                        options={assertionOptions}
+                        onChange={handleOperatorChange}
+                    />
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Actual" data-testid={`assertion-actual-${index}`}>
                     <EditableEditor


### PR DESCRIPTION
## Describe your changes

- Add option to select assertion operator
<img width="932" height="680" alt="image" src="https://github.com/user-attachments/assets/3740f7ff-c7ee-417b-a418-5f23b454b6fe" />

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
