### PR TITLE
[NU-2414] Flink: remove Flink 1.18 type compatibility code

### DIFF
--- a/docs/developers_guide/FlinkComponents.md
+++ b/docs/developers_guide/FlinkComponents.md
@@ -14,7 +14,7 @@ In order to implement any of those you need to provide:
 ## Sources
 
 ### Standard implementation
-The recommended way to implement a source is through [StandardFlinkSource](https://github.com/TouK/nussknacker/blob/staging/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkSource.scala)
+The recommended way to implement a source is through [FlinkSource](https://github.com/TouK/nussknacker/blob/staging/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/process/FlinkSource.scala)
 interface. Your source only has to implement a `sourceStream` method that provides [DataStreamSource](https://nightlies.apache.org/flink/flink-docs-master/api/java/org/apache/flink/streaming/api/datastream/DataStreamSource.html)
 based on [StreamExecutionEnvironment](https://nightlies.apache.org/flink/flink-docs-master/api/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.html).
 

--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/typeinformation/FlinkTypeInfoRegistrar.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/typeinformation/FlinkTypeInfoRegistrar.scala
@@ -6,37 +6,23 @@ import org.apache.flink.api.java.typeutils.TypeExtractor
 import java.lang.reflect.Type
 import java.time._
 import java.util
-import java.util.concurrent.atomic.AtomicBoolean
 
 // This class contains registers TypeInfoFactory for commonly used classes in Nussknacker.
 // It is a singleton as Flink's only contains a global registry for such purpose
 object FlinkTypeInfoRegistrar {
 
-  private val typeInfoRegistrationEnabled = new AtomicBoolean(true)
+  private case class RegistrationEntry[T](klass: Class[T], factoryClass: Class[_ <: TypeInfoFactory[T]])
 
-  private val DisableFlinkTypeInfoRegistrationEnvVarName = "NU_DISABLE_FLINK_TYPE_INFO_REGISTRATION"
-
-  // These members are package protected for purpose of TypingResultAwareTypeInformationDetection.FlinkBelow119AdditionalTypeInfo - see comment there
-  private[engine] case class RegistrationEntry[T](klass: Class[T], factoryClass: Class[_ <: TypeInfoFactory[T]])
-
-  private[engine] val typeInfoToRegister = List(
+  private val typeInfoToRegister = List(
     RegistrationEntry(classOf[LocalDate], classOf[LocalDateTypeInfoFactory]),
     RegistrationEntry(classOf[LocalTime], classOf[LocalTimeTypeInfoFactory]),
     RegistrationEntry(classOf[LocalDateTime], classOf[LocalDateTimeTypeInfoFactory]),
   )
 
   def ensureTypeInfosAreRegistered(): Unit = {
-    // TypeInfo registration is available in Flink >= 1.19. For backward compatibility purpose we allow
-    // to disable this by either environment variable or programmatically
-    if (typeInfoRegistrationEnabled.get() && !typeInfoRegistrationDisabledByEnvVariable) {
-      typeInfoToRegister.foreach { entry =>
-        register(entry)
-      }
+    typeInfoToRegister.foreach { entry =>
+      register(entry)
     }
-  }
-
-  private def typeInfoRegistrationDisabledByEnvVariable = {
-    Option(System.getenv(DisableFlinkTypeInfoRegistrationEnvVarName)).exists(_.toBoolean)
   }
 
   private def register(entry: RegistrationEntry[_]): Unit = {
@@ -47,18 +33,6 @@ object FlinkTypeInfoRegistrar {
         TypeExtractor.registerFactory(entry.klass, entry.factoryClass)
       }
     }
-  }
-
-  // These methods are mainly for purpose of tests in nussknacker-flink-compatibility project
-  // It should be used with caution as it changes the global state. They will be removed when we stop supporting Flink < 1.19
-  def isFlinkTypeInfoRegistrationEnabled: Boolean = typeInfoRegistrationEnabled.get()
-
-  def enableFlinkTypeInfoRegistration(): Unit = {
-    typeInfoRegistrationEnabled.set(true)
-  }
-
-  def disableFlinkTypeInfoRegistration(): Unit = {
-    typeInfoRegistrationEnabled.set(false)
   }
 
   class LocalDateTypeInfoFactory extends TypeInfoFactory[LocalDate] {

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetection.scala
@@ -12,7 +12,6 @@ import pl.touk.nussknacker.engine.flink.api.typeinformation.{
   CharsetTypeInformation,
   CurrencyTypeInformation,
   DurationTypeInformation,
-  FlinkTypeInfoRegistrar,
   LocaleTypeInformation,
   OffsetDateTimeTypeInformation,
   PeriodTypeInformation,
@@ -29,10 +28,7 @@ import pl.touk.nussknacker.engine.process.typeinformation.internal.typedobject.{
 }
 import pl.touk.nussknacker.engine.util.Implicits._
 
-import java.nio.charset.Charset
-import java.time.{Duration, OffsetDateTime, Period, ZonedDateTime, ZoneId}
-import java.util.{Currency, Locale, UUID}
-import scala.jdk.CollectionConverters._
+import java.time.ZoneId
 
 // TODO: handle avro types - see FlinkConfluentUtils
 /*
@@ -61,7 +57,6 @@ class TypingResultAwareTypeInformationDetection extends TypeInformationDetection
 
   override def forType[T](typingResult: TypingResult): TypeInformation[T] = {
     (typingResult match {
-      case FlinkBelow119AdditionalTypeInfo(typeInfo) => typeInfo
       case TypedClass(`ListClass`, elementType :: Nil) =>
         new ListTypeInfo[AnyRef](forType[AnyRef](elementType))
       case TypedClass(`ZonedDateTimeClass`, Nil)                             => ZonedDateTimeTypeInformation
@@ -99,29 +94,6 @@ class TypingResultAwareTypeInformationDetection extends TypeInformationDetection
       case _ =>
         TypeInformation.of(classOf[Any])
     }).asInstanceOf[TypeInformation[T]]
-  }
-
-  // This extractor is to allow using of predefined type infos in Flink < 1.19. Type info registration was added in 1.19
-  // It should be removed when we stop supporting Flink < 1.19
-  private object FlinkBelow119AdditionalTypeInfo extends Serializable {
-
-    def unapply(typingResult: TypingResult): Option[TypeInformation[_]] = {
-      if (FlinkTypeInfoRegistrar.isFlinkTypeInfoRegistrationEnabled) {
-        None
-      } else {
-        for {
-          clazz <- Option(typingResult).collect { case TypedClass(clazz, Nil) =>
-            clazz
-          }
-          typeInfo <- FlinkTypeInfoRegistrar.typeInfoToRegister.collectFirst {
-            case FlinkTypeInfoRegistrar.RegistrationEntry(`clazz`, factoryClass) =>
-              val factory = factoryClass.getDeclaredConstructor().newInstance()
-              factory.createTypeInfo(clazz, Map.empty[String, TypeInformation[_]].asJava)
-          }
-        } yield typeInfo
-      }
-    }
-
   }
 
   private def createScalaMapTypeInformation(typingResult: TypedObjectTypingResult) =

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetectionSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/typeinformation/TypingResultAwareTypeInformationDetectionSpec.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.process.typeinformation
 
-import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.common.typeutils.base.{
   GenericArraySerializer,
@@ -19,7 +19,6 @@ import pl.touk.nussknacker.engine.api.{Context, ValueWithContext}
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
 import pl.touk.nussknacker.engine.flink.api.typeinfo.caseclass.ScalaCaseClassSerializer
-import pl.touk.nussknacker.engine.flink.api.typeinformation.{FlinkTypeInfoRegistrar, TypeInformationDetection}
 import pl.touk.nussknacker.engine.flink.serialization.FlinkTypeInformationSerializationMixin
 import pl.touk.nussknacker.engine.process.typeinformation.internal.typedobject._
 
@@ -35,8 +34,6 @@ class TypingResultAwareTypeInformationDetectionSpec
     with OptionValues {
 
   private val detection = new TypingResultAwareTypeInformationDetection
-
-  FlinkTypeInfoRegistrar.ensureTypeInfosAreRegistered()
 
   test("test map serialization") {
     val map = Map("intF" -> 11, "strF" -> "sdfasf", "longF" -> 111L, "fixedLong" -> 12L, "taggedString" -> "1")
@@ -249,26 +246,6 @@ class TypingResultAwareTypeInformationDetectionSpec
       .snapshotConfiguration()
       .resolveSchemaCompatibility(oldSerializerSnapshot)
       .isCompatibleAfterMigration shouldBe true
-  }
-
-  test("return type info for LocalDate, LocalTime and LocalDateTime even if type info registration is disabled") {
-    withFlinkTypeInfoRegistrationDisabled {
-      TypeInformationDetection.instance.forClass[LocalDate] shouldBe Types.LOCAL_DATE
-      TypeInformationDetection.instance.forClass[LocalTime] shouldBe Types.LOCAL_TIME
-      TypeInformationDetection.instance.forClass[LocalDateTime] shouldBe Types.LOCAL_DATE_TIME
-    }
-  }
-
-  private def withFlinkTypeInfoRegistrationDisabled[T](f: => T): T = {
-    val stateBeforeChange = FlinkTypeInfoRegistrar.isFlinkTypeInfoRegistrationEnabled
-    FlinkTypeInfoRegistrar.disableFlinkTypeInfoRegistration()
-    try {
-      f
-    } finally {
-      if (stateBeforeChange) {
-        FlinkTypeInfoRegistrar.enableFlinkTypeInfoRegistration()
-      }
-    }
   }
 
   // We have to compare it this way because context can contains arrays

--- a/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/loader/ScalaServiceLoader.scala
+++ b/utils/utils-internal/src/main/scala/pl/touk/nussknacker/engine/util/loader/ScalaServiceLoader.scala
@@ -69,7 +69,7 @@ object ScalaServiceLoader extends LazyLogging {
         .map { cl =>
           val classLoader = cl.getClass.getClassLoader match {
             case urlCL: URLClassLoader =>
-              s"${urlCL.getURLs.map(_.toString).toList.mkCommaSeparatedStringWithPotentialEllipsis(10)})"
+              s"(${urlCL.getURLs.map(_.toString).toList.mkCommaSeparatedStringWithPotentialEllipsis(10)})"
             case other =>
               s"${other.getName}"
           }


### PR DESCRIPTION
## Describe your changes

Remove unused code for Flink 1.18 compatibility added in #7128. It could be enabled via an undocumented environment variable (`NU_DISABLE_FLINK_TYPE_INFO_REGISTRATION`).

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
