### PR TITLE
[NU-2399] Do not highlight wrong part of actual assertion expression

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -5,8 +5,10 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.syntax.all._
 import enumeratum.{Enum, EnumEntry}
 import enumeratum.EnumEntry.LowerCamelcase
+import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle.details
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.ExpressionParserCompilationError
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.compile.ExpressionCompiler
@@ -195,7 +197,9 @@ class AssertionsCompiler(
       )
       .leftMap { errors =>
         PredicateAssertionCompilationError(
-          errors,
+          // Clear the error details, including the position of the error in the comparison expression.
+          // Since this expression is never shown to the user, highlighting part of the actual expression at the wrong position would be confusing.
+          clearErrorsDetails(errors),
           assertion,
           // If comparison expression fails to compile because of uncomparable types, we report the error on actual field.
           PredicateAssertionCompilationError.Field.Actual,
@@ -209,6 +213,17 @@ class AssertionsCompiler(
     operator match {
       case AssertionOperator.Equals    => "=="
       case AssertionOperator.NotEquals => "!="
+    }
+  }
+
+  private def clearErrorsDetails(
+      errors: NonEmptyList[ProcessCompilationError]
+  ): NonEmptyList[ProcessCompilationError] = {
+    errors.map {
+      case e: ExpressionParserCompilationError =>
+        e.copy(details = None)
+      case other =>
+        other
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -5,7 +5,6 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.syntax.all._
 import enumeratum.{Enum, EnumEntry}
 import enumeratum.EnumEntry.LowerCamelcase
-import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle.details
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.{ProcessCompilationError, ValidationContext}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.ExpressionParserCompilationError

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -11,15 +11,10 @@ import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.Expression
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.typing.{Typed, TypingResult, Unknown}
 import pl.touk.nussknacker.engine.compile.ExpressionCompiler
-import pl.touk.nussknacker.engine.expression.parse.{CompiledExpression, TypedExpression}
+import pl.touk.nussknacker.engine.expression.parse.TypedExpression
 import pl.touk.nussknacker.engine.spel.SpelExtension.SpelExpresion
 import pl.touk.nussknacker.engine.test.testcase.{Assertion, TestCase}
-import pl.touk.nussknacker.engine.test.testcase.Assertion.{
-  assertionDecoder,
-  AssertionOperator,
-  ExpressionAssertion,
-  PredicateAssertion
-}
+import pl.touk.nussknacker.engine.test.testcase.Assertion.{AssertionOperator, ExpressionAssertion, PredicateAssertion}
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeTypingData
 import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.{

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -141,7 +141,7 @@ class AssertionsCompilerSpec
                 _,
                 Some(ParameterName(parameterName)),
                 originalExpr,
-                _
+                details
               ),
               Nil
             ),
@@ -153,6 +153,7 @@ class AssertionsCompilerSpec
         parameterName shouldBe PredicateAssertionCompilationError.Field.Expected.entryName
         field shouldBe PredicateAssertionCompilationError.Field.Expected
         originalExpr shouldBe "'123"
+        details shouldBe defined
         assertion shouldBe assertionWithSyntaxErrorsInBothExpressions
     }
 
@@ -164,7 +165,7 @@ class AssertionsCompilerSpec
                 _,
                 Some(ParameterName(parameterName)),
                 originalExpr,
-                _
+                details
               ),
               Nil
             ),
@@ -176,6 +177,7 @@ class AssertionsCompilerSpec
         parameterName shouldBe PredicateAssertionCompilationError.Field.Actual.entryName
         field shouldBe PredicateAssertionCompilationError.Field.Actual
         originalExpr shouldBe "#contexts.size,"
+        details shouldBe defined
         assertion shouldBe assertionWithSyntaxErrorsInBothExpressions
     }
 
@@ -187,7 +189,7 @@ class AssertionsCompilerSpec
                 `nodeId`,
                 Some(ParameterName(parameterName)),
                 originalExpr,
-                _
+                details
               ),
               Nil
             ),
@@ -199,6 +201,7 @@ class AssertionsCompilerSpec
         parameterName shouldBe PredicateAssertionCompilationError.Field.Actual.entryName
         field shouldBe PredicateAssertionCompilationError.Field.Actual
         originalExpr shouldBe "'string' == 123"
+        details shouldBe None
         assertion shouldBe assertionComparingUnrelatedTypes
     }
   }


### PR DESCRIPTION
Before:

<img width="1151" height="267" alt="Screenshot 2026-01-28 at 10-33-20 Nussknacker" src="https://github.com/user-attachments/assets/9cff0744-e97d-449e-9542-c32350651739" />

After:

<img width="987" height="271" alt="Screenshot 2026-01-28 at 11-14-49 Nussknacker" src="https://github.com/user-attachments/assets/c45851a7-e439-4b7e-a72e-29523c217d63" />


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
