### PR TITLE
Update Testcontainers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -304,8 +304,8 @@ val configV                 = "1.4.4"
 // rc16+ depend on slf4j 2.x
 val dropWizardV             = "5.0.0-rc15"
 val scalaCollectionsCompatV = "2.13.0"
-val testContainersScalaV    = "0.43.0"
-val testContainersJavaV     = "1.21.4"
+val testContainersScalaV    = "0.44.1"
+val testContainersJavaV     = "2.0.3"
 val nettyV                  = "4.1.123.Final"
 val nettyReactiveStreamsV   = "2.0.12"
 
@@ -1539,7 +1539,7 @@ lazy val liteK8sDeploymentManager = (project in lite("k8sDeploymentManager"))
     name                            := "nussknacker-lite-k8s-deploymentManager",
     libraryDependencies ++= {
       Seq(
-        "io.github.hagay3"              %% "skuber"                           % "4.0.4",
+        "io.github.hagay3"              %% "skuber"                           % "4.0.11",
         "com.github.julien-truffaut"    %% "monocle-core"                     % monocleV,
         "com.github.julien-truffaut"    %% "monocle-macro"                    % monocleV,
         "org.apache.pekko"              %% "pekko-slf4j"                      % pekkoV    % Test,
@@ -1558,7 +1558,12 @@ lazy val liteK8sDeploymentManager = (project in lite("k8sDeploymentManager"))
       )
       .value
   )
-  .dependsOn(liteDeploymentManager, deploymentManagerApi % Provided, testUtils % Test)
+  .dependsOn(
+    liteDeploymentManager,
+    deploymentManagerApi % Provided,
+    testUtils            % Test,
+    kafkaTestUtils       % Test
+  )
 
 lazy val liteDeploymentManager = (project in lite("deploymentManager"))
   .enablePlugins()
@@ -1672,10 +1677,7 @@ lazy val security = (project in file("security"))
       "com.softwaremill.sttp.tapir" %% "tapir-core"                     % tapirV,
       "com.softwaremill.sttp.tapir" %% "tapir-json-circe"               % tapirV,
       "com.dimafeng"                %% "testcontainers-scala-scalatest" % testContainersScalaV % "it,test",
-      "com.github.dasniko"           % "testcontainers-keycloak"        % "3.8.0"              % "it,test" excludeAll (
-        // we're using testcontainers-scala which requires a proper junit4 dependency
-        ExclusionRule("io.quarkus", "quarkus-junit4-mock")
-      )
+      "com.github.dasniko"           % "testcontainers-keycloak"        % "4.1.1"              % "it,test"
     )
   )
   .dependsOn(utilsInternal, httpUtils, testUtils % "it,test")

--- a/components/sql/src/test/scala/pl/touk/nussknacker/sql/utils/WithPostgresqlDB.scala
+++ b/components/sql/src/test/scala/pl/touk/nussknacker/sql/utils/WithPostgresqlDB.scala
@@ -13,7 +13,7 @@ trait WithPostgresqlDB {
   var conn: Connection = _
 
   override val container: PostgreSQLContainer = {
-    val container = PostgreSQLContainer(DockerImageName.parse("postgres:18"))
+    val container = PostgreSQLContainer(DockerImageName.parse("postgres:18-alpine"))
     container.container.setPortBindings(List("5432:5432").asJava)
     container
   }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/base/db/DbTesting.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/base/db/DbTesting.scala
@@ -51,7 +51,7 @@ trait WithTestPostgresDb extends WithTestDb {
   self: Suite with ForAllTestContainer =>
 
   override val container: PostgreSQLContainer =
-    PostgreSQLContainer(DockerImageName.parse("postgres:18"))
+    PostgreSQLContainer(DockerImageName.parse("postgres:18-alpine"))
 
   override def testDbConfig: Config = ConfigFactory.parseMap(
     Map(

--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithKafkaContainer.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithKafkaContainer.scala
@@ -12,7 +12,9 @@ trait WithKafkaContainer { self: Suite with WithDockerContainers =>
   protected val kafkaNetworkAlias = "kafka"
 
   protected val kafkaContainer: KafkaContainer =
-    KafkaContainer(DockerImageName.parse(s"${KafkaContainer.defaultImage}:7.4.0")).configure { self =>
+    KafkaContainer(DockerImageName.parse("apache/kafka-native:4.1.1")).configure { self =>
+      // can segfault on startup, we need retries - https://issues.apache.org/jira/browse/KAFKA-20314
+      self.withStartupAttempts(3)
       self.setNetwork(network)
       self.setNetworkAliases(asList(kafkaNetworkAlias))
     }
@@ -21,6 +23,6 @@ trait WithKafkaContainer { self: Suite with WithDockerContainers =>
   protected def hostKafkaAddress: String = kafkaContainer.bootstrapServers
 
   // on flink we have to access kafka via network alias
-  protected def dockerKafkaAddress = s"$kafkaNetworkAlias:9092"
+  protected def dockerKafkaAddress = s"$kafkaNetworkAlias:9093"
 
 }

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/BaseNuKafkaRuntimeDockerTest.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/BaseNuKafkaRuntimeDockerTest.scala
@@ -33,12 +33,8 @@ trait BaseNuKafkaRuntimeDockerTest
 
   protected val schemaRegistryContainer: GenericContainer = {
     GenericContainer(
-      "confluentinc/cp-schema-registry:7.5.13",
+      "ghcr.io/axonops/axonops-schema-registry:0.2.1",
       exposedPorts = Seq(schemaRegistryPort),
-      env = Map(
-        "SCHEMA_REGISTRY_HOST_NAME"                    -> schemaRegistryHostname,
-        "SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS" -> dockerNetworkKafkaBoostrapServer
-      )
     ).configure { configureNetwork(_, schemaRegistryHostname) }
   }
 

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/BaseNuKafkaRuntimeDockerTest.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/BaseNuKafkaRuntimeDockerTest.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine.lite.kafka
 
-import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer, KafkaContainer, SingleContainer}
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer, KafkaContainer}
 import com.typesafe.scalalogging.LazyLogging
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import org.scalatest.{BeforeAndAfterAll, TestSuite, TryValues}
@@ -31,17 +31,15 @@ trait BaseNuKafkaRuntimeDockerTest
   private val network       = Network.newNetwork
   private val kafkaHostname = "kafka"
 
-  protected val schemaRegistryContainer = {
-    val container = GenericContainer(
-      "confluentinc/cp-schema-registry:7.5.3",
+  protected val schemaRegistryContainer: GenericContainer = {
+    GenericContainer(
+      "confluentinc/cp-schema-registry:7.5.13",
       exposedPorts = Seq(schemaRegistryPort),
       env = Map(
         "SCHEMA_REGISTRY_HOST_NAME"                    -> schemaRegistryHostname,
         "SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS" -> dockerNetworkKafkaBoostrapServer
       )
-    )
-    configureNetwork(container, schemaRegistryHostname)
-    container
+    ).configure { configureNetwork(_, schemaRegistryHostname) }
   }
 
   protected def mappedSchemaRegistryAddress =
@@ -51,18 +49,20 @@ trait BaseNuKafkaRuntimeDockerTest
   protected lazy val schemaRegistryClient = new CachedSchemaRegistryClient(mappedSchemaRegistryAddress, 10)
 
   protected val kafkaContainer: KafkaContainer = {
-    val container = KafkaContainer(DockerImageName.parse(s"${KafkaContainer.defaultImage}:7.5.3"))
-      .configure(_.withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "FALSE"))
-    configureNetwork(container, kafkaHostname)
-    container
+    KafkaContainer(DockerImageName.parse("apache/kafka-native:4.1.1")).configure { self =>
+      self.withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
+      // can segfault on startup, we need retries - https://issues.apache.org/jira/browse/KAFKA-20314
+      self.withStartupAttempts(3)
+      configureNetwork(self, kafkaHostname)
+    }
   }
 
   protected def configureNetwork(
-      container: SingleContainer[_ <: JavaGenericContainer[_]],
+      container: JavaGenericContainer[_],
       networkAlias: String
   ): Unit = {
-    container.underlyingUnsafeContainer.withNetwork(network)
-    container.underlyingUnsafeContainer.withNetworkAliases(networkAlias)
+    container.withNetwork(network)
+    container.withNetworkAliases(networkAlias)
   }
 
   protected var fixture: NuKafkaRuntimeTestTestCaseFixture = _
@@ -91,7 +91,7 @@ trait BaseNuKafkaRuntimeDockerTest
 
   override protected def kafkaBoostrapServer: String = kafkaContainer.bootstrapServers
 
-  protected def dockerNetworkKafkaBoostrapServer: String = s"$kafkaHostname:9092"
+  protected def dockerNetworkKafkaBoostrapServer: String = s"$kafkaHostname:9093"
 
   protected lazy val kafkaClient = new KafkaClient(kafkaBoostrapServer, suiteName)
 

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/utils/BaseNuRuntimeBinTestMixin.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/utils/BaseNuRuntimeBinTestMixin.scala
@@ -22,8 +22,9 @@ trait BaseNuRuntimeBinTestMixin extends VeryPatientScalaFutures with Matchers { 
       executeBeforeProcessStatusCheck: => Unit,
       executeAfterProcessStatusCheck: => Unit
   ): Unit = {
+    val name                  = shellScriptArgs(0).split("[\\\\/]").last
     val process               = Runtime.getRuntime.exec(shellScriptArgs, shellScriptEnvs)
-    val processExitCodeFuture = ProcessUtils.attachLoggingAndReturnWaitingFuture(process)
+    val processExitCodeFuture = ProcessUtils.attachLoggingAndReturnWaitingFuture(name, process)
     ProcessUtils.destroyProcessEventually(process) {
       executeBeforeProcessStatusCheck
       ProcessUtils.checkIfFailedInstantly(processExitCodeFuture)

--- a/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
+++ b/engine/lite/k8sDeploymentManager/src/main/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManager.scala
@@ -317,6 +317,7 @@ class K8sDeploymentManager(
   override def getScenarioDeploymentsStatuses(
       scenarioName: ProcessName
   )(implicit freshnessPolicy: DataFreshnessPolicy): Future[WithDataFreshnessStatus[List[DeploymentStatusDetails]]] = {
+    // note: a deleted Deployment's Pods may still linger for a few seconds, Pod removal is asynchronous
     for {
       deployments <- scenarioStateK8sClient
         .listSelected[ListResource[Deployment]](requirementForName(scenarioName))

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/BaseK8sDeploymentManagerTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/BaseK8sDeploymentManagerTest.scala
@@ -17,9 +17,8 @@ import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.DeploymentData
 import pl.touk.nussknacker.test.{ExtremelyPatientScalaFutures, VeryPatientScalaFutures}
-import skuber.{k8sInit, ConfigMap, Event, LabelSelector, ListResource, Pod, Resource, Secret, Service}
+import skuber.{k8sInit, ConfigMap, LabelSelector, ListResource, Pod, Resource, Secret, Service}
 import skuber.LabelSelector.dsl._
-import skuber.Pod.LogQueryParams
 import skuber.api.client.KubernetesClient
 import skuber.apps.v1.Deployment
 import skuber.json.format._
@@ -29,7 +28,6 @@ import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
 
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 
 class BaseK8sDeploymentManagerTest
@@ -39,9 +37,11 @@ class BaseK8sDeploymentManagerTest
     with BeforeAndAfterAll {
   self: LazyLogging =>
 
-  private implicit val freshnessPolicy: DataFreshnessPolicy = DataFreshnessPolicy.Fresh
-  private implicit val system: ActorSystem                  = ActorSystem(getClass.getSimpleName)
   import system.dispatcher
+
+  private implicit val freshnessPolicy: DataFreshnessPolicy = DataFreshnessPolicy.Fresh
+
+  protected implicit val system: ActorSystem      = ActorSystem(getClass.getSimpleName)
   protected val backend: SttpBackend[Future, Any] = AsyncHttpClientFutureBackend()
 
   protected lazy val k8s: KubernetesClient = k8sInit(system)
@@ -146,9 +146,7 @@ class BaseK8sDeploymentManagerTest
         action
       } catch {
         case NonFatal(ex) =>
-          Try(printResourcesDetails()).failed.foreach { ex =>
-            logger.warn("Failure during printResourcesDetails", ex)
-          }
+          k8sTestUtils.printResourcesDetails()
           throw ex
       } finally {
         manager.processCommand(DMCancelScenarioCommand(version.processName, DeploymentData.systemUser)).futureValue
@@ -166,25 +164,6 @@ class BaseK8sDeploymentManagerTest
         state.map(_.status).headOption should matchPattern {
           case Some(s: SimpleStateStatus.Running) if s.version == version.versionId =>
         }
-      }
-    }
-
-    private def printResourcesDetails(): Unit = {
-      val pods = k8s.list[ListResource[Pod]]().futureValue.items
-      logger.info("pods:\n" + pods.mkString("\n"))
-      logger.info("services:\n" + k8s.list[ListResource[Service]]().futureValue.items.mkString("\n"))
-      logger.info("deployments:\n" + k8s.list[ListResource[Deployment]]().futureValue.items.mkString("\n"))
-      logger.info("ingresses:\n" + k8s.list[ListResource[Ingress]]().futureValue.items.mkString("\n"))
-      logger.info("events:\n" + k8s.list[ListResource[Event]]().futureValue.items.mkString("\n"))
-      pods.foreach { p =>
-        logger.info(s"Printing logs for pod: ${p.name}")
-        // It looks like it is a common situation that waiting for logs take a longer time than patient config.
-        // I guess that for still running pods, it can wait forever. Even if futureValue failed, printing of logs would
-        // still be continued. Because of that, I silently ignore this error
-        Try(
-          k8s.getPodLogSource(p.name, LogQueryParams()).futureValue.runForeach(bs => println(bs.utf8String)).futureValue
-        )
-        logger.info(s"Finished printing logs for pod: ${p.name}")
       }
     }
 

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/BaseK8sDeploymentManagerTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/BaseK8sDeploymentManagerTest.scala
@@ -16,6 +16,7 @@ import pl.touk.nussknacker.engine.api.deployment.DeploymentUpdateStrategy.StateR
 import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment.DeploymentData
+import pl.touk.nussknacker.k8s.manager.K8sDeploymentManager.{requirementForName, scenarioVersionLabel}
 import pl.touk.nussknacker.test.{ExtremelyPatientScalaFutures, VeryPatientScalaFutures}
 import skuber.{k8sInit, ConfigMap, LabelSelector, ListResource, Pod, Resource, Secret, Service}
 import skuber.LabelSelector.dsl._
@@ -28,6 +29,7 @@ import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
 
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
+import scala.language.reflectiveCalls
 import scala.util.control.NonFatal
 
 class BaseK8sDeploymentManagerTest
@@ -116,6 +118,35 @@ class BaseK8sDeploymentManagerTest
     backend.close()
   }
 
+  def waitForRunning(
+      manager: K8sDeploymentManager,
+      version: ProcessVersion,
+      waitForOldPodsTerminated: Boolean = false
+  ): Unit = {
+    eventually {
+      val state = manager.getScenarioDeploymentsStatuses(version.processName).map(_.value).futureValue
+      state.length shouldBe 1
+      state.map(_.status).headOption should matchPattern {
+        case Some(s: SimpleStateStatus.Running) if s.version == version.versionId =>
+      }
+    }
+
+    if (waitForOldPodsTerminated) {
+      // DM tells k8s to shut down old pods, but doesn't wait for this to happen
+      eventually {
+        k8s
+          .listSelected[ListResource[Pod]](
+            LabelSelector(
+              requirementForName(version.processName),
+              scenarioVersionLabel isNot version.versionId.value.toString
+            )
+          )
+          .futureValue
+          .items shouldBe empty
+      }
+    }
+  }
+
   class K8sDeploymentManagerTestFixture(
       val manager: K8sDeploymentManager,
       val scenario: CanonicalProcess,
@@ -142,7 +173,7 @@ class BaseK8sDeploymentManagerTest
         )
         .futureValue
       try {
-        waitForRunning(version)
+        waitForRunning(manager, version)
         action
       } catch {
         case NonFatal(ex) =>
@@ -152,17 +183,6 @@ class BaseK8sDeploymentManagerTest
         manager.processCommand(DMCancelScenarioCommand(version.processName, DeploymentData.systemUser)).futureValue
         eventually {
           manager.getScenarioDeploymentsStatuses(version.processName).futureValue.value shouldBe List.empty
-        }
-      }
-    }
-
-    def waitForRunning(version: ProcessVersion): Assertion = {
-      eventually {
-        val state = manager.getScenarioDeploymentsStatuses(version.processName).map(_.value).futureValue
-        logger.debug(s"Current process state: $state")
-        state.length shouldBe 1
-        state.map(_.status).headOption should matchPattern {
-          case Some(s: SimpleStateStatus.Running) if s.version == version.versionId =>
         }
       }
     }

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerKafkaTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerKafkaTest.scala
@@ -386,9 +386,9 @@ class K8sDeploymentManagerKafkaTest
     kafka.start()
   }
 
-  override protected def cleanup(): Unit = {
-    super.cleanup()
+  override protected def afterAll(): Unit = {
     kafka.stop()
+    super.afterAll()
   }
 
   private def cancelAndAssertCleanup(manager: K8sDeploymentManager, version: ProcessVersion) = {

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerKafkaTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerKafkaTest.scala
@@ -16,7 +16,6 @@ import pl.touk.nussknacker.engine.api.deployment.{
   DMValidateScenarioCommand
 }
 import pl.touk.nussknacker.engine.api.deployment.DeploymentUpdateStrategy.StateRestoringStrategy
-import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.{ProcessId, VersionId}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -101,16 +100,6 @@ class K8sDeploymentManagerKafkaTest
       pversion
     }
 
-    def waitForRunning(version: ProcessVersion) = {
-      eventually {
-        val state = manager.getScenarioDeploymentsStatuses(version.processName).map(_.value).futureValue
-        state.length shouldBe 1
-        state.map(_.status).head should matchPattern {
-          case s: SimpleStateStatus.Running if s.version == version.versionId =>
-        }
-      }
-    }
-
     val message = """{"message":"Nussknacker!"}"""
 
     def messageForVersion(version: Int) = s"""{"original":$message,"version":$version}"""
@@ -122,16 +111,16 @@ class K8sDeploymentManagerKafkaTest
     )
 
     val version1 = deployScenario(1)
-    waitForRunning(version1)
+    waitForRunning(manager, version1)
 
     kafka.sendToTopic(input, message)
     kafka.readFromTopic(output, 1) shouldBe List(messageForVersion(1))
 
     val version2 = deployScenario(2)
-    waitForRunning(version2)
+    waitForRunning(manager, version2, waitForOldPodsTerminated = true)
 
     kafka.sendToTopic(input, message)
-    kafka.readFromTopic(output, 2) shouldBe List(messageForVersion(1), messageForVersion(2))
+    kafka.readFromTopic(output, 2, secondsToWait = 15) shouldBe List(messageForVersion(1), messageForVersion(2))
 
     cancelAndAssertCleanup(manager, version2)
   }

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerReqRespTest.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sDeploymentManagerReqRespTest.scala
@@ -12,13 +12,11 @@ import pl.touk.nussknacker.engine.ModelData
 import pl.touk.nussknacker.engine.api.{NodeId, ProcessVersion}
 import pl.touk.nussknacker.engine.api.component.{ComponentProvider, NodesDeploymentData}
 import pl.touk.nussknacker.engine.api.deployment.{
-  DataFreshnessPolicy,
   DeploymentUpdateStrategy,
   DMRunDeploymentCommand,
   DMValidateScenarioCommand
 }
 import pl.touk.nussknacker.engine.api.deployment.DeploymentUpdateStrategy.StateRestoringStrategy
-import pl.touk.nussknacker.engine.api.deployment.simple.SimpleStateStatus
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName, VersionId}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -33,7 +31,6 @@ import skuber.json.format._
 import skuber.networking.v1.Ingress
 import sttp.client3._
 
-import scala.concurrent.ExecutionContext.Implicits._
 import scala.jdk.CollectionConverters._
 import scala.language.reflectiveCalls
 import scala.util.Random
@@ -46,7 +43,6 @@ class K8sDeploymentManagerReqRespTest
     with EitherValuesDetailedMessage
     with LazyLogging {
 
-  private implicit val freshnessPolicy: DataFreshnessPolicy = DataFreshnessPolicy.Fresh
   private val givenServicePort = 12345 // some random, remote port, we don't need to worry about collisions
 
   test("deployment of req-resp ping-pong") {
@@ -178,13 +174,7 @@ class K8sDeploymentManagerReqRespTest
             )
           )
           .futureValue
-        eventually {
-          val state = f.manager.getScenarioDeploymentsStatuses(secondVersionInfo.processName).map(_.value).futureValue
-          state.length shouldBe 1
-          state.map(_.status) should matchPattern {
-            case List(SimpleStateStatus.Running(version, _)) if version.value == secondVersion =>
-          }
-        }
+        waitForRunning(f.manager, secondVersionInfo)
         val versionsAfterRedeploy = checkVersions()
         versionsAfterRedeploy shouldEqual Set(secondVersion)
       }
@@ -260,7 +250,7 @@ class K8sDeploymentManagerReqRespTest
           )
         )
         .futureValue
-      f.waitForRunning(newVersion)
+      waitForRunning(f.manager, newVersion)
       val servicesForScenario = k8s
         .listSelected[ListResource[Service]](LabelSelector(requirementForName(newVersion.processName)))
         .futureValue

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sPortForwarder.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sPortForwarder.scala
@@ -1,0 +1,77 @@
+package pl.touk.nussknacker.k8s.manager
+
+import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.test.ProcessUtils
+import skuber.{ObjectResource, Pod, Service}
+
+import java.io.{File, IOException}
+import java.net.Socket
+import scala.util.control.NonFatal
+
+class K8sPortForwarder(val obj: ObjectResource, val remotePort: Int, val localPort: Int)
+    extends AutoCloseable
+    with LazyLogging {
+
+  private var portForwardProcess: Process = _
+
+  def start(): K8sPortForwarder = {
+    if (portForwardProcess != null) {
+      throw new IllegalStateException("forwarder is already running")
+    }
+
+    val typeAndName = s"${fixedKind(obj)}/${obj.name}"
+    portForwardProcess = new ProcessBuilder("kubectl", "port-forward", typeAndName, s"$localPort:$remotePort")
+      .directory(new File("/tmp"))
+      .start()
+
+    try {
+      val name              = s"port-forward($localPort)"
+      val processExitFuture = ProcessUtils.attachLoggingAndReturnWaitingFuture(name, portForwardProcess)
+      ProcessUtils.checkIfFailedInstantly(processExitFuture)
+      waitForPortOpen(portForwardProcess)
+      logger.info(s"Started port forwarder: localhost:$localPort -> $typeAndName:$remotePort")
+    } catch {
+      case NonFatal(ex) =>
+        close()
+        throw ex
+    }
+
+    this
+  }
+
+  private def waitForPortOpen(process: Process): Unit = {
+    val startTs = System.currentTimeMillis()
+    while (process.isAlive) {
+      try {
+        new Socket("localhost", localPort).close()
+        return
+      } catch {
+        case e: IOException =>
+          if (System.currentTimeMillis() - startTs < 10000) {
+            Thread.sleep(10)
+          } else {
+            throw e
+          }
+      }
+    }
+  }
+
+  // kind is sometimes blank - skuber resources keep kind as a field (not a constant) and looks like sometime it is set to blank string
+  private def fixedKind(obj: ObjectResource): String = {
+    Option(obj.kind.toLowerCase).filterNot(_.isBlank).getOrElse {
+      obj match {
+        case _: Pod     => "pod"
+        case _: Service => "service"
+        case other      => throw new IllegalArgumentException(s"Unknown resource with empty kind: $other")
+      }
+    }
+  }
+
+  override def close(): Unit = {
+    if (portForwardProcess != null && portForwardProcess.isAlive) {
+      portForwardProcess.destroy()
+      portForwardProcess = null
+    }
+  }
+
+}

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sTestUtils.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/K8sTestUtils.scala
@@ -2,20 +2,24 @@ package pl.touk.nussknacker.k8s.manager
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.Done
-import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Framing, Sink, Source}
+import org.apache.pekko.util.ByteString
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.test.{AvailablePortFinder, ExtremelyPatientScalaFutures, ProcessUtils}
-import skuber.{ConfigMap, Container, ObjectMeta, ObjectResource, Pod, Service, Volume}
-import skuber.Pod.Phase
+import pl.touk.nussknacker.test.{AvailablePortFinder, ExtremelyPatientScalaFutures}
+import skuber.{ConfigMap, Container, Event, ListResource, ObjectMeta, ObjectResource, Pod, Service, Volume}
+import skuber.Pod.{LogQueryParams, Phase}
 import skuber.api.client.KubernetesClient
+import skuber.apps.v1.Deployment
 import skuber.json.format._
+import skuber.networking.v1.Ingress
 
-import java.io.File
-import java.net.Socket
 import scala.collection.mutable
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{Await, Future, Promise}
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.{Try, Using}
 
 class K8sTestUtils(k8s: KubernetesClient)
     extends K8sUtils(k8s)
@@ -71,18 +75,9 @@ class K8sTestUtils(k8s: KubernetesClient)
 
   def withPortForwarded(obj: ObjectResource, remotePort: Int)(action: Int => Unit): Unit = {
     ensureRunningStatus(obj)
-    val localPort = AvailablePortFinder.findAvailablePorts(1).head
-    val portForwardProcess =
-      new ProcessBuilder("kubectl", "port-forward", s"${fixedKind(obj)}/${obj.name}", s"$localPort:$remotePort")
-        .directory(new File("/tmp"))
-        .start()
 
-    ProcessUtils.destroyProcessEventually(portForwardProcess) {
-      val processExitFuture = ProcessUtils.attachLoggingAndReturnWaitingFuture(portForwardProcess)
-      ProcessUtils.checkIfFailedInstantly(processExitFuture)
-      eventually {
-        new Socket("localhost", localPort)
-      }
+    val localPort = AvailablePortFinder.findAvailablePorts(1).head
+    Using.resource(new K8sPortForwarder(obj, remotePort, localPort).start()) { _ =>
       action(localPort)
     }
   }
@@ -94,19 +89,8 @@ class K8sTestUtils(k8s: KubernetesClient)
         eventually {
           k8s.get[Pod](p.name).futureValue.status.value.phase.value shouldEqual Phase.Running
         }
-      case s: Service =>
+      case _: Service =>
       case other      => throw new IllegalArgumentException(s"Unknown resource with empty kind: $other")
-    }
-  }
-
-  // kind is sometime blank - skuber resources keep kind as a field (not a constant) and looks like sometime it is set to blank string
-  private def fixedKind(obj: ObjectResource) = {
-    Option(obj.kind.toLowerCase).filterNot(_.isBlank).getOrElse {
-      obj match {
-        case _: Pod     => "pod"
-        case _: Service => "service"
-        case other      => throw new IllegalArgumentException(s"Unknown resource with empty kind: $other")
-      }
     }
   }
 
@@ -125,7 +109,7 @@ class K8sTestUtils(k8s: KubernetesClient)
       Pod.Spec(
         containers = List(
           Container(
-            image = "nginx:1.23.1",
+            image = "nginx:1.28-alpine",
             name = "reverse-proxy",
             volumeMounts = List(Volume.Mount(reverseProxyConfConfigMapName, "/etc/nginx/conf.d/"))
           )
@@ -167,6 +151,40 @@ class K8sTestUtils(k8s: KubernetesClient)
         )
       )
       .futureValue
+  }
+
+  def printResourcesDetails()(implicit materializer: Materializer): Unit = {
+    Try(doPrintResourcesDetails()).failed.foreach { ex =>
+      logger.warn("Failure during printResourcesDetails", ex)
+    }
+  }
+
+  private def doPrintResourcesDetails()(implicit materializer: Materializer): Unit = {
+    val pods = k8s.list[ListResource[Pod]]().futureValue.items
+    logger.info("pods:\n" + pods.mkString("\n"))
+    logger.info("services:\n" + k8s.list[ListResource[Service]]().futureValue.items.mkString("\n"))
+    logger.info("deployments:\n" + k8s.list[ListResource[Deployment]]().futureValue.items.mkString("\n"))
+    logger.info("ingresses:\n" + k8s.list[ListResource[Ingress]]().futureValue.items.mkString("\n"))
+    logger.info("events:\n" + k8s.list[ListResource[Event]]().futureValue.items.mkString("\n"))
+    pods.foreach { p =>
+      logger.info(s"Printing logs for pod: ${p.name}")
+      val logParams = LogQueryParams(
+        sinceTime = p.metadata.creationTimestamp,
+        follow = Some(false),
+      )
+      val podLogger = k8s.getPodLogSource(p.name, logParams).flatMap { source =>
+        source
+          .via(Framing.delimiter(ByteString('\n'), maximumFrameLength = 16384, allowTruncation = true))
+          .runForeach { bs =>
+            logger.info(s"[pod:${p.name}] ${bs.utf8String}")
+          }
+      }
+
+      Try(Await.result(podLogger, 5.seconds)).failed.foreach { e =>
+        logger.warn(s"Failed to fetch logs for ${p.name}: ${e.getMessage}")
+      }
+      logger.info(s"Finished printing logs for pod: ${p.name}")
+    }
   }
 
 }

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupport.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupport.scala
@@ -153,11 +153,16 @@ class KafkaK8sSupport(k8s: KubernetesClient)(private implicit val system: ActorS
     }
   }
 
-  def readFromTopic(name: String, count: Int): List[String] = {
+  def readFromTopic(name: String, count: Int, secondsToWait: Int = 5): List[String] = {
     Using.resource(kafkaClient.createConsumer()) { consumer =>
       new RichKafkaConsumer(consumer)
-        .consumeWithConsumerRecord(name, 5)
-        .map(record => new String(record.value()))
+        .consumeWithConsumerRecord(name, secondsToWait)
+        .map { record =>
+          logger.info(
+            s"Read Kafka message: ${record.topic()}:${record.partition()}:${record.offset()} = ${new String(record.value())}"
+          )
+          new String(record.value())
+        }
         .take(count)
         .toList
     }

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupport.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupport.scala
@@ -88,15 +88,8 @@ class KafkaK8sSupport(k8s: KubernetesClient)(private implicit val system: ActorS
 
     val srContainer = Container(
       name = srPodName,
-      image = "confluentinc/cp-schema-registry:7.5.13",
-      env = List(
-        EnvVar("SCHEMA_REGISTRY_HOST_NAME", "schemaregistry"),
-        EnvVar("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", s"$kafkaServiceName:9092")
-      ),
-      readinessProbe = Some(
-        Probe(new HTTPGetAction(Left(8081), path = "/subjects"), periodSeconds = Some(1), failureThreshold = Some(60))
-      ),
-      livenessProbe = Some(Probe(new HTTPGetAction(Left(8081), path = "/subjects")))
+      image = "ghcr.io/axonops/axonops-schema-registry:0.2.1",
+      readinessProbe = Some(Probe(new HTTPGetAction(Left(8081), path = "/health/ready"))),
     )
     val srPod = Pod(
       metadata = ObjectMeta(name = srPodName, labels = Map("run" -> srPodName)),
@@ -172,7 +165,7 @@ class KafkaK8sSupport(k8s: KubernetesClient)(private implicit val system: ActorS
 
   private def runInPod(
       podName: String,
-      command: String,
+      command: Seq[String],
       end: String => Boolean,
       input: Option[String] = None
   ): String = {
@@ -189,7 +182,7 @@ class KafkaK8sSupport(k8s: KubernetesClient)(private implicit val system: ActorS
     k8s
       .exec(
         podName,
-        command.split(" ").toIndexedSeq,
+        command,
         maybeStdout = Some(sink),
         maybeStdin = inputSource,
         maybeClose = Some(close)
@@ -207,8 +200,17 @@ class KafkaK8sSupport(k8s: KubernetesClient)(private implicit val system: ActorS
   }
 
   def createSchema(name: String, schema: String, schemaType: String = "JSON"): Unit = {
-    val req     = s"""{"schemaType":"$schemaType","schema":"${schema.replace(""""""", """\"""")}"}"""
-    val command = s"curl -v -H Content-Type:application/json localhost:8081/subjects/$name/versions -d $req"
+    val req = s"""{"schemaType":"$schemaType","schema":"${schema.replace(""""""", """\"""")}"}"""
+    val command = Seq(
+      "wget",
+      "--header",
+      "Content-Type: application/json",
+      "--post-data",
+      req,
+      "-O",
+      "-",
+      s"localhost:8081/subjects/$name/versions"
+    )
     runInPod(srPodName, command, _.contains(""""id":"""))
   }
 

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupport.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupport.scala
@@ -2,15 +2,18 @@ package pl.touk.nussknacker.k8s.manager
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.Done
+import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.k8s.manager.KafkaK8sSupport.{kafkaServiceName, srServiceName}
+import pl.touk.nussknacker.engine.kafka.{KafkaClient, RichKafkaConsumer}
 import pl.touk.nussknacker.test.ExtremelyPatientScalaFutures
-import skuber.{Container, EnvVar, HTTPGetAction, ObjectMeta, Pod, Probe, Service}
+import skuber.{Container, EnvVar, HTTPGetAction, ObjectMeta, Pod, Probe, Protocol, Service, TCPSocketAction}
 import skuber.api.client.KubernetesClient
 import skuber.json.format._
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.Using
+import scala.util.control.NonFatal
 
 object KafkaK8sSupport {
 
@@ -19,30 +22,51 @@ object KafkaK8sSupport {
 
 }
 
-//TODO: would it be faster if we run e.g. kcat as k8s job instead of exec into kafka pod?
-class KafkaK8sSupport(k8s: KubernetesClient) extends ExtremelyPatientScalaFutures with LazyLogging with Matchers {
+class KafkaK8sSupport(k8s: KubernetesClient)(private implicit val system: ActorSystem)
+    extends ExtremelyPatientScalaFutures
+    with LazyLogging
+    with Matchers {
+
+  import pl.touk.nussknacker.k8s.manager.KafkaK8sSupport._
 
   private val k8sUtils = new K8sTestUtils(k8s)
 
-  // set to false in development to reuse existing kafka pod
-  private val cleanupKafka = true
+  private val kafkaPodName        = "kafka-k8s-test"
+  private val kafkaPodExposedPort = 30092
+  private val srPodName           = "sr-k8s-test"
 
-  private val kafkaPodName = "kafka-k8s-test"
-  private val srPodName    = "sr-k8s-test"
+  private var kafkaPortForwarder: K8sPortForwarder = _
+
+  private val kafkaClient = new KafkaClient(s"localhost:$kafkaPodExposedPort", getClass.getSimpleName)
 
   def start()(implicit ec: ExecutionContext): Unit = if (k8s.getOption[Pod](kafkaPodName).futureValue.isEmpty) {
     val kafkaContainer = Container(
       name = kafkaPodName,
-      // we use debezium image as it makes it easy to use kraft (KIP-500)
-      // versions are not directly connected with Kafka versions
-      image = "debezium/kafka:1.8",
+      image = "apache/kafka-native:4.1.1",
+      ports = List(
+        Container.Port(9092, Protocol.TCP, "kafka-internal"),
+        Container.Port(kafkaPodExposedPort, Protocol.TCP, "kafka-localhost"),
+      ),
       env = List(
-        EnvVar("CLUSTER_ID", "5Yr1SIgYQz-b-dgRabWx4g"),
-        EnvVar("BROKER_ID", "1"),
-        EnvVar("KAFKA_LISTENERS", "PLAINTEXT://0.0.0.0:9092,CONTROLLER://localhost:9093"),
+        EnvVar("KAFKA_NODE_ID", "1"),
+        EnvVar("KAFKA_PROCESS_ROLES", "broker,controller"),
+        EnvVar("KAFKA_LISTENERS", s"BROKER://:9092,CONTROLLER://localhost:9093,LOCALHOST://:$kafkaPodExposedPort"),
+        EnvVar(
+          "KAFKA_ADVERTISED_LISTENERS",
+          s"BROKER://$kafkaServiceName:9092,CONTROLLER://localhost:9093,LOCALHOST://localhost:$kafkaPodExposedPort"
+        ),
+        EnvVar("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER"),
+        EnvVar("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER"),
+        EnvVar("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT,LOCALHOST:PLAINTEXT"),
         EnvVar("KAFKA_CONTROLLER_QUORUM_VOTERS", "1@localhost:9093"),
-        EnvVar("ADVERTISED_KAFKA_LISTENERS", "PLAINTEXT://kafkaservice:9092")
-      )
+        EnvVar("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1"),
+        EnvVar("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1"),
+        EnvVar("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1"),
+        EnvVar("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0"),
+      ),
+      readinessProbe = Some(
+        Probe(TCPSocketAction(Left(9092)))
+      ),
     )
     val kafkaPod = Pod(
       metadata = ObjectMeta(name = kafkaPodName, labels = Map("run" -> kafkaPodName)),
@@ -52,7 +76,11 @@ class KafkaK8sSupport(k8s: KubernetesClient) extends ExtremelyPatientScalaFuture
       metadata = ObjectMeta(name = kafkaServiceName),
       spec = Some(
         Service.Spec(
-          ports = List(Service.Port(port = 9092)),
+          _type = Service.Type.NodePort,
+          ports = List(
+            Service.Port(port = 9092, name = "internal"), // will get an auto-assigned nodePort
+            Service.Port(port = kafkaPodExposedPort, name = "localhost", nodePort = kafkaPodExposedPort)
+          ),
           selector = Map("run" -> kafkaPodName)
         )
       )
@@ -60,12 +88,10 @@ class KafkaK8sSupport(k8s: KubernetesClient) extends ExtremelyPatientScalaFuture
 
     val srContainer = Container(
       name = srPodName,
-      // we use debezium image as it makes it easy to use kraft (KIP-500)
-      // versions are not directly connected with Kafka versions
-      image = "confluentinc/cp-schema-registry:7.2.1",
+      image = "confluentinc/cp-schema-registry:7.5.13",
       env = List(
         EnvVar("SCHEMA_REGISTRY_HOST_NAME", "schemaregistry"),
-        EnvVar("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", s"${KafkaK8sSupport.kafkaServiceName}:9092")
+        EnvVar("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", s"$kafkaServiceName:9092")
       ),
       readinessProbe = Some(
         Probe(new HTTPGetAction(Left(8081), path = "/subjects"), periodSeconds = Some(1), failureThreshold = Some(60))
@@ -90,15 +116,32 @@ class KafkaK8sSupport(k8s: KubernetesClient) extends ExtremelyPatientScalaFuture
       .sequence(List(k8s.create(kafkaPod), k8s.create(kafkaService), k8s.create(srPod), k8s.create(srService)))
       .futureValue
 
-    def isContainerReady(podName: String) =
-      k8s.get[Pod](podName).futureValue.status.get.containerStatuses.headOption.get.ready
-    eventually {
-      isContainerReady(kafkaPodName) shouldBe true
-      isContainerReady(srPodName) shouldBe true
+    def isContainerDone(podName: String, allowFailed: Boolean = true) = {
+      val status = k8s.get[Pod](podName).futureValue.status.get.containerStatuses.headOption.get
+      status.ready || (allowFailed && status.restartCount > 0)
     }
+
+    try {
+      eventually {
+        isContainerDone(kafkaPodName) shouldBe true
+        isContainerDone(srPodName) shouldBe true
+      }
+      isContainerDone(kafkaPodName, allowFailed = false) shouldBe true
+      isContainerDone(srPodName, allowFailed = false) shouldBe true
+    } catch {
+      case NonFatal(e) =>
+        k8sUtils.printResourcesDetails()
+        throw e
+    }
+
+    kafkaPortForwarder = new K8sPortForwarder(kafkaPod, kafkaPodExposedPort, kafkaPodExposedPort).start()
   }
 
-  def stop()(implicit ec: ExecutionContext): Unit = if (cleanupKafka) {
+  def stop()(implicit ec: ExecutionContext): Unit = {
+    kafkaClient.shutdown()
+    if (kafkaPortForwarder != null) {
+      kafkaPortForwarder.close()
+    }
     Future
       .sequence(
         List(
@@ -118,14 +161,14 @@ class KafkaK8sSupport(k8s: KubernetesClient) extends ExtremelyPatientScalaFuture
   }
 
   def readFromTopic(name: String, count: Int): List[String] = {
-    val command =
-      s"/kafka/bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic $name --max-messages $count --from-beginning"
-    val messages = k8sUtils.execPodWithLogs(kafkaPodName, command, _.lines.toArray.length == count, None)
-    messages.split("\n").take(count).toList
+    Using.resource(kafkaClient.createConsumer()) { consumer =>
+      new RichKafkaConsumer(consumer)
+        .consumeWithConsumerRecord(name, 5)
+        .map(record => new String(record.value()))
+        .take(count)
+        .toList
+    }
   }
-
-  private def runInKafka(command: String, end: String => Boolean, input: Option[String] = None): String =
-    runInPod(kafkaPodName, command, end, input)
 
   private def runInPod(
       podName: String,
@@ -156,14 +199,11 @@ class KafkaK8sSupport(k8s: KubernetesClient) extends ExtremelyPatientScalaFuture
   }
 
   def sendToTopic(name: String, value: String): Unit = {
-    val command = s"/kafka/bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic $name"
-    k8sUtils.execPodWithLogs(kafkaPodName, command, _ => true, Some(value))
+    kafkaClient.sendMessage(name, value).futureValue
   }
 
   def createTopic(name: String): Unit = {
-    val command =
-      s"/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --create --topic $name --partitions 1 --replication-factor 1"
-    k8sUtils.execPodWithLogs(kafkaPodName, command, _.contains(s"Created topic $name"))
+    kafkaClient.createTopic(name, 1)
   }
 
   def createSchema(name: String, schema: String, schemaType: String = "JSON"): Unit = {

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupportTests.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupportTests.scala
@@ -1,0 +1,57 @@
+package pl.touk.nussknacker.k8s.manager
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.pekko.actor.ActorSystem
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, OptionValues}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.test.{EitherValuesDetailedMessage, PatientScalaFutures}
+import skuber.api.client.KubernetesClient
+import skuber.k8sInit
+
+import scala.language.reflectiveCalls
+
+/**
+ * Tests for use for testing [[KafkaK8sSupport]], should be run manually.
+ */
+@DoNotDiscover
+class KafkaK8sSupportTests
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with OptionValues
+    with PatientScalaFutures
+    with EitherValuesDetailedMessage
+    with LazyLogging {
+
+  import system.dispatcher
+
+  private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
+
+  private lazy val k8s: KubernetesClient = k8sInit(system)
+  private lazy val k8sTestUtils          = new K8sTestUtils(k8s)
+
+  private lazy val kafka = new KafkaK8sSupport(k8s)
+
+  override protected def beforeAll(): Unit = {
+    kafka.start()
+    k8sTestUtils.printResourcesDetails()
+  }
+
+  override protected def afterAll(): Unit = {
+    kafka.stop()
+  }
+
+  test("Kafka container") {
+    kafka.createTopic("k8s-test-topic")
+    kafka.sendToTopic("k8s-test-topic", "test1")
+    kafka.readFromTopic("k8s-test-topic", 1) shouldBe List("test1")
+    kafka.sendToTopic("k8s-test-topic", "test2")
+    kafka.readFromTopic("k8s-test-topic", 2) shouldBe List("test1", "test2")
+  }
+
+  test("Schema Registry container") {
+    kafka.createSchema("k8s-test-topic-subject", "{}")
+  }
+
+}

--- a/examples/dev/local-testing.docker-compose.yml
+++ b/examples/dev/local-testing.docker-compose.yml
@@ -24,7 +24,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:18
+    image: postgres:18-alpine
     restart: unless-stopped
     ports:
       - 5432:5432

--- a/examples/dev/nginx.override.yaml
+++ b/examples/dev/nginx.override.yaml
@@ -1,7 +1,7 @@
 services:
 
   nginx:
-    image: nginx:1.26.0-alpine
+    image: nginx:1.28-alpine
     restart: unless-stopped
     ports:
       - 3080:8080

--- a/examples/installation/docker-compose.yml
+++ b/examples/installation/docker-compose.yml
@@ -3,7 +3,7 @@ name: nussknacker
 services:
 
   nginx:
-    image: nginx:1.26.0-alpine
+    image: nginx:1.28-alpine
     restart: unless-stopped
     ports:
       - 8080:8080
@@ -70,7 +70,7 @@ services:
           memory: 1024M
 
   postgres:
-    image: postgres:18
+    image: postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: "nu-db"

--- a/utils/kafka-components-utils/src/it/scala/pl/touk/nussknacker/engine/kafka/validator/CachedTopicsExistenceValidatorTest.scala
+++ b/utils/kafka-components-utils/src/it/scala/pl/touk/nussknacker/engine/kafka/validator/CachedTopicsExistenceValidatorTest.scala
@@ -11,6 +11,7 @@ import pl.touk.nussknacker.engine.api.process.TopicName
 import pl.touk.nussknacker.engine.kafka._
 
 import java.util.{Collections, UUID}
+import java.util.concurrent.TimeUnit
 
 class CachedTopicsExistenceValidatorWhenAutoCreateDisabledTest
     extends BaseCachedTopicsExistenceValidatorTest(
@@ -165,7 +166,7 @@ abstract class BaseCachedTopicsExistenceValidatorTest(kafkaAutoCreateEnabled: Bo
   private def createKafkaTopic(name: String): Unit = {
     val topic = new NewTopic(name, Collections.emptyMap())
     KafkaUtils.usingAdminClient(defaultKafkaConfig) {
-      _.createTopics(Collections.singletonList[NewTopic](topic))
+      _.createTopics(Collections.singletonList[NewTopic](topic)).all().get(5, TimeUnit.SECONDS)
     }
   }
 

--- a/utils/kafka-components-utils/src/it/scala/pl/touk/nussknacker/engine/kafka/validator/CachedTopicsExistenceValidatorTest.scala
+++ b/utils/kafka-components-utils/src/it/scala/pl/touk/nussknacker/engine/kafka/validator/CachedTopicsExistenceValidatorTest.scala
@@ -120,10 +120,11 @@ abstract class BaseCachedTopicsExistenceValidatorTest(kafkaAutoCreateEnabled: Bo
     with Matchers {
 
   override val container: KafkaContainer =
-    KafkaContainer(DockerImageName.parse(s"${KafkaContainer.defaultImage}:7.4.0"))
-      .configure {
-        _.withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", kafkaAutoCreateEnabled.toString.toUpperCase)
-      }
+    KafkaContainer(DockerImageName.parse("apache/kafka-native:4.1.1")).configure { self =>
+      // can segfault on startup, we need retries - https://issues.apache.org/jira/browse/KAFKA-20314
+      self.withStartupAttempts(3)
+      self.withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", kafkaAutoCreateEnabled.toString.toLowerCase)
+    }
 
   lazy val defaultKafkaConfig: KafkaComponentsConfig = KafkaComponentsConfig(
     kafkaProperties = Map("bootstrap.servers" -> container.bootstrapServers),

--- a/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/RichKafkaConsumer.scala
+++ b/utils/kafka-test-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/RichKafkaConsumer.scala
@@ -7,6 +7,7 @@ import org.apache.kafka.common.TopicPartition
 import org.scalatest.concurrent.Eventually.{eventually, _}
 import org.scalatest.time.{Millis, Seconds, Span}
 
+import java.{lang, util}
 import java.time.Duration
 import java.util.concurrent.TimeoutException
 import scala.collection.compat.immutable.LazyList
@@ -32,6 +33,9 @@ class RichKafkaConsumer[K, M](consumer: Consumer[K, M]) extends LazyLogging {
       topic: String,
       secondsToWait: Int = DefaultSecondsToWait
   ): LazyList[ConsumerRecord[K, M]] = {
+    if (!consumer.subscription().isEmpty) {
+      throw new IllegalStateException(s"Consumer is already subscribed to topics: ${consumer.subscription().asScala}")
+    }
     val partitions = fetchTopicPartitions(topic, secondsToWait)
     consumer.assign(partitions.asJava)
     logger.debug(s"Consumer assigment: ${consumer.assignment().asScala}")
@@ -41,7 +45,7 @@ class RichKafkaConsumer[K, M](consumer: Consumer[K, M]) extends LazyLogging {
     LazyList.continually(()).flatMap(new Poller(secondsToWait))
   }
 
-  def getEndOffsets(topic: String, secondsToWait: Int = DefaultSecondsToWait) = {
+  def getEndOffsets(topic: String, secondsToWait: Int = DefaultSecondsToWait): util.Map[TopicPartition, lang.Long] = {
     val partitions = fetchTopicPartitions(topic, secondsToWait)
     consumer.assign(partitions.asJava)
     consumer.endOffsets(partitions.asJava)

--- a/utils/test-utils/src/main/scala/pl/touk/nussknacker/test/ProcessUtils.scala
+++ b/utils/test-utils/src/main/scala/pl/touk/nussknacker/test/ProcessUtils.scala
@@ -1,19 +1,20 @@
 package pl.touk.nussknacker.test
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.commons.io.IOUtils
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 
+import java.io.{BufferedReader, InputStream, InputStreamReader}
 import scala.concurrent.{blocking, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.control.NonFatal
 
 object ProcessUtils extends LazyLogging with Matchers with VeryPatientScalaFutures {
 
-  val successExitCodes: Set[Int] = Set(0, 143) // destroy causes SIGTERM which ends up process with 143 exit code
+  // Some applications, e.g. Java, exit with 128+cause, so SIGTERM (15) results in 128+15=143
+  private val successExitCodes: Set[Int] = Set(0, 143)
 
-  def attachLoggingAndReturnWaitingFuture(process: Process): Future[Int] = {
+  def attachLoggingAndReturnWaitingFuture(name: String, process: Process): Future[Int] = {
     logger.info(s"Started process: ${process.info()} with pid: ${process.pid()}")
     process.onExit().thenApply[Unit] { p =>
       if (successExitCodes.contains(p.exitValue())) {
@@ -22,16 +23,9 @@ object ProcessUtils extends LazyLogging with Matchers with VeryPatientScalaFutur
         logger.warn(s"Process exited with failure ${process.exitValue()} exit code")
       }
     }
-    Future {
-      blocking {
-        IOUtils.copy(process.getInputStream, System.out)
-      }
-    }
-    Future {
-      blocking {
-        IOUtils.copy(process.getErrorStream, System.err)
-      }
-    }
+    val logPrefix = s"[$name:${process.pid()}] "
+    streamLines(process.getInputStream, { line => System.out.println(logPrefix + line) })
+    streamLines(process.getErrorStream, { line => System.err.println(logPrefix + line) })
     val future = Future {
       blocking {
         process.waitFor()
@@ -74,5 +68,20 @@ object ProcessUtils extends LazyLogging with Matchers with VeryPatientScalaFutur
       }
     }
   }
+
+  private def streamLines(inputStream: InputStream, printFn: String => Unit): Future[Unit] =
+    Future {
+      blocking {
+        val reader = new BufferedReader(new InputStreamReader(inputStream))
+        try {
+          Iterator
+            .continually(reader.readLine())
+            .takeWhile(_ != null)
+            .foreach(line => printFn(line))
+        } finally {
+          reader.close()
+        }
+      }
+    }
 
 }

--- a/utils/test-utils/src/main/scala/pl/touk/nussknacker/test/installationexample/DockerBasedNuInstallationExampleEnvironment.scala
+++ b/utils/test-utils/src/main/scala/pl/touk/nussknacker/test/installationexample/DockerBasedNuInstallationExampleEnvironment.scala
@@ -8,7 +8,6 @@ import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.api.model.Container
 import com.typesafe.scalalogging.LazyLogging
 import org.slf4j.Logger
-import org.slf4j.MarkerFactory.getIMarkerFactory
 import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.DockerHealthcheckWaitStrategy
@@ -56,6 +55,8 @@ class DockerBasedInstallationExampleNuEnvironment(
       tailChildContainers = false
     ) {
 
+  useLocalCompose()
+
   slf4jLogger.info(s"Initializing ${getClass.getName}")
 
   Try(start()) match {
@@ -78,11 +79,11 @@ class DockerBasedInstallationExampleNuEnvironment(
     super.stop()
   }
 
-  private def captureAllContainerLogs() = {
+  private def captureAllContainerLogs(): Unit = {
     val dockerClient = DockerClientFactory.lazyClient()
     getNuDockerComposeContainers(dockerClient).foreach { container =>
       val logs = LogUtils.getOutput(dockerClient, container.getId)
-      slf4jLogger.info(getIMarkerFactory.getMarker(container.getNames.mkString(",")), logs)
+      slf4jLogger.info("{} {}", container.getNames()(0), logs)
     }
   }
 
@@ -101,6 +102,15 @@ class DockerBasedInstallationExampleNuEnvironment(
         }
       }
       .toList
+  }
+
+  /**
+   * work around https://github.com/testcontainers/testcontainers-scala/issues/543
+   */
+  private def useLocalCompose(): Unit = {
+    val localComposeField = container.getClass.getDeclaredField("localCompose")
+    localComposeField.setAccessible(true)
+    localComposeField.setBoolean(container, true)
   }
 
 }


### PR DESCRIPTION
## Describe your changes

* new Testcontainers version
* unified used containers:
  * `confluentinc/cp-kafka:7.4.0` (Kafka 3.4, 417 MB) -> `apache/kafka-native:4.1.1` (49 MB)
  * `confluentinc/cp-kafka:7.5.3` (Kafka 3.5, 426 MB) -> `apache/kafka-native:4.1.1` (49 MB)
  * `debezium/kafka:1.8` (Kafka 3.0, 418 MB) -> `apache/kafka-native:4.1.1` (49 MB)
  * `postgres:18` (154 MB) -> `postgres:18-alpine` (108 MB)
  * `confluentinc/cp-schema-registry`: `7.5.3`, `7.2.1` -> `7.5.13` (1st commit) -> `axonops/axonops-schema-registry` (77 MB, 2nd commit)
  * `nginx:1.23.1` (53 MB), `nginx:1.26.0-alpine` -> nginx:1.28-alpine (25 MB)
* a few improvements to K8s tests:
  * correct handling of newline in logs from K8s pods
  * Kafka operations are done by Kafka client, not a shell command executed in Kafka pod (I didn't touch Schema Registry, that would require another port forwarding)
* tagged output from `ProcessUtils.attachLoggingAndReturnWaitingFuture`

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
