### PR TITLE
[NU-2414] Backports from Flink 2.2 PR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,18 +137,18 @@ val ignoreExternalDepsTests = Tests.Argument(TestFrameworks.ScalaTest, "-l", "or
 lazy val commonSettings =
   publishSettings ++
     Seq(
-      licenses                         := Seq(License.Apache2),
-      crossScalaVersions               := supportedScalaVersions,
-      scalaVersion                     := defaultScalaV,
+      licenses                     := Seq(License.Apache2),
+      crossScalaVersions           := supportedScalaVersions,
+      scalaVersion                 := defaultScalaV,
       resolvers ++= Seq(
         "confluent" at "https://packages.confluent.io/maven",
       ),
       // We ignore k8s tests to keep development setup low-dependency
       Test / testOptions ++= Seq(scalaTestReports, ignoreSlowTests, ignoreExternalDepsTests),
       addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.4" cross CrossVersion.full),
-      semanticdbEnabled                := true,
-      semanticdbVersion                := "4.14.5",
-      scalacOptions                    := Seq(
+      semanticdbEnabled            := true,
+      semanticdbVersion            := "4.14.5",
+      scalacOptions                := Seq(
         "-unchecked",
         "-deprecation",
         "-encoding",
@@ -162,15 +162,16 @@ lazy val commonSettings =
         "-Ymacro-annotations",
         "-Wconf:cat=deprecation:silent"
       ),
-      Compile / compile / javacOptions := Seq(
+      javacOptions                 := Seq(
         "-Xlint:deprecation",
         "-Xlint:unchecked",
         // Using --release flag (available only on jdk >= 9) instead of -source -target to avoid usage of api from newer java version
         "--release",
         "11",
-        // we use it e.g. to provide consistent behaviour wrt extracting parameter names from scala and java
+        // we use it e.g. to provide consistent behavior wrt extracting parameter names from scala and java
         "-parameters"
       ),
+      Compile / doc / javacOptions := Seq(),
       // problem with scaladoc of api: https://github.com/scala/bug/issues/10134
       Compile / doc / scalacOptions -= "-Xfatal-warnings",
       // here we add dependencies that we want to have fixed across all modules

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -315,6 +315,7 @@ description: Stay informed with detailed changelogs covering new features, impro
   before final implicit conversion instead of after it. It sometimes caused "AAA cannot be cast to class BBB" in runtime.
 * [#8806](https://github.com/TouK/nussknacker/pull/8806) Test case running implementation
 * [#8903](https://github.com/TouK/nussknacker/pull/8903) Updated Flink dependency to 1.20.3, Scala to 2.13.18
+* [#8903](https://github.com/TouK/nussknacker/pull/8946) Fix default Kafka EOS configuration on Flink to use a unique transactional id prefix
 
 ## 1.18
 

--- a/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/definition/FlinkDdlParser.scala
+++ b/engine/flink/components/table/src/main/scala/pl/touk/nussknacker/engine/flink/table/definition/FlinkDdlParser.scala
@@ -5,6 +5,7 @@ import cats.implicits._
 import org.apache.calcite.config.Lex
 import org.apache.calcite.sql.{SqlNode, SqlNodeList}
 import org.apache.calcite.sql.parser.{SqlParser => CalciteSqlParser}
+import org.apache.calcite.util.Util
 import org.apache.flink.sql.parser.ddl.{SqlCreateCatalog, SqlCreateTable, SqlCreateTableAs, SqlTableOption}
 import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl
 import org.apache.flink.sql.parser.validate.FlinkSqlConformance
@@ -73,9 +74,9 @@ object FlinkDdlParser {
       // Doc: https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/create/#as-select_statement
       // Since these definitions are meant only for data source declarations, inserts are not allowed.
       // To achieve similar functionality, users should run a separate insert statement.
-      case ctas: SqlCreateTableAs => UnallowedStatement(SqlString(ctas.toString)).invalidNel
+      case ctas: SqlCreateTableAs => UnallowedStatement(SqlString(ctas.toLinuxString)).invalidNel
       case table: SqlCreateTable => {
-        val sqlString = SqlString(table.toString)
+        val sqlString = SqlString(table.toLinuxString)
         extractOptions(table.getPropertyList)
           .find(_.key == "connector")
           .toValidNel(MissingConnectorOption(sqlString))
@@ -84,7 +85,7 @@ object FlinkDdlParser {
             CreateTable(sqlString, Connector(connector))
           }
       }
-      case other => UnallowedStatement(SqlString(other.toString)).invalidNel
+      case other => UnallowedStatement(SqlString(other.toLinuxString)).invalidNel
     }
   }
 
@@ -101,5 +102,13 @@ object FlinkDdlParser {
     .withConformance(FlinkSqlConformance.DEFAULT)
     .withLex(Lex.JAVA)
     .withIdentifierMaxLength(256);
+
+  private implicit class SqlNodeExt(sqlNode: SqlNode) {
+
+    def toLinuxString: String =
+      if (Util.LINE_SEPARATOR != "\n") Util.toLinux(sqlNode.toString)
+      else sqlNode.toString
+
+  }
 
 }

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/functional/MetricsSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/functional/MetricsSpec.scala
@@ -238,7 +238,7 @@ class MetricsSpec
   }
 
   override protected def prepareFlinkConfiguration(): Configuration = {
-    TestReporterUtil.configWithTestMetrics(reporterName, new Configuration())
+    TestReporterUtil.configWithTestMetrics(reporterName, super.prepareFlinkConfiguration())
   }
 
 }

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/PartitionByKeyFlinkKafkaSink.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/PartitionByKeyFlinkKafkaSink.scala
@@ -4,6 +4,7 @@ import org.apache.flink.api.connector.sink2.Sink
 import org.apache.flink.connector.base.DeliveryGuarantee
 import org.apache.flink.connector.kafka.sink.KafkaSink
 import org.apache.kafka.clients.producer.ProducerConfig
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.kafka.serialization.FlinkSerializationSchemaConversions
 
 object PartitionByKeyFlinkKafkaSink {
@@ -11,27 +12,35 @@ object PartitionByKeyFlinkKafkaSink {
   def apply[T](
       kafkaComponentsConfig: KafkaComponentsConfig,
       serializationSchema: serialization.KafkaSerializationSchema[T],
-      clientId: String
+      clientId: String,
+      nodeId: NodeId
   ): Sink[T] = {
-    val props = KafkaUtils.toProducerProperties(kafkaComponentsConfig, clientId)
-    // we set default to 10min, as FlinkKafkaProducer logs warn if not set
+    val props = KafkaUtils.toProducerProperties(kafkaComponentsConfig, clientId, includeSerializerClassConfig = false)
+    // we set default to 10min, KafkaSink defaults to 1 hour
     props.putIfAbsent(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, "600000")
-    val deliveryGuarantee = kafkaComponentsConfig.sinkDeliveryGuarantee match {
-      case Some(value) =>
-        value match {
-          case SinkDeliveryGuarantee.ExactlyOnce => DeliveryGuarantee.EXACTLY_ONCE
-          case SinkDeliveryGuarantee.AtLeastOnce => DeliveryGuarantee.AT_LEAST_ONCE
-          case SinkDeliveryGuarantee.None        => DeliveryGuarantee.NONE
-        }
-      // AT_LEAST_ONCE is default
-      case None => DeliveryGuarantee.AT_LEAST_ONCE
-    }
-    KafkaSink
+
+    val sinkBuilder = KafkaSink
       .builder[T]
       .setKafkaProducerConfig(props)
       .setRecordSerializer(FlinkSerializationSchemaConversions.wrapToFlinkSerializationSchema(serializationSchema))
-      .setDeliveryGuarantee(deliveryGuarantee)
-      .build()
+
+    kafkaComponentsConfig.sinkDeliveryGuarantee match {
+      case Some(value) =>
+        value match {
+          case SinkDeliveryGuarantee.ExactlyOnce =>
+            sinkBuilder
+              .setDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
+              .setTransactionalIdPrefix(s"$clientId-${nodeId.id}")
+          case SinkDeliveryGuarantee.AtLeastOnce =>
+            sinkBuilder.setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+          case SinkDeliveryGuarantee.None =>
+            sinkBuilder.setDeliveryGuarantee(DeliveryGuarantee.NONE)
+        }
+      // AT_LEAST_ONCE is our default (Flink defaults to NONE)
+      case None => sinkBuilder.setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+    }
+
+    sinkBuilder.build()
   }
 
 }

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/sink/flink/FlinkKafkaSink.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/sink/flink/FlinkKafkaSink.scala
@@ -30,7 +30,7 @@ class FlinkKafkaSink(
     helper.lazyMapFunction(value)
 
   override def toFlinkSink(flinkNodeContext: FlinkCustomNodeContext): Sink[AnyRef] =
-    PartitionByKeyFlinkKafkaSink(kafkaComponentsConfig, serializationSchema, clientId)
+    PartitionByKeyFlinkKafkaSink(kafkaComponentsConfig, serializationSchema, clientId, flinkNodeContext.nodeId)
 
   override def prepareTestValueFunction: AnyRef => String =
     value =>

--- a/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/flink/FlinkKafkaSource.scala
+++ b/engine/flink/kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/source/flink/FlinkKafkaSource.scala
@@ -171,6 +171,9 @@ class FlinkKafkaSource[K, V](
     )
     val startingOffsetInitializer = prepareOffsetInitializer(offsetResetStrategy, autoOffsetResetKafkaConfigValue)
 
+    // prevent KafkaSourceBuilder from logging a warning, it derives this value from startingOffsetInitializer
+    consumerProperties.remove(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
+
     KafkaSource
       .builder()
       .setStartingOffsets(startingOffsetInitializer)

--- a/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/KafkaUtilsSpec.scala
+++ b/engine/flink/kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/kafka/KafkaUtilsSpec.scala
@@ -46,7 +46,8 @@ class KafkaUtilsSpec extends AnyFunSuite {
   test("test KafkaSink creation with defaults set by KafkaUtils") {
     val properties = KafkaUtils.toProducerProperties(
       KafkaComponentsConfig(kafkaProperties = Map("bootstrap.servers" -> "localhost:9200")),
-      clientId = "test"
+      clientId = "test",
+      includeSerializerClassConfig = false
     )
 
     def createSink(): Unit = {

--- a/engine/flink/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/FlinkKafkaUniversalSink.scala
+++ b/engine/flink/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/sink/flink/FlinkKafkaUniversalSink.scala
@@ -55,7 +55,7 @@ class FlinkKafkaUniversalSink(
     dataStream
       .map(new EncodeAvroRecordFunction(flinkNodeContext), typeInfo)
       .filter(_.value != null)
-      .sinkTo(toFlinkSink)
+      .sinkTo(toFlinkSink(flinkNodeContext))
   }
 
   def prepareValue(
@@ -75,8 +75,8 @@ class FlinkKafkaUniversalSink(
     )
   }
 
-  private def toFlinkSink: Sink[KeyedValue[AnyRef, AnyRef]] = {
-    PartitionByKeyFlinkKafkaSink(kafkaComponentsConfig, serializationSchema, clientId)
+  private def toFlinkSink(flinkNodeContext: FlinkCustomNodeContext): Sink[KeyedValue[AnyRef, AnyRef]] = {
+    PartitionByKeyFlinkKafkaSink(kafkaComponentsConfig, serializationSchema, clientId, flinkNodeContext.nodeId)
   }
 
   class EncodeAvroRecordFunction(flinkNodeContext: FlinkCustomNodeContext)

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/FlinkExactlyOnceItSpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/FlinkExactlyOnceItSpec.scala
@@ -15,7 +15,7 @@ import pl.touk.nussknacker.test.{KafkaConfigProperties, PatientScalaFutures}
 
 import scala.jdk.CollectionConverters._
 
-class FinkExactlyOnceItSpec extends FlinkWithKafkaSuite with PatientScalaFutures with LazyLogging {
+class FlinkExactlyOnceItSpec extends FlinkWithKafkaSuite with PatientScalaFutures with LazyLogging {
 
   override val avroAsJsonSerialization: Boolean = true
 

--- a/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
+++ b/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaUtils.scala
@@ -55,10 +55,16 @@ trait KafkaUtils extends LazyLogging {
     // https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/common/Config.scala#L25-L35
     originalId.replaceAll("[^a-zA-Z0-9\\._\\-]", "_")
 
-  def toProducerProperties(config: KafkaComponentsConfig, clientId: String): Properties = {
+  def toProducerProperties(
+      config: KafkaComponentsConfig,
+      clientId: String,
+      includeSerializerClassConfig: Boolean = true
+  ): Properties = {
     val props: Properties = new Properties
-    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
-    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+    if (includeSerializerClassConfig) {
+      props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+      props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+    }
     setClientId(props, clientId)
     withPropertiesFromConfig(props, config)
   }


### PR DESCRIPTION
## Describe your changes

Some fixes to make #8777 smaller:

1. Bugfix - our EOS config depended on default (i.e. constant) transactional ID prefix
2. Removal of some Kafka Consumer/Producer warnings caused by our code:
```
WARN  o.a.f.c.k.source.KafkaSourceBuilder - Property auto.offset.reset is provided but will be overridden from earliest to earliest
WARN  o.a.f.c.kafka.sink.KafkaSinkBuilder - Overwriting the 'key.serializer' is not recommended
WARN  o.a.f.c.kafka.sink.KafkaSinkBuilder - Overwriting the 'value.serializer' is not recommended
```
3. Refactoring of `javacOptions` in sbt so that IDEA can recognize them when running tests (`-parameters` is required to run type extraction tests)
4. `FlinkDdlParser` generated results with platform-dependent newline separators, breaking some tests on Windows

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
