### PR TITLE
[NU-2414] Backports from Flink 2.2 PR - part 2

### DIFF
--- a/designer/server/src/test/resources/config/business-cases/batch-designer.conf
+++ b/designer/server/src/test/resources/config/business-cases/batch-designer.conf
@@ -24,10 +24,10 @@ scenarioTypes {
           tableDefinition: """
             CREATE TABLE transactions
             (
-                datetime  TIMESTAMP,
-                client_id STRING,
-                amount    DECIMAL(15,2),
-                `date`    STRING
+                `datetime` TIMESTAMP,
+                client_id  STRING,
+                amount     DECIMAL(15,2),
+                `date`     STRING
             ) PARTITIONED BY (`date`) WITH (
                   'connector' = 'filesystem',
                   'path' = 'file:///transactions',

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/BaseDeploymentApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/BaseDeploymentApiHttpServiceBusinessSpec.scala
@@ -24,7 +24,7 @@ import pl.touk.nussknacker.test.config.{
 import pl.touk.nussknacker.test.containers.FileSystemBind
 
 import java.io.File
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, FileSystems, Path}
 import java.nio.file.attribute.PosixFilePermissions
 
 trait BaseDeploymentApiHttpServiceBusinessSpec extends WithFlinkContainersDeploymentManager {
@@ -72,10 +72,16 @@ trait BaseDeploymentApiHttpServiceBusinessSpec extends WithFlinkContainersDeploy
     .fragmentOutput("out", "out")
 
   private lazy val inputDirectory = {
+    val tempDirectoryAttributes =
+      if (FileSystems.getDefault.supportedFileAttributeViews().contains("posix")) {
+        List(PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x")))
+      } else {
+        Nil // Windows
+      }
     val directory = Files.createTempDirectory(
       s"nusssknacker-${getClass.getSimpleName}-transactions-",
       // be default temp directory is read only for user
-      PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x"))
+      tempDirectoryAttributes: _*
     )
     populateInputTransactionsDirectory(directory)
     directory

--- a/e2e-tests/src/test/resources/batch-data-generation/batch-customizations.conf
+++ b/e2e-tests/src/test/resources/batch-data-generation/batch-customizations.conf
@@ -16,9 +16,9 @@ scenarioTypes {
           componentPrefix: "live-test-mode-"
           tableDefinition: """
              CREATE TABLE transactions (
-                 datetime  TIMESTAMP,
-                 client_id STRING,
-                 amount    DECIMAL(15, 2),
+                 `datetime` TIMESTAMP,
+                 client_id  STRING,
+                 amount     DECIMAL(15, 2),
                  amountDoubled AS amount * 2,
                  `file.name` STRING NOT NULL METADATA
              ) WITH (

--- a/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/typeinformation/FlinkTypeInfoRegistrar.scala
+++ b/engine/flink/components-api/src/main/scala/pl/touk/nussknacker/engine/flink/api/typeinformation/FlinkTypeInfoRegistrar.scala
@@ -20,17 +20,17 @@ object FlinkTypeInfoRegistrar {
   )
 
   def ensureTypeInfosAreRegistered(): Unit = {
-    typeInfoToRegister.foreach { entry =>
-      register(entry)
-    }
+    register(typeInfoToRegister)
   }
 
-  private def register(entry: RegistrationEntry[_]): Unit = {
+  private def register(entries: List[RegistrationEntry[_]]): Unit = {
     // TypeExtractor is not thread safe, and we may arrive here as a result of concurrent initialization
     // of multiple Flink deployment managers
     classOf[TypeExtractor].synchronized {
-      if (TypeExtractor.getTypeInfoFactory(entry.klass) == null) {
-        TypeExtractor.registerFactory(entry.klass, entry.factoryClass)
+      entries.foreach { entry =>
+        if (TypeExtractor.getTypeInfoFactory(entry.klass) == null) {
+          TypeExtractor.registerFactory(entry.klass, entry.factoryClass)
+        }
       }
     }
   }

--- a/nussknacker-dist/src/universal/conf/dev-application.conf
+++ b/nussknacker-dist/src/universal/conf/dev-application.conf
@@ -206,10 +206,10 @@ scenarioTypes {
         tableDefinition: """
           CREATE TABLE transactions
           (
-              datetime  TIMESTAMP,
-              client_id STRING,
-              amount    DECIMAL(15, 2),
-              `date`    STRING
+              `datetime` TIMESTAMP,
+              client_id  STRING,
+              amount     DECIMAL(15, 2),
+              `date`     STRING
           ) WITH (
                 'connector' = 'datagen',
                 'number-of-rows' = '1000'


### PR DESCRIPTION
## Describe your changes

Some fixes to make #8777 smaller:

* correctly quote `datetime` column name, which became a reserved keyword
* allow `BaseDeploymentApiHttpServiceBusinessSpec` to run on Windows

## Checklist before merge
- [x] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [x] Verify that PR will be squashed during merge
