### PR TITLE
Fix Maven Central and workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 <div align="center">
   
-  [![Maven Central](https://maven-badges.herokuapp.com/maven-central/pl.touk.nussknacker/nussknacker-designer_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/pl.touk.nussknacker/nussknacker-designer_2.13)
-  [![Build status](https://github.com/touk/nussknacker/workflows/CI/badge.svg?branch=staging)](https://github.com/touk/nussknacker/actions?query=workflow%3ACI+branch%3Astaging++)
+  [![Maven Central](https://maven-badges.sml.io/maven-central/pl.touk.nussknacker/nussknacker-designer_2.13/badge.svg)](https://maven-badges.sml.io/maven-central/pl.touk.nussknacker/nussknacker-designer_2.13)
+  [![Build status](https://github.com/touk/nussknacker/actions/workflows/pr.yml/badge.svg?branch=staging)](https://github.com/touk/nussknacker/actions?query=workflow%3ACI+branch%3Astaging)
   [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/touk)](https://artifacthub.io/packages/search?repo=touk)
   [![PR](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING/README.md#Contributing)
 


### PR DESCRIPTION
## Describe your changes
1. Update address for Maven Central badge after migration
https://github.com/softwaremill/maven-badges?tab=readme-ov-file#a-new-dns-address

2. Update url path for Github workflow status badge
https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge#using-the-workflow-file-name 
The previous `.../workflows/CI/..` doesn't seem to work anymore - it shows no status

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
