### PR TITLE
[NU-2447] Add uber jar assembler for AWS Deployment Manager

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -318,6 +318,7 @@ val ujsonV                    = "4.2.1"
 val igniteV                   = "2.10.0"
 val retryV                    = "0.3.6"
 val restAssuredV              = "5.5.0"
+val awsSdkCommonsCodecV       = "1.17.1"
 
 lazy val commonDockerSettings = {
   Seq(
@@ -586,6 +587,11 @@ lazy val awsManagedFlinkDeploymentManager = (project in flink("aws-managed-flink
   .settings(commonSettings)
   .settings(
     name := "nussknacker-aws-managed-flink-deployment-manager",
+    libraryDependencies ++= {
+      Seq(
+        "commons-codec" % "commons-codec" % awsSdkCommonsCodecV
+      )
+    }
   )
   .dependsOn(
     commonUtils % Provided,

--- a/build.sbt
+++ b/build.sbt
@@ -582,6 +582,16 @@ lazy val flinkDeploymentManager = (project in flink("management"))
     kafkaTestUtils       % "it,test"
   )
 
+lazy val awsManagedFlinkDeploymentManager = (project in flink("aws-managed-flink-deployment-manager"))
+  .settings(commonSettings)
+  .settings(
+    name := "nussknacker-aws-managed-flink-deployment-manager",
+  )
+  .dependsOn(
+    commonUtils % Provided,
+    testUtils   % Test,
+  )
+
 lazy val flinkMetricsDeferredReporter = (project in flink("metrics-deferred-reporter"))
   .settings(commonSettings)
   .settings(
@@ -2202,6 +2212,7 @@ lazy val modules = List[ProjectReference](
   requestResponseRuntime,
   liteEngineRuntimeApp,
   flinkDeploymentManager,
+  awsManagedFlinkDeploymentManager,
   flinkDevModel,
   flinkDevModelJava,
   flinkTableApiComponents,

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/JarEntryWriter.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/JarEntryWriter.scala
@@ -1,0 +1,194 @@
+package pl.touk.nussknacker.engine.assembly
+
+import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.assembly.UberJarAssembler._
+
+import java.io.{InputStream, OutputStream}
+import java.nio.file.Path
+import java.security.{DigestInputStream, MessageDigest}
+import java.util.HexFormat
+import java.util.jar.{JarEntry, JarFile, JarOutputStream, Manifest}
+import scala.collection.mutable
+import scala.io.Source
+import scala.util.Using
+
+object JarEntryWriter extends LazyLogging {
+
+  def writeManifest(manifest: Manifest, outputJar: JarOutputStream): Unit =
+    outputJar.writeEntry(JarFile.MANIFEST_NAME) { outputJar =>
+      manifest.write(outputJar)
+    }
+
+  def write(
+      strategy: MergeStrategy,
+      entryName: String,
+      entryJarPath: Path,
+      openEntryStream: () => InputStream,
+      outputJar: JarOutputStream,
+      state: AssemblyState
+  ): Unit = strategy match {
+    case MergeStrategy.Discard     => logger.trace(s"[Discard] Skipped entry '$entryName' from '$entryJarPath'.")
+    case MergeStrategy.Deduplicate => writeWithoutDuplicates(entryName, entryJarPath, openEntryStream, outputJar, state)
+    case MergeStrategy.FilterDistinctLines =>
+      writeDistinctLinesToBuffer(entryName, entryJarPath, openEntryStream, state)
+    case MergeStrategy.First  => writeIfFirst(entryName, entryJarPath, openEntryStream, outputJar, state)
+    case MergeStrategy.Rename => writeRenamed(entryName, entryJarPath, openEntryStream, outputJar, state)
+  }
+
+  def writeBufferedEntries(
+      state: AssemblyState,
+      outputJar: JarOutputStream
+  ): Unit = {
+    val bufferedEntries = state.bufferedEntries
+    if (bufferedEntries.nonEmpty) {
+      logger.trace(s"[FilterDistinctLines] Writing ${bufferedEntries.size} buffered entries.")
+      bufferedEntries.toSeq.sortBy(_._1).foreach { case (entryName, buffer) =>
+        outputJar.writeArray(entryName, buffer.lines.mkString("\n").getBytes("UTF-8"))
+        logger.trace(s"[FilterDistinctLines] Wrote entry '$entryName' (${buffer.lines.size} unique lines).")
+      }
+    }
+  }
+
+  private def writeRenamed(
+      entryName: String,
+      entryJarPath: Path,
+      openEntryStream: () => InputStream,
+      outputJar: JarOutputStream,
+      state: AssemblyState
+  ): Unit = {
+    val jarName          = entryJarPath.getFileName.toString.stripSuffix(".jar")
+    val changedEntryName = s"${entryName}_$jarName"
+    state.writtenEntries.get(changedEntryName) match {
+      case None =>
+        outputJar.writeStream(changedEntryName, openEntryStream)
+        state.writtenEntries(changedEntryName) = WrittenEntry(None, entryJarPath)
+        logger.trace(s"[Rename] Wrote entry '$entryName' as '$changedEntryName' from '$entryJarPath'.")
+      case Some(prev) =>
+        throw new RuntimeException(
+          s"Conflict: '$changedEntryName' produced by both '${prev.jarSource}' and '$entryJarPath'."
+        )
+    }
+  }
+
+  private def writeDistinctLinesToBuffer(
+      entryName: String,
+      entryJarPath: Path,
+      openEntryStream: () => InputStream,
+      state: AssemblyState
+  ): Unit = {
+    val lines = Using.resource(openEntryStream()) { entryStream =>
+      Source.fromInputStream(entryStream, "UTF-8").getLines().toList
+    }
+    val buffer = state.bufferedEntries.getOrElseUpdate(
+      entryName,
+      BufferedEntry(mutable.LinkedHashSet.empty)
+    )
+    lines.foreach(buffer.lines.add)
+    logger.trace(
+      s"[FilterDistinctLines] Buffered entry '$entryName' from '$entryJarPath'."
+    )
+  }
+
+  private def writeWithoutDuplicates(
+      entryName: String,
+      entryJarPath: Path,
+      openEntryStream: () => InputStream,
+      outputJar: JarOutputStream,
+      state: AssemblyState
+  ): Unit = {
+    state.writtenEntries.get(entryName) match {
+      case None => {
+        val hash = outputJar.writeStreamThroughHash(entryName, openEntryStream)
+        state.writtenEntries(entryName) = WrittenEntry(Some(hash), entryJarPath)
+        logger.trace(s"[Deduplicate] Wrote entry '$entryName' from '$entryJarPath'.")
+      }
+      case Some(written) => {
+        val hash = computeHash(openEntryStream)
+        written.hash match {
+          case Some(previousHash) if hash == previousHash =>
+            logger.trace(
+              s"[Deduplicate] Skipped entry '$entryName' from '$entryJarPath' because it is identical to '${written.jarSource}'."
+            )
+          case Some(_) =>
+            throw new RuntimeException(
+              s"Conflict: entry '$entryName' has different content in ${written.jarSource} and $entryJarPath"
+            )
+          case None =>
+            throw new IllegalStateException(
+              s"Internal error: missing hash for entry with Deduplicate strategy: '$entryName' from '${written.jarSource}'."
+            )
+        }
+      }
+    }
+  }
+
+  private def computeHash(openEntryStream: () => InputStream) = {
+    val messageDigest = MessageDigest.getInstance(digestAlgorithmForEntryUniqueness)
+    Using.resource(openEntryStream()) { entryStream =>
+      Using.resource(new DigestInputStream(entryStream, messageDigest)) { dis =>
+        dis.transferTo(OutputStream.nullOutputStream())
+      }
+    }
+    HexFormat.of().formatHex(messageDigest.digest())
+  }
+
+  private def writeIfFirst(
+      entryName: String,
+      entryJarPath: Path,
+      openEntryStream: () => InputStream,
+      outputJar: JarOutputStream,
+      state: AssemblyState
+  ): Unit = {
+    if (!state.writtenEntries.contains(entryName)) {
+      outputJar.writeStream(entryName, openEntryStream)
+      state.writtenEntries(entryName) = WrittenEntry(None, entryJarPath)
+      logger.trace(s"[First] Wrote entry '$entryName' from '$entryJarPath'.")
+    } else {
+      logger.trace(
+        s"[First] Skipped entry '$entryName' from '$entryJarPath' because it was already written."
+      )
+    }
+  }
+
+  implicit class JarOutputStreamOps(outputJar: JarOutputStream) {
+
+    // timestamp has to be constant for content hash to be deterministic
+    val constantTimestamp = 0L
+
+    def writeStream(entryName: String, openEntryStream: () => InputStream): Unit =
+      writeEntry(entryName) { out =>
+        Using.resource(openEntryStream()) { entryStream =>
+          entryStream.transferTo(out)
+        }
+      }
+
+    def writeArray(entryName: String, byteArray: Array[Byte]): Unit =
+      writeEntry(entryName) { out =>
+        out.write(byteArray)
+      }
+
+    def writeStreamThroughHash(entryName: String, openEntryStream: () => InputStream): String = {
+      val messageDigest = MessageDigest.getInstance(digestAlgorithmForEntryUniqueness)
+      outputJar.writeEntry(entryName) { out =>
+        Using.resource(openEntryStream()) { entryStream =>
+          Using.resource(new DigestInputStream(entryStream, messageDigest)) { digestInputStream =>
+            digestInputStream.transferTo(out)
+          }
+        }
+      }
+      HexFormat.of().formatHex(messageDigest.digest())
+    }
+
+    def writeEntry(entryName: String)(write: OutputStream => _): Unit = {
+      val entry = new JarEntry(entryName)
+      entry.setTime(constantTimestamp)
+      outputJar.putNextEntry(entry)
+      write(outputJar)
+      outputJar.closeEntry()
+    }
+
+  }
+
+  private val digestAlgorithmForEntryUniqueness = "SHA-1"
+
+}

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/JarEntryWriter.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/JarEntryWriter.scala
@@ -1,12 +1,12 @@
 package pl.touk.nussknacker.engine.assembly
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.codec.binary.Hex
 import pl.touk.nussknacker.engine.assembly.UberJarAssembler._
 
 import java.io.{InputStream, OutputStream}
 import java.nio.file.Path
 import java.security.{DigestInputStream, MessageDigest}
-import java.util.HexFormat
 import java.util.jar.{JarEntry, JarFile, JarOutputStream, Manifest}
 import scala.collection.mutable
 import scala.io.Source
@@ -129,7 +129,7 @@ object JarEntryWriter extends LazyLogging {
         dis.transferTo(OutputStream.nullOutputStream())
       }
     }
-    HexFormat.of().formatHex(messageDigest.digest())
+    Hex.encodeHexString(messageDigest.digest())
   }
 
   private def writeIfFirst(
@@ -153,7 +153,7 @@ object JarEntryWriter extends LazyLogging {
   implicit class JarOutputStreamOps(outputJar: JarOutputStream) {
 
     // timestamp has to be constant for content hash to be deterministic
-    val constantTimestamp = 0L
+    private val constantTimestamp = 0L
 
     def writeStream(entryName: String, openEntryStream: () => InputStream): Unit =
       writeEntry(entryName) { out =>
@@ -176,7 +176,7 @@ object JarEntryWriter extends LazyLogging {
           }
         }
       }
-      HexFormat.of().formatHex(messageDigest.digest())
+      Hex.encodeHexString(messageDigest.digest())
     }
 
     def writeEntry(entryName: String)(write: OutputStream => _): Unit = {

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/MergeRuleResolver.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/MergeRuleResolver.scala
@@ -30,13 +30,15 @@ class MergeRuleResolver(mergeRules: List[MergeRule]) {
 
 object MergeRuleResolver {
 
-  val fallbackMergeRules: List[MergeRule] = List(
+  private val fallbackMergeRules: List[MergeRule] = List(
     // META-INF/services should be merged line-by-line
     MergeRule("META-INF/services/**", MergeStrategy.FilterDistinctLines),
     // These META-INF entries are either regenerated or not applicable to the uber-jar. Keeping originals can cause conflicts.
     MergeRule("META-INF/MANIFEST.MF", MergeStrategy.Discard),
     MergeRule("META-INF/INDEX.LIST", MergeStrategy.Discard),
     MergeRule("META-INF/DEPENDENCIES", MergeStrategy.Discard),
+    // Discard JPMS module descriptors (a proper solution would be to merge them)
+    MergeRule("**/module-info.class", MergeStrategy.Discard),
     // Signature files are invalid after merging and can fail verification
     MergeRule("META-INF/*.SF", MergeStrategy.Discard),
     MergeRule("META-INF/*.DSA", MergeStrategy.Discard),
@@ -44,7 +46,7 @@ object MergeRuleResolver {
   )
 
   // Based on sbt-assembly
-  def isLicenseFile(entryName: String): Boolean = {
+  private def isLicenseFile(entryName: String): Boolean = {
     val LicenseFilePattern = """(\._license|license|licence|notice|copying)([.]\w+)?$""".r
     fileName(entryName).toLowerCase match {
       case LicenseFilePattern(_, ext) if ext != ".class" => true
@@ -53,7 +55,7 @@ object MergeRuleResolver {
   }
 
   // Based on sbt-assembly
-  def isReadme(entryName: String): Boolean = {
+  private def isReadme(entryName: String): Boolean = {
     val ReadMePattern = """(readme|about)([.]\w+)?$""".r
     fileName(entryName).toLowerCase match {
       case ReadMePattern(_, ext) if ext != ".class" => true

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/MergeRuleResolver.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/MergeRuleResolver.scala
@@ -1,0 +1,69 @@
+package pl.touk.nussknacker.engine.assembly
+
+import org.springframework.util.AntPathMatcher
+
+final case class MergeRule(
+    pattern: String,
+    strategy: MergeStrategy
+)
+
+class MergeRuleResolver(mergeRules: List[MergeRule]) {
+
+  private val matcher = {
+    val m = new AntPathMatcher("/")
+    m.setCaseSensitive(false)
+    m
+  }
+
+  private val finalRules = mergeRules ++ MergeRuleResolver.fallbackMergeRules
+
+  def strategyFor(entryName: String): MergeStrategy = {
+    finalRules.find(rule => matcher.`match`(rule.pattern, entryName)) match {
+      case Some(rule) => rule.strategy
+      case None if MergeRuleResolver.isLicenseFile(entryName) || MergeRuleResolver.isReadme(entryName) =>
+        MergeStrategy.Rename
+      case None => MergeStrategy.Deduplicate
+    }
+  }
+
+}
+
+object MergeRuleResolver {
+
+  val fallbackMergeRules: List[MergeRule] = List(
+    // META-INF/services should be merged line-by-line
+    MergeRule("META-INF/services/**", MergeStrategy.FilterDistinctLines),
+    // These META-INF entries are either regenerated or not applicable to the uber-jar. Keeping originals can cause conflicts.
+    MergeRule("META-INF/MANIFEST.MF", MergeStrategy.Discard),
+    MergeRule("META-INF/INDEX.LIST", MergeStrategy.Discard),
+    MergeRule("META-INF/DEPENDENCIES", MergeStrategy.Discard),
+    // Signature files are invalid after merging and can fail verification
+    MergeRule("META-INF/*.SF", MergeStrategy.Discard),
+    MergeRule("META-INF/*.DSA", MergeStrategy.Discard),
+    MergeRule("META-INF/*.RSA", MergeStrategy.Discard)
+  )
+
+  // Based on sbt-assembly
+  def isLicenseFile(entryName: String): Boolean = {
+    val LicenseFilePattern = """(\._license|license|licence|notice|copying)([.]\w+)?$""".r
+    fileName(entryName).toLowerCase match {
+      case LicenseFilePattern(_, ext) if ext != ".class" => true
+      case _                                             => false
+    }
+  }
+
+  // Based on sbt-assembly
+  def isReadme(entryName: String): Boolean = {
+    val ReadMePattern = """(readme|about)([.]\w+)?$""".r
+    fileName(entryName).toLowerCase match {
+      case ReadMePattern(_, ext) if ext != ".class" => true
+      case _                                        => false
+    }
+  }
+
+  private def fileName(path: String): String = {
+    val lastSlash = path.lastIndexOf('/')
+    if (lastSlash >= 0) path.substring(lastSlash + 1) else path
+  }
+
+}

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/MergeStrategy.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/MergeStrategy.scala
@@ -1,0 +1,11 @@
+package pl.touk.nussknacker.engine.assembly
+
+sealed trait MergeStrategy
+
+object MergeStrategy {
+  case object Discard             extends MergeStrategy
+  case object Deduplicate         extends MergeStrategy
+  case object FilterDistinctLines extends MergeStrategy
+  case object First               extends MergeStrategy
+  case object Rename              extends MergeStrategy
+}

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarAssembler.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarAssembler.scala
@@ -1,0 +1,106 @@
+package pl.touk.nussknacker.engine.assembly
+
+import com.typesafe.scalalogging.LazyLogging
+import pl.touk.nussknacker.engine.assembly.UberJarAssembler._
+
+import java.nio.file.{Files, Path, StandardCopyOption}
+import java.security.{DigestOutputStream, MessageDigest}
+import java.util.HexFormat
+import java.util.jar.{Attributes, JarFile, JarOutputStream, Manifest}
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.EnumerationHasAsScala
+import scala.util.Using
+
+class UberJarAssembler(
+    val mergeRules: List[MergeRule],
+    val uberJarPrefix: String
+) extends LazyLogging {
+
+  private val mergeRuleMatcher = new MergeRuleResolver(mergeRules)
+
+  def buildJar(
+      outputDir: Path,
+      jarFiles: List[Path],
+      mainClass: String
+  ): Path = {
+    Files.createDirectories(outputDir)
+    val tempFile = Files.createTempFile(outputDir, uberJarPrefix, ".jar.tmp")
+    try {
+      val hash: String = buildJarAndComputeHash(jarFiles, mainClass, tempFile)
+      val finalPath    = outputDir.resolve(s"$uberJarPrefix-$hash.jar")
+      Files.move(tempFile, finalPath, StandardCopyOption.REPLACE_EXISTING)
+      finalPath
+    } finally {
+      Files.deleteIfExists(tempFile)
+    }
+  }
+
+  private def buildJarAndComputeHash(jarFiles: List[Path], mainClass: String, tempFile: Path) = {
+    val digest   = MessageDigest.getInstance(digestAlgorithmForFileName)
+    val manifest = buildManifest(mainClass)
+    val state = AssemblyState(
+      writtenEntries = mutable.Map.empty[String, WrittenEntry],
+      bufferedEntries = mutable.Map.empty[String, BufferedEntry]
+    )
+    Using.resource(Files.newOutputStream(tempFile)) { fos =>
+      Using.resource(new DigestOutputStream(fos, digest)) { dos =>
+        Using.resource(new JarOutputStream(dos)) { outputJar =>
+          JarEntryWriter.writeManifest(manifest, outputJar)
+          jarFiles.foreach(mergeJarIntoUberJar(_, outputJar, state))
+          JarEntryWriter.writeBufferedEntries(state, outputJar)
+        }
+      }
+    }
+    HexFormat.of().formatHex(digest.digest())
+  }
+
+  private def buildManifest(mainClass: String) = {
+    val manifest = new Manifest()
+    manifest.getMainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+    manifest.getMainAttributes.put(Attributes.Name.MAIN_CLASS, mainClass)
+    manifest
+  }
+
+  private def mergeJarIntoUberJar(
+      jarPath: Path,
+      outputJar: JarOutputStream,
+      state: AssemblyState
+  ): Unit = {
+    Using.resource(new JarFile(jarPath.toFile)) { jar =>
+      val entries = jar
+        .entries()
+        .asScala
+        .filterNot(_.isDirectory)
+        .toList
+        .sortBy(_.getName)
+
+      entries.foreach { entry =>
+        val entryName       = entry.getName
+        val strategy        = mergeRuleMatcher.strategyFor(entryName)
+        val openEntryStream = () => jar.getInputStream(entry)
+        JarEntryWriter.write(strategy, entryName, jarPath, openEntryStream, outputJar, state)
+      }
+    }
+  }
+
+}
+
+object UberJarAssembler {
+
+  private[assembly] case class WrittenEntry(
+      hash: Option[String],
+      jarSource: Path
+  )
+
+  private[assembly] case class BufferedEntry(
+      lines: mutable.LinkedHashSet[String]
+  )
+
+  private[assembly] case class AssemblyState(
+      writtenEntries: mutable.Map[String, WrittenEntry],
+      bufferedEntries: mutable.Map[String, BufferedEntry]
+  )
+
+  private val digestAlgorithmForFileName = "SHA-1"
+
+}

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarAssembler.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarAssembler.scala
@@ -36,7 +36,7 @@ class UberJarAssembler(
     }
   }
 
-  private def buildJarAndComputeHash(jarFiles: List[Path], mainClass: String, tempFile: Path): UberJarHash = {
+  private def buildJarAndComputeHash(jarFiles: List[Path], mainClass: String, tempFile: Path) = {
     val digest   = MessageDigest.getInstance(digestAlgorithmForFileName)
     val manifest = buildManifest(mainClass)
     val state = AssemblyState(

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarAssembler.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarAssembler.scala
@@ -1,11 +1,12 @@
 package pl.touk.nussknacker.engine.assembly
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.codec.binary.Hex
 import pl.touk.nussknacker.engine.assembly.UberJarAssembler._
 
+import java.io.BufferedOutputStream
 import java.nio.file.{Files, Path, StandardCopyOption}
 import java.security.{DigestOutputStream, MessageDigest}
-import java.util.HexFormat
 import java.util.jar.{Attributes, JarFile, JarOutputStream, Manifest}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
@@ -26,8 +27,8 @@ class UberJarAssembler(
     Files.createDirectories(outputDir)
     val tempFile = Files.createTempFile(outputDir, uberJarPrefix, ".jar.tmp")
     try {
-      val hash: String = buildJarAndComputeHash(jarFiles, mainClass, tempFile)
-      val finalPath    = outputDir.resolve(s"$uberJarPrefix-$hash.jar")
+      val hash      = buildJarAndComputeHash(jarFiles, mainClass, tempFile)
+      val finalPath = outputDir.resolve(s"$uberJarPrefix-${hash.value}.jar")
       Files.move(tempFile, finalPath, StandardCopyOption.REPLACE_EXISTING)
       finalPath
     } finally {
@@ -35,7 +36,7 @@ class UberJarAssembler(
     }
   }
 
-  private def buildJarAndComputeHash(jarFiles: List[Path], mainClass: String, tempFile: Path) = {
+  private def buildJarAndComputeHash(jarFiles: List[Path], mainClass: String, tempFile: Path): UberJarHash = {
     val digest   = MessageDigest.getInstance(digestAlgorithmForFileName)
     val manifest = buildManifest(mainClass)
     val state = AssemblyState(
@@ -43,15 +44,17 @@ class UberJarAssembler(
       bufferedEntries = mutable.Map.empty[String, BufferedEntry]
     )
     Using.resource(Files.newOutputStream(tempFile)) { fos =>
-      Using.resource(new DigestOutputStream(fos, digest)) { dos =>
-        Using.resource(new JarOutputStream(dos)) { outputJar =>
-          JarEntryWriter.writeManifest(manifest, outputJar)
-          jarFiles.foreach(mergeJarIntoUberJar(_, outputJar, state))
-          JarEntryWriter.writeBufferedEntries(state, outputJar)
+      Using.resource(new BufferedOutputStream(fos)) { bos =>
+        Using.resource(new DigestOutputStream(bos, digest)) { dos =>
+          Using.resource(new JarOutputStream(dos)) { outputJar =>
+            JarEntryWriter.writeManifest(manifest, outputJar)
+            jarFiles.foreach(mergeJarIntoUberJar(_, outputJar, state))
+            JarEntryWriter.writeBufferedEntries(state, outputJar)
+          }
         }
       }
     }
-    HexFormat.of().formatHex(digest.digest())
+    UberJarHash(Hex.encodeHexString(digest.digest()))
   }
 
   private def buildManifest(mainClass: String) = {
@@ -86,6 +89,8 @@ class UberJarAssembler(
 }
 
 object UberJarAssembler {
+
+  private[assembly] final case class UberJarHash(value: String) extends AnyVal
 
   private[assembly] case class WrittenEntry(
       hash: Option[String],

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarProvider.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarProvider.scala
@@ -1,0 +1,53 @@
+package pl.touk.nussknacker.engine.assembly
+
+import java.net.URL
+import java.nio.file.{Files, Path}
+import scala.reflect.io.Directory
+
+class UberJarProvider(
+    modelUrls: List[URL],
+    mergeRules: List[MergeRule],
+    mainClass: String,
+    uberJarPrefix: String
+) {
+
+  private var jarFile: Option[Path] = None
+
+  private val modelJarBuilder = new UberJarAssembler(mergeRules, uberJarPrefix)
+
+  def getUberJar(): Path = synchronized {
+    jarFile match {
+      case Some(file) if Files.exists(file) => file
+      case _ =>
+        val file = buildJar()
+        jarFile = Some(file)
+        file
+    }
+  }
+
+  private def buildJar(): Path = {
+    val outputDir = createTempOutputDir()
+    val jarPaths  = modelUrls.map { resolvePath(_, outputDir) }
+    modelJarBuilder.buildJar(
+      outputDir = outputDir,
+      jarFiles = jarPaths,
+      mainClass = mainClass
+    )
+  }
+
+  private def createTempOutputDir(): Path = {
+    val tempDir = Files.createTempDirectory("nussknacker-assembled-jars")
+    Runtime.getRuntime.addShutdownHook(new Thread() {
+      override def run(): Unit = new Directory(tempDir.toFile).deleteRecursively()
+    })
+    tempDir
+  }
+
+  private def resolvePath(url: URL, tempDir: Path): Path =
+    if (url.getProtocol == "file") {
+      Path.of(url.toURI)
+    } else {
+      throw new UnsupportedOperationException("Non-file jar URL's are not supported")
+    }
+
+}

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarProvider.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarProvider.scala
@@ -15,7 +15,7 @@ class UberJarProvider(
 
   private val modelJarBuilder = new UberJarAssembler(mergeRules, uberJarPrefix)
 
-  def getUberJar(): Path = synchronized {
+  def createOrGetUberJar(): Path = synchronized {
     jarFile match {
       case Some(file) if Files.exists(file) => file
       case _ =>

--- a/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarProvider.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/main/scala/pl/touk/nussknacker/engine/assembly/UberJarProvider.scala
@@ -27,7 +27,7 @@ class UberJarProvider(
 
   private def buildJar(): Path = {
     val outputDir = createTempOutputDir()
-    val jarPaths  = modelUrls.map { resolvePath(_, outputDir) }
+    val jarPaths  = modelUrls.map(resolvePath)
     modelJarBuilder.buildJar(
       outputDir = outputDir,
       jarFiles = jarPaths,
@@ -43,7 +43,7 @@ class UberJarProvider(
     tempDir
   }
 
-  private def resolvePath(url: URL, tempDir: Path): Path =
+  private def resolvePath(url: URL): Path =
     if (url.getProtocol == "file") {
       Path.of(url.toURI)
     } else {

--- a/engine/flink/aws-managed-flink-deployment-manager/src/test/scala/pl/touk/nussknacker/engine/assembly/UberJarAssemblerTest.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/test/scala/pl/touk/nussknacker/engine/assembly/UberJarAssemblerTest.scala
@@ -261,6 +261,28 @@ class UberJarAssemblerTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("discards JPMS module descriptors by default") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(
+        tempDir,
+        "jar1.jar",
+        List(
+          "module-info.class"                     -> "module a {}",
+          "META-INF/versions/x/module-info.class" -> "module a {}"
+        )
+      )
+
+      val outputJar = new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+        .buildJar(tempDir, List(jar1), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        val names = jarFile.entries().asScala.map(_.getName).toSet
+        names should not contain "module-info.class"
+        names should not contain "META-INF/versions/x/module-info.class"
+      }
+    }
+  }
+
   test("removes temporary jar file when assembly fails") {
     withTempDir { tempDir =>
       val jar1 = createJar(tempDir, "jar1.jar", List("a" -> "v1"))

--- a/engine/flink/aws-managed-flink-deployment-manager/src/test/scala/pl/touk/nussknacker/engine/assembly/UberJarAssemblerTest.scala
+++ b/engine/flink/aws-managed-flink-deployment-manager/src/test/scala/pl/touk/nussknacker/engine/assembly/UberJarAssemblerTest.scala
@@ -1,0 +1,312 @@
+package pl.touk.nussknacker.engine.assembly
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.jar.{JarEntry, JarFile, JarOutputStream}
+import scala.jdk.CollectionConverters.EnumerationHasAsScala
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+import scala.util.Using
+
+class UberJarAssemblerTest extends AnyFunSuite with Matchers {
+
+  test("builds uber jar with manifest and merged entries") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(
+        tempDir,
+        "jar1.jar",
+        List(
+          "a.txt"      -> "A",
+          "shared.txt" -> "identical"
+        )
+      )
+      val jar2 = createJar(
+        tempDir,
+        "jar2.jar",
+        List(
+          "b.txt"      -> "B",
+          "shared.txt" -> "identical"
+        )
+      )
+
+      val outputJar = new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+        .buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+
+      Files.exists(outputJar) shouldBe true
+      outputJar.getFileName.toString should startWith("test-jar-")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        val names = jarFile.entries().asScala.map(_.getName).toList
+        names should contain("META-INF/MANIFEST.MF")
+        names should contain("a.txt")
+        names should contain("b.txt")
+        names should contain("shared.txt")
+
+        val manifest = jarFile.getManifest
+        manifest.getMainAttributes.getValue("Main-Class") shouldBe "com.example.Main"
+        manifest.getMainAttributes.getValue("Manifest-Version") shouldBe "1.0"
+      }
+    }
+  }
+
+  test("uber jar file name is deterministic for jars in given order") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("a.txt" -> "a", "b.txt" -> "b"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("c.txt" -> "c", "d.txt" -> "d"))
+
+      val assembler  = new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+      val outputJar1 = assembler.buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+      val outputJar2 = assembler.buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+
+      outputJar1.getFileName.toString shouldBe outputJar2.getFileName.toString
+    }
+  }
+
+  test("applies Deduplicate strategy by default - writes single entry when matching entries have identical content") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("entryA" -> "identitcal"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("entryA" -> "identitcal"))
+
+      val outputJar = new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+        .buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        val names = jarFile.entries().asScala.map(_.getName).toList
+        names.count(_ == "entryA") shouldBe 1
+        readEntryText(jarFile, "entryA") shouldBe "identitcal"
+      }
+    }
+  }
+
+  test(
+    "applies Deduplicate strategy by default - throws exception when applying Deduplicate merge strategy for multiple files with different content"
+  ) {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("a" -> "v1"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("a" -> "v2"))
+
+      val ex = intercept[RuntimeException] {
+        new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+          .buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+      }
+
+      ex.getMessage should fullyMatch regex "^Conflict: entry '.*' has different content in .* and .*$"
+    }
+  }
+
+  test("applies First strategy rule - writes the first matching entry in order of input jars") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("conflict.txt" -> "v1"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("conflict.txt" -> "v2"))
+
+      val assembler = new UberJarAssembler(
+        mergeRules = List(MergeRule("conflict.txt", MergeStrategy.First)),
+        "test-jar"
+      )
+
+      val outputJar = assembler.buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        readEntryText(jarFile, "conflict.txt") shouldBe "v1"
+      }
+    }
+  }
+
+  test("applies Discard strategy rule - discards all matching files") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("discard.txt" -> "v1", "keep.txt" -> "k1"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("discard.txt" -> "v2", "keep.txt" -> "k1"))
+
+      val assembler = new UberJarAssembler(
+        mergeRules = List(MergeRule("discard.txt", MergeStrategy.Discard)),
+        "test-jar"
+      )
+
+      val outputJar = assembler.buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        jarFile.getEntry("discard.txt") shouldBe null
+        readEntryText(jarFile, "keep.txt") shouldBe "k1"
+      }
+    }
+  }
+
+  test(
+    "applies FilterDistinctLines strategy rule - writes a single entry with concatenated lines from matching entries"
+  ) {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("lines.txt" -> "a\nb\n"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("lines.txt" -> "b\nc\n"))
+
+      val assembler = new UberJarAssembler(
+        mergeRules = List(MergeRule("lines.txt", MergeStrategy.FilterDistinctLines)),
+        "test-jar"
+      )
+
+      val outputJar = assembler.buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        readEntryText(jarFile, "lines.txt") shouldBe
+          """a
+            |b
+            |c""".stripMargin
+      }
+    }
+  }
+
+  test("applies Rename strategy rule - appends source jar name to entry name") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("rename.txt" -> "r1"))
+
+      val assembler = new UberJarAssembler(
+        mergeRules = List(MergeRule("rename.txt", MergeStrategy.Rename)),
+        "test-jar"
+      )
+
+      val outputJar = assembler.buildJar(tempDir, List(jar1), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        val names = jarFile.entries().asScala.map(_.getName).toSet
+
+        names should contain("rename.txt_jar1")
+        names should not contain "rename.txt"
+        readEntryText(jarFile, "rename.txt_jar1") shouldBe "r1"
+      }
+    }
+  }
+
+  test("applies FilterDistinctLines strategy to META-INF/services files by default") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("META-INF/services/com.example.Service" -> "impl.A\nimpl.B\n"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("META-INF/services/com.example.Service" -> "impl.B\nimpl.C\n"))
+
+      val outputJar = new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+        .buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        val mergedText = readEntryText(jarFile, "META-INF/services/com.example.Service")
+        mergedText shouldBe
+          """impl.A
+            |impl.B
+            |impl.C""".stripMargin
+      }
+    }
+  }
+
+  test("applies Discard strategy to manifest and signature files by default") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(
+        tempDir,
+        "jar1.jar",
+        List(
+          "META-INF/MANIFEST.MF" -> "m",
+          "META-INF/TEST.SF"     -> "s",
+          "META-INF/TEST.RSA"    -> "s",
+          "META-INF/TEST.DSA"    -> "s",
+          "file.txt"             -> "ok"
+        )
+      )
+
+      val outputJar = new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+        .buildJar(tempDir, List(jar1), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        val names = jarFile.entries().asScala.map(_.getName).toList
+
+        names.count(_ == "META-INF/MANIFEST.MF") shouldBe 1
+        names should not contain "META-INF/TEST.SF"
+        names should not contain "META-INF/TEST.RSA"
+        names should not contain "META-INF/TEST.DSA"
+        names should contain("file.txt")
+      }
+    }
+  }
+
+  test("renames license and readme files by default") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("META-INF/LICENSE" -> "l1", "docs/README" -> "r1"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("META-INF/LICENSE" -> "l2", "docs/README" -> "r2"))
+
+      val outputJar = new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+        .buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        val names = jarFile.entries().asScala.map(_.getName).toSet
+
+        names should contain("META-INF/LICENSE_jar1")
+        names should contain("META-INF/LICENSE_jar2")
+        names should contain("docs/README_jar1")
+        names should contain("docs/README_jar2")
+      }
+    }
+  }
+
+  test("does not rename class files with readme and license typical names") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("LICENSE.class" -> "a"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("README.class" -> "a"))
+
+      val outputJar = new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+        .buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+
+      Using.resource(new JarFile(outputJar.toFile)) { jarFile =>
+        val names = jarFile.entries().asScala.map(_.getName).toSet
+
+        names should contain("LICENSE.class")
+        names should contain("README.class")
+      }
+    }
+  }
+
+  test("removes temporary jar file when assembly fails") {
+    withTempDir { tempDir =>
+      val jar1 = createJar(tempDir, "jar1.jar", List("a" -> "v1"))
+      val jar2 = createJar(tempDir, "jar2.jar", List("a" -> "v2"))
+
+      val assembler = new UberJarAssembler(mergeRules = List.empty, uberJarPrefix = "test-jar")
+
+      intercept[RuntimeException] {
+        assembler.buildJar(tempDir, List(jar1, jar2), "com.example.Main")
+      }
+
+      val jarTempFiles = Using.resource(Files.newDirectoryStream(tempDir, "test-jar*.jar.tmp")) { dirStream =>
+        dirStream.iterator().asScala.toList
+      }
+
+      jarTempFiles shouldBe empty
+    }
+  }
+
+  private def createJar(tempDir: Path, jarName: String, entries: List[(String, String)]): Path = {
+    val path = tempDir.resolve(jarName)
+    Using.resource(new JarOutputStream(Files.newOutputStream(path))) { jos =>
+      entries.foreach { case (name, content) =>
+        val entry = new JarEntry(name)
+        jos.putNextEntry(entry)
+        jos.write(content.getBytes(StandardCharsets.UTF_8))
+        jos.closeEntry()
+      }
+    }
+    path
+  }
+
+  private def readEntryText(jarFile: JarFile, entryName: String): String = {
+    val entry = jarFile.getEntry(entryName)
+    Using.resource(jarFile.getInputStream(entry)) { is =>
+      new String(is.readAllBytes(), StandardCharsets.UTF_8)
+    }
+  }
+
+  private def withTempDir(testBody: Path => Any): Unit = {
+    val tempDir = Files.createTempDirectory("uber-jar-test-")
+    try {
+      testBody(tempDir)
+    } finally {
+      FileUtils.deleteQuietly(tempDir.toFile)
+    }
+  }
+
+}


### PR DESCRIPTION
## Describe your changes

Our current approach to building application code jars for Flink deployments (`pl.touk.nussknacker.engine.management.jobrunner.FlinkModelJarProvider`) is building a jar with all model classloader jars as whole entries without merging. It's a jar with jars inside.

When trying to use this jar in AWS Manged Flink, the sdk throws `java.util.concurrent.CompletionException: software.amazon.awssdk.services.kinesisanalyticsv2.model.InvalidArgumentException: Found more than one JAR file in the zip file.`

This change adds logic for assembling uber jars which will be used in further development of AWS Managed Flink Deployment Manager.

Hashing of content is necessary for not uploading the same jar multiple times to S3.

Usage of `AntPathMatcher` is necessary for making the merge strategies configurable.

## Checklist before merge
- [X] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [X] Code is cleaned from temporary changes and commented out lines
- [X] Parts of the code that are not easy to understand are documented in the code
- [X] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [X] Verify that PR will be squashed during merge
