### PR TITLE
Improve validation of the test data for fragment inputs

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ScenarioTestingApiHttpService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/ScenarioTestingApiHttpService.scala
@@ -4,8 +4,10 @@ import cats.data.{EitherT, NonEmptyList}
 import com.typesafe.scalalogging.LazyLogging
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError
+import pl.touk.nussknacker.engine.api.graph.ScenarioGraph
 import pl.touk.nussknacker.engine.api.process.{ProcessId, ProcessName}
 import pl.touk.nussknacker.restmodel.definition.UISourceParameters
+import pl.touk.nussknacker.restmodel.scenariodetails.ScenarioWithDetails
 import pl.touk.nussknacker.restmodel.validation.{PrettyValidationErrors, ValidationResults}
 import pl.touk.nussknacker.restmodel.validation.ValidationResults.ValidationErrors
 import pl.touk.nussknacker.security.Permission
@@ -35,6 +37,7 @@ import pl.touk.nussknacker.ui.process.test.ScenarioTestService.{
   ParametersDefinitionError,
   TestingCapabilitiesError
 }
+import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.ScenarioNodeValidationErrors
 import pl.touk.nussknacker.ui.security.api.{AuthManager, LoggedUser}
 import pl.touk.nussknacker.ui.validation.ParametersValidator
 
@@ -140,6 +143,20 @@ class ScenarioTestingApiHttpService(
             scenarioTestService = processingTypeToScenarioTestServices.forProcessingTypeUnsafe(
               scenarioWithDetails.processingType
             )
+            validationErrors <- validateTestData(
+              scenarioName = scenarioName,
+              scenarioGraph = request.scenarioGraph,
+              scenarioWithDetails = scenarioWithDetails,
+              scenarioTestService = scenarioTestService,
+              scenarioTestData = request.testData,
+            )
+            _ <- EitherT.fromEither[Future](
+              Either.cond(
+                test = validationErrors.isEmpty,
+                right = (),
+                left = ErrorResult(TestingApiErrorMessages.from(ScenarioNodeValidationErrors(validationErrors)))
+              )
+            )
             resultWithCounts <- request.testData match {
               case ScenarioTestData.WithParameters(sourceParameters) =>
                 EitherT(
@@ -191,37 +208,53 @@ class ScenarioTestingApiHttpService(
         { case (scenarioName, request) =>
           for {
             scenarioWithDetails <- getScenarioWithDetailsByName(scenarioName)
-            validator = processingTypeToParametersValidator.forProcessingTypeUnsafe(scenarioWithDetails.processingType)
             scenarioTestService = processingTypeToScenarioTestServices.forProcessingTypeUnsafe(
               scenarioWithDetails.processingType
             )
-            metaData = request.scenarioGraph.properties.toMetaData(scenarioName)
-            validationResults <- request.testData match {
-              case ScenarioTestData.WithParameters(sourceParameters) =>
-                EitherT
-                  .fromEither[Future](
-                    scenarioTestService
-                      .validateAndGetTestParametersDefinition(
-                        request.scenarioGraph,
-                        scenarioWithDetails.processVersionUnsafe,
-                        scenarioWithDetails.isFragment
-                      )
-                      .left
-                      .map(toDto)
-                  )
-                  .map(validator.validate(sourceParameters, _)(metaData))
-              case ScenarioTestData.WithLiveData(numberOfSamples) =>
-                EitherT
-                  .fromEither[Future](
-                    scenarioTestService.validateRecordsCount[TestingError](numberOfSamples)(
-                      BadRequestTestingError.TooManyRecordsRequested(_)
-                    )
-                  )
-                  .map((_: Unit) => List.empty)
-            }
+            validationResults <- validateTestData(
+              scenarioName = scenarioName,
+              scenarioGraph = request.scenarioGraph,
+              scenarioWithDetails = scenarioWithDetails,
+              scenarioTestService = scenarioTestService,
+              scenarioTestData = request.testData,
+            )
           } yield ParametersValidationResultDto(validationResults, validationPerformed = true)
         }
       }
+  }
+
+  private def validateTestData(
+      scenarioName: ProcessName,
+      scenarioGraph: ScenarioGraph,
+      scenarioWithDetails: ScenarioWithDetails,
+      scenarioTestService: ScenarioTestService,
+      scenarioTestData: ScenarioTestData,
+  )(implicit loggedUser: LoggedUser): EitherT[Future, TestingError, List[ValidationResults.NodeValidationError]] = {
+    val validator = processingTypeToParametersValidator.forProcessingTypeUnsafe(scenarioWithDetails.processingType)
+    val metaData  = scenarioGraph.properties.toMetaData(scenarioName)
+    scenarioTestData match {
+      case ScenarioTestData.WithParameters(sourceParameters) =>
+        EitherT
+          .fromEither[Future](
+            scenarioTestService
+              .validateAndGetTestParametersDefinition(
+                scenarioGraph,
+                scenarioWithDetails.processVersionUnsafe,
+                scenarioWithDetails.isFragment
+              )
+              .left
+              .map(toDto)
+          )
+          .map(validator.validate(sourceParameters, _)(metaData))
+      case ScenarioTestData.WithLiveData(numberOfSamples) =>
+        EitherT
+          .fromEither[Future](
+            scenarioTestService.validateRecordsCount[TestingError](numberOfSamples)(
+              BadRequestTestingError.TooManyRecordsRequested(_)
+            )
+          )
+          .map((_: Unit) => List.empty)
+    }
   }
 
   expose {

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/api/TestingApiErrorMessages.scala
@@ -9,11 +9,14 @@ import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.test.testcase.Assertion
 import pl.touk.nussknacker.engine.test.testcase.Assertion.ExpressionAssertion
 import pl.touk.nussknacker.restmodel.validation.ValidationResults
+import pl.touk.nussknacker.restmodel.validation.ValidationResults.NodeValidationError
 import pl.touk.nussknacker.ui.process.test.PreliminaryScenarioRecordsSerDe.DeserializationError
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService
 import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError
-import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.ScenarioValidationError
-import pl.touk.nussknacker.ui.process.test.testcase.{AssertionCompilationError, AssertionValidationError}
+import pl.touk.nussknacker.ui.process.test.ScenarioTestService.PerformTestError.{
+  ScenarioNodeValidationErrors,
+  ScenarioValidationError
+}
 import pl.touk.nussknacker.ui.process.test.testcase.AssertionCompilationError.{
   ExpressionAssertionCompilationError,
   PredicateAssertionCompilationError
@@ -76,6 +79,8 @@ object TestingApiErrorMessages {
       case PerformTestError.TestResultsSizeExceededError(approxSizeInBytes, maxBytes) =>
         TestingApiErrorMessages.testResultsSizeExceeded(approxSizeInBytes, maxBytes)
       case ScenarioValidationError(errors) =>
+        TestingApiErrorMessages.scenarioHasValidationErrors(errors)
+      case ScenarioNodeValidationErrors(errors) =>
         TestingApiErrorMessages.scenarioHasValidationErrors(errors)
       case PerformTestError.MockConfiguredForNotExistingNodesError(nodeIds) =>
         TestingApiErrorMessages.mocksConfiguredForNotExistingNodes(nodeIds)
@@ -174,6 +179,9 @@ object TestingApiErrorMessages {
 
   def testResultsSizeExceeded(approxSizeInBytes: Long, maxBytes: Long) =
     s"Test results size exceeded (approximate size is $approxSizeInBytes B). The maximum permitted size is $maxBytes B. Contact the system administrator to increase this limit."
+
+  private def scenarioHasValidationErrors(errors: List[NodeValidationError]) =
+    s"Only scenario without validation errors can be tested. Errors: $errors"
 
   private def scenarioHasValidationErrors(errors: ValidationResults.ValidationErrors) =
     s"Only scenario without validation errors can be tested. Errors: $errors"

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/ScenarioTestService.scala
@@ -34,7 +34,11 @@ import pl.touk.nussknacker.engine.testmode.CommonTestDataFormatVariablesDecoder.
 import pl.touk.nussknacker.engine.testmode.TestProcess.TestResults
 import pl.touk.nussknacker.engine.util.ListUtil
 import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
-import pl.touk.nussknacker.restmodel.validation.ValidationResults.{NodeTypingData, ValidationErrors}
+import pl.touk.nussknacker.restmodel.validation.ValidationResults.{
+  NodeTypingData,
+  NodeValidationError,
+  ValidationErrors
+}
 import pl.touk.nussknacker.ui.api.{TestDataFormat, TestDataSettings}
 import pl.touk.nussknacker.ui.api.description.NodesApiEndpoints.Dtos.TestSourceParameters
 import pl.touk.nussknacker.ui.process.deployment.ScenarioTestExecutorService
@@ -640,6 +644,8 @@ object ScenarioTestService {
         extends PerformTestError
 
     final case class ScenarioValidationError(errors: ValidationErrors) extends PerformTestError
+
+    final case class ScenarioNodeValidationErrors(errors: List[NodeValidationError]) extends PerformTestError
 
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/ManagementApiHttpServiceBusinessSpec.scala
@@ -57,7 +57,7 @@ class ManagementApiHttpServiceBusinessSpec
              | "testData": {
              |   "type": "WITH_PARAMETERS",
              |   "sourceParameters": {
-             |     "sourceId": "1",
+             |     "sourceId": "sourceId",
              |     "parameterExpressions": {
              |       "$InputVariablesParameterName": {
              |         "language": "json",

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -15,6 +15,7 @@ description: Stay informed with detailed changelogs covering new features, impro
 
 ### 1.19.0 (Not released yet)
 
+* [#8988](https://github.com/TouK/nussknacker/pull/8988) Fixed fragment test data validation for required or restricted input parameters
 * [#8923](https://github.com/TouK/nussknacker/pull/8923) Add new functions to Collection/Geo/Numeric helpers
 * [#8897](https://github.com/TouK/nussknacker/pull/8897) Fix: Passing TraceId after collect in RequestResponse
 * [#8849](https://github.com/TouK/nussknacker/pull/8849) Vulnerability: Spring upgrade to 6.2.15

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/scenariotesting/StubbedFragmentSourceDefinitionPreparer.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/scenariotesting/StubbedFragmentSourceDefinitionPreparer.scala
@@ -31,17 +31,22 @@ class StubbedFragmentSourceDefinitionPreparer(
 ) {
 
   def createSourceDefinition(name: String, frag: FragmentInputDefinition): ComponentDefinitionWithImplementation = {
-    val inputParameters = fragmentDefinitionExtractor.extractParametersDefinition(frag).value
+    val inputParameters = fragmentDefinitionExtractor
+      .extractParametersDefinition(frag)
+      .value
+      .map(
+        // The input parameters are validated separately, before test execution.
+        // During test execution, we need to disable input parameter validations:
+        //   - during the test run the parameters are produced after the source is invoked
+        //   - as a result, they are not available when the validation is performed before the source invocation
+        _.copy(validators = Nil)
+      )
     FragmentComponentDefinition(
       name = name,
       implementationInvoker =
         (_: Params, _: NodeCompilationDependencies, _: Option[ComponentImplementationSpecificInvocationContext]) =>
           buildSource(inputParameters),
-      // The source is mocked. The input parameters are validated separately, before test execution.
-      // During test execution, we pretend the there are no input params.
-      // Otherwise, the validation would fail. It is because the parameters are produced after the source is invoked,
-      // and are not available during the validation phase before the source invocation
-      parameters = List.empty,
+      parameters = inputParameters,
       outputNames = List.empty,
       docsUrl = None,
       componentGroupName = None,

--- a/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/scenariotesting/StubbedFragmentSourceDefinitionPreparer.scala
+++ b/engine/flink/executor/src/main/scala/pl/touk/nussknacker/engine/process/scenariotesting/StubbedFragmentSourceDefinitionPreparer.scala
@@ -37,7 +37,11 @@ class StubbedFragmentSourceDefinitionPreparer(
       implementationInvoker =
         (_: Params, _: NodeCompilationDependencies, _: Option[ComponentImplementationSpecificInvocationContext]) =>
           buildSource(inputParameters),
-      parameters = inputParameters,
+      // The source is mocked. The input parameters are validated separately, before test execution.
+      // During test execution, we pretend the there are no input params.
+      // Otherwise, the validation would fail. It is because the parameters are produced after the source is invoked,
+      // and are not available during the validation phase before the source invocation
+      parameters = List.empty,
       outputNames = List.empty,
       docsUrl = None,
       componentGroupName = None,

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/engine/flink/minicluster/scenariotesting/schemedkafka/SchemedKafkaScenarioTestingSpec.scala
@@ -12,7 +12,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ModelConfig
 import pl.touk.nussknacker.engine.api.{ContextId, NodeId}
-import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.definition.FixedExpressionValue
+import pl.touk.nussknacker.engine.api.parameter.{ParameterName, ValueInputWithFixedValuesProvided}
 import pl.touk.nussknacker.engine.api.process.ProcessName
 import pl.touk.nussknacker.engine.api.test.{ScenarioTestData, ScenarioTestSourceSpecificFormatJsonRecord}
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
@@ -23,6 +24,7 @@ import pl.touk.nussknacker.engine.flink.minicluster.scenariotesting.schemedkafka
 import pl.touk.nussknacker.engine.flink.minicluster.util.DurationToRetryPolicyConverter
 import pl.touk.nussknacker.engine.flink.util.sink.SingleValueSinkFactory.SingleValueParamName
 import pl.touk.nussknacker.engine.graph.expression.Expression
+import pl.touk.nussknacker.engine.graph.node.FragmentInputDefinition.{FragmentClazzRef, FragmentParameter}
 import pl.touk.nussknacker.engine.kafka.UnspecializedTopicName
 import pl.touk.nussknacker.engine.process.helpers.TestResultsHolder
 import pl.touk.nussknacker.engine.schemedkafka.KafkaAvroIntegrationMockSchemaRegistry.schemaRegistryMockClient
@@ -243,6 +245,79 @@ class SchemedKafkaScenarioTestingSpec
       mockedTimestamp,
       "out",
       Json.fromFields(Seq("pretty" -> Json.fromString("some-text-id")))
+    )
+
+    results.exceptions shouldBe empty
+  }
+
+  test("should handle fragment test parameters in test when the input parameter is required") {
+    val fragmentFixedParameter = FragmentParameter(
+      ParameterName("in"),
+      FragmentClazzRef[java.lang.String],
+      required = true,
+      initialValue = None,
+      hintText = None,
+      valueEditor = Some(
+        ValueInputWithFixedValuesProvided(
+          fixedValuesList = List(
+            FixedExpressionValue("'uno'", "uno"),
+            FixedExpressionValue("'due'", "due"),
+          ),
+          allowOtherValue = false
+        )
+      ),
+      valueCompileTimeValidation = None
+    )
+    val fragment = ScenarioBuilder
+      .fragmentWithRawParameters("fragment1", fragmentFixedParameter)
+      .filter("filter", "#in != 'stop'".spel)
+      .fragmentOutput("fragmentEnd", "output", "out" -> "#in".spel)
+
+    val parameterExpressions = Map(
+      ParameterName("in") -> Expression.spel("'uno'")
+    )
+    val scenarioTestData = ScenarioTestData("fragment1", parameterExpressions)
+    val results          = testRunner.runTests(fragment, scenarioTestData).futureValue
+
+    nodeResults(results, "fragment1").loneElement shouldBe (
+      ContextId(
+        scenarioName = ProcessName("fragment1"),
+        originatingNodeId = NodeId("fragment1"),
+        taskId = 0,
+        index = 0
+      ),
+      Map(
+        "in" -> Json.fromFields(Seq("pretty" -> Json.fromString("uno")))
+      )
+    )
+
+    nodeResults(results, "fragmentEnd").loneElement shouldBe (
+      ContextId(
+        scenarioName = ProcessName("fragment1"),
+        originatingNodeId = NodeId("fragment1"),
+        taskId = 0,
+        index = 0
+      ),
+      Map(
+        "in"  -> Json.fromFields(Seq("pretty" -> Json.fromString("uno"))),
+        "out" -> Json.fromFields(Seq("pretty" -> Json.fromString("uno")))
+      )
+    )
+
+    val mockedTimestamp = Instant.now()
+    results
+      .expressionEvaluationResults(NodeId("fragmentEnd"))
+      .loneElement
+      .copy(timestamp = mockedTimestamp) shouldBe ExpressionEvaluationResult(
+      ContextId(
+        scenarioName = ProcessName("fragment1"),
+        originatingNodeId = NodeId("fragment1"),
+        taskId = 0,
+        index = 0
+      ),
+      mockedTimestamp,
+      "out",
+      Json.fromFields(Seq("pretty" -> Json.fromString("uno")))
     )
 
     results.exceptions shouldBe empty

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
@@ -350,16 +350,17 @@ class NodeCompiler(
       case frag @ FragmentInputDefinition(id, _, _) =>
         val parameterDefinitions = fragmentDefinitionExtractor.extractParametersDefinition(frag)
 
-        val compilationResult = definitions.getComponent(ComponentType.Fragment, id) match {
-          // This case is when the fragment is stubbed with test data
+        val (compilationResult, displayableErrors) = definitions.getComponent(ComponentType.Fragment, id) match {
+          // This case is when the fragment is stubbed with test data.
+          // The validation of the fragment input is performed before the test execution starts.
           case Some(definition) =>
-            compileComponentWithContextTransformation[Source](
+            val nodeCompilationResult = compileComponentWithContextTransformation[Source](
               nodeData = frag,
               customNodeIsEndingNode = None,
               inputContext = SingleInputNodeInputValidationContext(contextWithOnlyGlobalVariables),
               componentDefinition = definition
             ).map(_._1)
-
+            (nodeCompilationResult, Valid(()))
           // For default case, we create a source that supports test with parameters
           case None =>
             val validationContext =
@@ -375,7 +376,7 @@ class NodeCompiler(
               )
             }.sequence
 
-            NodeCompilationResult(
+            val nodeCompilationResult = NodeCompilationResult(
               Map.empty,
               None,
               Valid(validationContext),
@@ -383,26 +384,27 @@ class NodeCompiler(
                 Valid(new FragmentSourceWithTestWithParametersSupportFactory(parameterDefinitions.value).createSource())
               )
             )
+
+            val parameterNameValidation = fragmentParameterValidator.validateParameterNames(parameterDefinitions.value)
+
+            // by relying on name for the field names used on FE, we display the same errors under all fields with the
+            // duplicated name
+            // TODO: display all errors when switching to field name errors not reliant on parameter name
+            lazy val displayUniqueNameReliantErrors = parameterNameValidation.fold(
+              errors => !errors.exists(_.isInstanceOf[DuplicateFragmentInputParameter]),
+              _ => true
+            )
+
+            val validatedUniqueNameReliantErrorsV = nodeCompilationResult.validationContext match {
+              case Valid(validationContext) if displayUniqueNameReliantErrors =>
+                uniqueNameReliantErrors(frag, parameterDefinitions, validationContext)
+              case _ =>
+                Valid(())
+            }
+
+            val displayableErrors = parameterNameValidation |+| validatedUniqueNameReliantErrorsV
+            (nodeCompilationResult, displayableErrors)
         }
-
-        val parameterNameValidation = fragmentParameterValidator.validateParameterNames(parameterDefinitions.value)
-
-        // by relying on name for the field names used on FE, we display the same errors under all fields with the
-        // duplicated name
-        // TODO: display all errors when switching to field name errors not reliant on parameter name
-        lazy val displayUniqueNameReliantErrors = parameterNameValidation.fold(
-          errors => !errors.exists(_.isInstanceOf[DuplicateFragmentInputParameter]),
-          _ => true
-        )
-
-        val validatedUniqueNameReliantErrorsV = compilationResult.validationContext match {
-          case Valid(validationContext) if displayUniqueNameReliantErrors =>
-            uniqueNameReliantErrors(frag, parameterDefinitions, validationContext)
-          case _ =>
-            Valid(())
-        }
-
-        val displayableErrors = parameterNameValidation |+| validatedUniqueNameReliantErrorsV
 
         compilationResult.copy(compiledObject = displayableErrors.andThen(_ => compilationResult.compiledObject))
     }


### PR DESCRIPTION
## Describe your changes

There was an issue with input validation during fragment testing. Fragment input parameters can be configured with additional validation rules, such as being marked as required or restricted to a predefined set of values.

In the test mechanism, test data samples are generated by the mocked source and become available only after the source is invoked. However, for fragments, validation is executed before the source is invoked. As a result, validation of fragment input parameters always failed, when the parameters were marked as required.

Solution:
- always validate the test input before starting test execution. This was already partially implemented by calling the validation endpoint on the frontend, but validation is now also executed immediately before the test is performed.
- disable validation for mocked fragment input sources during test execution

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
