### PR TITLE
Downgrade kafka-clients to 3.9.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -248,7 +248,7 @@ val flinkScalaV           = "1.1.6"
 val calciteV              = "1.32.0"
 val avroV                 = "1.12.1"
 //we should use max(version used by confluent, version acceptable by flink), https://docs.confluent.io/platform/current/installation/versions-interoperability.html - confluent version reference
-val kafkaV                = "3.9.2"
+val kafkaV                = "3.9.1"
 // when updating note that we have copied and modified class org.springframework.expression.spel.ast.Projection
 // and org.springframework.util.NumberUtils and org.springframework.expression.spel.ast.Selection
 val springV               = "6.2.15"

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -316,7 +316,7 @@ description: Stay informed with detailed changelogs covering new features, impro
 * [#8806](https://github.com/TouK/nussknacker/pull/8806) Test case running implementation
 * [#8903](https://github.com/TouK/nussknacker/pull/8903) Updated Flink dependency to 1.20.3, Scala to 2.13.18
 * [#8903](https://github.com/TouK/nussknacker/pull/8946) Fix default Kafka EOS configuration on Flink to use a unique transactional id prefix
-* [#9002](https://github.com/TouK/nussknacker/pull/9002) Updated Kafka client 3.6.2 to 3.9.2
+* [#9002](https://github.com/TouK/nussknacker/pull/9002)[#9009](https://github.com/TouK/nussknacker/pull/9009) Updated Kafka client 3.6.2 to 3.9.1
 
 ## 1.18
 


### PR DESCRIPTION
## Describe your changes

Changed lz4-java location conflicts with Flink's dependency, we'll wait with updating for Flink 1.20.4.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
