### PR TITLE
Allow ciRunSbt.sh to work with "set" command, disable docs generation in test jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -177,7 +177,7 @@ jobs:
       - uses: ./.github/actions/prepare_sbt_test
       - name: Backend tests
         shell: bash
-        run: ./ciRunSbt.sh test
+        run: ./ciRunSbt.sh "set Seq(ThisBuild / packageDoc / publishArtifact := false, Compile / doc / sources := Seq.empty)" test
       - name: Upload test report
         if: success() || failure()
         uses: actions/upload-artifact@v6
@@ -200,7 +200,7 @@ jobs:
       - uses: ./.github/actions/prepare_sbt_test
       - name: E2E tests
         shell: bash
-        run: ./ciRunSbt.sh e2eTests/Slow/test
+        run: ./ciRunSbt.sh "set Seq(ThisBuild / packageDoc / publishArtifact := false, Compile / doc / sources := Seq.empty)" e2eTests/Slow/test
       - name: Upload test report
         if: success() || failure()
         uses: actions/upload-artifact@v6
@@ -225,7 +225,7 @@ jobs:
         shell: bash
         env:
           dockerUpLatest: true
-        run: ./ciRunSbt.sh It/test
+        run: ./ciRunSbt.sh "set Seq(ThisBuild / packageDoc / publishArtifact := false, Compile / doc / sources := Seq.empty)" It/test
       - name: Upload test report
         if: success() || failure()
         uses: actions/upload-artifact@v6
@@ -265,7 +265,13 @@ jobs:
           AZURE_EVENT_HUBS_SHARED_ACCESS_KEY: ${{ secrets.AZURE_EVENT_HUBS_SHARED_ACCESS_KEY }}
           AZURE_EVENT_HUBS_NAMESPACE: ${{ secrets.AZURE_EVENT_HUBS_NAMESPACE }}
         shell: bash
-        run: ./ciRunSbt.sh designer/Slow/test liteK8sDeploymentManager/ExternalDepsTests/test schemedKafkaComponentsUtils/ExternalDepsTests/test liteKafkaComponentsTests/ExternalDepsTests/test
+        run: >-
+          ./ciRunSbt.sh
+          "set Seq(ThisBuild / packageDoc / publishArtifact := false, Compile / doc / sources := Seq.empty)"
+          designer/Slow/test
+          liteK8sDeploymentManager/ExternalDepsTests/test
+          schemedKafkaComponentsUtils/ExternalDepsTests/test
+          liteKafkaComponentsTests/ExternalDepsTests/test
       - name: docker logs
         if: success() || failure()
         run: |
@@ -394,7 +400,7 @@ jobs:
           addDevArtifacts: true
         shell: bash
         #Doc generation is rather costly, we don't want it in test image creation
-        run: sbt "set ThisBuild / version := \"$NUSSKNACKER_VERSION\"; set ThisBuild / packageDoc / publishArtifact := false; set Compile / doc / sources := Seq.empty" dist/Docker/publishLocal
+        run: sbt "set Seq(ThisBuild / version := \"$NUSSKNACKER_VERSION\", ThisBuild / packageDoc / publishArtifact := false, Compile / doc / sources := Seq.empty)" dist/Docker/publishLocal
       - name: FE tests e2e on build docker image
         if: ${{ env.shouldBuildImage == 'true' }}
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,4 +73,4 @@ jobs:
           TMPDIR: ${{ github.workspace }}
         shell: bash
         #TODO: handle version better, do we want to publish docker image for older scala versions? If so, how should it be tagged?
-        run: sbt "set ThisBuild / version := \"$NUSSKNACKER_VERSION\"; set ThisBuild / packageDoc / publishArtifact := false; set Compile / doc / sources := Seq.empty" +publish +dist/Docker/publish +liteEngineRuntimeApp/Docker/publish
+        run: sbt "set Seq(ThisBuild / version := \"$NUSSKNACKER_VERSION\", ThisBuild / packageDoc / publishArtifact := false, Compile / doc / sources := Seq.empty)" +publish +dist/Docker/publish +liteEngineRuntimeApp/Docker/publish

--- a/ciRunSbt.sh
+++ b/ciRunSbt.sh
@@ -1,13 +1,30 @@
 #!/usr/bin/env bash
 set -e
+ARGS=()
 # When $NUSSKNACKER_SCALA_VERSION is not present, we check for $CROSS_BUILD. If it's true - we do cross build, otherwise we use default scala version
 if [[ -n "$NUSSKNACKER_SCALA_VERSION" ]]; then
-   ARGS="++$NUSSKNACKER_SCALA_VERSION $*"
+  # prepend each command chain with '++', 'set ...' resets this so we need to repeat '++' insertion
+  scala_version_inserted=0
+  for arg in "$@"; do
+    if [[ "$arg" != set* ]] && (( !scala_version_inserted )); then
+      ARGS+=("++$NUSSKNACKER_SCALA_VERSION")
+      scala_version_inserted=1
+    elif [[ "$arg" == set* ]]; then
+      scala_version_inserted=0
+    fi
+    ARGS+=("$arg")
+  done
 elif [[ $CROSS_BUILD == 'true' ]]; then
-   #for crossbuild we prepend each arg with +...
-   ARGS=`echo " $*" | sed "s/ \+/ \+/g"`
+  # for crossbuild we prepend each task with +...
+  for arg in "$@"; do
+    if [[ "$arg" == set* ]]; then
+      ARGS+=("$arg")
+    else
+      ARGS+=("+$arg")
+    fi
+  done
 else
-   ARGS="$*"
+  ARGS=("$@")
 fi
 echo "Executing: sbt $ARGS"
-exec sbt $ARGS
+exec sbt "${ARGS[@]}"


### PR DESCRIPTION
## Describe your changes

* refactor ciRunSbt.sh so that it won't break when trying to pass "set" to sbt
* remove docs generation from test commands (it's still active in main Build job)

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
