### PR TITLE
 Ensure that StateCompatibilityTest has only a single candidate state to restore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -845,8 +845,8 @@ lazy val benchmarks = (project in file("benchmarks"))
     name                                 := "nussknacker-benchmarks",
     libraryDependencies ++= {
       Seq(
-        "pl.touk"         %% "flink-scala"                    % flinkScalaV exclude ("com.esotericsoftware", "kryo-shaded"),
-        "org.apache.flink" % "flink-streaming-java"           % flinkV exclude ("com.esotericsoftware", "kryo-shaded"),
+        "pl.touk"         %% "flink-scala"                    % flinkScalaV,
+        "org.apache.flink" % "flink-streaming-java"           % flinkV,
         "org.apache.flink" % "flink-runtime"                  % flinkV,
         "com.dimafeng"    %% "testcontainers-scala-scalatest" % testContainersScalaV % Test,
       )

--- a/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/StateCompatibilityTest.scala
+++ b/engine/flink/tests/src/test/scala/pl/touk/nussknacker/defaultmodel/StateCompatibilityTest.scala
@@ -148,7 +148,10 @@ class StateCompatibilityTest extends FlinkWithKafkaSuite with PatientScalaFuture
     val inputTopicConfig  = createAndRegisterAvroTopicConfig(inTopic, RecordSchemaV1)
     val outputTopicConfig = createAndRegisterTopicConfig(outTopic, JsonSchemaV1)
 
-    val existingSavepointLocation = Files.list(savepointDir).iterator().asScala.toList.head
+    val existingSavepoints = Files.list(savepointDir).iterator().asScala.toSeq
+    existingSavepoints.size shouldBe 1
+
+    val existingSavepointLocation = existingSavepoints.head
     val process1                  = stateCompatibilityProcess(inputTopicConfig.input, outputTopicConfig.output)
 
     // Send one artificial message to mimic offsets saved in savepoint from the above test because kafka commit cannot be performed.


### PR DESCRIPTION
## Describe your changes

Add an assertion to make it more difficult to perform tests on old data rather than freshly generated snapshots.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
