### PR TITLE
Always close `SttpBackend` instances in OpenAPI services

### DIFF
--- a/components/openapi/src/it/scala/pl/touk/nussknacker/openapi/functional/OpenAPIServiceSpec.scala
+++ b/components/openapi/src/it/scala/pl/touk/nussknacker/openapi/functional/OpenAPIServiceSpec.scala
@@ -41,7 +41,7 @@ class OpenAPIServiceSpec
   def withFixture(test: OneArgTest): Outcome = {
     val definition = ResourceLoader.load("/customer-swagger.json")
 
-    val client = new DefaultAsyncHttpClient()
+    val clientProvider = new FixedAsyncHttpClientBackendProvider(new DefaultAsyncHttpClient())
     try {
       new StubService().withCustomerService { port =>
         val secretBySchemeName = Map(SecuritySchemeName("apikey") -> ApiKeySecret("TODO"))
@@ -57,7 +57,7 @@ class OpenAPIServiceSpec
         val enricher = OpenAPIEnricher(
           service = services.head,
           config = config,
-          clientProvider = new FixedAsyncHttpClientBackendProvider(client),
+          clientProvider = clientProvider,
           params = Params.fromRawValuesMap(Map(ParameterName("customer_id") -> "10")),
           getTimeMeasurement =
             () => new AsyncExecutionTimeMeasurement(TestEngineRuntimeContext(jobData), "openAPI", Map.empty)
@@ -66,12 +66,11 @@ class OpenAPIServiceSpec
         withFixture(test.toNoArgTest(enricher))
       }
     } finally {
-      client.close()
+      clientProvider.close()
     }
   }
 
   test("service returns customers") { service =>
-    implicit val contextId: ContextId = ContextId.dummy
     val valueWithChosenFields =
       service
         .invoke(context)

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/OpenAPIComponentProvider.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/OpenAPIComponentProvider.scala
@@ -8,9 +8,10 @@ import pl.touk.nussknacker.engine.api.component.{
   ComponentProvider,
   NussknackerVersion
 }
-import pl.touk.nussknacker.engine.util.config.ConfigEnrichments._
+import pl.touk.nussknacker.http.backend.HttpBackendProvider
 import pl.touk.nussknacker.openapi.discovery.{CachingOpenApiDefinitionDiscovery, SwaggerOpenApiDefinitionDiscovery}
 import pl.touk.nussknacker.openapi.enrichers.OpenAPIEnricherFactory
+import pl.touk.nussknacker.openapi.http.backend.HttpClientProvider
 
 class OpenAPIComponentProvider extends ComponentProvider with LazyLogging {
 
@@ -23,11 +24,15 @@ class OpenAPIComponentProvider extends ComponentProvider with LazyLogging {
       componentDependencies: ComponentDependencies
   ): List[ComponentDefinition] = {
     val openAPIsConfig = OpenAPIServicesConfig.parse(componentProviderConfig)
-    val openApiDefinitionDiscovery =
-      new CachingOpenApiDefinitionDiscovery(SwaggerOpenApiDefinitionDiscovery, openAPIsConfig)
+    implicit val backendProvider: HttpBackendProvider =
+      HttpClientProvider.getBackendProvider(openAPIsConfig.httpClientConfig)
+    val openApiDefinitionDiscovery = new CachingOpenApiDefinitionDiscovery(
+      new SwaggerOpenApiDefinitionDiscovery(),
+      openAPIsConfig.openApiServicesDiscoveryCacheTtl
+    )
     ComponentDefinition(
       name = "openAPI",
-      component = OpenAPIEnricherFactory(openAPIsConfig, openApiDefinitionDiscovery),
+      component = new OpenAPIEnricherFactory(openAPIsConfig, backendProvider, openApiDefinitionDiscovery),
       label = Some(s"${openAPIsConfig.componentPrefix.getOrElse("")}OpenAPI")
     ) :: Nil
   }

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/discovery/OpenApiDefinitionDiscovery.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/discovery/OpenApiDefinitionDiscovery.scala
@@ -3,19 +3,18 @@ package pl.touk.nussknacker.openapi.discovery
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
 import com.typesafe.scalalogging.LazyLogging
-import org.asynchttpclient.DefaultAsyncHttpClient
 import pl.touk.nussknacker.engine.util.ResourceLoader
 import pl.touk.nussknacker.engine.util.cache.SingleValueCache
-import pl.touk.nussknacker.http.backend.HttpClientConfig
+import pl.touk.nussknacker.http.backend.HttpBackendProvider
 import pl.touk.nussknacker.openapi.{OpenAPIServicesConfig, SwaggerService}
 import pl.touk.nussknacker.openapi.parser.{ServiceParseError, SwaggerParser}
-import sttp.client3.{SttpBackend, basicRequest}
-import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
+import sttp.client3.basicRequest
 import sttp.model.Uri
 
 import java.io.File
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.util.control.NonFatal
 
 trait OpenApiDefinitionDiscovery extends LazyLogging {
   def getServices(openAPIsConfig: OpenAPIServicesConfig): List[Validated[ServiceParseError, SwaggerService]]
@@ -34,28 +33,12 @@ trait OpenApiDefinitionDiscovery extends LazyLogging {
       logger.warn(s"Failed to parse following services: ${errors.mkString(", ")}")
     }
   }
+
 }
 
-object SwaggerOpenApiDefinitionDiscovery
-    extends SwaggerOpenApiDefinitionDiscovery()(
-      AsyncHttpClientFutureBackend.usingClient(
-        new DefaultAsyncHttpClient(
-          HttpClientConfig(
-            timeout = Some(5 seconds),
-            connectTimeout = Some(10 seconds),
-            maxPoolSize = Some(1),
-            None,
-            None,
-            None,
-            None,
-            None,
-          ).toAsyncHttpClientConfig(None).build()
-        )
-      )
-    )
-
-class SwaggerOpenApiDefinitionDiscovery(implicit val httpBackend: SttpBackend[Future, Any]) extends LazyLogging
-  with OpenApiDefinitionDiscovery {
+class SwaggerOpenApiDefinitionDiscovery()(implicit httpBeProvider: HttpBackendProvider)
+    extends LazyLogging
+    with OpenApiDefinitionDiscovery {
 
   override def getServices(
       openAPIsConfig: OpenAPIServicesConfig
@@ -64,22 +47,34 @@ class SwaggerOpenApiDefinitionDiscovery(implicit val httpBackend: SttpBackend[Fu
     val definition = if (discoveryUrl.getProtocol == "file") {
       ResourceLoader.load(new File(discoveryUrl.getPath))
     } else {
-      Await
-        .result(basicRequest.get(Uri(discoveryUrl.toURI)).send(httpBackend), 20 seconds)
-        .body
-        .fold(left => throw new IllegalStateException(s"Invalid response from discovery API: $left"), identity)
+      val httpBackend = httpBeProvider.httpBackendForEc(ExecutionContext.global)
+      try {
+        Await
+          .result(basicRequest.get(Uri(discoveryUrl.toURI)).send(httpBackend), 20 seconds)
+          .body
+          .fold(left => throw new IllegalStateException(s"Invalid response from discovery API: $left"), identity)
+      } finally {
+        try {
+          Await.result(httpBackend.close(), 5 seconds)
+        } catch {
+          case NonFatal(ex) =>
+            logger.warn(s"Could not close HTTP backend, this may result in leaked resources: ${ex.getMessage}", ex)
+        }
+      }
     }
     SwaggerParser.parse(definition, openAPIsConfig)
   }
+
 }
 
 class CachingOpenApiDefinitionDiscovery(
     discovery: OpenApiDefinitionDiscovery,
-    openAPIsConfig: OpenAPIServicesConfig,
+    cacheTtl: FiniteDuration,
 ) extends OpenApiDefinitionDiscovery {
+
   @transient private lazy val servicesCache = new SingleValueCache[List[Validated[ServiceParseError, SwaggerService]]](
     expireAfterAccess = None,
-    expireAfterWrite = Some(openAPIsConfig.openApiServicesDiscoveryCacheTtl)
+    expireAfterWrite = Some(cacheTtl)
   )
 
   override def getServices(
@@ -87,4 +82,5 @@ class CachingOpenApiDefinitionDiscovery(
   ): List[Validated[ServiceParseError, SwaggerService]] = servicesCache.getOrCreate {
     discovery.getServices(openAPIsConfig)
   }
+
 }

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/enrichers/OpenAPIEnricherFactory.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/enrichers/OpenAPIEnricherFactory.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.openapi.enrichers
 
 import com.typesafe.scalalogging.LazyLogging
-import pl.touk.nussknacker.engine.api.{EagerService, NodeId, Params, ServiceInvoker}
+import pl.touk.nussknacker.engine.api.{EagerService, NodeId, Params}
 import pl.touk.nussknacker.engine.api.component.AllProcessingModesComponent
 import pl.touk.nussknacker.engine.api.context.{OutputVar, ValidationContext}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomNodeError
@@ -34,7 +34,6 @@ import pl.touk.nussknacker.openapi.enrichers.OpenAPIEnricherFactory.Transformati
   SelectedServiceState
 }
 import pl.touk.nussknacker.openapi.extractor.ParametersExtractor
-import pl.touk.nussknacker.openapi.http.backend.HttpClientProvider
 
 class OpenAPIEnricherFactory(
     config: OpenAPIServicesConfig,
@@ -152,23 +151,14 @@ class OpenAPIEnricherFactory(
   }
 
   override def close(): Unit = {
-    super.close()
     httpBeProvider.close()
+    super.close()
   }
 
 }
 
 object OpenAPIEnricherFactory {
   final val ServiceParamName = ParameterName("Service")
-
-  def apply(
-      config: OpenAPIServicesConfig,
-      openApiDefinitionDiscovery: OpenApiDefinitionDiscovery,
-  ) = new OpenAPIEnricherFactory(
-    config,
-    HttpClientProvider.getBackendProvider(config.httpClientConfig),
-    openApiDefinitionDiscovery,
-  )
 
   sealed trait TransformationState
 

--- a/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/http/backend/SharedHttpClient.scala
+++ b/components/openapi/src/main/scala/pl/touk/nussknacker/openapi/http/backend/SharedHttpClient.scala
@@ -1,7 +1,7 @@
 package pl.touk.nussknacker.openapi.http.backend
 
 import org.asynchttpclient.{AsyncHttpClient, DefaultAsyncHttpClient}
-import pl.touk.nussknacker.engine.api.MetaData
+import pl.touk.nussknacker.engine.api.{CustomMetaData, MetaData}
 import pl.touk.nussknacker.engine.api.runtimecontext.EngineRuntimeContext
 import pl.touk.nussknacker.engine.util.sharedservice.{SharedService, SharedServiceHolder}
 import pl.touk.nussknacker.http.backend.{HttpBackendProvider, HttpClientConfig}
@@ -12,16 +12,33 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class SharedHttpClientBackendProvider(httpClientConfig: HttpClientConfig) extends HttpBackendProvider {
 
-  private var httpClient: SharedHttpClient = _
+  private var basicHttpClient: SharedHttpClient        = _
+  private var serviceAwareHttpClient: SharedHttpClient = _
 
   override def open(context: EngineRuntimeContext): Unit = {
-    httpClient = SharedHttpClientBackendProvider.retrieveService(httpClientConfig)(context.jobData.metaData)
+    serviceAwareHttpClient = SharedHttpClientBackendProvider.retrieveService(httpClientConfig)(context.jobData.metaData)
   }
 
-  override def httpBackendForEc(implicit ec: ExecutionContext): SttpBackend[Future, Any] =
+  override def httpBackendForEc(implicit ec: ExecutionContext): SttpBackend[Future, Any] = {
+    val httpClient = if (serviceAwareHttpClient == null) {
+      synchronized {
+        if (basicHttpClient == null) {
+          basicHttpClient = SharedHttpClientBackendProvider.retrieveService(httpClientConfig)(
+            MetaData("forEc", CustomMetaData(Map.empty))
+          )
+        }
+      }
+      basicHttpClient
+    } else {
+      serviceAwareHttpClient
+    }
     AsyncHttpClientFutureBackend.usingClient(httpClient.httpClient)
+  }
 
-  override def close(): Unit = Option(httpClient).foreach(_.close())
+  override def close(): Unit = {
+    Option(basicHttpClient).foreach(_.close())
+    Option(serviceAwareHttpClient).foreach(_.close())
+  }
 
 }
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -332,6 +332,7 @@ description: Stay informed with detailed changelogs covering new features, impro
   * Optimized table discovery through configurable caching (especially important for catalogs for systems with slow connections)
   * More precise validation and error messages during scenario authoring
   * Fixed bug for non-deterministic validation multiple validations were performent at the same time
+* [#9095](https://github.com/TouK/nussknacker/pull/9095) Always close `SttpBackend` instances in OpenAPI services
 
 ## 1.18
 

--- a/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/metrics/dropwizard/influxdb/InfluxDbHttpReporter.scala
+++ b/engine/lite/runtime/src/main/scala/pl/touk/nussknacker/engine/lite/metrics/dropwizard/influxdb/InfluxDbHttpReporter.scala
@@ -61,7 +61,7 @@ class InfluxDbHttpSender(conf: InfluxSenderConfig) extends InfluxDbSender with L
 
   override def isConnected: Boolean = true
 
-  override def close(): Unit = {}
+  override def close(): Unit = backend.close()
 }
 
 case class InfluxSenderConfig(

--- a/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/HttpBackendProvider.scala
+++ b/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/HttpBackendProvider.scala
@@ -18,4 +18,6 @@ class FixedAsyncHttpClientBackendProvider(httpClient: AsyncHttpClient) extends H
   override def httpBackendForEc(implicit ec: ExecutionContext): SttpBackend[Future, Any] =
     AsyncHttpClientFutureBackend.usingClient(httpClient)
 
+  override def close(): Unit = httpClient.close()
+
 }

--- a/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/HttpClientConfig.scala
+++ b/utils/http-utils/src/main/scala/pl/touk/nussknacker/http/backend/HttpClientConfig.scala
@@ -35,7 +35,7 @@ case class HttpClientConfig(
       .setIoThreadsCount(effectiveConfig.maxPoolSize)
       .setUseNativeTransport(effectiveConfig.useNative)
       .setFollowRedirect(effectiveConfig.followRedirect)
-      .setThreadPoolName(processName.map(_.value + s"-http-pool").getOrElse(s"http-pool"))
+      .setThreadPoolName(processName.map(_.value + s"-nu-http-pool").getOrElse(s"nu-http-pool"))
       .setForbiddenCidrRequestFilter(effectiveConfig.resolvedCidrs)
       .setForbiddenHostResponseFilter(effectiveConfig.followRedirect, effectiveConfig.resolvedCidrs)
   }


### PR DESCRIPTION
## Describe your changes

Always close `SttpBackend` instances in OpenAPI services

- we could leak a backend in service discovery - deployment created a new backend with its dedicated thread pool, this change also uses backend configuration from service config instead of hardcoded one
- Lite/RR never closed their `AsyncHttpClient` - `FixedAsyncHttpClientBackendProvider.close` was not implemented
- `InfluxDbHttpReporter` didn't close its backend - it didn't have to, as `close` in `TryHttpURLConnectionBackend` is a noop, but let's use a correct lifecycle pattern anyway

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
