### PR TITLE
Improvements for expressions typing

### DIFF
--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminer.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminer.scala
@@ -143,7 +143,7 @@ private[engine] object AssignabilityDeterminer {
   private def isSingleTypeMatchesTargetObjType(from: SingleTypingResult, to: TypedClass)(
       implicit conversionStrategy: ConversionStrategy
   ): ValidatedNel[String, ConversionNecessaryForTypeAssignment] = {
-    def typeParametersMatches(givenClass: TypedClass, targetCandidate: TypedClass) = {
+    def typeParametersMatches(givenClass: TypedClass, targetCandidate: TypedClass, maybeValue: Option[Any]) = {
       def canBeAssignedToOrAssignedFrom(givenClassParam: TypingResult, targetParam: TypingResult) =
         condNel(
           isAssignable(givenClassParam, targetParam).isValid ||
@@ -152,25 +152,57 @@ private[engine] object AssignabilityDeterminer {
           f"None of ${givenClassParam.display} and ${targetParam.display} can be assigned to another"
         )
 
-      (givenClass, targetCandidate, conversionStrategy) match {
-        case (TypedClass(_, givenElementParam :: Nil), TypedClass(targetClass, targetParam :: Nil), _)
+      def isEmptyListOrArrayLiteral(givenClassParam: TypingResult): Option[NoConvertionIsNeeded.type] = {
+        givenClassParam match {
+          // after splitting Unknown to Any and Nothing, here should be Nothing
+          case Unknown(_) =>
+            maybeValue match {
+              case Some(list: java.util.List[_]) => Option.when(list.isEmpty)(NoConvertionIsNeeded)
+              case Some(array: Array[_])         => Option.when(array.isEmpty)(NoConvertionIsNeeded)
+              case None | Some(_)                => None
+            }
+          case _ => None
+        }
+      }
+
+      def isEmptyMapLiteral(givenClassParam: TypingResult): Option[NoConvertionIsNeeded.type] = {
+        givenClassParam match {
+          // after splitting Unknown to Any and Nothing, here should be Nothing
+          case Unknown(_) =>
+            maybeValue match {
+              case Some(map: java.util.Map[_, _]) => Option.when(map.isEmpty)(NoConvertionIsNeeded)
+              case None | Some(_)                 => None
+            }
+          case _ => None
+        }
+      }
+
+      (givenClass, targetCandidate) match {
+        case (TypedClass(_, givenElementParam :: Nil), TypedClass(targetClass, targetParam :: Nil))
             if ListClass.isAssignableFrom(targetClass) || ArrayClass.isAssignableFrom(targetClass) =>
-          isAssignable(givenElementParam, targetParam)
+          isAssignable(givenElementParam, targetParam).handleErrorWith { errors =>
+            isEmptyListOrArrayLiteral(givenElementParam).toValid(errors)
+          }
         case (
               TypedClass(_, givenKeyParam :: givenValueParam :: Nil),
               TypedClass(targetClass, targetKeyParam :: targetValueParam :: Nil),
-              _
             ) if MapClass.isAssignableFrom(targetClass) =>
           // Map's key generic param is invariant. We can't just check givenKeyParam == targetKeyParam because of Unknown type which is a kind of wildcard
           condNel(
-            isAssignable(givenKeyParam, targetKeyParam).isValid &&
-              isAssignable(targetKeyParam, givenKeyParam).isValid,
+            isAssignable(givenKeyParam, targetKeyParam).isValid && (isAssignable(
+              targetKeyParam,
+              givenKeyParam
+            ).isValid || targetKeyParam.isUnknown),
             (),
             s"Key types of Maps ${givenKeyParam.display} and ${targetKeyParam.display} are not equals"
-          ) andThen (_ => isAssignable(givenValueParam, targetValueParam))
+          ) andThen { _ =>
+            isAssignable(givenValueParam, targetValueParam).handleErrorWith { errors =>
+              isEmptyMapLiteral(givenValueParam).toValid(errors)
+            }
+          }
         case _ =>
           // for unknown types we are lax - the generic type may be co- contra- or in-variant - and we don't want to
-          // return validation errors in this case. It's better to accept to much than too little
+          // return validation errors in this case. It's better to accept too much than too little
           condNel(
             targetCandidate.params.zip(givenClass.params).forall { case (targetParam, givenClassParam) =>
               canBeAssignedToOrAssignedFrom(givenClassParam, targetParam).isValid
@@ -192,7 +224,7 @@ private[engine] object AssignabilityDeterminer {
         isAssignable(givenClass.klass, to.klass)
 
     val canAssignAndParametersMatches = equalClassesOrCanAssign andThen
-      (_ => typeParametersMatches(givenClass, to)) map (_ => NoConvertionIsNeeded)
+      (_ => typeParametersMatches(givenClass, to, from.valueOpt)) map (_ => NoConvertionIsNeeded)
     conversionStrategy match {
       case NoConversion => canAssignAndParametersMatches
       case nonEmptyStrategy: NonEmptyConversionStrategy =>

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminer.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/AssignabilityDeterminer.scala
@@ -189,10 +189,8 @@ private[engine] object AssignabilityDeterminer {
             ) if MapClass.isAssignableFrom(targetClass) =>
           // Map's key generic param is invariant. We can't just check givenKeyParam == targetKeyParam because of Unknown type which is a kind of wildcard
           condNel(
-            isAssignable(givenKeyParam, targetKeyParam).isValid && (isAssignable(
-              targetKeyParam,
-              givenKeyParam
-            ).isValid || targetKeyParam.isUnknown),
+            isAssignable(givenKeyParam, targetKeyParam).isValid &&
+              isAssignable(targetKeyParam, givenKeyParam).isValid,
             (),
             s"Key types of Maps ${givenKeyParam.display} and ${targetKeyParam.display} are not equals"
           ) andThen { _ =>

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/CommonSupertypeFinder.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/CommonSupertypeFinder.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.engine.api.typed.supertype
 
 import cats.data.NonEmptyList
 import cats.implicits.toTraverseOps
+import pl.touk.nussknacker.engine.api.typed.StandardTypesClasses._
 import pl.touk.nussknacker.engine.api.typed.supertype.CommonSupertypeFinder.{
   looseFinder,
   SupertypeClassResolutionStrategy
@@ -66,22 +67,29 @@ class CommonSupertypeFinder private (classResolutionStrategy: SupertypeClassReso
       case (l, r) if l == r => Some(l)
       // TODO We can't do at the beginning if (l.canBeSubclassOf(r) => Some(l) and the same in opposite direction
       //      because canBeSubclassOf handles conversions and many more - see comment next to it
-      case (l: TypedClass, r: TypedClass)                           => classCommonSupertype(l, r)
+      case (l: TypedClass, r: TypedClass) => classCommonSupertype(l, r)
       case (l: TypedObjectTypingResult, r: TypedObjectTypingResult) =>
-        // In most cases we compare java.util.Map or GenericRecord, the only difference can be on generic params, but
-        // still we'll got a class here, so this getOrElse should occur in the rare situations
-        looseFinder
-          .classCommonSupertypeReturningTypedClass(l.runtimeObjType, r.runtimeObjType)
-          .map { commonSupertype =>
-            val fields = prepareFields(l, r)
-            // We don't return None in case when fields are empty, because we can't be sure the intention of the user
-            // e.g. someone can pass json object with missing field declared as optional in schema
-            // and want to compare it with literal record that doesn't have this field
-            Typed.record(fields, commonSupertype)
+        handleEmptyRecords(l, r)
+          .orElse {
+            // In most cases we compare java.util.Map or GenericRecord, the only difference can be on generic params, but
+            // still we'll got a class here, so this getOrElse should occur in the rare situations
+            looseFinder
+              .classCommonSupertypeReturningTypedClass(l.runtimeObjType, r.runtimeObjType)
+              .map { commonSupertype =>
+                val fields = prepareFields(l, r)
+                // We don't return None in case when fields are empty, because we can't be sure the intention of the user
+                // e.g. someone can pass json object with missing field declared as optional in schema
+                // and want to compare it with literal record that doesn't have this field
+                Typed.record(fields, commonSupertype)
+              }
           }
           .orElse(fallback)
-      case (l: TypedObjectTypingResult, r) => singleCommonSupertype(l.runtimeObjType, r)
-      case (l, r: TypedObjectTypingResult) => singleCommonSupertype(l, r.runtimeObjType)
+      case (l: TypedObjectTypingResult, r) =>
+        handleEmptyRecord(l, r)
+          .orElse(singleCommonSupertype(l.runtimeObjType, r))
+      case (l, r: TypedObjectTypingResult) =>
+        handleEmptyRecord(r, l)
+          .orElse(singleCommonSupertype(l, r.runtimeObjType))
       case (TypedTaggedValue(leftType, leftTag), TypedTaggedValue(rightType, rightTag)) if leftTag == rightTag =>
         singleCommonSupertype(leftType, rightType).map {
           case single: SingleTypingResult => TypedTaggedValue(single, leftTag)
@@ -95,10 +103,14 @@ class CommonSupertypeFinder private (classResolutionStrategy: SupertypeClassReso
           case typedClass: TypedClass => TypedObjectWithValue(typedClass, leftValue)
           case other                  => other
         }
-      case (l: TypedObjectWithValue, r) => singleCommonSupertype(l.underlying, r)
-      case (l, r: TypedObjectWithValue) => singleCommonSupertype(l, r.underlying)
-      case (_: TypedDict, _)            => fallback
-      case (_, _: TypedDict)            => fallback
+      case (l: TypedObjectWithValue, r) =>
+        handleEmptyList(l, r)
+          .orElse(singleCommonSupertype(l.underlying, r))
+      case (l, r: TypedObjectWithValue) =>
+        handleEmptyList(r, l)
+          .orElse(singleCommonSupertype(r.underlying, l))
+      case (_: TypedDict, _) => fallback
+      case (_, _: TypedDict) => fallback
     }
   }
 
@@ -182,6 +194,72 @@ class CommonSupertypeFinder private (classResolutionStrategy: SupertypeClassReso
     classResolutionStrategy match {
       case SupertypeClassResolutionStrategy.Intersection                  => result
       case SupertypeClassResolutionStrategy.LooseWithFallbackToObjectType => result.orElse(Some(Unknown))
+    }
+  }
+
+  private def handleEmptyRecords(
+      left: TypedObjectTypingResult,
+      right: TypedObjectTypingResult
+  ) = {
+    Option
+      .when(isEmptyRecordLiteral(left))(right)
+      .orElse(Option.when(isEmptyRecordLiteral(right))(left))
+  }
+
+  private def handleEmptyList(
+      typedObjectWithValue: TypedObjectWithValue,
+      other: SingleTypingResult
+  ): Option[TypedClass] = {
+    asListClass(other).filter(_ => isEmptyListLiteral(typedObjectWithValue))
+  }
+
+  private def handleEmptyRecord(
+      typedObjectWithValue: TypedObjectTypingResult,
+      other: SingleTypingResult
+  ): Option[TypedClass] = {
+    asMapClass(other).filter(_ => isEmptyRecordLiteral(typedObjectWithValue))
+  }
+
+  private def isEmptyListLiteral(typedObjectWithValue: TypedObjectWithValue): Boolean = {
+    (for {
+      _ <- asListClass(typedObjectWithValue).filter { typedClass =>
+        typedClass.params.forall(_.isUnknown)
+      }
+      isEmptyList <- Option(typedObjectWithValue.value).map {
+        case list: java.util.List[_] => list.isEmpty
+        case _                       => false
+      }
+    } yield isEmptyList).contains(true)
+  }
+
+  private def isEmptyRecordLiteral(typedObjectTypingResult: TypedObjectTypingResult) = {
+    val expectedRecordRuntimeType = Typed.genericTypeClass(
+      MapClass,
+      List(Typed.typedClass[String], Unknown)
+    )
+    typedObjectTypingResult.fields.isEmpty && typedObjectTypingResult.runtimeObjType == expectedRecordRuntimeType
+  }
+
+  private def asListClass(typingResult: SingleTypingResult) = {
+    extractTypedClass(typingResult)
+      .collect {
+        case tc @ TypedClass(clazz, List(_)) if ListClass.isAssignableFrom(clazz) => tc
+      }
+  }
+
+  private def asMapClass(typingResult: SingleTypingResult) = {
+    extractTypedClass(typingResult)
+      .collect {
+        case tc @ TypedClass(clazz, List(_, _)) if MapClass.isAssignableFrom(clazz) => tc
+      }
+  }
+
+  private def extractTypedClass(t: SingleTypingResult): Option[TypedClass] = {
+    t match {
+      case tc: TypedClass              => Some(tc)
+      case tc: TypedObjectWithValue    => Some(tc.underlying)
+      case tc: TypedObjectTypingResult => Some(tc.runtimeObjType)
+      case _                           => None
     }
   }
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/CommonSupertypeFinder.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/supertype/CommonSupertypeFinder.scala
@@ -233,11 +233,7 @@ class CommonSupertypeFinder private (classResolutionStrategy: SupertypeClassReso
   }
 
   private def isEmptyRecordLiteral(typedObjectTypingResult: TypedObjectTypingResult) = {
-    val expectedRecordRuntimeType = Typed.genericTypeClass(
-      MapClass,
-      List(Typed.typedClass[String], Unknown)
-    )
-    typedObjectTypingResult.fields.isEmpty && typedObjectTypingResult.runtimeObjType == expectedRecordRuntimeType
+    typedObjectTypingResult == emptyRecord
   }
 
   private def asListClass(typingResult: SingleTypingResult) = {
@@ -262,6 +258,8 @@ class CommonSupertypeFinder private (classResolutionStrategy: SupertypeClassReso
       case _                           => None
     }
   }
+
+  private val emptyRecord: SingleTypingResult = Typed.record(List.empty)
 
 }
 

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
@@ -7,11 +7,12 @@ import io.circe.{Decoder, Encoder}
 import org.apache.commons.lang3.ClassUtils
 import pl.touk.nussknacker.engine.api.json.encoders.TypeEncoders
 import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.{Loose, Strict}
-import pl.touk.nussknacker.engine.api.typed.StandardTypesClasses.{ArrayClass, ListClass}
+import pl.touk.nussknacker.engine.api.typed.StandardTypesClasses._
 import pl.touk.nussknacker.engine.api.typed.supertype.CommonSupertypeFinder.Default.superTypeOfTypes
 import pl.touk.nussknacker.engine.api.typed.typing.DisplayStrategy.{DefaultDisplayStrategy, JsonDisplayStrategy}
 import pl.touk.nussknacker.engine.api.util.{NotNothing, ReflectUtils}
 
+import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
 import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
@@ -424,8 +425,94 @@ object typing {
         case Some(Nil)                                             =>
           // It shouldn't happen because only TypedNull can be translated into Set.empty
           throw new IllegalStateException(s"Typed(${possibleTypes.toList.mkString(", ")}) flatten to empty list")
-        case Some(single :: Nil)           => single
-        case Some(first :: second :: rest) => new TypedUnion(first, second, rest)
+        case Some(single :: Nil) => single
+        case Some(atLeastTwoTypes) =>
+          reduceTypes(NonEmptyList.fromListUnsafe(atLeastTwoTypes)) match {
+            case NonEmptyList(single, Nil) =>
+              single
+            case NonEmptyList(first, second :: rest) =>
+              new TypedUnion(first, second, rest)
+          }
+      }
+    }
+
+    @tailrec
+    private def reduceTypes(types: NonEmptyList[SingleTypingResult]): NonEmptyList[SingleTypingResult] = {
+      def tryReduce(
+          isEmptyCollectionLiteral: SingleTypingResult => Boolean,
+          findMatchingType: SingleTypingResult => Option[SingleTypingResult]
+      ): Option[NonEmptyList[SingleTypingResult]] = {
+        val indexedTypes                = types.toList.zipWithIndex
+        val (emptyTypes, nonEmptyTypes) = indexedTypes.partition { case (t, _) => isEmptyCollectionLiteral(t) }
+        for {
+          (_, emptyIdx)             <- emptyTypes.headOption
+          (candidate, candidateIdx) <- nonEmptyTypes.find { case (t, _) => findMatchingType(t).isDefined }
+        } yield {
+          val updated = types.toList.updated(candidateIdx, candidate.withoutValue)
+          val result  = updated.patch(emptyIdx, Nil, 1)
+          NonEmptyList.fromListUnsafe(result)
+        }
+      }
+
+      tryReduce(isEmptyListLiteral, findListOrNonEmptyListLiteral)
+        .orElse(tryReduce(isEmptyRecordLiteral, findNonEmptyRecord))
+        .orElse(tryReduce(isEmptyRecordLiteral, findMap)) match {
+        case Some(reducedTypes) => reduceTypes(reducedTypes)
+        case None               => types
+      }
+    }
+
+    private def isEmptyListLiteral(typingResult: SingleTypingResult): Boolean = {
+      typingResult match {
+        case TypedObjectWithValue(TypedClass(clazz, List(componentType)), value: java.util.List[_])
+            if ListClass.isAssignableFrom(clazz) && value.isEmpty && componentType.isUnknown =>
+          true
+        case _ =>
+          false
+      }
+    }
+
+    private def findListOrNonEmptyListLiteral(typingResult: SingleTypingResult): Option[SingleTypingResult] = {
+      typingResult match {
+        case tr @ TypedObjectWithValue(TypedClass(clazz, List(_)), value: java.util.List[_])
+            if ListClass.isAssignableFrom(clazz) && !value.isEmpty =>
+          Some(tr)
+        case tr @ TypedClass(clazz, List(_)) if ListClass.isAssignableFrom(clazz) =>
+          Some(tr)
+        case _ =>
+          None
+      }
+    }
+
+    private def findNonEmptyRecord(typingResult: SingleTypingResult): Option[SingleTypingResult] = {
+      typingResult match {
+        case tr @ TypedObjectTypingResult(
+              fields,
+              TypedClass(clazz, List(TypedClass(`StringClass`, Nil), _)),
+              _
+            ) if fields.nonEmpty && MapClass.isAssignableFrom(clazz) =>
+          Some(tr)
+        case _ =>
+          None
+      }
+    }
+
+    private def findMap(typingResult: SingleTypingResult): Option[SingleTypingResult] = {
+      typingResult match {
+        case tr @ TypedClass(clazz, List(_, _)) if MapClass.isAssignableFrom(clazz) =>
+          Some(tr)
+        case _ =>
+          None
+      }
+    }
+
+    private def isEmptyRecordLiteral(typingResult: SingleTypingResult): Boolean = {
+      typingResult match {
+        case TypedObjectTypingResult(fields, TypedClass(clazz, List(TypedClass(`StringClass`, Nil), Unknown(_))), _)
+            if fields.isEmpty && MapClass.isAssignableFrom(clazz) =>
+          true
+        case _ =>
+          false
       }
     }
 
@@ -466,6 +553,17 @@ object typing {
 
   trait TypedFromInstance {
     def typingResult: TypingResult
+  }
+
+  private[engine] implicit class TypingResultOps(val typingResult: TypingResult) extends AnyVal {
+
+    def isUnknown: Boolean = {
+      typingResult match {
+        case Unknown(_) => true
+        case _          => false
+      }
+    }
+
   }
 
   case class CastTypedValue[T: TypeTag]() {

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/typed/typing.scala
@@ -507,14 +507,10 @@ object typing {
     }
 
     private def isEmptyRecordLiteral(typingResult: SingleTypingResult): Boolean = {
-      typingResult match {
-        case TypedObjectTypingResult(fields, TypedClass(clazz, List(TypedClass(`StringClass`, Nil), Unknown(_))), _)
-            if fields.isEmpty && MapClass.isAssignableFrom(clazz) =>
-          true
-        case _ =>
-          false
-      }
+      typingResult == emptyRecord
     }
+
+    private val emptyRecord: TypedObjectTypingResult = record(List.empty)
 
     def record(fields: Iterable[(String, TypingResult)]): TypedObjectTypingResult =
       TypedObjectTypingResult(ListMap(fields.toSeq: _*), mapBasedRecordUnderlyingType[java.util.Map[_, _]](fields))

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
@@ -5,14 +5,12 @@ import org.scalatest.{Inside, OptionValues}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.Strict
 import pl.touk.nussknacker.engine.api.typed.supertype.{CommonSupertypeFinder, NumberTypesPromotionStrategy}
 import pl.touk.nussknacker.engine.api.typed.typing._
 
 import java.time.{LocalDate, LocalDateTime}
 import java.util
 import java.util.{Collections, Currency}
-import scala.jdk.CollectionConverters.IterableHasAsJava
 
 // TODO: clean-up, split tests for Intersection (equals operator), Default (ternary), number promotion, can be subclass etc.
 class TypingResultSpec

--- a/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
+++ b/components-api/src/test/scala/pl/touk/nussknacker/engine/api/typed/TypingResultSpec.scala
@@ -5,12 +5,14 @@ import org.scalatest.{Inside, OptionValues}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import pl.touk.nussknacker.engine.api.typed.ConversionStrategy.Strict
 import pl.touk.nussknacker.engine.api.typed.supertype.{CommonSupertypeFinder, NumberTypesPromotionStrategy}
 import pl.touk.nussknacker.engine.api.typed.typing._
 
 import java.time.{LocalDate, LocalDateTime}
 import java.util
-import java.util.Currency
+import java.util.{Collections, Currency}
+import scala.jdk.CollectionConverters.IterableHasAsJava
 
 // TODO: clean-up, split tests for Intersection (equals operator), Default (ternary), number promotion, can be subclass etc.
 class TypingResultSpec
@@ -91,6 +93,24 @@ class TypingResultSpec
 
     Unknown.canBeLooselyAssignedTo(typeMap("field1" -> Typed[String])) shouldBe true
     typeMap("field1" -> Typed[String]).canBeLooselyAssignedTo(Unknown) shouldBe true
+  }
+
+  test("determine if empty collections can be assigned to collection of any type") {
+    val stringList  = Typed.genericTypeClass(classOf[java.util.List[_]], List(Typed.fromDetailedType[String]))
+    val unknownList = Typed.genericTypeClass(classOf[java.util.List[_]], List(Unknown))
+    val emptyList   = Typed.fromInstance(Collections.emptyList())
+
+    emptyList.canBeLooselyAssignedTo(stringList) shouldBe true
+    emptyList.canBeLooselyAssignedTo(unknownList) shouldBe true
+    unknownList.canBeLooselyAssignedTo(stringList) shouldBe true
+
+    val emptyMap   = Typed.fromInstance(Collections.EMPTY_MAP)
+    val stringMap  = Typed.fromDetailedType[java.util.Map[String, String]]
+    val unknownMap = Typed.fromDetailedType[java.util.Map[String, Any]]
+
+    emptyMap.canBeLooselyAssignedTo(stringMap) shouldBe true
+    emptyMap.canBeLooselyAssignedTo(unknownMap) shouldBe true
+    unknownMap.canBeLooselyAssignedTo(stringMap) shouldBe true
   }
 
   test("determine if can be assigned for class") {
@@ -272,20 +292,72 @@ class TypingResultSpec
         Typed.fromDetailedType[util.List[String]],
         Typed.fromDetailedType[util.Collection[Integer]]
       ) shouldEqual Typed.genericTypeClass[util.Collection[_]](List(Unknown))
+
+    CommonSupertypeFinder.Default
+      .commonSupertype(
+        Typed.fromDetailedType[util.List[String]],
+        Typed.typedListWithElementValues(Unknown, Collections.EMPTY_LIST)
+      ) shouldEqual Typed.genericTypeClass[util.List[_]](List(Typed[String]))
+
+    CommonSupertypeFinder.Default
+      .commonSupertype(
+        Typed.fromDetailedType[util.List[String]],
+        Typed.typedListWithElementValues(Typed[String], Collections.emptyList[String])
+      ) shouldEqual Typed.genericTypeClass[util.List[_]](List(Typed[String]))
+
     val tupleIterable = Typed.fromDetailedType[Iterable[(String, Integer)]]
-    val map           = Typed.fromDetailedType[Map[String, Integer]]
+    val scalaMap      = Typed.fromDetailedType[Map[String, Integer]]
+    val javaMap       = Typed.fromDetailedType[java.util.Map[String, Integer]]
+    val record        = Typed.record(List("a" -> Typed[String]))
+    val emptyRecord   = Typed.record(List.empty)
+
     intersectionSuperTypeFinder
       .commonSupertypeOpt(
-        map,
+        scalaMap,
         tupleIterable
       )
       .value shouldEqual tupleIterable
     intersectionSuperTypeFinder
       .commonSupertypeOpt(
         tupleIterable,
-        map,
+        scalaMap,
       )
       .value shouldEqual tupleIterable
+    intersectionSuperTypeFinder
+      .commonSupertypeOpt(
+        tupleIterable,
+        javaMap,
+      ) shouldEqual None
+
+    CommonSupertypeFinder.Default
+      .commonSupertype(
+        record,
+        emptyRecord
+      ) shouldEqual record
+
+    CommonSupertypeFinder.Default
+      .commonSupertype(
+        emptyRecord,
+        record
+      ) shouldEqual record
+
+    CommonSupertypeFinder.Default
+      .commonSupertype(
+        javaMap,
+        emptyRecord
+      ) shouldEqual javaMap
+
+    CommonSupertypeFinder.Default
+      .commonSupertype(
+        emptyRecord,
+        javaMap,
+      ) shouldEqual javaMap
+
+    CommonSupertypeFinder.Default
+      .commonSupertype(
+        javaMap,
+        record
+      ) shouldEqual Typed.fromDetailedType[java.util.Map[String, Any]]
   }
 
   test("common supertype for not matching classes") {
@@ -405,6 +477,7 @@ class TypingResultSpec
 
   test("should correctly handle standard java collections") {
     Typed(classOf[java.util.List[_]]) shouldEqual Typed.fromDetailedType[java.util.List[Any]]
+    Typed(classOf[java.util.Set[_]]) shouldEqual Typed.fromDetailedType[java.util.Set[Any]]
     Typed(classOf[java.util.Map[_, _]]) shouldEqual Typed.fromDetailedType[java.util.Map[Any, Any]]
     an[IllegalArgumentException] shouldBe thrownBy {
       Typed.genericTypeClass(classOf[java.util.List[_]], List.empty)

--- a/designer/client/cypress/e2e/fragment.cy.ts
+++ b/designer/client/cypress/e2e/fragment.cy.ts
@@ -304,7 +304,7 @@ describe("Fragment", () => {
 
             // Expression should be clear after switch
             cy.get("@anyValueWithSuggestionField").should("have.value", "");
-            cy.get("@anyValueWithSuggestionField").find("#ace-editor").type("#RGB.Black");
+            cy.get("@anyValueWithSuggestionField").find("#ace-editor").type("'H000000'");
 
             cy.intercept("POST", "/api/nodes/*/validation").as("validation");
             cy.wait("@validation");
@@ -356,7 +356,7 @@ describe("Fragment", () => {
 
             // Verify if Frontend received correct data after save
             cy.openNodeWindow("@fragmentName");
-            cy.get('[title="any_value_with_suggestions_preset"]').siblings().eq(0).find("#ace-editor").contains("#RGB.Black");
+            cy.get('[title="any_value_with_suggestions_preset"]').siblings().eq(0).find("#ace-editor").contains("'H000000'");
             cy.get("@window").get("[title='test5']").should("not.exist");
 
             cy.applyNodeChanges();

--- a/designer/client/cypress/e2e/fragment.cy.ts
+++ b/designer/client/cypress/e2e/fragment.cy.ts
@@ -304,7 +304,7 @@ describe("Fragment", () => {
 
             // Expression should be clear after switch
             cy.get("@anyValueWithSuggestionField").should("have.value", "");
-            cy.get("@anyValueWithSuggestionField").find("#ace-editor").type("#RGB()");
+            cy.get("@anyValueWithSuggestionField").find("#ace-editor").type("#RGB.Black");
 
             cy.intercept("POST", "/api/nodes/*/validation").as("validation");
             cy.wait("@validation");
@@ -356,7 +356,7 @@ describe("Fragment", () => {
 
             // Verify if Frontend received correct data after save
             cy.openNodeWindow("@fragmentName");
-            cy.get('[title="any_value_with_suggestions_preset"]').siblings().eq(0).find("#ace-editor").contains("#RGB()");
+            cy.get('[title="any_value_with_suggestions_preset"]').siblings().eq(0).find("#ace-editor").contains("#RGB.Black");
             cy.get("@window").get("[title='test5']").should("not.exist");
 
             cy.applyNodeChanges();

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -328,11 +328,17 @@ description: Stay informed with detailed changelogs covering new features, impro
   * `/processManagement/testCase/{scenarioName}` endpoint to `/scenarioTesting/{scenarioName)/performTestCase`
   * `/processManagement/test/{scenarioName}` to multipart variant of `/scenarioTesting/{scenarioName}/performTest`
 * [#8943](https://github.com/TouK/nussknacker/pull/8943) Replaced `spring-jcl` library with contemporary version of `commons-logging` 
-* [#9037](https://github.com/TouK/nussknacker/pull/9037) Improvments to Table Source and Table Sink components:
+* [#9037](https://github.com/TouK/nussknacker/pull/9037) Improvements to Table Source and Table Sink components:
   * Optimized table discovery through configurable caching (especially important for catalogs for systems with slow connections)
   * More precise validation and error messages during scenario authoring
   * Fixed bug for non-deterministic validation multiple validations were performent at the same time
 * [#9095](https://github.com/TouK/nussknacker/pull/9095) Always close `SttpBackend` instances in OpenAPI services
+* [#9096](https://github.com/TouK/nussknacker/pull/9096) Improvements to SpEL expressions typing:
+  * Ternary and Elvis operators (`?:`) now preserve list and map/record types
+  * Empty collections (`{}`, `{:}`) are universal and assignable to any list/map/record
+  * Dynamic record indexing returns value type instead of `Unknown`
+  * Limited support for function references in SpEL
+  * Improved typing for properties derived from `Unknown` values
 
 ## 1.18
 

--- a/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkScenarioJobSpec.scala
+++ b/engine/flink/executor/src/test/scala/pl/touk/nussknacker/engine/process/runner/FlinkScenarioJobSpec.scala
@@ -28,8 +28,8 @@ class FlinkScenarioJobSpec extends AnyFlatSpec with Matchers with Inside with Be
         ScenarioBuilder
           .streaming("proc1")
           .source("id", "input")
-          .filter("filter1", "#sum(#input.![value1]) > 24".spel)
-          .processor("proc2", "logService", "all" -> "#distinct(#input.![value2])".spel)
+          .filter("filter1", "#input.value1 > 24".spel)
+          .processor("proc2", "logService", "all" -> "#input.value2".spel)
           .emptySink("out", "monitor")
 
       val modelData = LocalModelData(ConfigFactory.empty(), List.empty, configCreator = new SimpleProcessConfigCreator)

--- a/examples/dev/local-testing.docker-compose.yml
+++ b/examples/dev/local-testing.docker-compose.yml
@@ -37,7 +37,7 @@ services:
       interval: 10s
       retries: 10
     volumes:
-      - nussknacker_designer_data:/var/lib/postgresql/data
+      - nussknacker_designer_data:/var/lib/postgresql
     deploy:
       resources:
         limits:

--- a/examples/dev/local-testing.docker-compose.yml
+++ b/examples/dev/local-testing.docker-compose.yml
@@ -37,7 +37,7 @@ services:
       interval: 10s
       retries: 10
     volumes:
-      - nussknacker_designer_data:/var/lib/postgresql
+      - nussknacker_designer_data:/var/lib/postgresql/data
     deploy:
       resources:
         limits:

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelTyper.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelTyper.scala
@@ -221,8 +221,8 @@ private[spel] class SpelTyper(
     }
 
     def getRecordValueType(record: TypedObjectTypingResult) = {
-      val fieldValues = record.withoutValue.fields.values
-      CommonSupertypeFinder.Default.superTypeOfTypes(fieldValues)
+      val fieldTypes = record.withoutValue.fields.values
+      CommonSupertypeFinder.Default.superTypeOfTypes(fieldTypes)
     }
 
     def catchUnexpectedErrors(block: => NodeTypingResult): NodeTypingResult = Try(block) match {

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelTyper.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelTyper.scala
@@ -220,6 +220,11 @@ private[spel] class SpelTyper(
       }
     }
 
+    def getRecordValueType(record: TypedObjectTypingResult) = {
+      val fieldValues = record.withoutValue.fields.values
+      CommonSupertypeFinder.Default.superTypeOfTypes(fieldValues)
+    }
+
     def catchUnexpectedErrors(block: => NodeTypingResult): NodeTypingResult = Try(block) match {
       case Success(value) =>
         value
@@ -241,10 +246,13 @@ private[spel] class SpelTyper(
         record: TypedObjectTypingResult
     ): TypingR[TypingResult] = {
       val fieldIndexedByLiteralStringOpt = record.fields.find(_._1 == indexString)
-      fieldIndexedByLiteralStringOpt.map(f => f._2.validTypingResult).getOrElse {
-        if (dynamicPropertyAccessAllowed) Unknown.validTypingResult
-        else NoPropertyError(record, indexString).invalidTypingResult()
-      }
+      fieldIndexedByLiteralStringOpt
+        .map(f => f._2.validTypingResult)
+        .getOrElse {
+          if (dynamicPropertyAccessAllowed) {
+            getRecordValueType(record).validTypingResult
+          } else NoPropertyError(record, indexString).invalidTypingResult()
+        }
     }
 
     def typeIndexerOnRecord(indexer: Indexer, record: TypedObjectTypingResult) = {
@@ -256,7 +264,7 @@ private[spel] class SpelTyper(
             case _                                      => typeFieldNameReferenceOnRecord(indexString, record)
           }
         case indexKey :: Nil if indexKey.canBeLooselyAssignedTo(Typed[String]) =>
-          if (dynamicPropertyAccessAllowed) Unknown.validTypingResult
+          if (dynamicPropertyAccessAllowed) getRecordValueType(record).validTypingResult
           else
             record.runtimeObjType.params match {
               case _ :: value :: Nil if record.runtimeObjType.klass == MapClass =>
@@ -391,7 +399,9 @@ private[spel] class SpelTyper(
       case u: Unknown =>
         val w = Writer.value[List[SpelExpressionTypingErrorWithTextRange], TypingResult](u)
         if (anyMethodExecutionForUnknownAllowed) {
-          w
+          unknownPropertyTypeBasedOnMethod(e, u)
+            .map(_.validTypingResult)
+            .getOrElse(w)
         } else {
           // we allow some methods to be used on unknown
           unknownPropertyTypeBasedOnMethod(e, u)
@@ -552,8 +562,19 @@ private[spel] class SpelTyper(
               s"Illegal construction of elvis. Found ${other.size} children, but 2 children expected"
             )
         }
-      // TODO: what should be here?
-      case e: FunctionReference => Unknown.validNodeResult
+      // The only valid case in NU seems to be a call to a method defined in global variables
+      case e: FunctionReference =>
+        val functionName = e.toStringAST.stripPrefix("#").takeWhile(_ != '(')
+        validationContext
+          .get(functionName)
+          .flatMap {
+            case TypedClass(clazz, List()) if classOf[java.lang.reflect.Method].isAssignableFrom(clazz) =>
+              Some(Unknown.validNodeResult)
+            case _ =>
+              None
+          }
+          .toRight(UnresolvedReferenceError(functionName).invalidNodeResult)
+          .merge
 
       // TODO: what should be here?
       case e: Identifier => Unknown.validNodeResult

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelTyper.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/SpelTyper.scala
@@ -567,14 +567,13 @@ private[spel] class SpelTyper(
         val functionName = e.toStringAST.stripPrefix("#").takeWhile(_ != '(')
         validationContext
           .get(functionName)
-          .flatMap {
+          .map {
             case TypedClass(clazz, List()) if classOf[java.lang.reflect.Method].isAssignableFrom(clazz) =>
-              Some(Unknown.validNodeResult)
-            case _ =>
-              None
+              Unknown.validNodeResult
+            case other =>
+              IllegalInvocationError(other).invalidNodeResult
           }
-          .toRight(UnresolvedReferenceError(functionName).invalidNodeResult)
-          .merge
+          .getOrElse(UnresolvedReferenceError(functionName).invalidNodeResult)
 
       // TODO: what should be here?
       case e: Identifier => Unknown.validNodeResult

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/typer/MethodReferenceTyper.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/spel/typer/MethodReferenceTyper.scala
@@ -126,6 +126,9 @@ class MethodReferenceTyper(classDefinitionSet: ClassDefinitionSet, methodExecuti
         xs.map(_._2.asInstanceOf[ArgumentTypeError]).toList.reduce(combineArgumentTypeErrors)
       case NonEmptyList(head, Nil) =>
         head._2
+      case xs @ NonEmptyList(_, _) if xs.toList.exists(!_._2.isInstanceOf[ArgumentTypeError]) =>
+        // In an overloaded generic method, if one of the method signatures is matched, the error may be more detailed than OverloadedFunctionError
+        xs.filterNot(_._2.isInstanceOf[ArgumentTypeError]).head._2
       case _ =>
         OverloadedFunctionError
     }

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -284,7 +284,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     ) shouldBe 100
   }
 
-  test("should type toString on unknown") {
+  test("should type conversion methods on unknown") {
     parse[String](
       "#unknownString.value.toString",
       methodExecutionForUnknownAllowed = true
@@ -399,7 +399,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
       Typed.genericTypeClass[java.util.Map[_, _]](List(Typed[String], Typed[String]))
   }
 
-  test("should allow access element type on array4") {
+  test("should allow access element type on array") {
     parse[java.lang.Integer](
       "#intArray[0]",
     ).validExpression.returnType shouldBe Typed[java.lang.Integer]

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -320,10 +320,18 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     }
   }
 
-  test("function reference with unknown reference should be forbidden") {
-    val errors = parse[Any]("#get()").invalidValue
-    errors should matchPattern {
-      case NonEmptyList(SpelExpressionTypingParseError(UnresolvedReferenceError("get"), _), _) =>
+  test("function reference with unknown reference should return an error") {
+    inside(parse[Any]("#get()")) {
+      case Invalid(NonEmptyList(SpelExpressionTypingParseError(UnresolvedReferenceError("get"), _), _)) =>
+    }
+  }
+
+  test(
+    "function reference with known reference should return an error when it is not used with the java.lang.reflect.Method instance"
+  ) {
+    inside(parse[Any]("#mapValue()")) {
+      case Invalid(NonEmptyList(SpelExpressionTypingParseError(e: IllegalInvocationError, _), _)) =>
+        e.message shouldBe "Method invocation on Record{foo: String(bar)} is not allowed"
     }
   }
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/spel/SpelExpressionSpec.scala
@@ -46,13 +46,12 @@ import pl.touk.nussknacker.engine.spel.SpelExpressionParseError.{
   SpelExpressionTypingParseError,
   SpelExpressionUnderlyingParserError
 }
-import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.{ArgumentTypeError, GenericFunctionError}
-import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.IllegalOperationError.{
-  IllegalInvocationError,
-  IllegalProjectionSelectionError,
-  InvalidMethodReference,
-  TypeReferenceError
+import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.{
+  ArgumentTypeError,
+  GenericFunctionError,
+  MissingObjectError
 }
+import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.IllegalOperationError._
 import pl.touk.nussknacker.engine.spel.SpelExpressionTypingError.MissingObjectError.{
   NoPropertyError,
   UnknownClassError,
@@ -98,7 +97,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
 
     def evaluateSync[T](ctx: Context = ctx, skipReturnTypeCheck: Boolean = false): T = {
       val evaluationResult = expression.expression.evaluate[T](ctx, Map.empty)
-      expression.typingInfo.typingResult match {
+      expression.returnType match {
         case result: SingleTypingResult if evaluationResult != null && !skipReturnTypeCheck =>
           result.runtimeObjType.klass isAssignableFrom evaluationResult.getClass shouldBe true
         case _ =>
@@ -285,9 +284,135 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
     ) shouldBe 100
   }
 
+  test("should type toString on unknown") {
+    parse[String](
+      "#unknownString.value.toString",
+      methodExecutionForUnknownAllowed = true
+    ).validExpression.returnType shouldBe Typed[String]
+
+    parse[java.lang.Long](
+      "#unknownString.value.toLong",
+      methodExecutionForUnknownAllowed = true
+    ).validExpression.returnType shouldBe Typed[java.lang.Long]
+
+    parse[Object](
+      "#unknownString.value.toDummyValue",
+      methodExecutionForUnknownAllowed = true
+    ).validExpression.returnType shouldBe Typed[Object]
+
+    parse[String](
+      "#unknownString.value.toString",
+      methodExecutionForUnknownAllowed = false
+    ).validExpression.returnType shouldBe Typed[String]
+
+    parse[java.lang.Long](
+      "#unknownString.value.toLong",
+      methodExecutionForUnknownAllowed = false
+    ).validExpression.returnType shouldBe Typed[java.lang.Long]
+
+    inside(
+      parse[Object](
+        "#unknownString.value.toDummyValue",
+        methodExecutionForUnknownAllowed = false
+      )
+    ) { case Invalid(NonEmptyList(SpelExpressionTypingParseError(error: IllegalPropertyAccessError, _), Nil)) =>
+      error.message shouldBe "Property access on Unknown is not allowed"
+    }
+  }
+
+  test("function reference with unknown reference should be forbidden") {
+    val errors = parse[Any]("#get()").invalidValue
+    errors should matchPattern {
+      case NonEmptyList(SpelExpressionTypingParseError(UnresolvedReferenceError("get"), _), _) =>
+    }
+  }
+
+  test("ternary operator should work for list and arrays") {
+    parse[java.util.List[String]](
+      "true ? {'a'} : {}",
+    ).validExpression.returnType shouldBe Typed.genericTypeClass[java.util.List[_]](List(Typed[String]))
+
+    parse[java.util.List[java.lang.Integer]](
+      "true ? #processHelper.listOfInteger : {}",
+      ctxWithGlobal
+    ).validExpression.returnType shouldBe Typed
+      .genericTypeClass[java.util.List[_]](List(Typed[java.lang.Integer]))
+
+    parse[Any]("({'1', '2'} ?: {}) ?: '123'", ctxWithGlobal).validExpression.returnType shouldBe
+      Typed(
+        NonEmptyList.of(
+          Typed.genericTypeClass[java.util.List[_]](List(Typed[String])),
+          TypedObjectWithValue(Typed.typedClass[String], "123")
+        )
+      )
+  }
+
+  test("elvis operator should work for list and arrays") {
+    parse[java.util.List[String]](
+      "{'a'} ?: {}",
+    ).validExpression.returnType shouldBe Typed.genericTypeClass[java.util.List[_]](List(Typed[String]))
+
+    parse[java.util.List[Int]](
+      "#intArray ?: {}",
+    ).validExpression.returnType shouldBe Typed.genericTypeClass[java.util.List[_]](List(Typed[Int]))
+
+    parse[java.util.List[java.lang.Integer]](
+      "#processHelper.listOfInteger ?: {}",
+      ctxWithGlobal
+    ).validExpression.returnType shouldBe Typed
+      .genericTypeClass[java.util.List[_]](List(Typed[java.lang.Integer]))
+  }
+
+  test("elvis operator should work for maps and records") {
+    parse[java.util.Map[String, java.lang.Integer]](
+      "{'a': 1} ?: {:}",
+    ).validExpression.returnType shouldBe Typed.record(List("a" -> Typed[java.lang.Integer]))
+
+    parse[java.util.Map[String, String]](
+      "#processHelper.stringOnStringMap ?: {:}",
+      ctxWithGlobal
+    ).validExpression.returnType shouldBe
+      Typed.genericTypeClass[java.util.Map[_, _]](List(Typed[String], Typed[String]))
+  }
+
+  test("ternary operator should work for maps and records") {
+    parse[java.util.Map[String, java.lang.Integer]](
+      "true ? {'a': 1} : {:}",
+    ).validExpression.returnType shouldBe Typed.record(List("a" -> Typed.fromInstance(1)))
+
+    parse[java.util.Map[String, java.lang.Integer]](
+      "true ? {'a': 1} : {'a': 2}",
+    ).validExpression.returnType shouldBe Typed.record(List("a" -> Typed[java.lang.Integer]))
+
+    parse[java.util.Map[String, String]](
+      "true ? #processHelper.stringOnStringMap : {:}",
+      ctxWithGlobal
+    ).validExpression.returnType shouldBe
+      Typed.genericTypeClass[java.util.Map[_, _]](List(Typed[String], Typed[String]))
+  }
+
+  test("should allow access element type on array4") {
+    parse[java.lang.Integer](
+      "#intArray[0]",
+    ).validExpression.returnType shouldBe Typed[java.lang.Integer]
+
+    parse[java.lang.Integer](
+      "#intArray[#intArray.size % 2]",
+    ).validExpression.returnType shouldBe Typed[java.lang.Integer]
+  }
+
   test("parsing first selection on array") {
     parse[Any]("{1,2,3,4,5,6,7,8,9,10}.^[(#this%2==0)]").validExpression
       .evaluateSync[java.util.ArrayList[Int]](ctx) should equal(2)
+  }
+
+  test("should allow to get value from record by literal key") {
+    parse[String]("{a: 'A', b: 'B'}['a']").validExpression.evaluateSync[String](ctx) should equal("A")
+  }
+
+  test("should allow to get value from record by dynamic key") {
+    parse[String]("{a: 'A', b: #strVal}['b'.replaceAll('b','c')]").validExpression
+      .evaluateSync[String](ctx) should equal(null)
   }
 
   test("parsing expression that exceeding the limit") {
@@ -577,10 +702,17 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
 
   test("register functions") {
     val twoDaysAgo = LocalDate.now().minusDays(2)
-    val withDays = ctx
+    val context = ctx
       .withVariable("date", twoDaysAgo)
       .withVariable("today", classOf[LocalDate].getDeclaredMethod("now"))
-    parse[Any]("#date.until(#today()).days", withDays).validExpression.evaluateSync[Integer](withDays) should equal(2)
+      .withVariable("timestampFromMillis", classOf[Instant].getMethod("ofEpochSecond", java.lang.Long.TYPE))
+
+    val daysRawExpression      = "#date.until(#today()).days"
+    val timestampRawExpression = "#timestampFromMillis(60)"
+    parse[Integer](daysRawExpression, context).validExpression.evaluateSync[Integer](context) should equal(2)
+    parse[Instant](timestampRawExpression, context).validExpression.evaluateSync[Instant](context) should equal(
+      Instant.parse("1970-01-01T00:01:00Z")
+    )
   }
 
   test("be possible to use SpEL's #this object") {
@@ -804,7 +936,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   test("generic record projection typing") {
     val (validationCtx: ValidationContext, ctxWithMap: Context) = prepareGenericRecordTest
     val validationResult = parseV[JInteger]("#genericRecord.![#this.value].get(0)", validationCtx)
-    val typingResult     = validationResult.validValue.typingInfo.typingResult
+    val typingResult     = validationResult.validValue.returnType
     typingResult shouldBe Typed[Int]
     validationResult.validExpression.evaluateSync[JInteger](ctxWithMap) shouldBe 42
   }
@@ -812,7 +944,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   test("generic record selecting by key") {
     val (validationCtx: ValidationContext, ctxWithMap: Context) = prepareGenericRecordTest
     val validationResult = parseV[JInteger]("#genericRecord.?[#this.key == 'foo'].get('foo')", validationCtx)
-    val typingResult     = validationResult.validValue.typingInfo.typingResult
+    val typingResult     = validationResult.validValue.returnType
     typingResult shouldBe Typed[Int]
     validationResult.validExpression.evaluateSync[JInteger](ctxWithMap) shouldBe 42
   }
@@ -820,7 +952,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   test("flink row projection typing") {
     val (validationCtx: ValidationContext, ctxWithMap: Context) = prepareFlinkRowTest
     val validationResult = parseV[JInteger]("#flinkTableApiRow.![#this.value].^[#this == 42]", validationCtx)
-    val typingResult     = validationResult.validValue.typingInfo.typingResult
+    val typingResult     = validationResult.validValue.returnType
     typingResult shouldBe Typed[Int]
     validationResult.validExpression.evaluateSync[JInteger](ctxWithMap) shouldBe 42
   }
@@ -828,7 +960,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   test("flink row selection typing") {
     val (validationCtx: ValidationContext, ctxWithMap: Context) = prepareFlinkRowTest
     val validationResult = parseV[JInteger]("#flinkTableApiRow.?[#this.key == 'foo'].get('foo')", validationCtx)
-    val typingResult     = validationResult.validValue.typingInfo.typingResult
+    val typingResult     = validationResult.validValue.returnType
     typingResult shouldBe Typed[Int]
     validationResult.validExpression.evaluateSync[JInteger](ctxWithMap) shouldBe 42
   }
@@ -858,7 +990,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   test("literal map selecting by key") {
     val (validationCtx: ValidationContext, ctxWithMap: Context) = prepareGenericRecordTest
     val validationResult = parseV[JInteger]("{foo: 42, bar: 43}.?[#this.key == 'foo'].get('foo')", validationCtx)
-    val typingResult     = validationResult.validValue.typingInfo.typingResult
+    val typingResult     = validationResult.validValue.returnType
     typingResult shouldBe Typed[Int]
     validationResult.validExpression.evaluateSync[JInteger](ctxWithMap) shouldBe 42
   }
@@ -1024,9 +1156,9 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
         "unknownString" -> ContainerOfUnknown("a"),
       )
     )
-
-    evaluate[Int]("""{{key: "a", value: 5}}.toMap[#unknownString.value]""", context) shouldBe 5
-    evaluate[Integer]("""{{key: "b", value: 5}}.toMap[#unknownString.value]""", context) shouldBe null
+    // typed maps, we know that the key is string, so the #unknownString must be cast to string
+    evaluate[Int]("""{{key: "a", value: 5}}.toMap[#unknownString.value.toString]""", context) shouldBe 5
+    evaluate[Integer]("""{{key: "b", value: 5}}.toMap[#unknownString.value.toString]""", context) shouldBe null
   }
 
   test("validate ternary operator") {
@@ -1049,8 +1181,14 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
   }
 
   test("validate selection for inline list") {
-    parse[Long]("{44, 44}.?[#this.alamakota]", ctx) should not be Symbol("valid")
     parse[java.util.List[_]]("{44, 44}.?[#this > 4]", ctx) shouldBe Symbol("valid")
+
+    val parsedExpression = parse[Long]("{44, 44}.?[#this.alamakota]", ctx)
+    inside(parsedExpression) {
+      case Invalid(
+            NonEmptyList(SpelExpressionTypingParseError(MissingObjectError.NoPropertyError(_, "alamakota"), _), Nil)
+          ) =>
+    }
   }
 
   test("validate selection and projection for list variable") {
@@ -1699,7 +1837,7 @@ class SpelExpressionSpec extends AnyFunSuite with Matchers with ValidatedValuesD
       val validationContext = ValidationContext.empty
         .withVariable("optional", Typed.fromDetailedType[Optional[Integer]], None)
         .validValue
-      parseV[Any](expression, validationContext).validValue.typingInfo.typingResult shouldBe expectedResultType
+      parseV[Any](expression, validationContext).validValue.returnType shouldBe expectedResultType
     }
   }
 
@@ -2670,6 +2808,7 @@ object SampleGlobalObject {
   def stringList(arg: java.util.List[String]): Int                             = arg.size()
   def toAny(value: Any): Any                                                   = value
   def stringOnStringMap: java.util.Map[String, String] = Map("key1" -> "value1", "key2" -> "value2").asJava
+  def listOfInteger: java.util.List[java.lang.Integer] = List(1, 2, 3).map(Integer.valueOf).asJava
 
   def methodWithPrimitiveParams(int: Int, long: Long, bool: Boolean): String = s"$int $long $bool"
 


### PR DESCRIPTION
## Describe your changes

- Ternary and Elvis operators preserve list and map/record types
- Empty collections (list, record) are now universal, can be assigned to any list/record/map
- Indexing record fields with a dynamic key returns the record value type instead of the Unknown type
- Limited usage of function references in SpEL
- Better typing of properties for Unknown values

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
