### PR TITLE
ForEach: add default value for Elements parameter

### DIFF
--- a/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
+++ b/engine/flink/components/base/src/main/scala/pl/touk/nussknacker/engine/flink/util/transformer/ForEachTransformer.scala
@@ -20,7 +20,7 @@ object ForEachTransformer extends CustomStreamTransformer with Serializable {
 
   @MethodToInvoke(returnType = classOf[Object])
   def invoke(
-      @ParamName("Elements") elements: LazyParameter[util.Collection[AnyRef]],
+      @ParamName("Elements") @DefaultValue("{\"item1\", \"item2\"}") elements: LazyParameter[util.Collection[AnyRef]],
       @OutputVariableName outputVariable: String
   ): FlinkCustomStreamTransformation with ReturningType = {
     FlinkCustomStreamTransformation(

--- a/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/ForEachTransformer.scala
+++ b/engine/lite/components/base/src/main/scala/pl/touk/nussknacker/engine/lite/components/ForEachTransformer.scala
@@ -15,7 +15,7 @@ object ForEachTransformer extends CustomStreamTransformer {
 
   @MethodToInvoke(returnType = classOf[Object])
   def invoke(
-      @ParamName("Elements") elements: LazyParameter[java.util.Collection[Any]],
+      @ParamName("Elements") @DefaultValue("{\"item1\", \"item2\"}") elements: LazyParameter[java.util.Collection[Any]],
       @OutputVariableName outputVariable: String
   ): LiteCustomComponent = {
     new ForEachTransformerComponent(elements, outputVariable)


### PR DESCRIPTION
## Summary
- Adds `@DefaultValue({"item1", "item2"})` to the `Elements` parameter in both Flink and Lite `ForEachTransformer`
- Prevents an immediate mandatory-field validation error when a For Each node is added to the graph before the user has had a chance to fill in the field

## Test plan
- [ ] Add a For Each node to a scenario — verify no validation error appears immediately
- [ ] Verify the Elements field is pre-filled with `{"item1", "item2"}`
- [ ] Verify that changing Elements to a real expression works correctly
