### PR TITLE
DataMapper/ConditionBuilder: use bracket notation for untyped fields

### DIFF
--- a/designer/client/src/components/builderComponents/typeUtils.ts
+++ b/designer/client/src/components/builderComponents/typeUtils.ts
@@ -31,7 +31,7 @@ export function typingResultToSample(t: any): unknown {
 /** Convert a dragged path expression to null-safe SpEL: #a.b.c → #a?.b?.c */
 export function toNullSafe(spelExpr: string): string {
     if (!spelExpr.startsWith("#")) return spelExpr;
-    return "#" + spelExpr.slice(1).replace(/\./g, "?.");
+    return "#" + spelExpr.slice(1).replace(/(?<!\?)\./g, "?.");
 }
 
 export function treeNodeMatchesFilter(name: string, value: unknown, filterText: string): boolean {

--- a/designer/client/src/components/conditionBuilder/ConditionBuilder.tsx
+++ b/designer/client/src/components/conditionBuilder/ConditionBuilder.tsx
@@ -203,6 +203,9 @@ export function ConditionBuilder({
                                         depth={0}
                                         onSelect={handleTreeInsert}
                                         highlight={highlightKeys?.has(name.replace(/^#/, ""))}
+                                        useTypedPaths
+                                        nullSafe
+                                        typing={variableTypes?.[name.replace(/^#/, "")]}
                                         doubleClickToInsert
                                     />
                                 ))

--- a/designer/client/src/components/dataMapper/DataMapper.tsx
+++ b/designer/client/src/components/dataMapper/DataMapper.tsx
@@ -191,7 +191,10 @@ export function DataMapper({
                                         onSelect={dm.onTreeSelect}
                                         selectedPath={dm.selPath}
                                         filterText={dm.contextFilter}
+                                        useTypedPaths
+                                        nullSafe
                                         nullSafeDrag
+                                        typing={variableTypes?.[key]}
                                     />
                                 ))}
                         </ScrollArea>

--- a/designer/client/src/components/dataMapper/useDataMapper.test.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.test.ts
@@ -592,7 +592,7 @@ describe("nested record: handleAutoMap", () => {
         const childId = result.current.fields[0].children[0].id;
         act(() => result.current.updateField(childId, "name", "city"));
         act(() => result.current.handleAutoMap());
-        expect(result.current.fields[0].children[0].expression).toBe("#user.city");
+        expect(result.current.fields[0].children[0].expression).toBe("#user['city']");
     });
 
     it("does not overwrite already-mapped nested fields", () => {

--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -162,7 +162,8 @@ export function useDataMapper({
     const addFieldFromDrop = useCallback(
         (path: string) => {
             const rawPath = path.replace(/^#/, "").replace(/\?/g, "");
-            const lastSegment = rawPath.split(".").pop() ?? "";
+            const bracketMatch = rawPath.match(/\['([^']+)'\]$/);
+            const lastSegment = bracketMatch ? bracketMatch[1] : rawPath.split(".").pop() ?? "";
             const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, rawPath) : undefined;
             const field = makeField(lastSegment, sourceType ?? "Any");
             field.expression = nullSafe ? toNullSafe(`#${rawPath}`) : `#${rawPath}`;
@@ -244,15 +245,22 @@ export function useDataMapper({
 
     const handleAutoMap = useCallback(() => {
         const pathMap = new Map<string, string>();
-        function traverse(obj: unknown, path: string) {
+        function traverse(obj: unknown, path: string, typing: { fields?: Record<string, unknown> } | undefined) {
             if (obj !== null && typeof obj === "object" && !Array.isArray(obj)) {
-                Object.entries(obj as Record<string, unknown>).forEach(([k, v]) => traverse(v, `${path}.${k}`));
+                Object.entries(obj as Record<string, unknown>).forEach(([k, v]) => {
+                    const childTyping = typing?.fields?.[k] as { fields?: Record<string, unknown> } | undefined;
+                    const segment = childTyping !== undefined ? `.${k}` : `['${k}']`;
+                    traverse(v, `${path}${segment}`, childTyping);
+                });
             } else {
-                const key = path.split(".").pop()!.toLowerCase().replace(/[_\s]/g, "");
+                const bracketMatch = path.match(/\['([^']+)'\]$/);
+                const key = (bracketMatch ? bracketMatch[1] : path.split(".").pop() ?? "").toLowerCase().replace(/[_\s]/g, "");
                 if (!pathMap.has(key)) pathMap.set(key, path);
             }
         }
-        Object.entries(enrichedContext).forEach(([key, val]) => traverse(val, key));
+        Object.entries(enrichedContext).forEach(([key, val]) =>
+            traverse(val, key, variableTypes?.[key] as { fields?: Record<string, unknown> } | undefined),
+        );
 
         function autoMap(fs: FieldDef[]): FieldDef[] {
             return fs.map((f) => {
@@ -265,7 +273,7 @@ export function useDataMapper({
             });
         }
         setFields(autoMap);
-    }, [enrichedContext, nullSafe]);
+    }, [enrichedContext, nullSafe, variableTypes]);
 
     const onTreeSelect = useCallback(
         (path: string) => {
@@ -286,7 +294,8 @@ export function useDataMapper({
     const onDrop = useCallback(
         (path: string, fieldId: number) => {
             const rawPath = path.replace(/^#/, "").replace(/\?/g, "");
-            const lastSegment = rawPath.split(".").pop() ?? "";
+            const bracketMatch = rawPath.match(/\['([^']+)'\]$/);
+            const lastSegment = bracketMatch ? bracketMatch[1] : rawPath.split(".").pop() ?? "";
             const baseExpr = nullSafe ? toNullSafe(`#${rawPath}`) : `#${rawPath}`;
             const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, rawPath) : undefined;
             setFields((prev) => {


### PR DESCRIPTION
## Summary

- Fields visible only via example data (no type definition, e.g. under an `Any`-typed parent) now produce `['field']` paths instead of `?.field` in drag-and-drop, auto-map, and click-to-insert in DataMapper and ConditionBuilder
- Consistent with the existing ExpressionPicker behaviour which already handled this correctly
- Also fixes `toNullSafe` to be idempotent — negative lookbehind prevents doubling existing `?.` sequences when the function is called on an already-converted expression

## Root cause

`ContextTreeNode` in DataMapper and ConditionBuilder was rendered without `useTypedPaths`/`nullSafe`/`typing` props, so it always produced dot-notation paths regardless of whether the field had a type definition. The auto-map (`handleAutoMap`) traversal also always used dot notation.

## Changes

- `DataMapper.tsx` — pass `useTypedPaths`, `nullSafe`, `typing` to `ContextTreeNode`
- `ConditionBuilder.tsx` — same
- `useDataMapper.ts` — fix `handleAutoMap` traverse to use `['key']` for keys absent from `typing.fields`; fix `addFieldFromDrop` / `onDrop` last-segment extraction to handle bracket notation
- `typeUtils.ts` — make `toNullSafe` idempotent with negative lookbehind

## Test plan

- [ ] In DataMapper, drag a field that lives under an `Any`-typed parent (visible only via example data) — path should use `['field']` not `?.field`
- [ ] Click Auto-map — same fields should get `['field']` notation
- [ ] In ConditionBuilder, drag or double-click such a field — same
- [ ] Typed fields still use `?.field` notation
- [ ] `toNullSafe` called twice on the same expression produces no change