### PR TITLE
Copy upstream outgoing records as incoming records for newly connected nodes

### DIFF
--- a/designer/client/src/reducers/graph/reducer.ts
+++ b/designer/client/src/reducers/graph/reducer.ts
@@ -136,6 +136,29 @@ const adjustScenarioData = flow(
     }),
 );
 
+type NodeTransition = NonNullable<NonNullable<GraphState["testing"]["testResults"]>["nodeTransitionResults"]>[number];
+
+function withSyntheticTransitions(
+    state: GraphState,
+    newState: GraphState,
+    buildSynthetic: (existing: NodeTransition[]) => NodeTransition[],
+): GraphState {
+    const existing = state.testing.testResults?.nodeTransitionResults;
+    if (!existing?.length) return newState;
+    const synthetic = buildSynthetic(existing);
+    if (!synthetic.length) return newState;
+    return {
+        ...newState,
+        testing: {
+            ...newState.testing,
+            testResults: {
+                ...newState.testing.testResults,
+                nodeTransitionResults: [...existing, ...synthetic],
+            },
+        },
+    };
+}
+
 const graphReducer: Reducer<GraphState> = (state = emptyGraphState, action): GraphState => {
     const currentNodes = state.scenario.scenarioGraph.nodes;
     const currentEdges = state.scenario.scenarioGraph.edges;
@@ -283,7 +306,7 @@ const graphReducer: Reducer<GraphState> = (state = emptyGraphState, action): Gra
                   )
                 : concat(currentEdges, newEdge);
 
-            return {
+            const newState = {
                 ...state,
                 scenario: {
                     ...state.scenario,
@@ -296,6 +319,10 @@ const graphReducer: Reducer<GraphState> = (state = emptyGraphState, action): Gra
                     },
                 },
             };
+
+            return withSyntheticTransitions(state, newState, (existing) =>
+                existing.filter((t) => t.sourceNodeId === action.fromNode.id).map((t) => ({ ...t, destinationNodeId: action.toNode.id })),
+            );
         }
         case "NODES_DISCONNECTED": {
             const nodesToSet = adjustBranchParametersAfterDisconnect(currentNodes, [action]);
@@ -365,11 +392,17 @@ const graphReducer: Reducer<GraphState> = (state = emptyGraphState, action): Gra
         }
         case "NODES_WITH_EDGES_ADDED": {
             const { nodes, layout, idMapping, processDefinitionData, edges } = action;
-            return addNodesWithLayout(state, {
-                nodes,
-                layout,
-                edges: adjustEdges(nodes, edges, currentNodes, currentEdges, processDefinitionData, idMapping),
-            });
+            const adjustedEdges = adjustEdges(nodes, edges, currentNodes, currentEdges, processDefinitionData, idMapping);
+            const newState = addNodesWithLayout(state, { nodes, layout, edges: adjustedEdges });
+
+            const newNodeIds = new Set(nodes.map((n) => n.id));
+            return withSyntheticTransitions(state, newState, (existing) =>
+                adjustedEdges
+                    .filter((e) => newNodeIds.has(e.to) && !newNodeIds.has(e.from))
+                    .flatMap((edge) =>
+                        existing.filter((t) => t.sourceNodeId === edge.from).map((t) => ({ ...t, destinationNodeId: edge.to })),
+                    ),
+            );
         }
         case "VALIDATION_RESULT": {
             return {


### PR DESCRIPTION
## Summary

When a node is added or connected to an existing node that already has test/live data, its incoming records are now populated from the upstream node's outgoing records — no need to re-run tests after wiring a new node.

Covers two flows:
- `NODES_WITH_EDGES_ADDED` — node added with an edge in one action (e.g. drag from palette)
- `NODES_CONNECTED` — existing node connected to another via drag

## Test plan
- [ ] Run tests on a scenario, then add a new node connected to an existing one — incoming records should appear immediately
- [ ] Delete a node, add a replacement and connect it — incoming records should appear without re-running tests