### PR TITLE
DataMapper: exclude 'Value' param from Avro field detection in topic schema fetch

### DIFF
--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -392,6 +392,7 @@ export function useDataMapper({
                             "Raw editor",
                             "Content type",
                             "Value validation mode",
+                            "Value",
                         ]);
 
                         // Case 1: single "Value" param (raw editor mode) — use its typing result


### PR DESCRIPTION
## Summary

- In `defaultFetchTopicDefinitions`, the `KAFKA_SYSTEM_PARAMS` set now explicitly includes `"Value"` to prevent it from being treated as an Avro schema field (Case 2)
- The `"Value"` param is already handled separately as the raw-editor param (Case 1), so including it in `fieldParams` was a bug that could produce a false single-field schema

## Test plan

- [ ] Open DataMapper for a Kafka sink with a topic that has an Avro schema selected
- [ ] Verify "From Schema" correctly loads all Avro fields (not just a single "Value" field)