### PR TITLE
DataMapper: fix Float/Any type conversion and Elvis default value round-trip

### DIFF
--- a/designer/client/src/components/builderComponents/typeUtils.ts
+++ b/designer/client/src/components/builderComponents/typeUtils.ts
@@ -22,8 +22,8 @@ export function typingResultToSample(t: any): unknown {
     }
     if (name === "java.lang.String") return "";
     if (name === "java.lang.Boolean") return false;
-    if (name.includes("Integer") || name.includes("Long") || name.includes("Short") || name.includes("Double") || name.includes("Float"))
-        return 0;
+    if (name.includes("Integer") || name.includes("Long") || name.includes("Short")) return 0;
+    if (name.includes("Double") || name.includes("Float")) return 0.5;
     if (name.includes("Map")) return {};
     return null;
 }

--- a/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
@@ -51,8 +51,28 @@ describe("applyTypeConversion", () => {
         expect(applyTypeConversion("#x", undefined, "Boolean")).toBe("#x");
     });
 
-    it("Any source returns expr unchanged (no conversion for Any → Boolean)", () => {
-        expect(applyTypeConversion("#x", "Any", "Boolean")).toBe("#x");
+    it.each([
+        ["Boolean", "#x?.toBooleanOrNull ?: false"],
+        ["Integer", "#x?.toIntegerOrNull ?: 0"],
+        ["Long", "#x?.toLongOrNull ?: 0"],
+        ["Double", "#x?.toDoubleOrNull ?: 0.0"],
+        ["Float", "#x?.toDoubleOrNull ?: 0.0"],
+        ["String", "#x?.toString() ?: ''"],
+        ["BigDecimal", "#x?.toBigDecimalOrNull ?: 0"],
+    ] as [string, string][])("Any → %s applies extension method with default fallback", (target, expected) => {
+        expect(applyTypeConversion("#x", "Any", target as never)).toBe(expected);
+    });
+
+    it("Any → Boolean uses custom defaultValue when provided", () => {
+        expect(applyTypeConversion("#x", "Any", "Boolean", "true")).toBe("#x?.toBooleanOrNull ?: true");
+    });
+
+    it("Any → Double uses custom defaultValue when provided", () => {
+        expect(applyTypeConversion("#x", "Any", "Double", "99.9")).toBe("#x?.toDoubleOrNull ?: 99.9");
+    });
+
+    it("ZonedDateTime → Long uses DATE conversion (not Any fallback)", () => {
+        expect(applyTypeConversion("#x", "ZonedDateTime", "Long")).toBe("#DATE.toEpochMilli(#x)");
     });
 
     it("String → Boolean falls back to Any-style conversion", () => {
@@ -63,20 +83,8 @@ describe("applyTypeConversion", () => {
         expect(applyTypeConversion("#x", "String", "Float")).toBe("#x?.toDoubleOrNull ?: 0.0");
     });
 
-    it("String → Double falls back to Any-style toDoubleOrNull", () => {
-        expect(applyTypeConversion("#x", "String", "Double")).toBe("#x?.toDoubleOrNull ?: 0.0");
-    });
-
-    it("String → Integer falls back to Any-style toIntegerOrNull", () => {
-        expect(applyTypeConversion("#x", "String", "Integer")).toBe("#x?.toIntegerOrNull ?: 0");
-    });
-
     it("String → ZonedDateTime uses TYPE_CONVERSIONS (takes priority over Any fallback)", () => {
         expect(applyTypeConversion("#x", "String", "ZonedDateTime")).toBe('#DATE_FORMAT.parseZonedDateTime(#x, "yyyyMMdd-HH:mm:ss.SSS")');
-    });
-
-    it("ZonedDateTime → Long uses TYPE_CONVERSIONS", () => {
-        expect(applyTypeConversion("#x", "ZonedDateTime", "Long")).toBe("#DATE.toEpochMilli(#x)");
     });
 
     it("unknown source type also falls back to Any-style conversion if target has one", () => {
@@ -183,6 +191,24 @@ describe("parseSpelToFields", () => {
         const result = parseSpelToFields("{ valid: #x, noColon }");
         expect(result).toHaveLength(1);
         expect(result![0]).toMatchObject({ name: "valid" });
+    });
+
+    it("Elvis expression splits into expression + defaultValue", () => {
+        const result = parseSpelToFields("{ on_ground: #x?.toBooleanOrNull ?: false }");
+        expect(result).toHaveLength(1);
+        expect(result![0]).toMatchObject({ name: "on_ground", expression: "#x?.toBooleanOrNull", defaultValue: "false" });
+    });
+
+    it("Elvis with float fallback splits correctly", () => {
+        const result = parseSpelToFields("{ altitude: #x?.toDoubleOrNull ?: 0.0 }");
+        expect(result).toHaveLength(1);
+        expect(result![0]).toMatchObject({ name: "altitude", expression: "#x?.toDoubleOrNull", defaultValue: "0.0" });
+    });
+
+    it("null-ternary format (backward compat) splits into expression + defaultValue", () => {
+        const result = parseSpelToFields("{ name: #input.name != null ? #input.name : 'unknown' }");
+        expect(result).toHaveLength(1);
+        expect(result![0]).toMatchObject({ name: "name", expression: "#input.name", defaultValue: "'unknown'" });
     });
 
     it("all fields receive unique numeric ids", () => {

--- a/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
@@ -256,6 +256,21 @@ describe("genSpelFromFields", () => {
         f.expression = "#input.meta";
         expect(genSpelFromFields([f])).toBe("{\n  meta: #input.meta\n}");
     });
+
+    it("field with defaultValue uses Elvis format", () => {
+        const f = makeField("active", "Boolean");
+        f.expression = "#input.flag";
+        f.defaultValue = "false";
+        expect(genSpelFromFields([f])).toBe("{\n  active: #input.flag ?: false\n}");
+    });
+
+    it("field with type-converted expression and defaultValue uses Elvis", () => {
+        const f = makeField("active", "Boolean");
+        // After splitElvisIntoField, expression has no Elvis — defaultValue holds the fallback
+        f.expression = "#outputVar[8]?.toBooleanOrNull";
+        f.defaultValue = "true";
+        expect(genSpelFromFields([f])).toBe("{\n  active: #outputVar[8]?.toBooleanOrNull ?: true\n}");
+    });
 });
 
 // ─── fieldsFromSample ─────────────────────────────────────────────────────────

--- a/designer/client/src/components/dataMapper/dataMapperUtils.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.ts
@@ -185,17 +185,26 @@ export const TYPE_CONVERSIONS: Partial<Record<NuType, Partial<Record<NuType, (ex
 
 /** Extension-method fallbacks for when no specific TYPE_CONVERSIONS entry exists. */
 const ANY_CONVERSIONS: Partial<Record<NuType, { method: string; fallback: string }>> = {
-    Boolean: { method: "toBooleanOrNull", fallback: "false" },
-    Integer: { method: "toIntegerOrNull", fallback: "0" },
+    String: { method: "toString()", fallback: "''" },
     Long: { method: "toLongOrNull", fallback: "0" },
+    Integer: { method: "toIntegerOrNull", fallback: "0" },
+    // Nu has no toFloatOrNull — Float fields use toDoubleOrNull (SpEL treats both as double)
     Float: { method: "toDoubleOrNull", fallback: "0.0" },
     Double: { method: "toDoubleOrNull", fallback: "0.0" },
     BigDecimal: { method: "toBigDecimalOrNull", fallback: "0" },
+    Boolean: { method: "toBooleanOrNull", fallback: "false" },
 };
 
 /** Apply a type conversion from sourceType to targetType, or return expr unchanged if no conversion available. */
-export function applyTypeConversion(expr: string, sourceType: NuType | undefined, targetType: NuType): string {
-    if (!sourceType || sourceType === targetType || targetType === "Any" || sourceType === "Any") return expr;
+export function applyTypeConversion(expr: string, sourceType: NuType | undefined, targetType: NuType, defaultValue?: string): string {
+    if (!sourceType || sourceType === targetType || targetType === "Any") return expr;
+    if (sourceType === "Any") {
+        const conv = ANY_CONVERSIONS[targetType];
+        if (!conv) return expr;
+        const fallback = defaultValue ?? conv.fallback;
+        const converted = `${expr}?.${conv.method}`;
+        return fallback ? `${converted} ?: ${fallback}` : converted;
+    }
     const conversion = TYPE_CONVERSIONS[sourceType]?.[targetType];
     if (conversion) return conversion(expr);
     // No specific conversion — fall back to Any-style extension methods if available
@@ -210,14 +219,25 @@ export function applyTypeConversion(expr: string, sourceType: NuType | undefined
 
 /** Get the NuType of a value at a dotted path within variableTypes (strips leading # and ? from path). */
 export function getNuTypeAtPath(variableTypes: Record<string, TypingResult>, path: string): NuType | undefined {
-    const parts = path.replace(/^#/, "").replace(/\?/g, "").split(".").filter(Boolean);
-    if (parts.length === 0) return undefined;
-    let current: TypingResult | undefined = variableTypes[parts[0]];
+    // Tokenize: split by "." and also extract "[N]" / "['key']" index segments
+    const segments =
+        path
+            .replace(/^#/, "")
+            .replace(/\?/g, "")
+            .match(/[^.[]+|\[\d+\]|\['[^']+'\]/g) ?? [];
+    if (segments.length === 0) return undefined;
+    let current: TypingResult | undefined = variableTypes[segments[0]];
     if (!current) return undefined;
-    for (let i = 1; i < parts.length; i++) {
-        const fields = (current as { fields?: Record<string, TypingResult> }).fields;
-        if (!fields) return undefined;
-        current = fields[parts[i]];
+    for (let i = 1; i < segments.length; i++) {
+        const seg = segments[i];
+        if (seg.startsWith("[")) {
+            const params = (current as { params?: TypingResult[] }).params;
+            // Empty params = untyped list — treat element as Any
+            if (!params?.length) return "Any";
+            current = params[0];
+        } else {
+            current = (current as { fields?: Record<string, TypingResult> }).fields?.[seg];
+        }
         if (!current) return undefined;
     }
     return refClazzToNuType(current.refClazzName);
@@ -287,13 +307,18 @@ export function splitTopLevel(inner: string): string[] {
 }
 
 function parseNullDefault(value: string): { expression: string; defaultValue: string } | null {
+    // Parse: expr != null ? expr : defaultValue  (null-ternary format, backward compat)
     const marker = " != null ? ";
     const idx = value.indexOf(marker);
-    if (idx < 0) return null;
-    const expr = value.slice(0, idx);
-    const rest = value.slice(idx + marker.length);
-    if (!rest.startsWith(expr + " : ")) return null;
-    return { expression: expr, defaultValue: rest.slice(expr.length + 3) };
+    if (idx >= 0) {
+        const expr = value.slice(0, idx);
+        const rest = value.slice(idx + marker.length);
+        if (rest.startsWith(expr + " : ")) return { expression: expr, defaultValue: rest.slice(expr.length + 3) };
+    }
+    // Parse: expr ?: defaultValue  (Elvis format)
+    const elvisIdx = value.lastIndexOf(" ?: ");
+    if (elvisIdx >= 0) return { expression: value.slice(0, elvisIdx), defaultValue: value.slice(elvisIdx + 4) };
+    return null;
 }
 
 /** Parse a SpEL record expression `{ key: expr, ... }` back into FieldDef[] (recursive). */
@@ -405,7 +430,7 @@ export function genSpelFromFields(fields: FieldDef[], depth = 0): string {
             return `${innerIndent}${f.name}: ${genSpelFromFields(f.children, depth + 1)}`;
         }
         const expr = f.expression || "null";
-        const value = f.expression && f.defaultValue !== undefined ? `${f.expression} != null ? ${f.expression} : ${f.defaultValue}` : expr;
+        const value = f.expression && f.defaultValue !== undefined ? `${f.expression} ?: ${f.defaultValue}` : expr;
         return `${innerIndent}${f.name}: ${value}`;
     });
     return `{\n${lines.join(",\n")}\n${outerIndent}}`;

--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -70,6 +70,15 @@ function findInTree(fields: FieldDef[], id: number): FieldDef | undefined {
     return undefined;
 }
 
+/** When expr contains an Elvis fallback (e.g. from applyTypeConversion), split it into expression + defaultValue. */
+function splitElvisIntoField(field: FieldDef, expr: string): FieldDef {
+    const elvisIdx = expr.lastIndexOf(" ?: ");
+    if (elvisIdx >= 0) {
+        return { ...field, expression: expr.slice(0, elvisIdx), defaultValue: expr.slice(elvisIdx + 4) };
+    }
+    return { ...field, expression: expr };
+}
+
 function mergeTypesFromSchema(parsed: FieldDef[], schema: FieldDef[]): FieldDef[] {
     return parsed.map((f) => {
         const schemaField = schema.find((s) => s.name === f.name);
@@ -109,7 +118,15 @@ export function useDataMapper({
                 return parsed;
             }
         }
-        if (initialFieldsProp && initialFieldsProp.length > 0) return initialFieldsProp;
+        if (initialFieldsProp && initialFieldsProp.length > 0) {
+            return initialFieldsProp.map((f) => {
+                const elvisIdx = f.expression.lastIndexOf(" ?: ");
+                if (elvisIdx >= 0) {
+                    return { ...f, expression: f.expression.slice(0, elvisIdx), defaultValue: f.expression.slice(elvisIdx + 4) };
+                }
+                return f;
+            });
+        }
         return isEmbedded ? [] : INITIAL_FIELDS.map((f) => ({ ...f, id: nextId() }));
     });
     const [selField, setSelField] = useState<number | null>(null);
@@ -275,8 +292,8 @@ export function useDataMapper({
                 const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, path) : undefined;
                 setFields((f) => {
                     const targetField = findInTree(f, selField);
-                    const expr = applyTypeConversion(baseExpr, sourceType, targetField?.type ?? "Any");
-                    return updateInTree(f, selField, (x) => ({ ...x, expression: expr }));
+                    const expr = applyTypeConversion(baseExpr, sourceType, targetField?.type ?? "Any", targetField?.defaultValue);
+                    return updateInTree(f, selField, (x) => splitElvisIntoField(x, expr));
                 });
             }
         },
@@ -291,10 +308,10 @@ export function useDataMapper({
             const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, rawPath) : undefined;
             setFields((prev) => {
                 const targetField = findInTree(prev, fieldId);
-                const expr = applyTypeConversion(baseExpr, sourceType, targetField?.type ?? "Any");
+                const expr = applyTypeConversion(baseExpr, sourceType, targetField?.type ?? "Any", targetField?.defaultValue);
                 return updateInTree(prev, fieldId, (x) => {
                     const nameUpdate = !x.name?.trim() && lastSegment ? { name: lastSegment } : {};
-                    return { ...x, expression: expr, ...nameUpdate };
+                    return { ...splitElvisIntoField(x, expr), ...nameUpdate };
                 });
             });
             setDragOverId(null);

--- a/designer/client/src/components/graph/node-modal/NamedParamsDataMapper.tsx
+++ b/designer/client/src/components/graph/node-modal/NamedParamsDataMapper.tsx
@@ -62,8 +62,9 @@ export function NamedParamsDataMapper({
             for (const field of parsed) {
                 const paramIndex = currentParams.findIndex((p) => p.name === field.name);
                 if (paramIndex >= 0 && field.expression) {
+                    const fullExpr = field.defaultValue !== undefined ? `${field.expression} ?: ${field.defaultValue}` : field.expression;
                     setProperty(`${parametersBasePath}[${paramIndex}].expression`, {
-                        expression: field.expression,
+                        expression: fullExpr,
                         language: ExpressionLang.SpEL,
                     });
                 }


### PR DESCRIPTION
## Summary

- Float in Avro nullable unions was shown as Any; added Float to ANY_CONVERSIONS using toDoubleOrNull (Nu has no toFloatOrNull). Fixed typingResultToSample to return 0.5 for Float/Double so inferNuType returns Double.
- Dropping onto an Any-source field generated expr ?: fallback, then setting a default value double-wrapped it. Fixed by splitting Elvis at drop time (splitElvisIntoField); genSpelFromFields now always uses Elvis format.
- After Apply+reopen, default value field was empty. NamedParamsDataMapper was reading the raw expression without splitting Elvis. Fixed by splitting in useDataMapper initialFieldsProp and reconstructing the full Elvis in handleInsert before saving.

## Test plan

- Drop an Any-source variable onto a Boolean field: Value shows toBooleanOrNull expression, Default value shows false
- Set a custom default value: expression preview shows full Elvis
- Apply, reopen: Value and Default value fields are correctly populated
- Drop onto a Float Avro field: toDoubleOrNull conversion is applied
- Existing null-ternary expressions still parse correctly on reopen