### PR TITLE
DataMapper: scroll to focused field on open

### DIFF
--- a/designer/client/src/components/dataMapper/DataMapper.tsx
+++ b/designer/client/src/components/dataMapper/DataMapper.tsx
@@ -93,6 +93,16 @@ export function DataMapper({
         }
         prevFieldsLengthRef.current = dm.fields.length;
     }, [dm.fields.length]);
+    useEffect(() => {
+        if (dm.selField == null || !fieldsScrollRef.current) return;
+        const container = fieldsScrollRef.current;
+        const id = dm.selField;
+        // Wait for MUI Collapse animation to finish before scrolling
+        const timer = setTimeout(() => {
+            container.querySelector(`[data-field-id="${id}"]`)?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+        }, 320);
+        return () => clearTimeout(timer);
+    }, [dm.selField]);
 
     return (
         <RootBox embedded={!!onInsert}>

--- a/designer/client/src/components/dataMapper/FieldRow.tsx
+++ b/designer/client/src/components/dataMapper/FieldRow.tsx
@@ -127,6 +127,7 @@ export function FieldRow({
     return (
         // Outer box: only border + drag handlers. NO background — prevents stacking through nesting.
         <Box
+            data-field-id={field.id}
             onDragOver={(e) => {
                 e.preventDefault();
                 e.stopPropagation();


### PR DESCRIPTION
When the magic wand is clicked on a specific field in the Kafka sink form, the DataMapper opens with that field selected and expanded. Previously it did not scroll to the field, so it was out of view for long parameter lists.

Fix: add `data-field-id` attribute to each FieldRow outer box, then after the MUI Collapse animation completes (~320ms), query the element and call `scrollIntoView({ block: "nearest", behavior: "smooth" })`.

The same scroll-to-view also triggers whenever the user manually selects a field.

## Test plan
- Open a Kafka sink node with 10+ parameters, click the magic wand on the last field — DataMapper should open and smoothly scroll to that field