### PR TITLE
DataMapper: apply Nu extension method conversions for non-Any source types

### DIFF
--- a/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
@@ -1,4 +1,12 @@
-import { fieldsFromSample, genSpelFromFields, inferNuType, makeField, parseSpelToFields, splitTopLevel } from "./dataMapperUtils";
+import {
+    applyTypeConversion,
+    fieldsFromSample,
+    genSpelFromFields,
+    inferNuType,
+    makeField,
+    parseSpelToFields,
+    splitTopLevel,
+} from "./dataMapperUtils";
 
 // ─── inferNuType ──────────────────────────────────────────────────────────────
 
@@ -25,6 +33,54 @@ describe("inferNuType", () => {
         [{ a: 1 }, "Map"],
     ] as [unknown, string][])("inferNuType(%p) → %s", (input, expected) => {
         expect(inferNuType(input)).toBe(expected);
+    });
+});
+
+// ─── applyTypeConversion ─────────────────────────────────────────────────────
+
+describe("applyTypeConversion", () => {
+    it("returns expr unchanged when sourceType equals targetType", () => {
+        expect(applyTypeConversion("#x", "Boolean", "Boolean")).toBe("#x");
+    });
+
+    it("returns expr unchanged when targetType is Any", () => {
+        expect(applyTypeConversion("#x", "String", "Any")).toBe("#x");
+    });
+
+    it("returns expr unchanged when sourceType is undefined", () => {
+        expect(applyTypeConversion("#x", undefined, "Boolean")).toBe("#x");
+    });
+
+    it("Any source returns expr unchanged (no conversion for Any → Boolean)", () => {
+        expect(applyTypeConversion("#x", "Any", "Boolean")).toBe("#x");
+    });
+
+    it("String → Boolean falls back to Any-style conversion", () => {
+        expect(applyTypeConversion("#x", "String", "Boolean")).toBe("#x?.toBooleanOrNull ?: false");
+    });
+
+    it("String → Float falls back to Any-style toDoubleOrNull", () => {
+        expect(applyTypeConversion("#x", "String", "Float")).toBe("#x?.toDoubleOrNull ?: 0.0");
+    });
+
+    it("String → Double falls back to Any-style toDoubleOrNull", () => {
+        expect(applyTypeConversion("#x", "String", "Double")).toBe("#x?.toDoubleOrNull ?: 0.0");
+    });
+
+    it("String → Integer falls back to Any-style toIntegerOrNull", () => {
+        expect(applyTypeConversion("#x", "String", "Integer")).toBe("#x?.toIntegerOrNull ?: 0");
+    });
+
+    it("String → ZonedDateTime uses TYPE_CONVERSIONS (takes priority over Any fallback)", () => {
+        expect(applyTypeConversion("#x", "String", "ZonedDateTime")).toBe('#DATE_FORMAT.parseZonedDateTime(#x, "yyyyMMdd-HH:mm:ss.SSS")');
+    });
+
+    it("ZonedDateTime → Long uses TYPE_CONVERSIONS", () => {
+        expect(applyTypeConversion("#x", "ZonedDateTime", "Long")).toBe("#DATE.toEpochMilli(#x)");
+    });
+
+    it("unknown source type also falls back to Any-style conversion if target has one", () => {
+        expect(applyTypeConversion("#x", "List", "Boolean")).toBe("#x?.toBooleanOrNull ?: false");
     });
 });
 

--- a/designer/client/src/components/dataMapper/dataMapperUtils.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.ts
@@ -187,7 +187,16 @@ export const TYPE_CONVERSIONS: Partial<Record<NuType, Partial<Record<NuType, (ex
 export function applyTypeConversion(expr: string, sourceType: NuType | undefined, targetType: NuType): string {
     if (!sourceType || sourceType === targetType || targetType === "Any" || sourceType === "Any") return expr;
     const conversion = TYPE_CONVERSIONS[sourceType]?.[targetType];
-    return conversion ? conversion(expr) : expr;
+    if (conversion) return conversion(expr);
+    // No specific conversion — fall back to Any-style extension methods if available
+    // (e.g. String → Float/Boolean using toDoubleOrNull/toBooleanOrNull)
+    const anyConv = ANY_CONVERSIONS[targetType];
+    if (anyConv) {
+        const fallback = defaultValue ?? anyConv.fallback;
+        const converted = `${expr}?.${anyConv.method}`;
+        return fallback ? `${converted} ?: ${fallback}` : converted;
+    }
+    return expr;
 }
 
 /** Get the NuType of a value at a dotted path within variableTypes (strips leading # and ? from path). */

--- a/designer/client/src/components/dataMapper/dataMapperUtils.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.ts
@@ -183,6 +183,16 @@ export const TYPE_CONVERSIONS: Partial<Record<NuType, Partial<Record<NuType, (ex
     },
 };
 
+/** Extension-method fallbacks for when no specific TYPE_CONVERSIONS entry exists. */
+const ANY_CONVERSIONS: Partial<Record<NuType, { method: string; fallback: string }>> = {
+    Boolean: { method: "toBooleanOrNull", fallback: "false" },
+    Integer: { method: "toIntegerOrNull", fallback: "0" },
+    Long: { method: "toLongOrNull", fallback: "0" },
+    Float: { method: "toDoubleOrNull", fallback: "0.0" },
+    Double: { method: "toDoubleOrNull", fallback: "0.0" },
+    BigDecimal: { method: "toBigDecimalOrNull", fallback: "0" },
+};
+
 /** Apply a type conversion from sourceType to targetType, or return expr unchanged if no conversion available. */
 export function applyTypeConversion(expr: string, sourceType: NuType | undefined, targetType: NuType): string {
     if (!sourceType || sourceType === targetType || targetType === "Any" || sourceType === "Any") return expr;
@@ -192,9 +202,8 @@ export function applyTypeConversion(expr: string, sourceType: NuType | undefined
     // (e.g. String → Float/Boolean using toDoubleOrNull/toBooleanOrNull)
     const anyConv = ANY_CONVERSIONS[targetType];
     if (anyConv) {
-        const fallback = defaultValue ?? anyConv.fallback;
         const converted = `${expr}?.${anyConv.method}`;
-        return fallback ? `${converted} ?: ${fallback}` : converted;
+        return `${converted} ?: ${anyConv.fallback}`;
     }
     return expr;
 }


### PR DESCRIPTION
When dropping a `String` expression (e.g. `#http_output?.response?.statusText`) onto a `Float` or `Boolean` field, no type conversion was applied because `TYPE_CONVERSIONS["String"]` only covers date types. The field then showed a "Bad expression type" validation error.

Fix: in `applyTypeConversion`, after checking `TYPE_CONVERSIONS`, fall back to `ANY_CONVERSIONS` if an entry exists for the target type. Nu's extension methods (`toDoubleOrNull`, `toBooleanOrNull`, etc.) work on any object, so this is safe for all source types.

Examples:
- `String → Float`: `#expr?.toDoubleOrNull ?: 0.0`
- `String → Boolean`: `#expr?.toBooleanOrNull ?: false`
- `String → Integer`: `#expr?.toIntegerOrNull ?: 0`

## Test plan
- Drop a String field onto a Float target field — should generate `?.toDoubleOrNull ?: 0.0` conversion
- Drop a String field onto a Boolean target field — should generate `?.toBooleanOrNull ?: false` conversion
- Existing Any-source conversions still work