### PR TITLE
Rename SpelExpressionPicker to SpelExpressionBuilder

### DIFF
--- a/designer/client/src/components/graph/node-modal/parametersListField.tsx
+++ b/designer/client/src/components/graph/node-modal/parametersListField.tsx
@@ -10,7 +10,7 @@ import { ParameterExpressionField } from "./ParameterExpressionField";
 import type { ParamKeys } from "./parameterHelpers";
 import { OverrideKeys } from "./parameterHelpers";
 import type { ParametersListProps, ParameterWithIndex } from "./parametersList";
-import { SpelExpressionPickerFieldWrapper } from "./spelExpressionPickerFieldWrapper";
+import { SpelExpressionBuilderFieldWrapper } from "./spelExpressionBuilderFieldWrapper";
 import { WebSocketUrlFieldWrapper } from "./webSocketUrlFieldWrapper";
 
 export type ParametersListFieldProps = ParametersListProps & {
@@ -29,7 +29,7 @@ function pickFieldWrapper(paramKey: ParamKeys) {
         case OverrideKeys.DecisionTableMatch:
             return ConditionBuilderFieldWrapper;
         case OverrideKeys.ForEachElements:
-            return SpelExpressionPickerFieldWrapper;
+            return SpelExpressionBuilderFieldWrapper;
         case OverrideKeys.SinkKafkaValue:
         case OverrideKeys.SinkKafkaValue2:
         case OverrideKeys.HttpBody:

--- a/designer/client/src/components/graph/node-modal/spelExpressionBuilderFieldWrapper.tsx
+++ b/designer/client/src/components/graph/node-modal/spelExpressionBuilderFieldWrapper.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 
-import { SpelExpressionPickerComponent } from "../../spelExpressionPicker/SpelExpressionPickerComponent";
+import { SpelExpressionBuilderComponent } from "../../spelExpressionBuilder/SpelExpressionBuilderComponent";
 import { BaseBuilderFieldWrapper } from "./BaseBuilderFieldWrapper";
 import type { FieldWrapperProps } from "./ParameterExpressionField";
 
-export function SpelExpressionPickerFieldWrapper(props: FieldWrapperProps) {
+export function SpelExpressionBuilderFieldWrapper(props: FieldWrapperProps) {
     return (
         <BaseBuilderFieldWrapper
             {...props}
-            buttonLabel="Expression Picker"
+            buttonLabel="Expression Builder"
             renderBuilder={({ node, onInsert, initialExpression, paramName, paramDef, open, onClose }) => (
-                <SpelExpressionPickerComponent
+                <SpelExpressionBuilderComponent
                     node={node}
                     onInsert={onInsert}
                     initialExpression={initialExpression}

--- a/designer/client/src/components/spelExpressionBuilder/SpelExpressionBuilder.tsx
+++ b/designer/client/src/components/spelExpressionBuilder/SpelExpressionBuilder.tsx
@@ -31,7 +31,7 @@ import { getProcessName, getProcessProperties } from "../graph/node-modal/NodeDe
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-export interface SpelExpressionPickerProps {
+export interface SpelExpressionBuilderProps {
     onInsert?: (spel: string) => void;
     initialExpression?: string;
     variableTypes?: VariableTypes;
@@ -80,14 +80,14 @@ function resolveSpelPath(expression: string, contextData: ContextData): unknown 
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function SpelExpressionPicker({
+export function SpelExpressionBuilder({
     onInsert,
     initialExpression,
     variableTypes,
     contextData,
     buildProbeNode,
     targetTypeDisplay,
-}: SpelExpressionPickerProps): React.JSX.Element {
+}: SpelExpressionBuilderProps): React.JSX.Element {
     const theme = useTheme();
     const processName = useAppSelector(getProcessName);
     const processProperties = useAppSelector(getProcessProperties);

--- a/designer/client/src/components/spelExpressionBuilder/SpelExpressionBuilderComponent.tsx
+++ b/designer/client/src/components/spelExpressionBuilder/SpelExpressionBuilderComponent.tsx
@@ -8,7 +8,7 @@ import type { ContextData } from "../dataMapper/DataMapper";
 import { DataMapperDialogTitle } from "../dataMapper/DataMapperDialogTitle";
 import { useInputOutputContext } from "../graph/node-modal/io/InputOutputContext";
 import { getFindAvailableVariables } from "../graph/node-modal/NodeDetailsContent/selectors";
-import { SpelExpressionPicker } from "./SpelExpressionPicker";
+import { SpelExpressionBuilder } from "./SpelExpressionBuilder";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -25,7 +25,7 @@ interface Props {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function SpelExpressionPickerComponent({
+export function SpelExpressionBuilderComponent({
     node,
     onInsert,
     initialExpression,
@@ -69,9 +69,9 @@ export function SpelExpressionPickerComponent({
         <>
             {open && (
                 <Dialog open onClose={handleClose} maxWidth="xl" fullWidth>
-                    <DataMapperDialogTitle node={node} onClose={handleClose} title="expression picker" />
+                    <DataMapperDialogTitle node={node} onClose={handleClose} title="expression builder" />
                     <DialogContent sx={{ p: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-                        <SpelExpressionPicker
+                        <SpelExpressionBuilder
                             onInsert={(spel) => {
                                 onInsert(spel);
                                 handleClose();


### PR DESCRIPTION
Renames the ForEach expression editor from "Picker" to "Builder" — a picker implies selecting from a list, while a builder better describes constructing a SpEL expression.

Changes:
- Folder `spelExpressionPicker/` → `spelExpressionBuilder/`
- `SpelExpressionPicker` / `SpelExpressionPickerComponent` → `SpelExpressionBuilder` / `SpelExpressionBuilderComponent`
- `spelExpressionPickerFieldWrapper` → `spelExpressionBuilderFieldWrapper`
- Button label: `Expression Picker` → `Expression Builder`
- Dialog title: `expression picker` → `expression builder`