### PR TITLE
[NU-2483] fix scenario validation error for imported scenario

### DIFF
--- a/designer/client/src/actions/nk/createFragment.ts
+++ b/designer/client/src/actions/nk/createFragment.ts
@@ -69,7 +69,7 @@ export function createFragment(): ThunkAction<Promise<NodeType | null>> {
             processingMode: processingMode,
             engineSetupName: engineSetupName,
         });
-        const { data } = await HttpService.importProcess(uniqueName, jsonToFileInFormData(FRAGMENT_TEMPLATE));
+        const { data } = await HttpService.importScenario(uniqueName, jsonToFileInFormData(FRAGMENT_TEMPLATE));
         await HttpService.saveProcess(uniqueName, data.scenarioGraph, "import placeholder data", []);
         const { componentGroups } = await dispatch(fetchProcessDefinition(processingType, false));
         const component = componentGroups

--- a/designer/client/src/actions/nk/importExport.ts
+++ b/designer/client/src/actions/nk/importExport.ts
@@ -7,8 +7,8 @@ export function importFiles(processName: ProcessName, files: File[]): ThunkActio
         files.forEach(async (file: File) => {
             try {
                 dispatch({ type: "PROCESS_LOADING" });
-                const process = await HttpService.importProcess(processName, file);
-                dispatch({ type: "UPDATE_IMPORTED_PROCESS", scenario: process.data });
+                const importedScenario = await HttpService.importScenario(processName, file);
+                dispatch({ type: "UPDATE_IMPORTED_PROCESS", importedScenarioData: importedScenario.data });
             } catch (error) {
                 dispatch({ type: "LOADING_FAILED" });
             }

--- a/designer/client/src/actions/nk/process.ts
+++ b/designer/client/src/actions/nk/process.ts
@@ -34,7 +34,7 @@ export type ScenarioActions =
       }
     | {
           type: "UPDATE_IMPORTED_PROCESS";
-          scenario: Scenario;
+          importedScenarioData: Pick<Scenario, "scenarioGraph" | "validationResult">;
       }
     | { type: "CLEAR_PROCESS" }
     | { type: "HIDE_RUN_PROCESS_DETAILS" }

--- a/designer/client/src/http/HttpService/HttpService.ts
+++ b/designer/client/src/http/HttpService/HttpService.ts
@@ -837,11 +837,14 @@ export class HttpService {
         return promise;
     }
 
-    importProcess(processName: ProcessName, file: File) {
+    importScenario(scenarioName: ProcessName, file: File) {
         const data = new FormData();
         data.append("process", file);
 
-        const promise = api.post(`/processes/import/${encodeURIComponent(processName)}`, data);
+        const promise = api.post<Pick<Scenario, "scenarioGraph" | "validationResult">>(
+            `/processes/import/${encodeURIComponent(scenarioName)}`,
+            data,
+        );
         promise.catch((error) => {
             this.#addError(i18next.t("notification.error.failedToImport", "Failed to import"), error, true);
         });

--- a/designer/client/src/reducers/graph/reducer.ts
+++ b/designer/client/src/reducers/graph/reducer.ts
@@ -180,7 +180,8 @@ const graphReducer: Reducer<GraphState> = (state = emptyGraphState, action): Gra
         }
         case "UPDATE_IMPORTED_PROCESS": {
             const oldNodeIds = sortBy(currentNodes.map((n) => n.id));
-            const adjustedScenario = adjustScenarioData(action.scenario);
+            const scenario: Scenario = { ...state.scenario, ...action.importedScenarioData };
+            const adjustedScenario = adjustScenarioData(scenario);
             const newNodeids = sortBy(adjustedScenario.scenarioGraph.nodes.map((n) => n.id));
             const newLayout = isEqual(oldNodeIds, newNodeids) ? state.layout : null;
 


### PR DESCRIPTION
## Describe your changes
- There were missing scenario data from the imported scenario. During import,w e received only {scenarioGraph and validationResult, so the scenario name required for validation was missing

Before:


https://github.com/user-attachments/assets/db860b4e-9eaa-478e-a6e6-97f2036279cb



After:

https://github.com/user-attachments/assets/29428e2b-fdd2-4601-9f23-3dee307198aa



## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
