### PR TITLE
Replace cancel-workflow-action with concurrency configuration

### DIFF
--- a/.github/actions/prepare_sbt_test/action.yml
+++ b/.github/actions/prepare_sbt_test/action.yml
@@ -2,11 +2,6 @@ name: Prepare build artifacts for sbt tests
 runs:
   using: "composite"
   steps:
-    - name: Cancel previous runs
-      if: github.event_name != 'push'
-      uses: styfle/cancel-workflow-action@0.13.0
-      with:
-        access_token: ${{ github.token }}
     - uses: coursier/setup-action@v1
       with:
         jvm: temurin:1.17.0.5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,9 @@ on:
     #TODO: currently release is done manually, we don't want to run this pipeline on released version, to avoid accidental pushes
     tags-ignore:
       - '**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 env:
   #we use this variable in ciRunSbt.sh
   #NOTE: for publishing we use different settings, we don't use ciRunSbt.sh there
@@ -73,11 +76,6 @@ jobs:
       # We can't just use conditional jobs mechanism ('if' directive) because 'cypressTests' job depends on this one
       shouldPerformBackendBuild: ${{ needs.setup.outputs.fe_changes_count != needs.setup.outputs.all_changes_count || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/demo' || startsWith(github.ref, 'refs/heads/preview') || startsWith(github.ref, 'refs/heads/release') }}
     steps:
-      - name: Cancel previous runs
-        if: ${{ env.shouldPerformBackendBuild == 'true' && github.event_name != 'push' }}
-        uses: styfle/cancel-workflow-action@0.13.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v6
         if: ${{ env.shouldPerformBackendBuild == 'true' }}
       - uses: coursier/setup-action@v1
@@ -117,11 +115,6 @@ jobs:
     env:
       NUSSKNACKER_VERSION: ${{ needs.setup.outputs.nk_snapshot_version }}
     steps:
-      - name: Cancel previous runs
-        if: github.event_name != 'push'
-        uses: styfle/cancel-workflow-action@0.13.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Cache npm
         id: cache-npm
@@ -287,11 +280,6 @@ jobs:
       # We can't just use conditional jobs mechanism ('if' directive) because 'publish' job depends on this one.
       shouldPerformFrontendTests: ${{ needs.setup.outputs.fe_changes_count > 0 }}
     steps:
-      - name: Cancel previous runs
-        if: ${{ env.shouldPerformFrontendTests == 'true' && github.event_name != 'push' }}
-        uses: styfle/cancel-workflow-action@0.13.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v6
         if: ${{ env.shouldPerformFrontendTests == 'true' }}
       - name: Cache npm
@@ -335,16 +323,11 @@ jobs:
       # We skip docker build for fe-only changes. Would be more clean to split this step into two steps: build image and run tests
       # e.g. by using ishworkh/docker-image-artifact-upload/download but it caused ~3min overhead for the whole pipeline so we
       # have this conditional logic in this step. We force building images on our "special" branches because run between merges
-      # could cause that cypress tests will be run at stale image (because of cancel-workflow-action).
+      # could cause that cypress tests will be run at stale image.
       shouldBuildImage: ${{ needs.setup.outputs.fe_changes_count != needs.setup.outputs.all_changes_count || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/demo' || startsWith(github.ref, 'refs/heads/preview') || startsWith(github.ref, 'refs/heads/release') }}
       GIT_SOURCE_BRANCH: ${{ needs.setup.outputs.git_source_branch }}
       BE_PORT: 7251
     steps:
-      - name: Cancel previous runs
-        if: github.event_name != 'push'
-        uses: styfle/cancel-workflow-action@0.13.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       # On self-hosted runners, docker can have some obsolete containers. Because of that, we clean them all
       - name: Clean all docker containers
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,9 @@ on:
         required: true
       dockerhub_token:
         required: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
         required: true
         default: true
         type: boolean
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -37,11 +40,6 @@ jobs:
         run: |
           echo Specified branch is not a release branch. Specified branch name: ${GITHUB_REF_NAME}. Expected branch name should start with 'release/'.
           exit 1
-
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.13.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Describe your changes

Replaces custom `cancel-workflow-action` with standard `concurrency` configuration.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
