### PR TITLE
feat: Node Details panel

### DIFF
--- a/designer/client/src/components/toolbarSettings/getToolbarComponent.ts
+++ b/designer/client/src/components/toolbarSettings/getToolbarComponent.ts
@@ -7,6 +7,7 @@ import type { ToolbarPanelProps } from "../toolbarComponents/ButtonsToolbar";
 import { ButtonsToolbar } from "../toolbarComponents/ButtonsToolbar";
 import { ActivitiesPanel } from "../toolbars/activities/ActivitiesPanel";
 import { CreatorPanel } from "../toolbars/creator/CreatorPanel";
+import { NodeDetailsPanel } from "../toolbars/nodeDetails/NodeDetailsPanel";
 import ProcessActions from "../toolbars/scenarioActions/ProcessActions";
 import ScenarioDetails from "../toolbars/scenarioDetails/ScenarioDetails";
 import ScenarioStatusPanel from "../toolbars/scenarioDetails/ScenarioStatusPanel";
@@ -35,6 +36,8 @@ export function getToolbarComponent(config?: ToolbarConfig): ComponentType<Toolb
             return lazy(() => import("../toolbars/testCases/testCasesPanel"));
         case "activities-panel":
             return ActivitiesPanel;
+        case "node-details-panel":
+            return NodeDetailsPanel;
         default:
             return ButtonsToolbar;
     }

--- a/designer/client/src/components/toolbars/nodeDetails/NodeDetailsPanel.tsx
+++ b/designer/client/src/components/toolbars/nodeDetails/NodeDetailsPanel.tsx
@@ -1,0 +1,120 @@
+import EditIcon from "@mui/icons-material/Edit";
+import { Box, Chip, IconButton, Tooltip, Typography, alpha, useTheme } from "@mui/material";
+import i18next from "i18next";
+import React, { useCallback } from "react";
+
+import { getScenario, getSelectionState } from "../../../reducers/selectors/graph";
+import { useAppSelector } from "../../../store/storeHelpers";
+import { useWindows } from "../../../windowManager/useWindows";
+import { getComponentsDefinition } from "../../graph/node-modal/NodeDetailsContent/selectors";
+import type { ToolbarPanelProps } from "../../toolbarComponents/ButtonsToolbar";
+import { ToolbarWrapper } from "../../toolbarComponents/toolbarWrapper/ToolbarWrapper";
+import { getNodeSummaryItems } from "./nodeDetailsUtils";
+
+export function NodeDetailsPanel(props: ToolbarPanelProps): React.JSX.Element {
+    const theme = useTheme();
+    const selectionState = useAppSelector(getSelectionState);
+    const scenario = useAppSelector(getScenario);
+    const components = useAppSelector(getComponentsDefinition);
+    const { openNodeWindow } = useWindows();
+
+    const selectedIds = selectionState ?? [];
+    const nodes = scenario?.scenarioGraph?.nodes ?? [];
+    const edges = scenario?.scenarioGraph?.edges ?? [];
+    const selectedNode = selectedIds.length === 1 ? nodes.find((n) => n.id === selectedIds[0]) : undefined;
+
+    const handleEdit = useCallback(() => {
+        if (selectedNode && scenario) {
+            openNodeWindow(selectedNode, scenario);
+        }
+    }, [selectedNode, scenario, openNodeWindow]);
+
+    const items = selectedNode ? getNodeSummaryItems(selectedNode, components, { edges, nodes }) : [];
+
+    return (
+        <ToolbarWrapper {...props} title={i18next.t("panels.nodeDetails.title", "Node details")}>
+            <Box px={1} pb={1}>
+                {selectedIds.length === 0 && (
+                    <Typography variant="body2" color="text.secondary" sx={{ fontStyle: "italic", mt: 0.5 }}>
+                        {i18next.t("panels.nodeDetails.noSelection", "No node selected")}
+                    </Typography>
+                )}
+
+                {selectedIds.length > 1 && (
+                    <Typography variant="body2" color="text.secondary" sx={{ fontStyle: "italic", mt: 0.5 }}>
+                        {i18next.t("panels.nodeDetails.multiSelection", "{{count}} nodes selected", { count: selectedIds.length })}
+                    </Typography>
+                )}
+
+                {selectedNode && (
+                    <>
+                        <Box display="flex" alignItems="center" justifyContent="space-between" mt={0.5} mb={1.5} gap={1}>
+                            <Box display="flex" alignItems="center" gap={1} minWidth={0}>
+                                <Tooltip title={selectedNode.name}>
+                                    <Typography variant="subtitle2" noWrap fontWeight={600}>
+                                        {selectedNode.name}
+                                    </Typography>
+                                </Tooltip>
+                                {selectedNode.isDisabled && (
+                                    <Chip label={i18next.t("panels.nodeDetails.disabled", "disabled")} size="small" color="warning" />
+                                )}
+                            </Box>
+                            <Tooltip title={i18next.t("panels.nodeDetails.edit", "Edit node")}>
+                                <IconButton
+                                    size="small"
+                                    onClick={handleEdit}
+                                    sx={{ flexShrink: 0 }}
+                                    aria-label={i18next.t("panels.nodeDetails.edit", "Edit node")}
+                                >
+                                    <EditIcon fontSize="small" />
+                                </IconButton>
+                            </Tooltip>
+                        </Box>
+
+                        {items.length > 0 && (
+                            <Box display="flex" flexDirection="column" gap={0.5}>
+                                {items.map((item) => (
+                                    <Box
+                                        key={item.label}
+                                        sx={{
+                                            borderLeft: `3px solid ${theme.palette.primary.main}`,
+                                            pl: 1,
+                                            py: 0.25,
+                                            borderRadius: "0 4px 4px 0",
+                                            backgroundColor: alpha(theme.palette.primary.main, 0.06),
+                                        }}
+                                    >
+                                        <Typography
+                                            variant="caption"
+                                            color="text.secondary"
+                                            display="block"
+                                            sx={{ lineHeight: 1.4, textTransform: "uppercase", fontSize: "0.65rem", letterSpacing: 0.4 }}
+                                        >
+                                            {item.label}
+                                        </Typography>
+                                        <Tooltip title={item.value} enterDelay={600} placement="left">
+                                            <Typography
+                                                variant="body2"
+                                                sx={{
+                                                    fontFamily: "monospace",
+                                                    fontSize: "0.72rem",
+                                                    overflow: "hidden",
+                                                    textOverflow: "ellipsis",
+                                                    whiteSpace: "nowrap",
+                                                    cursor: "default",
+                                                    color: theme.palette.text.primary,
+                                                }}
+                                            >
+                                                {item.value}
+                                            </Typography>
+                                        </Tooltip>
+                                    </Box>
+                                ))}
+                            </Box>
+                        )}
+                    </>
+                )}
+            </Box>
+        </ToolbarWrapper>
+    );
+}

--- a/designer/client/src/components/toolbars/nodeDetails/nodeDetailsUtils.test.ts
+++ b/designer/client/src/components/toolbars/nodeDetails/nodeDetailsUtils.test.ts
@@ -1,0 +1,486 @@
+import type { Edge } from "../../../types/edge";
+import { EdgeKind } from "../../../types/edge";
+import type { NodeType } from "../../../types/node";
+import { formatValue, getNodeSummaryItems } from "./nodeDetailsUtils";
+
+// eslint-disable-next-line i18next/no-literal-string
+const expr = (expression: string) => ({ expression });
+const param = (name: string, expression: string) => ({ name, expression: expr(expression) });
+
+describe("nodeDetailsUtils", () => {
+    describe("formatValue", () => {
+        describe("duration formatting", () => {
+            it("should format seconds", () => {
+                expect(formatValue("timeout", "T(java.time.Duration).parse('PT10S')")).toBe("10s");
+            });
+
+            it("should format minutes", () => {
+                expect(formatValue("timeout", "T(java.time.Duration).parse('PT30M')")).toBe("30m");
+            });
+
+            it("should format hours and minutes", () => {
+                expect(formatValue("timeout", "T(java.time.Duration).parse('PT1H30M')")).toBe("1h 30m");
+            });
+
+            it("should format Period with years and months", () => {
+                expect(formatValue("period", "T(java.time.Period).parse('P1Y2M')")).toBe("1y 2mo");
+            });
+
+            it("should add 'every' prefix for schedule label", () => {
+                expect(formatValue("schedule", "T(java.time.Duration).parse('PT10M')")).toBe("every 10m");
+            });
+
+            it("should not add 'every' prefix for non-schedule labels", () => {
+                expect(formatValue("delay", "T(java.time.Duration).parse('PT10M')")).toBe("10m");
+            });
+        });
+
+        describe("enum formatting", () => {
+            it("should format SCREAMING_SNAKE_CASE enum", () => {
+                expect(formatValue("trigger", "T(com.example.Trigger).ON_EACH_EVENT")).toBe("On each event");
+            });
+
+            it("should format PascalCase enum", () => {
+                expect(formatValue("emitWhen", "T(com.example.Trigger).OnEvent")).toBe("On event");
+            });
+
+            it("should format multi-word PascalCase enum", () => {
+                expect(formatValue("trigger", "T(com.example.Trigger).AfterWindowCloses")).toBe("After window closes");
+            });
+
+            it("should format single word PascalCase enum", () => {
+                expect(formatValue("mode", "T(com.example.Mode).Enabled")).toBe("Enabled");
+            });
+        });
+
+        describe("string literal stripping", () => {
+            it("should strip surrounding single quotes", () => {
+                expect(formatValue("topic", "'my-topic'")).toBe("my-topic");
+            });
+
+            it("should strip quotes from empty string literal", () => {
+                expect(formatValue("topic", "''")).toBe("");
+            });
+
+            it("should not strip mismatched quotes", () => {
+                expect(formatValue("x", "'hello")).toBe("'hello");
+            });
+        });
+
+        describe("plain values", () => {
+            it("should return SpEL variable unchanged", () => {
+                expect(formatValue("key", "#input.id")).toBe("#input.id");
+            });
+
+            it("should return numeric literal unchanged", () => {
+                expect(formatValue("count", "42")).toBe("42");
+            });
+        });
+    });
+
+    describe("getNodeSummaryItems", () => {
+        describe("Filter", () => {
+            it("should show condition and true/false paths with target node names", () => {
+                const node = { type: "Filter", id: "f1", name: "f", expression: expr("#input.age > 18") } as unknown as NodeType;
+                const nodes = [
+                    { id: "f1", name: "f", type: "Filter" },
+                    { id: "n1", name: "adult path", type: "Sink" },
+                    { id: "n2", name: "rejected", type: "Sink" },
+                ] as unknown as NodeType[];
+                const edges: Edge[] = [
+                    { from: "f1", to: "n1", edgeType: { type: EdgeKind.filterTrue } },
+                    { from: "f1", to: "n2", edgeType: { type: EdgeKind.filterFalse } },
+                ];
+                expect(getNodeSummaryItems(node, undefined, { edges, nodes })).toEqual([
+                    { label: "condition", value: "#input.age > 18" },
+                    { label: "true", value: "-> adult path" },
+                    { label: "false", value: "-> rejected" },
+                ]);
+            });
+
+            it("should show only paths when expression is empty", () => {
+                const node = { type: "Filter", id: "f1", name: "f", expression: expr("") } as unknown as NodeType;
+                const nodes = [
+                    { id: "n1", name: "pass", type: "Sink" },
+                    { id: "n2", name: "drop", type: "Sink" },
+                ] as unknown as NodeType[];
+                const edges: Edge[] = [
+                    { from: "f1", to: "n1", edgeType: { type: EdgeKind.filterTrue } },
+                    { from: "f1", to: "n2", edgeType: { type: EdgeKind.filterFalse } },
+                ];
+                expect(getNodeSummaryItems(node, undefined, { edges, nodes })).toEqual([
+                    { label: "true", value: "-> pass" },
+                    { label: "false", value: "-> drop" },
+                ]);
+            });
+        });
+
+        describe("Switch", () => {
+            it("should show conditions with target node names from edges", () => {
+                const node = { type: "Switch", id: "s1", name: "s" } as unknown as NodeType;
+                const nodes = [
+                    { id: "s1", name: "s", type: "Switch" },
+                    { id: "n1", name: "adult path", type: "Filter" },
+                    { id: "n2", name: "default path", type: "Sink" },
+                ] as unknown as NodeType[];
+                const edges: Edge[] = [
+                    {
+                        from: "s1",
+                        to: "n1",
+                        edgeType: { type: EdgeKind.switchNext, condition: { language: "spel", expression: "#input.age > 18" } },
+                    },
+                    { from: "s1", to: "n2", edgeType: { type: EdgeKind.switchDefault } },
+                ];
+                expect(getNodeSummaryItems(node, undefined, { edges, nodes })).toEqual([
+                    { label: "-> adult path", value: "#input.age > 18" },
+                    { label: "-> default path", value: "default" },
+                ]);
+            });
+        });
+
+        describe("Variable", () => {
+            it("should show output variable and value", () => {
+                const node = { type: "Variable", id: "v1", name: "v", outputVar: "result", value: expr("1 + 2") } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([
+                    { label: "output variable", value: "#result" },
+                    { label: "value", value: "1 + 2" },
+                ]);
+            });
+        });
+
+        describe("MapVariable", () => {
+            it("should show only output variable", () => {
+                const node = { type: "MapVariable", id: "mv1", name: "mv", outputVar: "result" } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([{ label: "output variable", value: "#result" }]);
+            });
+        });
+
+        describe("Source", () => {
+            it("should show topic parameter for Kafka source", () => {
+                const node = {
+                    type: "Source",
+                    id: "src1",
+                    name: "src",
+                    ref: { parameters: [param("topic", "'my-topic'")] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([{ label: "topic", value: "my-topic" }]);
+            });
+
+            it("should show empty topic for Kafka source when not yet filled", () => {
+                const node = {
+                    type: "Source",
+                    id: "src0",
+                    name: "src",
+                    ref: { parameters: [param("topic", "")] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([{ label: "topic", value: "" }]);
+            });
+
+            it("should show schedule for EventGenerator source", () => {
+                const node = {
+                    type: "Source",
+                    id: "src2",
+                    name: "eg",
+                    ref: {
+                        typ: "event-generator",
+                        parameters: [param("schedule", "T(java.time.Duration).parse('PT10M')"), param("value", "123")],
+                    },
+                } as unknown as NodeType;
+                const items = getNodeSummaryItems(node, undefined);
+                expect(items).toEqual([{ label: "schedule", value: "every 10m" }]);
+            });
+
+            it("should show ref.typ as topic fallback for per-topic Kafka source", () => {
+                const node = {
+                    type: "Source",
+                    id: "src3",
+                    name: "src",
+                    ref: { typ: "some.kafka.InputTopic", parameters: [] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([{ label: "topic", value: "some.kafka.InputTopic" }]);
+            });
+
+            it("should show url for HTTP source", () => {
+                const node = {
+                    type: "Source",
+                    id: "src4",
+                    name: "src",
+                    ref: { parameters: [param("url", "'https://api.example.com'")] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toContainEqual({ label: "url", value: "https://api.example.com" });
+            });
+        });
+
+        describe("Sink", () => {
+            it("should show topic parameter", () => {
+                const node = {
+                    type: "Sink",
+                    id: "snk1",
+                    name: "snk",
+                    ref: { parameters: [param("topic", "'output-topic'")] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([{ label: "topic", value: "output-topic" }]);
+            });
+
+            it("should show empty topic for Kafka sink when not yet filled", () => {
+                const node = {
+                    type: "Sink",
+                    id: "snk0",
+                    name: "snk",
+                    ref: { parameters: [param("topic", "")] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([{ label: "topic", value: "" }]);
+            });
+        });
+
+        describe("Enricher", () => {
+            it("should show endpoint and output variable", () => {
+                const node = {
+                    type: "Enricher",
+                    id: "e1",
+                    name: "e",
+                    output: "result",
+                    service: { parameters: [param("endpoint", "'https://api.example.com/data'")] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([
+                    { label: "endpoint", value: "https://api.example.com/data" },
+                    { label: "output variable", value: "#result" },
+                ]);
+            });
+
+            it("should show url and output variable for http callback enricher", () => {
+                const node = {
+                    type: "Enricher",
+                    id: "e2",
+                    name: "http",
+                    output: "response",
+                    service: { parameters: [param("url", "'https://api.example.com/callback'"), param("method", "'POST'")] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([
+                    { label: "url", value: "https://api.example.com/callback" },
+                    { label: "output variable", value: "#response" },
+                ]);
+            });
+
+            it("should show empty url for http enricher when not yet filled", () => {
+                const node = {
+                    type: "Enricher",
+                    id: "e3",
+                    name: "http",
+                    output: "response",
+                    service: { parameters: [param("url", ""), param("method", "'POST'")] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([
+                    { label: "url", value: "" },
+                    { label: "output variable", value: "#response" },
+                ]);
+            });
+
+            it("should show service id and all params for OpenAPI enricher including empty", () => {
+                const node = {
+                    type: "Enricher",
+                    id: "oa1",
+                    name: "flights",
+                    output: "flightData",
+                    service: {
+                        id: "flights-openAPI",
+                        parameters: [param("departureAirport", "'WAW'"), param("arrivalAirport", "")],
+                    },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([
+                    { label: "service", value: "flights-openAPI" },
+                    { label: "departureAirport", value: "WAW" },
+                    { label: "arrivalAirport", value: "" },
+                    { label: "output variable", value: "#flightData" },
+                ]);
+            });
+        });
+
+        describe("Processor", () => {
+            it("should show url for http callback processor", () => {
+                const node = {
+                    type: "Processor",
+                    id: "p1",
+                    name: "http",
+                    service: { parameters: [param("url", "'https://api.example.com/notify'"), param("method", "'POST'")] },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([{ label: "url", value: "https://api.example.com/notify" }]);
+            });
+        });
+
+        describe("CustomNode", () => {
+            it("should show matchCondition and output variable for Decision Table", () => {
+                const node = {
+                    type: "CustomNode",
+                    id: "dt1",
+                    name: "dt",
+                    nodeType: "decision-table",
+                    outputVar: "dtResult",
+                    parameters: [param("Match condition", "true"), param("Decision Table", "{'columns':[],'rows':[]}")],
+                } as unknown as NodeType;
+                const items = getNodeSummaryItems(node, undefined);
+                expect(items).toContainEqual({ label: "Match condition", value: "true" });
+                expect(items).toContainEqual({ label: "output variable", value: "#dtResult" });
+                expect(items).not.toContainEqual(expect.objectContaining({ label: "Decision Table" }));
+            });
+
+            it("should show key, value and stateTimeout for Union Memo", () => {
+                const node = {
+                    type: "CustomNode",
+                    id: "um1",
+                    name: "um",
+                    nodeType: "union-memo",
+                    parameters: [
+                        param("key", "#input.id"),
+                        param("value", "#input.amount"),
+                        param("stateTimeout", "T(java.time.Duration).parse('PT1H')"),
+                    ],
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([
+                    { label: "key", value: "#input.id" },
+                    { label: "value", value: "#input.amount" },
+                    { label: "stateTimeout", value: "1h" },
+                ]);
+            });
+
+            it("should show emitWhen, endSessionCondition, sessionTimeout, groupBy, key and outputVar for aggregate-session", () => {
+                const node = {
+                    type: "CustomNode",
+                    id: "as1",
+                    name: "as",
+                    nodeType: "aggregate-session",
+                    outputVar: "sessionResult",
+                    parameters: [
+                        param("emitWhen", "T(foo.SessionWindowTrigger).OnEvent"),
+                        param("endSessionCondition", "#input.isLast"),
+                        param("sessionTimeout", "T(java.time.Duration).parse('PT30M')"),
+                        param("groupBy", "#input.userId"),
+                        param("key", "#input.id"),
+                        param("aggregator", "T(foo.Agg).Sum"),
+                    ],
+                } as unknown as NodeType;
+                const items = getNodeSummaryItems(node, undefined);
+                expect(items).toContainEqual({ label: "emitWhen", value: "On event" });
+                expect(items).toContainEqual({ label: "endSessionCondition", value: "#input.isLast" });
+                expect(items).toContainEqual({ label: "sessionTimeout", value: "30m" });
+                expect(items).toContainEqual({ label: "groupBy", value: "#input.userId" });
+                expect(items).toContainEqual({ label: "key", value: "#input.id" });
+                expect(items).toContainEqual({ label: "output variable", value: "#sessionResult" });
+                expect(items).not.toContainEqual(expect.objectContaining({ label: "aggregator" }));
+            });
+
+            it("should show emitWhen, windowLength and outputVar for aggregate-tumbling, hide aggregator", () => {
+                const node = {
+                    type: "CustomNode",
+                    id: "ag1",
+                    name: "ag",
+                    nodeType: "aggregate-tumbling",
+                    outputVar: "tumblingResult",
+                    parameters: [
+                        param("emitWhen", "T(foo.SessionWindowTrigger).OnEvent"),
+                        param("windowLength", "T(java.time.Duration).parse('PT1H')"),
+                        param("aggregator", "T(foo.Agg).Sum"),
+                        param("aggregateBy", "#input.value"),
+                    ],
+                } as unknown as NodeType;
+                const items = getNodeSummaryItems(node, undefined);
+                expect(items).toContainEqual({ label: "emitWhen", value: "On event" });
+                expect(items).toContainEqual({ label: "windowLength", value: "1h" });
+                expect(items).toContainEqual({ label: "output variable", value: "#tumblingResult" });
+                expect(items).not.toContainEqual(expect.objectContaining({ label: "aggregator" }));
+                expect(items).not.toContainEqual(expect.objectContaining({ label: "aggregateBy" }));
+            });
+
+            it("should show emitWhen, emitWhenEventLeft, windowLength, groupBy, key and outputVar for aggregate-sliding", () => {
+                const node = {
+                    type: "CustomNode",
+                    id: "ag3",
+                    name: "sliding",
+                    nodeType: "aggregate-sliding",
+                    outputVar: "slidingResult",
+                    parameters: [
+                        param("emitWhen", "T(foo.SlidingTrigger).OnEvent"),
+                        param("emitWhenEventLeft", "true"),
+                        param("windowLength", "T(java.time.Duration).parse('PT1H')"),
+                        param("groupBy", "#input.category"),
+                        param("key", "#input.id"),
+                        param("aggregator", "T(foo.Agg).Sum"),
+                    ],
+                } as unknown as NodeType;
+                const items = getNodeSummaryItems(node, undefined);
+                expect(items).toContainEqual({ label: "emitWhen", value: "On event" });
+                expect(items).toContainEqual({ label: "emitWhenEventLeft", value: "true" });
+                expect(items).toContainEqual({ label: "windowLength", value: "1h" });
+                expect(items).toContainEqual({ label: "groupBy", value: "#input.category" });
+                expect(items).toContainEqual({ label: "key", value: "#input.id" });
+                expect(items).toContainEqual({ label: "output variable", value: "#slidingResult" });
+                expect(items).not.toContainEqual(expect.objectContaining({ label: "aggregator" }));
+            });
+
+            it("should show key and delay for Delay node", () => {
+                const node = {
+                    type: "CustomNode",
+                    id: "d1",
+                    name: "delay",
+                    nodeType: "delay",
+                    parameters: [param("key", "#input.id"), param("delay", "T(java.time.Duration).parse('PT30S')")],
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([
+                    { label: "key", value: "#input.id" },
+                    { label: "delay", value: "30s" },
+                ]);
+            });
+
+            it("should include groupBy when present", () => {
+                const node = {
+                    type: "CustomNode",
+                    id: "ag2",
+                    name: "ag",
+                    nodeType: "aggregate-sliding",
+                    parameters: [
+                        param("emitWhen", "T(foo.Trigger).OnEvent"),
+                        param("groupBy", "#input.category"),
+                        param("key", "#input.id"),
+                    ],
+                } as unknown as NodeType;
+                const items = getNodeSummaryItems(node, undefined);
+                expect(items).toContainEqual({ label: "groupBy", value: "#input.category" });
+            });
+        });
+
+        describe("FragmentInput", () => {
+            it("should show ref id and output variable names", () => {
+                const node = {
+                    type: "FragmentInput",
+                    id: "fi1",
+                    name: "fi",
+                    ref: { id: "my-fragment", outputVariableNames: { out1: "result", out2: "extra" } },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([
+                    { label: "ref", value: "my-fragment" },
+                    { label: "output.out1", value: "#result" },
+                    { label: "output.out2", value: "#extra" },
+                ]);
+            });
+
+            it("should show ref id, input parameters with values, and output variable names", () => {
+                const node = {
+                    type: "FragmentInput",
+                    id: "fi2",
+                    name: "fi",
+                    ref: {
+                        id: "empty fragment",
+                        parameters: [param("a", "'hello'"), param("b", "#input.id"), param("c", "")],
+                        outputVariableNames: { output: "empty_fragment_output" },
+                    },
+                } as unknown as NodeType;
+                expect(getNodeSummaryItems(node, undefined)).toEqual([
+                    { label: "ref", value: "empty fragment" },
+                    { label: "a", value: "hello" },
+                    { label: "b", value: "#input.id" },
+                    { label: "output variable", value: "#empty_fragment_output" },
+                ]);
+            });
+        });
+    });
+});

--- a/designer/client/src/components/toolbars/nodeDetails/nodeDetailsUtils.ts
+++ b/designer/client/src/components/toolbars/nodeDetails/nodeDetailsUtils.ts
@@ -1,0 +1,316 @@
+import ProcessUtils from "../../../common/ProcessUtils";
+import { ParameterCategory } from "../../../types/definition";
+import type { UIParameter } from "../../../types/definition";
+import type { Edge } from "../../../types/edge";
+import { EdgeKind } from "../../../types/edge";
+import type { NodeType } from "../../../types/node";
+import type { ComponentDefinition } from "../../../types/scenarioGraph";
+import { EditorType } from "../../graph/node-modal/editors/expression/types";
+
+export interface NodeSummaryContext {
+    edges: Edge[];
+    nodes: NodeType[];
+}
+
+export interface SummaryItem {
+    label: string;
+    value: string;
+}
+
+// ─── Value formatting ──────────────────────────────────────────────────────────
+
+const DURATION_EXPR_RE = /^T\(java\.time\.(?:Duration|Period)\)\.parse\('([^']+)'\)$/;
+const ENUM_EXPR_RE = /^T\([^)]+\)\.([A-Za-z][A-Za-z0-9_]*)$/;
+
+function formatIso8601Duration(iso: string): string {
+    const m = iso.match(/^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:([\d.]+)S)?)?$/);
+    if (!m) return iso;
+    const [, years, months, weeks, days, hours, mins, secs] = m;
+    const parts: string[] = [];
+    if (years) parts.push(`${years}y`);
+    if (months) parts.push(`${months}mo`);
+    if (weeks) parts.push(`${weeks}w`);
+    if (days) parts.push(`${days}d`);
+    if (hours) parts.push(`${hours}h`);
+    if (mins) parts.push(`${mins}m`);
+    if (secs) {
+        const s = parseFloat(secs);
+        parts.push(`${s % 1 === 0 ? Math.round(s) : s}s`);
+    }
+    return parts.join(" ") || iso;
+}
+
+function formatEnumExpression(value: string): string | null {
+    const m = value.match(ENUM_EXPR_RE);
+    if (!m) return null;
+    const name = m[1];
+    // SCREAMING_SNAKE_CASE: ON_EACH_EVENT → "On each event"
+    if (name.includes("_")) {
+        return name
+            .split("_")
+            .map((word, i) => (i === 0 ? word.charAt(0).toUpperCase() + word.slice(1).toLowerCase() : word.toLowerCase()))
+            .join(" ");
+    }
+    // PascalCase: OnEvent → "On event", AfterWindowCloses → "After window closes"
+    return name
+        .replace(/([A-Z])/g, " $1")
+        .trim()
+        .split(" ")
+        .map((word, i) => (i === 0 ? word.charAt(0).toUpperCase() + word.slice(1).toLowerCase() : word.toLowerCase()))
+        .join(" ");
+}
+
+/** Format a raw SpEL expression value into a human-readable string.
+ *  @param label - parameter name, used to add "every" prefix for schedule params */
+export function formatValue(label: string, value: string): string {
+    const durationMatch = value.match(DURATION_EXPR_RE);
+    if (durationMatch) {
+        const formatted = formatIso8601Duration(durationMatch[1]);
+        return label.toLowerCase() === "schedule" ? `every ${formatted}` : formatted;
+    }
+    const enumFormatted = formatEnumExpression(value);
+    if (enumFormatted) return enumFormatted;
+    // Strip surrounding single quotes from SpEL string literals: 'foo' → foo
+    if (value.startsWith("'") && value.endsWith("'") && value.length >= 2) {
+        return value.slice(1, -1);
+    }
+    return value;
+}
+
+// ─── Parameter helpers ────────────────────────────────────────────────────────
+
+type RawParam = { name: string; expression: { expression: string } };
+
+/** Parameters that are too complex / irrelevant to show in the summary panel. */
+const HIDDEN_PARAM_NAMES = new Set(["aggregator", "aggregateBy", "body", "Decision Table"]);
+
+function paramItems(parameters: RawParam[] | undefined, nameFilter?: (name: string) => boolean, includeEmpty = false): SummaryItem[] {
+    if (!parameters?.length) return [];
+    const filtered = nameFilter ? parameters.filter((p) => nameFilter(p.name)) : parameters;
+    const mapped = filtered.map((p) => ({ label: p.name, value: p.expression?.expression ?? "" }));
+    return includeEmpty ? mapped : mapped.filter((item) => item.value !== "");
+}
+
+function outputVarItem(node: NodeType): SummaryItem[] {
+    const outputVar = node.outputVar ?? node.output ?? node.varName ?? node.outputName;
+    if (!outputVar) return [];
+    return [{ label: "output variable", value: `#${outputVar}` }];
+}
+
+function isTopicParam(name: string): boolean {
+    return name.toLowerCase().includes("topic");
+}
+
+function standardParamItems(
+    parameters: RawParam[] | undefined,
+    componentDef: ComponentDefinition | null,
+    hiddenNames: Set<string> = HIDDEN_PARAM_NAMES,
+): SummaryItem[] {
+    if (!parameters?.length) return [];
+    const paramDefs = componentDef?.parameters ?? [];
+    return parameters
+        .filter((p) => {
+            if (hiddenNames.has(p.name)) return false;
+            const def = paramDefs.find((d) => d.name === p.name);
+            return !def || def.category !== ParameterCategory.Advanced;
+        })
+        .map((p) => ({ label: p.name, value: p.expression?.expression ?? "" }))
+        .filter((item) => item.value !== "");
+}
+
+// ─── Per-type config ──────────────────────────────────────────────────────────
+
+type NodeSummaryFn = (node: NodeType, componentDef: ComponentDefinition | null, context: NodeSummaryContext) => SummaryItem[];
+
+const NODE_SUMMARY_CONFIG: Partial<Record<string, NodeSummaryFn>> = {
+    Filter: (n, _def, { edges, nodes }) => {
+        const items: SummaryItem[] = [];
+        if (n.expression?.expression) items.push({ label: "condition", value: n.expression.expression });
+        const outgoing = edges.filter((e) => e.from === n.id);
+        for (const e of outgoing) {
+            const targetName = `-> ${nodes.find((nd) => nd.id === e.to)?.name ?? e.to}`;
+            if (e.edgeType?.type === EdgeKind.filterTrue) items.push({ label: "true", value: targetName });
+            if (e.edgeType?.type === EdgeKind.filterFalse) items.push({ label: "false", value: targetName });
+        }
+        return items;
+    },
+
+    Switch: (n, _def, { edges, nodes }) => {
+        const outgoing = edges.filter((e) => e.from === n.id);
+        return outgoing.flatMap((e) => {
+            const targetName = `-> ${nodes.find((nd) => nd.id === e.to)?.name ?? e.to}`;
+            if (e.edgeType?.type === EdgeKind.switchNext && e.edgeType.condition?.expression) {
+                return [{ label: targetName, value: e.edgeType.condition.expression }];
+            }
+            if (e.edgeType?.type === EdgeKind.switchDefault) {
+                return [{ label: targetName, value: "default" }];
+            }
+            return [];
+        });
+    },
+
+    Variable: (n) => [...outputVarItem(n), { label: "value", value: n.value?.expression ?? "" }].filter((i) => i.value !== ""),
+
+    MapVariable: (n) => outputVarItem(n),
+
+    Source: (n, def) => {
+        const params = n.ref?.parameters ?? [];
+        const topicItems = paramItems(params, isTopicParam, true);
+        if (topicItems.length > 0) return [...topicItems, ...outputVarItem(n)];
+        const urlItems = paramItems(params, (name) => name.toLowerCase() === "url" || name.toLowerCase() === "endpoint", true);
+        if (urlItems.length > 0) return [...urlItems, ...outputVarItem(n)];
+        const isEventGenerator = n.ref?.typ?.toLowerCase().includes("event-generator");
+        const eventGeneratorHidden = isEventGenerator ? new Set([...HIDDEN_PARAM_NAMES, "value"]) : HIDDEN_PARAM_NAMES;
+        const standardItems = standardParamItems(params, def, eventGeneratorHidden);
+        // Fallback: if nothing useful found, show ref.typ as topic (Kafka per-topic components)
+        if (standardItems.length === 0 && n.ref?.typ) {
+            return [{ label: "topic", value: n.ref.typ }, ...outputVarItem(n)];
+        }
+        return [...standardItems, ...outputVarItem(n)].filter((i) => i.value !== "");
+    },
+
+    Sink: (n, def) => {
+        const params = n.ref?.parameters ?? [];
+        const topicItems = paramItems(params, isTopicParam, true);
+        if (topicItems.length > 0) return topicItems;
+        return standardParamItems(params, def).filter((i) => i.value !== "");
+    },
+
+    Enricher: (n, def) => {
+        const params = n.service?.parameters ?? [];
+        const urlItems = paramItems(params, (name) => name.toLowerCase() === "url" || name.toLowerCase() === "endpoint", true);
+        if (urlItems.length > 0) return [...urlItems, ...outputVarItem(n)];
+        // OpenAPI / lookup enrichers: always show service id + all dynamic params (including empty)
+        const serviceId = n.service?.id ?? "";
+        if (serviceId.endsWith("openAPI") || serviceId.endsWith("lookup")) {
+            return [{ label: "service", value: serviceId }, ...paramItems(params, undefined, true), ...outputVarItem(n)];
+        }
+        return [...standardParamItems(params, def), ...outputVarItem(n)].filter((i) => i.value !== "");
+    },
+
+    Processor: (n, def) => {
+        const params = n.service?.parameters ?? [];
+        const urlItems = paramItems(params, (name) => name.toLowerCase() === "url" || name.toLowerCase() === "endpoint", true);
+        if (urlItems.length > 0) return urlItems;
+        return standardParamItems(params, def).filter((i) => i.value !== "");
+    },
+
+    CustomNode: (n, def) => {
+        const params = n.parameters ?? [];
+        const nodeType = n.nodeType ?? "";
+        // Decision table: show only matchCondition + output variable
+        if (nodeType === "decision-table") {
+            const matchItems = params
+                .filter((p) => p.name.toLowerCase().replace(/[\s_-]/g, "") === "matchcondition")
+                .map((p) => ({ label: p.name, value: p.expression?.expression ?? "" }));
+            return [...matchItems, ...outputVarItem(n)].filter((i) => i.value !== "");
+        }
+        // Union Memo: show key + value + stateTimeout + groupBy
+        if (nodeType === "union-memo") {
+            return paramItems(params, (name) => {
+                const normalized = name.toLowerCase().replace(/[\s_-]/g, "");
+                return normalized === "key" || normalized === "value" || normalized === "statetimeout" || normalized === "groupby";
+            });
+        }
+        // Aggregate Session: show emitWhen + endSessionCondition + sessionTimeout + groupBy + key + outputVar
+        if (nodeType === "aggregate-session") {
+            return [
+                ...paramItems(params, (name) => {
+                    const normalized = name.toLowerCase().replace(/[\s_-]/g, "");
+                    return (
+                        normalized === "emitwhen" ||
+                        normalized === "endsessioncondition" ||
+                        normalized === "sessiontimeout" ||
+                        normalized === "groupby" ||
+                        normalized === "key"
+                    );
+                }),
+                ...outputVarItem(n),
+            ].filter((i) => i.value !== "");
+        }
+        // Aggregate Sliding: show emitWhen + emitWhenEventLeft + windowLength + groupBy + key + outputVar
+        if (nodeType === "aggregate-sliding") {
+            return [
+                ...paramItems(params, (name) => {
+                    const normalized = name.toLowerCase().replace(/[\s_-]/g, "");
+                    return (
+                        normalized === "emitwhen" ||
+                        normalized === "emitwheneventleft" ||
+                        normalized === "windowlength" ||
+                        normalized === "groupby" ||
+                        normalized === "key"
+                    );
+                }),
+                ...outputVarItem(n),
+            ].filter((i) => i.value !== "");
+        }
+        // Aggregate Tumbling: show emitWhen + windowLength + groupBy + key + outputVar
+        if (nodeType === "aggregate-tumbling") {
+            return [
+                ...paramItems(params, (name) => {
+                    const normalized = name.toLowerCase().replace(/[\s_-]/g, "");
+                    return normalized === "emitwhen" || normalized === "windowlength" || normalized === "groupby" || normalized === "key";
+                }),
+                ...outputVarItem(n),
+            ].filter((i) => i.value !== "");
+        }
+        // Delay: show key + delay duration + groupBy
+        if (nodeType === "delay") {
+            return paramItems(params, (name) => {
+                const normalized = name.toLowerCase().replace(/[\s_-]/g, "");
+                return normalized === "key" || normalized === "delay" || normalized === "groupby";
+            });
+        }
+        return [...outputVarItem(n), ...standardParamItems(params, def)].filter((i) => i.value !== "");
+    },
+
+    FragmentInput: (n) => {
+        const base: SummaryItem[] = [{ label: "ref", value: n.ref?.id ?? "" }];
+        const inputParams = paramItems(n.ref?.parameters);
+        inputParams.forEach((item) => base.push(item));
+        const outputVarNames = n.ref?.outputVariableNames;
+        if (outputVarNames) {
+            Object.entries(outputVarNames).forEach(([k, v]) =>
+                base.push({ label: k === "output" ? "output variable" : `output.${k}`, value: `#${v}` }),
+            );
+        }
+        return base.filter((i) => i.value !== "");
+    },
+};
+
+function findFixedValueLabel(paramDef: UIParameter | undefined, expression: string): string | null {
+    if (!paramDef?.editors) return null;
+    for (const editor of paramDef.editors) {
+        if (
+            (editor.type === EditorType.FIXED_VALUES_PARAMETER_EDITOR ||
+                editor.type === EditorType.FIXED_VALUES_WITH_ICON_PARAMETER_EDITOR ||
+                editor.type === EditorType.FIXED_VALUES_WITH_RADIO_PARAMETER_EDITOR) &&
+            "possibleValues" in editor
+        ) {
+            const match = editor.possibleValues.find((v) => v.expression === expression);
+            if (match) return match.label;
+        }
+    }
+    return null;
+}
+
+export function getNodeSummaryItems(
+    node: NodeType,
+    components: Record<string, ComponentDefinition> | undefined,
+    context: NodeSummaryContext = { edges: [], nodes: [] },
+): SummaryItem[] {
+    const componentDef = components ? ProcessUtils.extractComponentDefinition(node, components) : null;
+    const specific = NODE_SUMMARY_CONFIG[node.type];
+    const items = specific
+        ? specific(node, componentDef, context)
+        : [
+              ...outputVarItem(node),
+              ...standardParamItems(node.parameters ?? node.ref?.parameters ?? node.service?.parameters ?? [], componentDef),
+          ];
+
+    return items.map((item) => {
+        const paramDef = componentDef?.parameters?.find((p) => p.name === item.label);
+        const fixedLabel = findFixedValueLabel(paramDef, item.value);
+        return { ...item, value: fixedLabel ?? formatValue(item.label, item.value) };
+    });
+}

--- a/designer/client/src/reducers/selectors/toolbars.ts
+++ b/designer/client/src/reducers/selectors/toolbars.ts
@@ -21,6 +21,11 @@ const appendTestCasesPanel = produce((draft: WithId<ToolbarsConfig>) => {
     draft.bottomRight.unshift({ id: "test-cases-panel" });
 });
 
+const appendNodeDetailsPanel = produce((draft: WithId<ToolbarsConfig>) => {
+    draft.topRight ||= [];
+    draft.topRight.unshift({ id: "node-details-panel" });
+});
+
 const appendAlignToolbar = produce((draft: WithId<ToolbarsConfig>) => {
     draft.topRight ||= [];
     draft.topRight.push({
@@ -39,7 +44,9 @@ const appendAlignToolbar = produce((draft: WithId<ToolbarsConfig>) => {
 });
 
 export const getToolbarsConfig = createSelector([getSettings, getUserSettings], (settings, userSettings) => {
-    const withDynamicToolbars = appendTestCasesPanel(appendSurveyToolbar(settings?.processToolbarsConfiguration));
+    const withSurvey = appendSurveyToolbar(settings?.processToolbarsConfiguration);
+    const withNodeDetails = userSettings["scenario.showNodeDetailsPanel"] ? appendNodeDetailsPanel(withSurvey) : withSurvey;
+    const withDynamicToolbars = appendTestCasesPanel(withNodeDetails);
     if (userSettings["debug.scenario.showNodeAlignToolbar"]) {
         return appendAlignToolbar(withDynamicToolbars);
     }

--- a/designer/client/src/reducers/userSettings.ts
+++ b/designer/client/src/reducers/userSettings.ts
@@ -65,9 +65,10 @@ export const getDefaultUserSettings = (initialUserFlags?: Record<string, boolean
         createFlag("scenario.liveData.showNodeAnimations", true),
         createFlag("scenario.liveData.showTransitionAnimations", true),
         createFlag("scenario.showBreadcrumbs"),
+        createFlag("scenario.showNodeDetailsPanel"),
+        createFlag("scenario.showTestCasesPanel"),
         createFlag("toolbar.autoSaveDuringDeployRedeploy"),
         createFlag(SNOW_SNOW_FLAG, false),
-        createFlag("scenario.showTestCasesPanel"),
     ];
     return Object.fromEntries(entries) as Readonly<Prettify<Record<KeysOfEntries<typeof entries>, boolean>>>;
 };


### PR DESCRIPTION
## Summary

- Adds a new **Node Details** sidebar panel displaying key parameters of a selected node without opening the node editor
- Panel is behind feature flag `scenario.showNodeDetailsPanel` in `__settings`
- Supported node types: Filter (condition + true/false paths), Switch/Choice (conditions with target node names), Variable/MapVariable, Source/Sink (Kafka topic, always shown even when empty), Enricher/Processor (url/endpoint; OpenAPI: service id + all dynamic params), CustomNode (aggregate-tumbling/sliding/session, union-memo, delay, decision-table), FragmentInput (ref + input params + output vars)
- Value formatting: ISO 8601 durations, SpEL enum expressions (SCREAMING_SNAKE_CASE and PascalCase), SpEL string literals, FixedValues labels from component definitions

## Test plan

- [ ] Enable `scenario.showNodeDetailsPanel` in `__settings`
- [ ] Select a Kafka source/sink — topic shown even when empty
- [ ] Select an HTTP enricher — url shown, method hidden
- [ ] Select an OpenAPI enricher — service id + all params shown
- [ ] Select a Filter node — condition + true/false paths with target node names
- [ ] Select a Switch/Choice node — conditions with target node names
- [ ] Select aggregate-tumbling/sliding/session — correct params shown
- [ ] Select a FragmentInput — ref + input params + output variable names
- [ ] Unit tests: `jest --testPathPattern=nodeDetailsUtils` (41 tests)