### PR TITLE
Add #records hint to Assertions tooltip and Actual field info icon

### DIFF
--- a/designer/client/src/components/graph/node-modal/editors/ParamKeyProvider.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/ParamKeyProvider.tsx
@@ -11,12 +11,12 @@ const ParamKey = React.createContext<ParamKeys>(null);
 export const ParamKeyProvider = ({
     node,
     param,
-    value: valueProp,
+    custom,
     children,
-}: PropsWithChildren<{ node?: NodeType; param?: Parameter; value?: ParamKeys }>) => {
+}: PropsWithChildren<{ node?: NodeType; param?: Parameter; custom: ParamKeys }>) => {
     const value = useMemo(() => {
-        return valueProp ?? determineParameterKey(node, param);
-    }, [valueProp, node, param]);
+        return custom ?? determineParameterKey(node, param);
+    }, [custom, node, param]);
 
     return (
         <ParamKey.Provider value={value}>

--- a/designer/client/src/components/graph/node-modal/editors/ParamKeyProvider.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/ParamKeyProvider.tsx
@@ -8,10 +8,15 @@ import { determineParameterKey } from "../parameterHelpers";
 
 const ParamKey = React.createContext<ParamKeys>(null);
 
-export const ParamKeyProvider = ({ node, param, children }: PropsWithChildren<{ node?: NodeType; param?: Parameter }>) => {
+export const ParamKeyProvider = ({
+    node,
+    param,
+    value: valueProp,
+    children,
+}: PropsWithChildren<{ node?: NodeType; param?: Parameter; value?: ParamKeys }>) => {
     const value = useMemo(() => {
-        return determineParameterKey(node, param);
-    }, [node, param]);
+        return valueProp ?? determineParameterKey(node, param);
+    }, [valueProp, node, param]);
 
     return (
         <ParamKey.Provider value={value}>

--- a/designer/client/src/components/graph/node-modal/editors/expression/helpText.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/helpText.tsx
@@ -48,6 +48,11 @@ Use autocompletion to explore available options. To read more see [Documentation
                             ),
                             helpText,
                         );
+                    case OverrideKeys.AssertionActual:
+                        return t(
+                            "editors.spelEditor.additionalInfoText.assertionActual",
+                            "Use **#records** to access all events that passed through this node.\n\ncount `#records.size()`  \nfield access `#records[0].status`  \nfilter `#records.?[#this.amount > 100].size()`",
+                        );
                     case OverrideKeys.SinkKafkaValue:
                         return mergeTexts(
                             t(

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -140,7 +140,7 @@ const AssertionItemComponent = ({
                     />
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Actual" data-testid={`assertion-actual-${index}`}>
-                    <ParamKeyProvider value={OverrideKeys.AssertionActual}>
+                    <ParamKeyProvider custom={OverrideKeys.AssertionActual}>
                         <EditableEditor
                             showSwitch={false}
                             editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -10,9 +10,11 @@ import { EditableEditor } from "../../../editors/EditableEditor";
 import type { ExpressionObj } from "../../../editors/expression/types";
 import { EditorType, ExpressionLang } from "../../../editors/expression/types";
 import Input from "../../../editors/field/Input";
+import { ParamKeyProvider } from "../../../editors/ParamKeyProvider";
 import { FieldsRow } from "../../../fragment-input-definition/FieldsRow";
 import { TypeSelect } from "../../../fragment-input-definition/TypeSelect";
 import type { Option } from "../../../fragment-input-definition/TypeSelect";
+import { OverrideKeys } from "../../../parameterHelpers";
 import { AssertionStatus } from "./AssertionStatus";
 
 export const ASSERTION_SYMBOLS: Record<AssertionOperator, string> = {
@@ -127,6 +129,7 @@ const AssertionItemComponent = ({
                         onValueChange={handleExpectedChange}
                         showValidation
                         fieldErrors={expectedErrors}
+                        placeholder="true, 12, 'xxxx'"
                     />
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Assertion" data-testid={`assertion-operator-${index}`}>
@@ -137,15 +140,18 @@ const AssertionItemComponent = ({
                     />
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Actual" data-testid={`assertion-actual-${index}`}>
-                    <EditableEditor
-                        showSwitch={false}
-                        editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
-                        expressionObj={actual}
-                        variableTypes={variableTypes}
-                        onValueChange={handleActualChange}
-                        showValidation
-                        fieldErrors={actualErrors}
-                    />
+                    <ParamKeyProvider value={OverrideKeys.AssertionActual}>
+                        <EditableEditor
+                            showSwitch={false}
+                            editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
+                            expressionObj={actual}
+                            variableTypes={variableTypes}
+                            onValueChange={handleActualChange}
+                            showValidation
+                            fieldErrors={actualErrors}
+                            placeholder="#records.size()"
+                        />
+                    </ParamKeyProvider>
                 </RowFieldLabel>
             </FieldsRow>
             {testAssertionResult && (

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
@@ -15,12 +15,26 @@ import type { NodeType } from "../../../../../../types/node";
 import type { VariableTypes } from "../../../../../../types/validation";
 import { Expandable } from "../../../../../common/Expandable";
 import { withUuid } from "../../../appendUuid";
+import { useHelpText } from "../../../editors/expression/helpText";
+import { ExpressionLang } from "../../../editors/expression/types";
 import { InfoTooltip } from "../../../editors/InfoTooltip/InfoTooltip";
+import { ParamKeyProvider } from "../../../editors/ParamKeyProvider";
 import { NodeRowFieldsProvider } from "../../../node-row-fields-provider/NodeRowFieldsProvider";
 import { NodeTable } from "../../../NodeDetailsContent/NodeTable";
+import { OverrideKeys } from "../../../parameterHelpers";
 import { useGetNodeTestCasesErrors, useValidation, useVariableTypes } from "../../../useNodeTypeDetailsContentLogic";
 import { AssertionItem } from "./AssertionItem";
 import { StyledStack } from "./components/Styled";
+
+function AssertionHelpTooltip() {
+    return (
+        <InfoTooltip
+            variant="hover"
+            customComponentsProps={{ tooltip: { sx: { maxWidth: 400 } } }}
+            title={useHelpText(ExpressionLang.SpEL)}
+        />
+    );
+}
 
 interface Props {
     node: NodeType;
@@ -94,14 +108,9 @@ export const Assertions = ({ node, edges }: Props) => {
                         <Typography variant={"body2"} color={"text.secondary"}>
                             {t("testingDialog.label.assertions", "Assertions")}
                         </Typography>
-                        <InfoTooltip
-                            variant={"hover"}
-                            customComponentsProps={{ tooltip: { sx: { maxWidth: 400 } } }}
-                            title={t(
-                                "testingDialog.assertions.hint",
-                                "Use **#records** to access all events that passed through this node.\n\ncount `#records.size()`  \nfield access `#records[0].status`  \nfilter `#records.?[#this.amount > 100].size()`",
-                            )}
-                        />
+                        <ParamKeyProvider custom={OverrideKeys.AssertionActual}>
+                            <AssertionHelpTooltip />
+                        </ParamKeyProvider>
                     </Box>
                 }
                 expanded={isExpanded}

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { omit } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -15,6 +15,7 @@ import type { NodeType } from "../../../../../../types/node";
 import type { VariableTypes } from "../../../../../../types/validation";
 import { Expandable } from "../../../../../common/Expandable";
 import { withUuid } from "../../../appendUuid";
+import { InfoTooltip } from "../../../editors/InfoTooltip/InfoTooltip";
 import { NodeRowFieldsProvider } from "../../../node-row-fields-provider/NodeRowFieldsProvider";
 import { NodeTable } from "../../../NodeDetailsContent/NodeTable";
 import { useGetNodeTestCasesErrors, useValidation, useVariableTypes } from "../../../useNodeTypeDetailsContentLogic";
@@ -86,7 +87,26 @@ export const Assertions = ({ node, edges }: Props) => {
 
     return (
         <StyledStack>
-            <Expandable componentId={"Assertions"} expandableTitle={"Assertions"} expanded={isExpanded} onChange={setIsExpanded}>
+            <Expandable
+                componentId={"Assertions"}
+                expandableTitle={
+                    <Box display={"flex"} gap={2} alignItems={"center"}>
+                        <Typography variant={"body2"} color={"text.secondary"}>
+                            {t("testingDialog.label.assertions", "Assertions")}
+                        </Typography>
+                        <InfoTooltip
+                            variant={"hover"}
+                            customComponentsProps={{ tooltip: { sx: { maxWidth: 400 } } }}
+                            title={t(
+                                "testingDialog.assertions.hint",
+                                "Use **#records** to access all events that passed through this node.\n\ncount `#records.size()`  \nfield access `#records[0].status`  \nfilter `#records.?[#this.amount > 100].size()`",
+                            )}
+                        />
+                    </Box>
+                }
+                expanded={isExpanded}
+                onChange={setIsExpanded}
+            >
                 {testCaseAssertions.length === 0 && (
                     <Typography variant={"body2"}>{t("assertions.noAssertionsDefined", "No assertions defined")}</Typography>
                 )}

--- a/designer/client/src/components/graph/node-modal/parameterHelpers.tsx
+++ b/designer/client/src/components/graph/node-modal/parameterHelpers.tsx
@@ -31,6 +31,7 @@ export const OverrideKeys = {
     SinkKafkaValue2: "sink-sendSms/Value",
     SourceEventGeneratorValue: "source-event-generator/value",
     ForEachElements: "custom-for-each/Elements",
+    AssertionActual: "assertion/actual",
 } as const;
 
 export type ParamKeys = (typeof OverrideKeys)[keyof typeof OverrideKeys] | (string & NonNullable<unknown>);


### PR DESCRIPTION
## Summary

- Add `InfoTooltip` with `#records` usage examples to the Assertions section title (same pattern as Mock section)
- Add `AssertionActual` override key so the built-in `(i)` icon inside the Actual SpEL editor shows the same `#records` hint
- Add `value` prop to `ParamKeyProvider` to allow setting `paramKey` directly without a node+param pair
- Add placeholders: Expected → `true, 12, 'xxxx'`; Actual → `#records.size()`

## Test plan

- [ ] Open a node modal → Testing tab → verify Assertions section title has `(i)` icon with `#records` hint
- [ ] Click the `(i)` inside the Actual input field → verify same hint text appears
- [ ] Verify placeholder text shows in empty Expected and Actual fields
- [ ] Verify no layout regression in the Assertions grid (Description / Expected / Assertion / Actual columns)