### PR TITLE
fix: null-safety for testCases selectors and activeTestCasePreset

### DIFF
--- a/designer/client/src/components/toolbars/test/buttons/scenarioTestButtonContent/useScenarioTestPresets.tsx
+++ b/designer/client/src/components/toolbars/test/buttons/scenarioTestButtonContent/useScenarioTestPresets.tsx
@@ -37,8 +37,6 @@ export const useScenarioTestPresets = () => {
 
     const activeTestCaseId = useAppSelector(getActiveTestCaseId);
 
-    const activeTestCasePreset = testCasePresets.find((testCasePreset) => testCasePreset.value === activeTestCaseId);
-
     const runAllPreset: Preset = useMemo(
         () => ({
             icon: <PlayArrow sx={{ fontSize: "20px" }} />,
@@ -47,6 +45,8 @@ export const useScenarioTestPresets = () => {
         }),
         [t],
     );
+
+    const activeTestCasePreset = testCasePresets.find((testCasePreset) => testCasePreset.value === activeTestCaseId) ?? runAllPreset;
 
     const testCasesHeader = useMemo(() => ({ header: t("testingForm.test.menu.testCasesHeader", "Test cases") }), [t]);
 

--- a/designer/client/src/reducers/selectors/testCases.ts
+++ b/designer/client/src/reducers/selectors/testCases.ts
@@ -21,14 +21,14 @@ export const getTestCaseAssertions = createSelector(getTestCase, ({ assertions }
 export const getTestCaseAssertionsForNode = createSelector(
     getTestCaseAssertions,
     getNodeId,
-    (assertions, nodeId) => assertions[nodeId]?.map(withUuid) || [],
+    (assertions, nodeId) => (assertions ?? {})[nodeId]?.map(withUuid) || [],
 );
 
 export const getTestCaseMocks = createSelector(getTestCase, ({ mocks }) => mocks);
 export const getTestCaseMockForNode = createSelector(
     getTestCaseMocks,
     getNodeId,
-    (mocks, nodeId) => mocks[nodeId] || { expression: MockExpressionParameter.defaultValue },
+    (mocks, nodeId) => (mocks ?? {})[nodeId] || { expression: MockExpressionParameter.defaultValue },
 );
 export const getTestData = createSelector(getTestCase, ({ inputs }) => safeParseExpression<TestingDataRecords[]>(inputs) || []);
 
@@ -44,8 +44,8 @@ export const getTestCaseNodeValidationData = createSelector(getScenarioGraph, ge
     return {
         [testCase.name]: {
             ...testCase,
-            assertions: testCase.assertions[nodeId] ?? [],
-            enricherMock: testCase.mocks[nodeId],
+            assertions: (testCase.assertions ?? {})[nodeId] ?? [],
+            enricherMock: (testCase.mocks ?? {})[nodeId],
         },
     };
 });


### PR DESCRIPTION
## Summary
- Fix crash when no test cases are defined: `getTestCase` returns `{}`, so `assertions` and `mocks` are `undefined`, causing `TypeError: Cannot read properties of undefined` in `getTestCaseAssertionsForNode` and `getTestCaseMockForNode`
- Fix crash in `ScenarioTestButton`: `activeTestCasePreset` could be `undefined` when `find()` finds no matching preset, causing `.value` access to throw

## Root cause
These are pre-existing bugs present on `staging` — the selectors assumed `assertions` and `mocks` are always defined objects, but the `TestCase` type allows them to be `undefined`.

## Test plan
- [ ] Open a scenario with no test cases defined
- [ ] Open node details — should not crash
- [ ] Verify ScenarioTestButton renders without error when no test case is active