### PR TITLE
fix: remove debug console.log from pickFieldWrapper

### DIFF
--- a/designer/client/src/components/graph/node-modal/parametersListField.tsx
+++ b/designer/client/src/components/graph/node-modal/parametersListField.tsx
@@ -18,7 +18,6 @@ export type ParametersListFieldProps = ParametersListProps & {
 };
 
 function pickFieldWrapper(paramKey: ParamKeys) {
-    console.debug(`pickFieldWrapper: ${paramKey}`);
     switch (paramKey) {
         case OverrideKeys.SourceEndpoint:
             return EndpointFieldWrapper;


### PR DESCRIPTION
## Summary
- Remove accidental `console.debug` left in `pickFieldWrapper` from PR #9054

## Test plan
- [ ] Open node modal — no more `pickFieldWrapper: ...` spam in browser console