### PR TITLE
[NU-2470] Add hasSize, contains and matches assertion operators

### DIFF
--- a/designer/client/src/actions/nk/testCasesActions.ts
+++ b/designer/client/src/actions/nk/testCasesActions.ts
@@ -7,7 +7,7 @@ import { getActiveTestCaseId } from "../../reducers/selectors/testing";
 import type { ThunkAction } from "../reduxTypes";
 import { changeActiveTestCase } from "./testingActions";
 
-export type AssertionOperator = "equals" | "notEquals" | "greaterThan" | "lessThan" | "greaterThanOrEqual" | "lessThanOrEqual";
+export type AssertionOperator = "equals" | "notEquals" | "greaterThan" | "lessThan" | "greaterThanOrEqual" | "lessThanOrEqual" | "hasSize";
 export type Assertion = { description?: string; expected: ExpressionObj; operator: AssertionOperator; actual: ExpressionObj };
 export type Assertions = Record<string, Assertion[]>;
 

--- a/designer/client/src/actions/nk/testCasesActions.ts
+++ b/designer/client/src/actions/nk/testCasesActions.ts
@@ -7,7 +7,15 @@ import { getActiveTestCaseId } from "../../reducers/selectors/testing";
 import type { ThunkAction } from "../reduxTypes";
 import { changeActiveTestCase } from "./testingActions";
 
-export type AssertionOperator = "equals" | "notEquals" | "greaterThan" | "lessThan" | "greaterThanOrEqual" | "lessThanOrEqual" | "hasSize";
+export type AssertionOperator =
+    | "equals"
+    | "notEquals"
+    | "greaterThan"
+    | "lessThan"
+    | "greaterThanOrEqual"
+    | "lessThanOrEqual"
+    | "hasSize"
+    | "contains";
 export type Assertion = { description?: string; expected: ExpressionObj; operator: AssertionOperator; actual: ExpressionObj };
 export type Assertions = Record<string, Assertion[]>;
 

--- a/designer/client/src/actions/nk/testCasesActions.ts
+++ b/designer/client/src/actions/nk/testCasesActions.ts
@@ -15,7 +15,8 @@ export type AssertionOperator =
     | "greaterThanOrEqual"
     | "lessThanOrEqual"
     | "hasSize"
-    | "contains";
+    | "contains"
+    | "matches";
 export type Assertion = { description?: string; expected: ExpressionObj; operator: AssertionOperator; actual: ExpressionObj };
 export type Assertions = Record<string, Assertion[]>;
 

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -26,6 +26,7 @@ export const ASSERTION_SYMBOLS: Record<AssertionOperator, string> = {
     lessThanOrEqual: "<=",
     hasSize: "has size",
     contains: "contains",
+    matches: "matches",
 };
 
 const gridContainerStyle = css({

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -123,25 +123,6 @@ const AssertionItemComponent = ({
                         placeholder={"Optional description"}
                     />
                 </RowFieldLabel>
-                <RowFieldLabel showLabel={isFirstRow} label="Expected" data-testid={`assertion-expected-${index}`}>
-                    <EditableEditor
-                        showSwitch={false}
-                        editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
-                        expressionObj={expected}
-                        variableTypes={variableTypes}
-                        onValueChange={handleExpectedChange}
-                        showValidation
-                        fieldErrors={expectedErrors}
-                        placeholder="true, 12, 'xxxx'"
-                    />
-                </RowFieldLabel>
-                <RowFieldLabel showLabel={isFirstRow} label="Assertion" data-testid={`assertion-operator-${index}`}>
-                    <TypeSelect
-                        value={assertionOptions.find((o) => o.value === operator)}
-                        options={assertionOptions}
-                        onChange={handleOperatorChange}
-                    />
-                </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Actual" data-testid={`assertion-actual-${index}`}>
                     <ParamKeyProvider custom={OverrideKeys.AssertionActual}>
                         <EditableEditor
@@ -155,6 +136,25 @@ const AssertionItemComponent = ({
                             placeholder="#records.size()"
                         />
                     </ParamKeyProvider>
+                </RowFieldLabel>
+                <RowFieldLabel showLabel={isFirstRow} label="Assertion" data-testid={`assertion-operator-${index}`}>
+                    <TypeSelect
+                        value={assertionOptions.find((o) => o.value === operator)}
+                        options={assertionOptions}
+                        onChange={handleOperatorChange}
+                    />
+                </RowFieldLabel>
+                <RowFieldLabel showLabel={isFirstRow} label="Expected" data-testid={`assertion-expected-${index}`}>
+                    <EditableEditor
+                        showSwitch={false}
+                        editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
+                        expressionObj={expected}
+                        variableTypes={variableTypes}
+                        onValueChange={handleExpectedChange}
+                        showValidation
+                        fieldErrors={expectedErrors}
+                        placeholder="true, 12, 'xxxx'"
+                    />
                 </RowFieldLabel>
             </FieldsRow>
             {testAssertionResult && (

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -24,6 +24,7 @@ export const ASSERTION_SYMBOLS: Record<AssertionOperator, string> = {
     lessThan: "<",
     greaterThanOrEqual: ">=",
     lessThanOrEqual: "<=",
+    hasSize: "has size",
 };
 
 const gridContainerStyle = css({

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -33,7 +33,7 @@ const gridContainerStyle = css({
     "&&&&": {
         width: "100%",
         display: "grid",
-        gridTemplateColumns: "5fr 5fr 3fr 5fr",
+        gridTemplateColumns: "1fr 1fr minmax(7rem, max-content) 1fr",
         gridTemplateRows: "auto auto",
         gridTemplateAreas: `"field field field field remove" "expr expr expr expr remove"`,
     },

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -33,7 +33,7 @@ const gridContainerStyle = css({
     "&&&&": {
         width: "100%",
         display: "grid",
-        gridTemplateColumns: "3fr 3fr 2fr 3fr",
+        gridTemplateColumns: "5fr 5fr 3fr 5fr",
         gridTemplateRows: "auto auto",
         gridTemplateAreas: `"field field field field remove" "expr expr expr expr remove"`,
     },

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -33,7 +33,7 @@ const gridContainerStyle = css({
     "&&&&": {
         width: "100%",
         display: "grid",
-        gridTemplateColumns: "3fr 3fr 1fr 3fr",
+        gridTemplateColumns: "3fr 3fr 2fr 3fr",
         gridTemplateRows: "auto auto",
         gridTemplateAreas: `"field field field field remove" "expr expr expr expr remove"`,
     },

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -25,6 +25,7 @@ export const ASSERTION_SYMBOLS: Record<AssertionOperator, string> = {
     greaterThanOrEqual: ">=",
     lessThanOrEqual: "<=",
     hasSize: "has size",
+    contains: "contains",
 };
 
 const gridContainerStyle = css({

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -19,6 +19,12 @@ object AssertionResult {
     FailedAssertion(s"Expected value different from: [$expectedStr]")
   }
 
+  def produceFailedComparisonAssertion(operator: String, expected: Any, actual: Any): FailedAssertion = {
+    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
+    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
+    FailedAssertion(s"Expected: [$expectedStr] $operator [$actualStr]")
+  }
+
   def produceFailedHasSizeAssertion(expectedSize: Any, actualSize: Int): FailedAssertion = {
     val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expectedSize)
     FailedAssertion(s"Expected size: [$expectedStr] but found: [$actualSize]")
@@ -30,10 +36,10 @@ object AssertionResult {
     FailedAssertion(s"Expected [$actualStr] to contain [$expectedStr]")
   }
 
-  def produceFailedComparisonAssertion(operator: String, expected: Any, actual: Any): FailedAssertion = {
-    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
-    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
-    FailedAssertion(s"Expected: [$expectedStr] $operator [$actualStr]")
+  def produceFailedMatchesAssertion(pattern: Any, actual: Any): FailedAssertion = {
+    val patternStr = SpelValuePrettyPrinter.prettyPrintValue(pattern)
+    val actualStr  = SpelValuePrettyPrinter.prettyPrintValue(actual)
+    FailedAssertion(s"Expected [$actualStr] to match [$patternStr]")
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -20,14 +20,14 @@ object AssertionResult {
   }
 
   def produceFailedComparisonAssertion(operator: String, expected: Any, actual: Any): FailedAssertion =
-    nullGuard(actual, expected).getOrElse {
+    ensureNotNullValues(actual, expected).getOrElse {
       val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
       val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
       FailedAssertion(s"Expected: [$expectedStr] $operator [$actualStr]")
     }
 
   def produceFailedHasSizeAssertion(expectedSize: Any, actualValue: Any): FailedAssertion =
-    nullGuard(actualValue, expectedSize).getOrElse {
+    ensureNotNullValues(actualValue, expectedSize).getOrElse {
       val actualSize = actualValue match {
         case c: java.util.Collection[_] => c.size()
         case m: java.util.Map[_, _]     => m.size()
@@ -39,20 +39,20 @@ object AssertionResult {
     }
 
   def produceFailedContainsAssertion(expected: Any, actual: Any): FailedAssertion =
-    nullGuard(actual, expected).getOrElse {
+    ensureNotNullValues(actual, expected).getOrElse {
       val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
       val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
       FailedAssertion(s"Expected [$actualStr] to contain [$expectedStr]")
     }
 
   def produceFailedMatchesAssertion(pattern: Any, actual: Any): FailedAssertion =
-    nullGuard(actual, pattern).getOrElse {
+    ensureNotNullValues(actual, pattern).getOrElse {
       val patternStr = SpelValuePrettyPrinter.prettyPrintValue(pattern)
       val actualStr  = SpelValuePrettyPrinter.prettyPrintValue(actual)
       FailedAssertion(s"Expected [$actualStr] to match [$patternStr]")
     }
 
-  private def nullGuard(actualValue: Any, expectedValue: Any): Option[FailedAssertion] = {
+  private def ensureNotNullValues(actualValue: Any, expectedValue: Any): Option[FailedAssertion] = {
     if (actualValue == null) Some(FailedAssertion("Actual value is null"))
     else if (expectedValue == null) Some(FailedAssertion("Expected value is null"))
     else None

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -19,27 +19,43 @@ object AssertionResult {
     FailedAssertion(s"Expected value different from: [$expectedStr]")
   }
 
-  def produceFailedComparisonAssertion(operator: String, expected: Any, actual: Any): FailedAssertion = {
-    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
-    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
-    FailedAssertion(s"Expected: [$expectedStr] $operator [$actualStr]")
-  }
+  def produceFailedComparisonAssertion(operator: String, expected: Any, actual: Any): FailedAssertion =
+    nullGuard(actual, expected).getOrElse {
+      val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
+      val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
+      FailedAssertion(s"Expected: [$expectedStr] $operator [$actualStr]")
+    }
 
-  def produceFailedHasSizeAssertion(expectedSize: Any, actualSize: Int): FailedAssertion = {
-    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expectedSize)
-    FailedAssertion(s"Expected size: [$expectedStr] but found: [$actualSize]")
-  }
+  def produceFailedHasSizeAssertion(expectedSize: Any, actualValue: Any): FailedAssertion =
+    nullGuard(actualValue, expectedSize).getOrElse {
+      val actualSize = actualValue match {
+        case c: java.util.Collection[_] => c.size()
+        case m: java.util.Map[_, _]     => m.size()
+        case a: Array[_]                => a.length
+        case _                          => -1
+      }
+      val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expectedSize)
+      FailedAssertion(s"Expected size: [$expectedStr] but found: [$actualSize]")
+    }
 
-  def produceFailedContainsAssertion(expected: Any, actual: Any): FailedAssertion = {
-    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
-    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
-    FailedAssertion(s"Expected [$actualStr] to contain [$expectedStr]")
-  }
+  def produceFailedContainsAssertion(expected: Any, actual: Any): FailedAssertion =
+    nullGuard(actual, expected).getOrElse {
+      val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
+      val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
+      FailedAssertion(s"Expected [$actualStr] to contain [$expectedStr]")
+    }
 
-  def produceFailedMatchesAssertion(pattern: Any, actual: Any): FailedAssertion = {
-    val patternStr = SpelValuePrettyPrinter.prettyPrintValue(pattern)
-    val actualStr  = SpelValuePrettyPrinter.prettyPrintValue(actual)
-    FailedAssertion(s"Expected [$actualStr] to match [$patternStr]")
+  def produceFailedMatchesAssertion(pattern: Any, actual: Any): FailedAssertion =
+    nullGuard(actual, pattern).getOrElse {
+      val patternStr = SpelValuePrettyPrinter.prettyPrintValue(pattern)
+      val actualStr  = SpelValuePrettyPrinter.prettyPrintValue(actual)
+      FailedAssertion(s"Expected [$actualStr] to match [$patternStr]")
+    }
+
+  private def nullGuard(actualValue: Any, expectedValue: Any): Option[FailedAssertion] = {
+    if (actualValue == null) Some(FailedAssertion("Actual value is null"))
+    else if (expectedValue == null) Some(FailedAssertion("Expected value is null"))
+    else None
   }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -24,6 +24,12 @@ object AssertionResult {
     FailedAssertion(s"Expected size: [$expectedStr] but found: [$actualSize]")
   }
 
+  def produceFailedContainsAssertion(expected: Any, actual: Any): FailedAssertion = {
+    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
+    val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)
+    FailedAssertion(s"Expected [$actualStr] to contain [$expectedStr]")
+  }
+
   def produceFailedComparisonAssertion(operator: String, expected: Any, actual: Any): FailedAssertion = {
     val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
     val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -19,6 +19,11 @@ object AssertionResult {
     FailedAssertion(s"Expected value different from: [$expectedStr]")
   }
 
+  def produceFailedHasSizeAssertion(expectedSize: Any, actualSize: Int): FailedAssertion = {
+    val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expectedSize)
+    FailedAssertion(s"Expected size: [$expectedStr] but found: [$actualSize]")
+  }
+
   def produceFailedComparisonAssertion(operator: String, expected: Any, actual: Any): FailedAssertion = {
     val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expected)
     val actualStr   = SpelValuePrettyPrinter.prettyPrintValue(actual)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionResult.scala
@@ -28,14 +28,21 @@ object AssertionResult {
 
   def produceFailedHasSizeAssertion(expectedSize: Any, actualValue: Any): FailedAssertion =
     ensureNotNullValues(actualValue, expectedSize).getOrElse {
-      val actualSize = actualValue match {
-        case c: java.util.Collection[_] => c.size()
-        case m: java.util.Map[_, _]     => m.size()
-        case a: Array[_]                => a.length
-        case _                          => -1
+      val actualSizeOpt = actualValue match {
+        case c: java.util.Collection[_] => Some(c.size())
+        case m: java.util.Map[_, _]     => Some(m.size())
+        case a: Array[_]                => Some(a.length)
+        case _                          => None
       }
-      val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expectedSize)
-      FailedAssertion(s"Expected size: [$expectedStr] but found: [$actualSize]")
+      actualSizeOpt match {
+        case Some(actualSize) =>
+          val expectedStr = SpelValuePrettyPrinter.prettyPrintValue(expectedSize)
+          FailedAssertion(s"Expected size: [$expectedStr] but found: [$actualSize]")
+        case None =>
+          val actualStr  = SpelValuePrettyPrinter.prettyPrintValue(actualValue)
+          val actualType = actualValue.getClass.getSimpleName
+          FailedAssertion(s"Cannot check size of [$actualStr] (type: $actualType)")
+      }
     }
 
   def produceFailedContainsAssertion(expected: Any, actual: Any): FailedAssertion =

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -108,6 +108,8 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
           AssertionResult.produceFailedComparisonAssertion("<=", expectedValue, actualValue)
         case AssertionOperator.Contains =>
           AssertionResult.produceFailedContainsAssertion(expectedValue, actualValue)
+        case AssertionOperator.Matches =>
+          AssertionResult.produceFailedMatchesAssertion(expectedValue, actualValue)
         case AssertionOperator.HasSize =>
           val actualSize = actualValue match {
             case c: java.util.Collection[_] => c.size()

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -106,6 +106,8 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
           AssertionResult.produceFailedComparisonAssertion(">=", expectedValue, actualValue)
         case AssertionOperator.LessThanOrEqual =>
           AssertionResult.produceFailedComparisonAssertion("<=", expectedValue, actualValue)
+        case AssertionOperator.Contains =>
+          AssertionResult.produceFailedContainsAssertion(expectedValue, actualValue)
         case AssertionOperator.HasSize =>
           val actualSize = actualValue match {
             case c: java.util.Collection[_] => c.size()

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -106,6 +106,14 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
           AssertionResult.produceFailedComparisonAssertion(">=", expectedValue, actualValue)
         case AssertionOperator.LessThanOrEqual =>
           AssertionResult.produceFailedComparisonAssertion("<=", expectedValue, actualValue)
+        case AssertionOperator.HasSize =>
+          val actualSize = actualValue match {
+            case c: java.util.Collection[_] => c.size()
+            case m: java.util.Map[_, _]     => m.size()
+            case a: Array[_]                => a.length
+            case _                          => -1
+          }
+          AssertionResult.produceFailedHasSizeAssertion(expectedValue, actualSize)
       }
     }
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -106,18 +106,9 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
           AssertionResult.produceFailedComparisonAssertion(">=", expectedValue, actualValue)
         case AssertionOperator.LessThanOrEqual =>
           AssertionResult.produceFailedComparisonAssertion("<=", expectedValue, actualValue)
-        case AssertionOperator.Contains =>
-          AssertionResult.produceFailedContainsAssertion(expectedValue, actualValue)
-        case AssertionOperator.Matches =>
-          AssertionResult.produceFailedMatchesAssertion(expectedValue, actualValue)
-        case AssertionOperator.HasSize =>
-          val actualSize = actualValue match {
-            case c: java.util.Collection[_] => c.size()
-            case m: java.util.Map[_, _]     => m.size()
-            case a: Array[_]                => a.length
-            case _                          => -1
-          }
-          AssertionResult.produceFailedHasSizeAssertion(expectedValue, actualSize)
+        case AssertionOperator.Contains => AssertionResult.produceFailedContainsAssertion(expectedValue, actualValue)
+        case AssertionOperator.Matches  => AssertionResult.produceFailedMatchesAssertion(expectedValue, actualValue)
+        case AssertionOperator.HasSize  => AssertionResult.produceFailedHasSizeAssertion(expectedValue, actualValue)
       }
     }
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifier.scala
@@ -96,8 +96,10 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
       val expectedValue = expectedExpression.evaluate[Any](context, globalVariables)
       val actualValue   = actualExpression.evaluate[Any](context, globalVariables)
       operator match {
-        case AssertionOperator.Equals    => AssertionResult.produceFailedEqualsAssertion(expectedValue, actualValue)
-        case AssertionOperator.NotEquals => AssertionResult.produceFailedNotEqualsAssertion(expectedValue)
+        case AssertionOperator.Equals =>
+          AssertionResult.produceFailedEqualsAssertion(expectedValue, actualValue)
+        case AssertionOperator.NotEquals =>
+          AssertionResult.produceFailedNotEqualsAssertion(expectedValue)
         case AssertionOperator.GreaterThan =>
           AssertionResult.produceFailedComparisonAssertion(">", expectedValue, actualValue)
         case AssertionOperator.LessThan =>
@@ -106,9 +108,12 @@ class AssertionVerifier(globalVariablesPreparer: GlobalVariablesPreparer) {
           AssertionResult.produceFailedComparisonAssertion(">=", expectedValue, actualValue)
         case AssertionOperator.LessThanOrEqual =>
           AssertionResult.produceFailedComparisonAssertion("<=", expectedValue, actualValue)
-        case AssertionOperator.Contains => AssertionResult.produceFailedContainsAssertion(expectedValue, actualValue)
-        case AssertionOperator.Matches  => AssertionResult.produceFailedMatchesAssertion(expectedValue, actualValue)
-        case AssertionOperator.HasSize  => AssertionResult.produceFailedHasSizeAssertion(expectedValue, actualValue)
+        case AssertionOperator.Contains =>
+          AssertionResult.produceFailedContainsAssertion(expectedValue, actualValue)
+        case AssertionOperator.Matches =>
+          AssertionResult.produceFailedMatchesAssertion(expectedValue, actualValue)
+        case AssertionOperator.HasSize =>
+          AssertionResult.produceFailedHasSizeAssertion(expectedValue, actualValue)
       }
     }
   }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -239,7 +239,8 @@ class AssertionsCompiler(
       case AssertionOperator.GreaterThanOrEqual => s"($expected) >= ($actual)"
       case AssertionOperator.LessThanOrEqual    => s"($expected) <= ($actual)"
       case AssertionOperator.HasSize            => s"($actual).size() == ($expected)"
-      case AssertionOperator.Contains           => s"($actual).contains($expected)"
+      case AssertionOperator.Contains           => s"($actual).contains(($expected))"
+      case AssertionOperator.Matches            => s"($actual).matches(($expected))"
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -240,7 +240,7 @@ class AssertionsCompiler(
       case AssertionOperator.LessThanOrEqual    => s"($expected) <= ($actual)"
       case AssertionOperator.HasSize            => s"($actual).size() == ($expected)"
       case AssertionOperator.Contains           => s"($actual).contains(($expected))"
-      case AssertionOperator.Matches            => s"($actual).matches(($expected))"
+      case AssertionOperator.Matches            => s"($actual) matches ($expected)"
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -239,6 +239,7 @@ class AssertionsCompiler(
       case AssertionOperator.GreaterThanOrEqual => s"($expected) >= ($actual)"
       case AssertionOperator.LessThanOrEqual    => s"($expected) <= ($actual)"
       case AssertionOperator.HasSize            => s"($actual).size() == ($expected)"
+      case AssertionOperator.Contains           => s"($actual).contains($expected)"
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -205,7 +205,7 @@ class AssertionsCompiler(
       .compile(
         // Compiling the below expression can result in errors like: Operator '==' used with not comparable types: String and Integer
         // If we need to report more user-friendly error (without: Operator '=='), we can use CommonSupertypeFinder here to check if types are comparable before compiling.
-        s"(${assertion.expected.expression}) ${toComparisonOperator(assertion.operator)} (${assertion.actual.expression})".spel,
+        buildComparisonExpression(assertion.operator, assertion.expected.expression, assertion.actual.expression).spel,
         // See comment below - we report errors on actual field.
         paramName = Some(ParameterName(PredicateAssertionCompilationError.Field.Actual.entryName)),
         context,
@@ -226,14 +226,19 @@ class AssertionsCompiler(
       .toValidatedNel
   }
 
-  private def toComparisonOperator(operator: Assertion.AssertionOperator): String = {
+  private def buildComparisonExpression(
+      operator: Assertion.AssertionOperator,
+      expected: String,
+      actual: String
+  ): String = {
     operator match {
-      case AssertionOperator.Equals             => "=="
-      case AssertionOperator.NotEquals          => "!="
-      case AssertionOperator.GreaterThan        => ">"
-      case AssertionOperator.LessThan           => "<"
-      case AssertionOperator.GreaterThanOrEqual => ">="
-      case AssertionOperator.LessThanOrEqual    => "<="
+      case AssertionOperator.Equals             => s"($expected) == ($actual)"
+      case AssertionOperator.NotEquals          => s"($expected) != ($actual)"
+      case AssertionOperator.GreaterThan        => s"($expected) > ($actual)"
+      case AssertionOperator.LessThan           => s"($expected) < ($actual)"
+      case AssertionOperator.GreaterThanOrEqual => s"($expected) >= ($actual)"
+      case AssertionOperator.LessThanOrEqual    => s"($expected) <= ($actual)"
+      case AssertionOperator.HasSize            => s"($actual).size() == ($expected)"
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -232,16 +232,24 @@ class AssertionsCompiler(
       actual: String
   ): String = {
     operator match {
-      case AssertionOperator.Equals      => s"($expected) == ($actual)"
-      case AssertionOperator.NotEquals   => s"($expected) != ($actual)"
-      case AssertionOperator.GreaterThan => s"($expected) != null && ($actual) != null && ($expected) > ($actual)"
-      case AssertionOperator.LessThan    => s"($expected) != null && ($actual) != null && ($expected) < ($actual)"
+      case AssertionOperator.Equals =>
+        s"($actual) == ($expected)"
+      case AssertionOperator.NotEquals =>
+        s"($actual) != ($expected)"
+      case AssertionOperator.GreaterThan =>
+        s"($actual) != null && ($expected) != null && ($actual) > ($expected)"
+      case AssertionOperator.LessThan =>
+        s"($actual) != null && ($expected) != null && ($actual) < ($expected)"
       case AssertionOperator.GreaterThanOrEqual =>
-        s"($expected) != null && ($actual) != null && ($expected) >= ($actual)"
-      case AssertionOperator.LessThanOrEqual => s"($expected) != null && ($actual) != null && ($expected) <= ($actual)"
-      case AssertionOperator.HasSize  => s"($actual) != null && ($expected) != null && ($actual).size() == ($expected)"
-      case AssertionOperator.Contains => s"($actual) != null && ($expected) != null && ($actual).contains(($expected))"
-      case AssertionOperator.Matches  => s"($actual) != null && ($expected) != null && ($actual) matches ($expected)"
+        s"($actual) != null && ($expected) != null && ($actual) >= ($expected)"
+      case AssertionOperator.LessThanOrEqual =>
+        s"($actual) != null && ($expected) != null && ($actual) <= ($expected)"
+      case AssertionOperator.HasSize =>
+        s"($actual) != null && ($expected) != null && ($actual).size() == ($expected)"
+      case AssertionOperator.Contains =>
+        s"($actual) != null && ($expected) != null && ($actual).contains(($expected))"
+      case AssertionOperator.Matches =>
+        s"($actual) != null && ($expected) != null && ($actual) matches ($expected)"
     }
   }
 

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompiler.scala
@@ -232,15 +232,16 @@ class AssertionsCompiler(
       actual: String
   ): String = {
     operator match {
-      case AssertionOperator.Equals             => s"($expected) == ($actual)"
-      case AssertionOperator.NotEquals          => s"($expected) != ($actual)"
-      case AssertionOperator.GreaterThan        => s"($expected) > ($actual)"
-      case AssertionOperator.LessThan           => s"($expected) < ($actual)"
-      case AssertionOperator.GreaterThanOrEqual => s"($expected) >= ($actual)"
-      case AssertionOperator.LessThanOrEqual    => s"($expected) <= ($actual)"
-      case AssertionOperator.HasSize            => s"($actual).size() == ($expected)"
-      case AssertionOperator.Contains           => s"($actual).contains(($expected))"
-      case AssertionOperator.Matches            => s"($actual) matches ($expected)"
+      case AssertionOperator.Equals      => s"($expected) == ($actual)"
+      case AssertionOperator.NotEquals   => s"($expected) != ($actual)"
+      case AssertionOperator.GreaterThan => s"($expected) != null && ($actual) != null && ($expected) > ($actual)"
+      case AssertionOperator.LessThan    => s"($expected) != null && ($actual) != null && ($expected) < ($actual)"
+      case AssertionOperator.GreaterThanOrEqual =>
+        s"($expected) != null && ($actual) != null && ($expected) >= ($actual)"
+      case AssertionOperator.LessThanOrEqual => s"($expected) != null && ($actual) != null && ($expected) <= ($actual)"
+      case AssertionOperator.HasSize  => s"($actual) != null && ($expected) != null && ($actual).size() == ($expected)"
+      case AssertionOperator.Contains => s"($actual) != null && ($expected) != null && ($actual).contains(($expected))"
+      case AssertionOperator.Matches  => s"($actual) != null && ($expected) != null && ($actual) matches ($expected)"
     }
   }
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -289,6 +289,30 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
     }
   }
 
+  test("should handle null values gracefully") {
+    forAll(
+      Table(
+        ("operator", "expectedExpr", "actualExpr", "expectedResult"),
+        (AssertionOperator.GreaterThan, "10", "#records[0].someNumber", FailedAssertion("Actual value is null")),
+        (AssertionOperator.LessThan, "10", "#records[0].someNumber", FailedAssertion("Actual value is null")),
+        (AssertionOperator.GreaterThanOrEqual, "10", "#records[0].someNumber", FailedAssertion("Actual value is null")),
+        (AssertionOperator.LessThanOrEqual, "10", "#records[0].someNumber", FailedAssertion("Actual value is null")),
+        (AssertionOperator.Contains, "'x'", "#records[0].someVariable", FailedAssertion("Actual value is null")),
+        (AssertionOperator.Matches, "'.*'", "#records[0].someVariable", FailedAssertion("Actual value is null")),
+        (AssertionOperator.HasSize, "3", "#records[0].someCollection", FailedAssertion("Actual value is null")),
+        (AssertionOperator.HasSize, "#records[0].someNumber", "{'a', 'b'}", FailedAssertion("Expected value is null")),
+      )
+    ) { (operator, expectedExpr, actualExpr, expectedResult) =>
+      val testCase = prepareTestCase(
+        List(PredicateAssertion(operator, expectedExpr.spel, actualExpr.spel))
+      )
+      val nodesResultsAfterTestRun =
+        prepareNodeResults(List(Map("someNumber" -> null, "someVariable" -> null, "someCollection" -> null)))
+      val results = verifyForTestCase(testCase, nodesResultsAfterTestRun)
+      results shouldBe List(expectedResult)
+    }
+  }
+
   test("should not evaluate empty assertions") {
     forAll(
       Table(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -270,6 +270,25 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
     }
   }
 
+  test("should verify matches operator") {
+    forAll(
+      Table(
+        ("patternExpr", "actualString", "expectedResult"),
+        ("'[A-Z]{3}-\\d+'", "ABC-123", SuccessfulAssertion),
+        ("'[A-Z]{3}-\\d+'", "abc-123", FailedAssertion("Expected ['abc-123'] to match ['[A-Z]{3}-\\d+']")),
+        ("'.*world.*'", "hello world", SuccessfulAssertion),
+        ("'.*world.*'", "hello universe", FailedAssertion("Expected ['hello universe'] to match ['.*world.*']")),
+      )
+    ) { (patternExpr, actualString, expectedResult) =>
+      val testCase = prepareTestCase(
+        List(PredicateAssertion(AssertionOperator.Matches, patternExpr.spel, "#records[0].someVariable".spel))
+      )
+      val nodesResultsAfterTestRun = prepareNodeResults(List(Map("someVariable" -> actualString)))
+      val results                  = verifyForTestCase(testCase, nodesResultsAfterTestRun)
+      results shouldBe List(expectedResult)
+    }
+  }
+
   test("should not evaluate empty assertions") {
     forAll(
       Table(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -119,26 +119,26 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   test("should properly compare various types used in SpEL") {
     forAll(
       Table(
-        ("expected expression", "actual expression", "expected assertion result"),
+        ("actual expression", "expected expression", "expected assertion result"),
         ("'valid'", "'valid'", SuccessfulAssertion),
         ("{}", "{}", SuccessfulAssertion),
         ("{:}", "{:}", SuccessfulAssertion),
-        ("#CONV.toAny('abc')", "'abc'", SuccessfulAssertion),
-        ("{'foo'}", "#records[0].someJavaList", SuccessfulAssertion),
+        ("'abc'", "#CONV.toAny('abc')", SuccessfulAssertion),
+        ("#records[0].someJavaList", "{'foo'}", SuccessfulAssertion),
         ("{'foo'}", "{'foo'}", SuccessfulAssertion),
         ("{'foo': 'bar'}", "{'foo': 'bar'}", SuccessfulAssertion),
-        ("1", "1L", SuccessfulAssertion),
+        ("1L", "1", SuccessfulAssertion),
         ("null", "null", SuccessfulAssertion),
-        ("{'foo'}", "{}", FailedAssertion("Expected: [{'foo'}] but found [{}]")),
+        ("{}", "{'foo'}", FailedAssertion("Expected: [{'foo'}] but found [{}]")),
         ("'1,2,3'.split(',')", "'1,2,3'.split(',')", SuccessfulAssertion), // comparing arrays
         (
-          "'1,2'.split(',')",
           "'1,2,3'.split(',')",
+          "'1,2'.split(',')",
           FailedAssertion("Expected: [{'1', '2'}] but found [{'1', '2', '3'}]")
         ),
-        ("{'a': 1}", "{:}", FailedAssertion("Expected: [{'a': 1}] but found [{:}]")),
+        ("{:}", "{'a': 1}", FailedAssertion("Expected: [{'a': 1}] but found [{:}]")),
       )
-    ) { (expectedExpression, actualExpression, expectedResult) =>
+    ) { (actualExpression, expectedExpression, expectedResult) =>
       val testCase = prepareTestCase(
         List(
           ExpressionAssertion(s"#TESTS.assertEquals($expectedExpression, $actualExpression)".spel, description = None),
@@ -164,16 +164,16 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   test("should apply SpEL conversions") {
     forAll(
       Table(
-        ("expected expression", "actual expression", "expected assertion result"),
-        ("1", "#records[0].someBigDecimal", SuccessfulAssertion),
-        ("1L", "#records[0].someBigDecimal", SuccessfulAssertion),
-        ("1.0", "#records[0].someBigDecimal", SuccessfulAssertion),
-        ("1.0f", "#records[0].someBigDecimal", SuccessfulAssertion),
-        ("1", "T(java.math.BigDecimal).ONE", SuccessfulAssertion),
-        ("{a: 1}", """#CONV.toJson('{"a": 1}')""", SuccessfulAssertion),
-        ("{a: 1}", """#CONV.toJson('{"a": 2}')""", FailedAssertion("Expected: [{'a': 1}] but found [{'a': 2}]")),
+        ("actual expression", "expected expression", "expected assertion result"),
+        ("#records[0].someBigDecimal", "1", SuccessfulAssertion),
+        ("#records[0].someBigDecimal", "1L", SuccessfulAssertion),
+        ("#records[0].someBigDecimal", "1.0", SuccessfulAssertion),
+        ("#records[0].someBigDecimal", "1.0f", SuccessfulAssertion),
+        ("T(java.math.BigDecimal).ONE", "1", SuccessfulAssertion),
+        ("""#CONV.toJson('{"a": 1}')""", "{a: 1}", SuccessfulAssertion),
+        ("""#CONV.toJson('{"a": 2}')""", "{a: 1}", FailedAssertion("Expected: [{'a': 1}] but found [{'a': 2}]")),
       )
-    ) { (expectedExpression, actualExpression, expectedResult) =>
+    ) { (actualExpression, expectedExpression, expectedResult) =>
       val testCase = prepareTestCase(
         List(
           PredicateAssertion(
@@ -198,13 +198,13 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   test("should verify comparison operators") {
     forAll(
       Table(
-        ("operator", "expectedExpr", "actualValue", "expectedResult"),
-        (AssertionOperator.GreaterThan, "10", 5, SuccessfulAssertion),
-        (AssertionOperator.LessThan, "10", 10, FailedAssertion("Expected: [10] < [10]")),
-        (AssertionOperator.GreaterThanOrEqual, "10", 10, SuccessfulAssertion),
-        (AssertionOperator.LessThanOrEqual, "10", 5, FailedAssertion("Expected: [10] <= [5]")),
+        ("operator", "actualValue", "expectedExpr", "expectedResult"),
+        (AssertionOperator.GreaterThan, 15, "10", SuccessfulAssertion),
+        (AssertionOperator.LessThan, 10, "10", FailedAssertion("Expected: [10] < [10]")),
+        (AssertionOperator.GreaterThanOrEqual, 10, "10", SuccessfulAssertion),
+        (AssertionOperator.LessThanOrEqual, 15, "10", FailedAssertion("Expected: [10] <= [15]")),
       )
-    ) { (operator, expectedExpr, actualValue, expectedResult) =>
+    ) { (operator, actualValue, expectedExpr, expectedResult) =>
       val testCase = prepareTestCase(
         List(
           PredicateAssertion(operator, expectedExpr.spel, "#records[0].someNumber".spel)
@@ -219,14 +219,14 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   test("should verify hasSize operator") {
     forAll(
       Table(
-        ("expectedSizeExpr", "actualList", "expectedResult"),
-        ("3", java.util.List.of("a", "b", "c"), SuccessfulAssertion),
-        ("2", java.util.List.of("a", "b", "c"), FailedAssertion("Expected size: [2] but found: [3]")),
-        ("0", new java.util.ArrayList[String](), SuccessfulAssertion),
-        ("2", java.util.Map.of("k1", "v1", "k2", "v2"), SuccessfulAssertion),
-        ("1", java.util.Map.of("k1", "v1", "k2", "v2"), FailedAssertion("Expected size: [1] but found: [2]")),
+        ("actualList", "expectedSizeExpr", "expectedResult"),
+        (java.util.List.of("a", "b", "c"), "3", SuccessfulAssertion),
+        (java.util.List.of("a", "b", "c"), "2", FailedAssertion("Expected size: [2] but found: [3]")),
+        (new java.util.ArrayList[String](), "0", SuccessfulAssertion),
+        (java.util.Map.of("k1", "v1", "k2", "v2"), "2", SuccessfulAssertion),
+        (java.util.Map.of("k1", "v1", "k2", "v2"), "1", FailedAssertion("Expected size: [1] but found: [2]")),
       )
-    ) { (expectedSizeExpr, actualList, expectedResult) =>
+    ) { (actualList, expectedSizeExpr, expectedResult) =>
       val testCase = prepareTestCase(
         List(PredicateAssertion(AssertionOperator.HasSize, expectedSizeExpr.spel, "#records[0].someCollection".spel))
       )
@@ -239,11 +239,11 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   test("should verify contains operator for collections") {
     forAll(
       Table(
-        ("expectedExpr", "actualCollection", "expectedResult"),
-        ("'b'", java.util.List.of("a", "b", "c"), SuccessfulAssertion),
-        ("'d'", java.util.List.of("a", "b", "c"), FailedAssertion("Expected [{'a', 'b', 'c'}] to contain ['d']")),
+        ("actualCollection", "expectedExpr", "expectedResult"),
+        (java.util.List.of("a", "b", "c"), "'b'", SuccessfulAssertion),
+        (java.util.List.of("a", "b", "c"), "'d'", FailedAssertion("Expected [{'a', 'b', 'c'}] to contain ['d']")),
       )
-    ) { (expectedExpr, actualCollection, expectedResult) =>
+    ) { (actualCollection, expectedExpr, expectedResult) =>
       val testCase = prepareTestCase(
         List(PredicateAssertion(AssertionOperator.Contains, expectedExpr.spel, "#records[0].someCollection".spel))
       )
@@ -256,11 +256,11 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   test("should verify contains operator for strings") {
     forAll(
       Table(
-        ("expectedExpr", "actualString", "expectedResult"),
-        ("'ello'", "hello world", SuccessfulAssertion),
-        ("'xyz'", "hello world", FailedAssertion("Expected ['hello world'] to contain ['xyz']")),
+        ("actualString", "expectedExpr", "expectedResult"),
+        ("hello world", "'ello'", SuccessfulAssertion),
+        ("hello world", "'xyz'", FailedAssertion("Expected ['hello world'] to contain ['xyz']")),
       )
-    ) { (expectedExpr, actualString, expectedResult) =>
+    ) { (actualString, expectedExpr, expectedResult) =>
       val testCase = prepareTestCase(
         List(PredicateAssertion(AssertionOperator.Contains, expectedExpr.spel, "#records[0].someVariable".spel))
       )
@@ -273,13 +273,13 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   test("should verify matches operator") {
     forAll(
       Table(
-        ("patternExpr", "actualString", "expectedResult"),
-        ("'[A-Z]{3}-\\d+'", "ABC-123", SuccessfulAssertion),
-        ("'[A-Z]{3}-\\d+'", "abc-123", FailedAssertion("Expected ['abc-123'] to match ['[A-Z]{3}-\\d+']")),
-        ("'.*world.*'", "hello world", SuccessfulAssertion),
-        ("'.*world.*'", "hello universe", FailedAssertion("Expected ['hello universe'] to match ['.*world.*']")),
+        ("actualString", "patternExpr", "expectedResult"),
+        ("ABC-123", "'[A-Z]{3}-\\d+'", SuccessfulAssertion),
+        ("abc-123", "'[A-Z]{3}-\\d+'", FailedAssertion("Expected ['abc-123'] to match ['[A-Z]{3}-\\d+']")),
+        ("hello world", "'.*world.*'", SuccessfulAssertion),
+        ("hello universe", "'.*world.*'", FailedAssertion("Expected ['hello universe'] to match ['.*world.*']")),
       )
-    ) { (patternExpr, actualString, expectedResult) =>
+    ) { (actualString, patternExpr, expectedResult) =>
       val testCase = prepareTestCase(
         List(PredicateAssertion(AssertionOperator.Matches, patternExpr.spel, "#records[0].someVariable".spel))
       )
@@ -292,17 +292,17 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   test("should handle null values gracefully") {
     forAll(
       Table(
-        ("operator", "expectedExpr", "actualExpr", "expectedResult"),
-        (AssertionOperator.GreaterThan, "10", "#records[0].someNumber", FailedAssertion("Actual value is null")),
-        (AssertionOperator.LessThan, "10", "#records[0].someNumber", FailedAssertion("Actual value is null")),
-        (AssertionOperator.GreaterThanOrEqual, "10", "#records[0].someNumber", FailedAssertion("Actual value is null")),
-        (AssertionOperator.LessThanOrEqual, "10", "#records[0].someNumber", FailedAssertion("Actual value is null")),
-        (AssertionOperator.Contains, "'x'", "#records[0].someVariable", FailedAssertion("Actual value is null")),
-        (AssertionOperator.Matches, "'.*'", "#records[0].someVariable", FailedAssertion("Actual value is null")),
-        (AssertionOperator.HasSize, "3", "#records[0].someCollection", FailedAssertion("Actual value is null")),
-        (AssertionOperator.HasSize, "#records[0].someNumber", "{'a', 'b'}", FailedAssertion("Expected value is null")),
+        ("operator", "actualExpr", "expectedExpr", "expectedResult"),
+        (AssertionOperator.GreaterThan, "#records[0].someNumber", "10", FailedAssertion("Actual value is null")),
+        (AssertionOperator.LessThan, "#records[0].someNumber", "10", FailedAssertion("Actual value is null")),
+        (AssertionOperator.GreaterThanOrEqual, "#records[0].someNumber", "10", FailedAssertion("Actual value is null")),
+        (AssertionOperator.LessThanOrEqual, "#records[0].someNumber", "10", FailedAssertion("Actual value is null")),
+        (AssertionOperator.Contains, "#records[0].someVariable", "'x'", FailedAssertion("Actual value is null")),
+        (AssertionOperator.Matches, "#records[0].someVariable", "'.*'", FailedAssertion("Actual value is null")),
+        (AssertionOperator.HasSize, "#records[0].someCollection", "3", FailedAssertion("Actual value is null")),
+        (AssertionOperator.HasSize, "{'a', 'b'}", "#records[0].someNumber", FailedAssertion("Expected value is null")),
       )
-    ) { (operator, expectedExpr, actualExpr, expectedResult) =>
+    ) { (operator, actualExpr, expectedExpr, expectedResult) =>
       val testCase = prepareTestCase(
         List(PredicateAssertion(operator, expectedExpr.spel, actualExpr.spel))
       )
@@ -316,14 +316,14 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
   test("should not evaluate empty assertions") {
     forAll(
       Table(
-        ("expected expression", "actual expression", "expected assertion result"),
+        ("actual expression", "expected expression", "expected assertion result"),
         ("", "", SuccessfulAssertion),
-        ("  ", "    ", SuccessfulAssertion),
-        ("", "#records[0].someBigDecimal", SuccessfulAssertion),
-        ("   ", "#records[0].someBigDecimal", SuccessfulAssertion),
-        ("{a: 1}", "  ", SuccessfulAssertion),
+        ("    ", "  ", SuccessfulAssertion),
+        ("#records[0].someBigDecimal", "", SuccessfulAssertion),
+        ("#records[0].someBigDecimal", "   ", SuccessfulAssertion),
+        ("  ", "{a: 1}", SuccessfulAssertion),
       )
-    ) { (expectedExpression, actualExpression, expectedResult) =>
+    ) { (actualExpression, expectedExpression, expectedResult) =>
       val testCase = prepareTestCase(
         List(
           PredicateAssertion(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -236,6 +236,40 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
     }
   }
 
+  test("should verify contains operator for collections") {
+    forAll(
+      Table(
+        ("expectedExpr", "actualCollection", "expectedResult"),
+        ("'b'", java.util.List.of("a", "b", "c"), SuccessfulAssertion),
+        ("'d'", java.util.List.of("a", "b", "c"), FailedAssertion("Expected [{'a', 'b', 'c'}] to contain ['d']")),
+      )
+    ) { (expectedExpr, actualCollection, expectedResult) =>
+      val testCase = prepareTestCase(
+        List(PredicateAssertion(AssertionOperator.Contains, expectedExpr.spel, "#records[0].someCollection".spel))
+      )
+      val nodesResultsAfterTestRun = prepareNodeResults(List(Map("someCollection" -> actualCollection)))
+      val results                  = verifyForTestCase(testCase, nodesResultsAfterTestRun)
+      results shouldBe List(expectedResult)
+    }
+  }
+
+  test("should verify contains operator for strings") {
+    forAll(
+      Table(
+        ("expectedExpr", "actualString", "expectedResult"),
+        ("'ello'", "hello world", SuccessfulAssertion),
+        ("'xyz'", "hello world", FailedAssertion("Expected ['hello world'] to contain ['xyz']")),
+      )
+    ) { (expectedExpr, actualString, expectedResult) =>
+      val testCase = prepareTestCase(
+        List(PredicateAssertion(AssertionOperator.Contains, expectedExpr.spel, "#records[0].someVariable".spel))
+      )
+      val nodesResultsAfterTestRun = prepareNodeResults(List(Map("someVariable" -> actualString)))
+      val results                  = verifyForTestCase(testCase, nodesResultsAfterTestRun)
+      results shouldBe List(expectedResult)
+    }
+  }
+
   test("should not evaluate empty assertions") {
     forAll(
       Table(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionVerifierSpec.scala
@@ -63,6 +63,7 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
         "someArray"      -> Typed.fromInstance(new Array[String](1)),
         "someBigDecimal" -> Typed[java.math.BigDecimal],
         "someNumber"     -> Typed[java.lang.Integer],
+        "someCollection" -> Typed.fromInstance(new util.ArrayList[String]()),
       ),
       parameters = None,
       typingInfo = Map.empty
@@ -210,6 +211,26 @@ class AssertionVerifierSpec extends AnyFunSuite with Matchers {
         )
       )
       val nodesResultsAfterTestRun = prepareNodeResults(List(Map("someNumber" -> actualValue)))
+      val results                  = verifyForTestCase(testCase, nodesResultsAfterTestRun)
+      results shouldBe List(expectedResult)
+    }
+  }
+
+  test("should verify hasSize operator") {
+    forAll(
+      Table(
+        ("expectedSizeExpr", "actualList", "expectedResult"),
+        ("3", java.util.List.of("a", "b", "c"), SuccessfulAssertion),
+        ("2", java.util.List.of("a", "b", "c"), FailedAssertion("Expected size: [2] but found: [3]")),
+        ("0", new java.util.ArrayList[String](), SuccessfulAssertion),
+        ("2", java.util.Map.of("k1", "v1", "k2", "v2"), SuccessfulAssertion),
+        ("1", java.util.Map.of("k1", "v1", "k2", "v2"), FailedAssertion("Expected size: [1] but found: [2]")),
+      )
+    ) { (expectedSizeExpr, actualList, expectedResult) =>
+      val testCase = prepareTestCase(
+        List(PredicateAssertion(AssertionOperator.HasSize, expectedSizeExpr.spel, "#records[0].someCollection".spel))
+      )
+      val nodesResultsAfterTestRun = prepareNodeResults(List(Map("someCollection" -> actualList)))
       val results                  = verifyForTestCase(testCase, nodesResultsAfterTestRun)
       results shouldBe List(expectedResult)
     }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/test/testcase/AssertionsCompilerSpec.scala
@@ -98,12 +98,12 @@ class AssertionsCompilerSpec
     compiledAssertionsForNode(0).operator shouldBe Assertion.AssertionOperator.Equals
     compiledAssertionsForNode(0).expectedExpression.original shouldBe "1"
     compiledAssertionsForNode(0).actualExpression.original shouldBe "#records.size"
-    compiledAssertionsForNode(0).comparisonExpression.original shouldBe "(1) == (#records.size)"
+    compiledAssertionsForNode(0).comparisonExpression.original shouldBe "(#records.size) == (1)"
 
     compiledAssertionsForNode(1).operator shouldBe Assertion.AssertionOperator.Equals
     compiledAssertionsForNode(1).expectedExpression.original shouldBe "true"
     compiledAssertionsForNode(1).actualExpression.original shouldBe "#records.size > 0"
-    compiledAssertionsForNode(1).comparisonExpression.original shouldBe "(true) == (#records.size > 0)"
+    compiledAssertionsForNode(1).comparisonExpression.original shouldBe "(#records.size > 0) == (true)"
   }
 
   test("should produce errors for assertions on missing nodes") {
@@ -211,10 +211,10 @@ class AssertionsCompilerSpec
             `nodeId`,
             _
           ) =>
-        message shouldBe "Operator '==' used with not comparable types: String and Integer"
+        message shouldBe "Operator '==' used with not comparable types: Integer and String"
         parameterName shouldBe PredicateAssertionCompilationError.Field.Actual.entryName
         field shouldBe PredicateAssertionCompilationError.Field.Actual
-        originalExpr shouldBe "('string') == (123)"
+        originalExpr shouldBe "(123) == ('string')"
         details shouldBe None
         assertion shouldBe assertionComparingUnrelatedTypes
     }
@@ -238,7 +238,7 @@ class AssertionsCompilerSpec
         ),
         (
           PredicateAssertion(Assertion.AssertionOperator.Equals, "'abc'".spel, "123".spel),
-          Validated.invalidNel("Operator '==' used with not comparable types: String and Integer")
+          Validated.invalidNel("Operator '==' used with not comparable types: Integer and String")
         ),
         (
           PredicateAssertion(
@@ -254,7 +254,7 @@ class AssertionsCompilerSpec
             "{'abc', 'def'}".spel,
             "{123}".spel,
           ),
-          Validated.invalidNel("Operator '==' used with not comparable types: List[String] and List[Integer]")
+          Validated.invalidNel("Operator '==' used with not comparable types: List[Integer] and List[String]")
         ),
         (
           PredicateAssertion(

--- a/docs-internal/api/nu-designer-openapi.yaml
+++ b/docs-internal/api/nu-designer-openapi.yaml
@@ -5878,11 +5878,14 @@ components:
       title: AssertionOperator
       type: string
       enum:
+      - contains
       - equals
       - greaterThan
       - greaterThanOrEqual
+      - hasSize
       - lessThan
       - lessThanOrEqual
+      - matches
       - notEquals
     AssertionResult:
       title: AssertionResult

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
@@ -78,6 +78,7 @@ object Assertion {
     case object LessThanOrEqual    extends AssertionOperator
     case object HasSize            extends AssertionOperator
     case object Contains           extends AssertionOperator
+    case object Matches            extends AssertionOperator
 
     override def values: IndexedSeq[AssertionOperator] = findValues
   }

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
@@ -77,6 +77,7 @@ object Assertion {
     case object GreaterThanOrEqual extends AssertionOperator
     case object LessThanOrEqual    extends AssertionOperator
     case object HasSize            extends AssertionOperator
+    case object Contains           extends AssertionOperator
 
     override def values: IndexedSeq[AssertionOperator] = findValues
   }

--- a/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
+++ b/scenario-api/src/main/scala/pl/touk/nussknacker/engine/test/testcase/TestCase.scala
@@ -76,6 +76,7 @@ object Assertion {
     case object LessThan           extends AssertionOperator
     case object GreaterThanOrEqual extends AssertionOperator
     case object LessThanOrEqual    extends AssertionOperator
+    case object HasSize            extends AssertionOperator
 
     override def values: IndexedSeq[AssertionOperator] = findValues
   }


### PR DESCRIPTION
## Describe your changes

... and reverse order of actual and expected expressions.

<img width="783" height="503" alt="image" src="https://github.com/user-attachments/assets/de89c9ac-af19-49ff-967c-259dc3652b0a" />


## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
