### PR TITLE
perf: unmount collapsed ContextTreeNode children to prevent DOM bloat

### DIFF
--- a/designer/client/src/components/builderComponents/ContextTreeNode.tsx
+++ b/designer/client/src/components/builderComponents/ContextTreeNode.tsx
@@ -181,7 +181,7 @@ export function ContextTreeNode({
                     </Typography>
                 )}
             </Box>
-            <Collapse in={forceOpen || open}>
+            <Collapse in={forceOpen || open} unmountOnExit>
                 {isExpandable &&
                     visibleChildren.map(([k, v]) => {
                         const childPath = isArr


### PR DESCRIPTION
## Summary
- MUI Collapse keeps children mounted even when closed by default
- Large context trees caused expression builder / data mapper / condition builder to freeze on open
- Adding unmountOnExit ensures collapsed subtrees are not rendered

## Test plan
- [ ] Open expression builder on a node with many test records — verify fast open
- [ ] Verify expanding/collapsing nodes still works correctly