### PR TITLE
feat: improve DnD in assertion Expected and Actual fields

### DIFF
--- a/designer/client/src/components/graph/node-modal/editors/expression/useAceDndTarget.test.ts
+++ b/designer/client/src/components/graph/node-modal/editors/expression/useAceDndTarget.test.ts
@@ -1,0 +1,100 @@
+import type { SpelDndContext } from "../../io/ContextTree";
+import { ExpressionLang } from "./types";
+import { getInsertText, jsonToSpelString } from "./useAceDndTarget";
+
+describe("jsonToSpelString", () => {
+    it("converts null", () => {
+        expect(jsonToSpelString(null)).toBe("null");
+    });
+
+    it("converts string with escaping", () => {
+        expect(jsonToSpelString("hello")).toBe('"hello"');
+        expect(jsonToSpelString('say "hi"')).toBe('"say \\"hi\\""');
+    });
+
+    it("converts number", () => {
+        expect(jsonToSpelString(42)).toBe("42");
+        expect(jsonToSpelString(3.14)).toBe("3.14");
+    });
+
+    it("converts boolean", () => {
+        expect(jsonToSpelString(true)).toBe("true");
+        expect(jsonToSpelString(false)).toBe("false");
+    });
+
+    it("converts array", () => {
+        expect(jsonToSpelString([1, "a"])).toBe('{1,"a"}');
+    });
+
+    it("converts object", () => {
+        expect(jsonToSpelString({ a: 1 })).toBe("{ a: 1 }");
+    });
+
+    it("quotes object keys with spaces", () => {
+        expect(jsonToSpelString({ "my key": 1 })).toBe('{ "my key": 1 }');
+    });
+});
+
+describe("getInsertText", () => {
+    const noOverrides = { recordsPrefix: false, valueInsert: false };
+
+    describe("recordsPrefix=true — Actual field DnD", () => {
+        const opts = { recordsPrefix: true, valueInsert: false };
+
+        it("produces #records[N].path for SpEL", () => {
+            const item: SpelDndContext = { type: "key", path: ["status"], value: "active", recordIndex: 2 };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("#records[2].status");
+        });
+
+        it("uses recordIndex from first record", () => {
+            const item: SpelDndContext = { type: "key", path: ["amount"], value: 100, recordIndex: 0 };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("#records[0].amount");
+        });
+
+        it("falls back to standard path when recordIndex is undefined", () => {
+            const item: SpelDndContext = { type: "key", path: ["status"], value: "active" };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("#status");
+        });
+    });
+
+    describe("valueInsert=true — Expected field DnD", () => {
+        const opts = { recordsPrefix: false, valueInsert: true };
+
+        it("inserts string value as SpEL string literal", () => {
+            const item: SpelDndContext = { type: "value", path: ["status"], value: "active" };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe('"active"');
+        });
+
+        it("inserts numeric value as-is", () => {
+            const item: SpelDndContext = { type: "value", path: ["amount"], value: 42 };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("42");
+        });
+
+        it("inserts boolean value", () => {
+            const item: SpelDndContext = { type: "value", path: ["active"], value: true };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("true");
+        });
+
+        it("inserts null value", () => {
+            const item: SpelDndContext = { type: "value", path: ["field"], value: null };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("null");
+        });
+
+        it("ignores recordIndex — always inserts value", () => {
+            const item: SpelDndContext = { type: "value", path: ["status"], value: "done", recordIndex: 5 };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe('"done"');
+        });
+    });
+
+    describe("no overrides — standard behaviour", () => {
+        it("inserts #path for key type in SpEL", () => {
+            const item: SpelDndContext = { type: "key", path: ["input", "status"], value: "active" };
+            expect(getInsertText(item, ExpressionLang.SpEL, noOverrides)).toBe('#input["status"]');
+        });
+
+        it("inserts value for value type in SpEL", () => {
+            const item: SpelDndContext = { type: "value", path: ["amount"], value: 99 };
+            expect(getInsertText(item, ExpressionLang.SpEL, noOverrides)).toBe("99");
+        });
+    });
+});

--- a/designer/client/src/components/graph/node-modal/editors/expression/useAceDndTarget.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/useAceDndTarget.tsx
@@ -1,5 +1,4 @@
-import type React from "react";
-import { useCallback, useContext, useEffect } from "react";
+import React, { useCallback, useContext, useEffect } from "react";
 import type ReactAce from "react-ace/lib/ace";
 import type { XYCoord } from "react-dnd";
 import { useDragLayer, useDrop } from "react-dnd";
@@ -11,7 +10,10 @@ import { AcceptedLangCtx } from "../../../../ValueDragPreview";
 import type { SpelDndContext } from "../../io/ContextTree";
 import { ExpressionLang } from "./types";
 
-function jsonToSpelString(value: any): string {
+export const UseRecordsPrefixContext = React.createContext(false);
+export const UseValueInsertContext = React.createContext(false);
+
+export function jsonToSpelString(value: any): string {
     if (value === null) return "null";
     if (typeof value === "string") return `"${value.replace(/"/g, '\\"')}"`;
     if (typeof value === "number" || typeof value === "boolean") return String(value);
@@ -69,6 +71,20 @@ const getTextToInsert = memoizeByArgsWithTTL((item: SpelDndContext, language: Ex
     return JSON.stringify(item?.value);
 });
 
+export function getInsertText(
+    item: SpelDndContext,
+    language: ExpressionLang,
+    { recordsPrefix, valueInsert }: { recordsPrefix: boolean; valueInsert: boolean },
+): string {
+    if (recordsPrefix && item.recordIndex !== undefined) {
+        return `#records[${item.recordIndex}].${getPathString(item.path)}`;
+    }
+    if (valueInsert) {
+        return jsonToSpelString(item.value);
+    }
+    return getTextToInsert(item, language);
+}
+
 export function useAceDndTarget(editorRef: React.MutableRefObject<ReactAce>, language: ExpressionLang) {
     const getEditor = useCallback(() => editorRef?.current?.editor, [editorRef]);
 
@@ -76,7 +92,13 @@ export function useAceDndTarget(editorRef: React.MutableRefObject<ReactAce>, lan
         getEditor()?.removeGhostText();
     }, [getEditor]);
 
-    const getText = useCallback((item: SpelDndContext) => getTextToInsert(item, language), [language]);
+    const useRecordsPrefix = useContext(UseRecordsPrefixContext);
+    const useValueInsert = useContext(UseValueInsertContext);
+
+    const getText = useCallback(
+        (item: SpelDndContext) => getInsertText(item, language, { recordsPrefix: useRecordsPrefix, valueInsert: useValueInsert }),
+        [language, useRecordsPrefix, useValueInsert],
+    );
 
     const addPlaceholder = useCallback(
         (clientOffset: XYCoord, item: SpelDndContext) => {

--- a/designer/client/src/components/graph/node-modal/io/ContextData.tsx
+++ b/designer/client/src/components/graph/node-modal/io/ContextData.tsx
@@ -7,6 +7,7 @@ import { getIsLiveDataWorking } from "../../../../reducers/selectors/getLiveData
 import { useAppSelector } from "../../../../store/storeHelpers";
 import { ContextAccordion } from "./ContextAccordion";
 import { ContextDataDisplay } from "./ContextDataDisplay";
+import { RecordIndexContext } from "./ContextTree";
 import type { Direction, VariableContextType } from "./VariableContextTree";
 
 export const ContextData = memo(function Data({
@@ -81,8 +82,10 @@ export const ContextData = memo(function Data({
                             locked={index >= availableContexts}
                             showNodes={showNodes}
                         >
-                            {direction === "output" ? <>{r.error}</> : null}
-                            <ContextDataDisplay direction={direction} context={r} inputVariables={inputVariables} />
+                            <RecordIndexContext.Provider value={data.length - 1 - index}>
+                                {direction === "output" ? <>{r.error}</> : null}
+                                <ContextDataDisplay direction={direction} context={r} inputVariables={inputVariables} />
+                            </RecordIndexContext.Provider>
                         </ContextAccordion>
                     </Slide>
                 ))}

--- a/designer/client/src/components/graph/node-modal/io/ContextTree.tsx
+++ b/designer/client/src/components/graph/node-modal/io/ContextTree.tsx
@@ -22,10 +22,13 @@ function normalizePath(keyPath: KeyPath | (string | number)[]) {
     return [...keyPath].reverse();
 }
 
+export const RecordIndexContext = React.createContext<number | undefined>(undefined);
+
 export type SpelDndContext = {
     value: any;
     path: KeyPath;
     type: "key" | "value";
+    recordIndex?: number;
 };
 
 function DraggableValue({
@@ -40,13 +43,17 @@ function DraggableValue({
     value: unknown;
     type?: SpelDndContext["type"];
 }>) {
-    const [{ isActive }, drag, preview] = useDrag<SpelDndContext, void, { isActive: boolean }>(() => ({
-        type: DndTypes.VALUE,
-        item: { path, type, value },
-        options: { dropEffect: "copy" },
-        canDrag: !disabled,
-        collect: (monitor) => ({ isActive: monitor.isDragging() }),
-    }));
+    const recordIndex = React.useContext(RecordIndexContext);
+    const [{ isActive }, drag, preview] = useDrag<SpelDndContext, void, { isActive: boolean }>(
+        () => ({
+            type: DndTypes.VALUE,
+            item: { path, type, value, recordIndex },
+            options: { dropEffect: "copy" },
+            canDrag: !disabled,
+            collect: (monitor) => ({ isActive: monitor.isDragging() }),
+        }),
+        [path, type, value, recordIndex, disabled],
+    );
 
     useEffect(() => {
         preview(getEmptyImage());

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -9,6 +9,7 @@ import { RowFieldLabel } from "../../../aggregate/rowFieldLabel";
 import { EditableEditor } from "../../../editors/EditableEditor";
 import type { ExpressionObj } from "../../../editors/expression/types";
 import { EditorType, ExpressionLang } from "../../../editors/expression/types";
+import { UseRecordsPrefixContext, UseValueInsertContext } from "../../../editors/expression/useAceDndTarget";
 import Input from "../../../editors/field/Input";
 import { ParamKeyProvider } from "../../../editors/ParamKeyProvider";
 import { FieldsRow } from "../../../fragment-input-definition/FieldsRow";
@@ -124,18 +125,20 @@ const AssertionItemComponent = ({
                     />
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Actual" data-testid={`assertion-actual-${index}`}>
-                    <ParamKeyProvider custom={OverrideKeys.AssertionActual}>
-                        <EditableEditor
-                            showSwitch={false}
-                            editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
-                            expressionObj={actual}
-                            variableTypes={variableTypes}
-                            onValueChange={handleActualChange}
-                            showValidation
-                            fieldErrors={actualErrors}
-                            placeholder="#records.size()"
-                        />
-                    </ParamKeyProvider>
+                    <UseRecordsPrefixContext.Provider value={true}>
+                        <ParamKeyProvider custom={OverrideKeys.AssertionActual}>
+                            <EditableEditor
+                                showSwitch={false}
+                                editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
+                                expressionObj={actual}
+                                variableTypes={variableTypes}
+                                onValueChange={handleActualChange}
+                                showValidation
+                                fieldErrors={actualErrors}
+                                placeholder="#records.size()"
+                            />
+                        </ParamKeyProvider>
+                    </UseRecordsPrefixContext.Provider>
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Assertion" data-testid={`assertion-operator-${index}`}>
                     <TypeSelect
@@ -145,16 +148,18 @@ const AssertionItemComponent = ({
                     />
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Expected" data-testid={`assertion-expected-${index}`}>
-                    <EditableEditor
-                        showSwitch={false}
-                        editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
-                        expressionObj={expected}
-                        variableTypes={variableTypes}
-                        onValueChange={handleExpectedChange}
-                        showValidation
-                        fieldErrors={expectedErrors}
-                        placeholder="true, 12, 'xxxx'"
-                    />
+                    <UseValueInsertContext.Provider value={true}>
+                        <EditableEditor
+                            showSwitch={false}
+                            editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
+                            expressionObj={expected}
+                            variableTypes={variableTypes}
+                            onValueChange={handleExpectedChange}
+                            showValidation
+                            fieldErrors={expectedErrors}
+                            placeholder="true, 12, 'xxxx'"
+                        />
+                    </UseValueInsertContext.Provider>
                 </RowFieldLabel>
             </FieldsRow>
             {testAssertionResult && (


### PR DESCRIPTION
## Summary
- Dragging from incoming records to **Actual** field inserts `#records[N].path` (where N is the record index)
- Dragging any item (key or value) to **Expected** field inserts the concrete value instead of the path

## How it works
- `RecordIndexContext` tracks which record index is being dragged from in the incoming records tree
- `UseRecordsPrefixContext` tells the ACE drop target to prepend `#records[N].` — active only for Actual
- `UseValueInsertContext` tells the ACE drop target to insert the value — active only for Expected

## Test plan
- [ ] Drag a field from record 3 (index 2) in incoming records → Actual field should get `#records[2].fieldPath`
- [ ] Drag a value from incoming records → Expected field should get the concrete value (e.g. `"Hungary"`)
- [ ] DnD to other fields (outside assertions) unchanged