### PR TITLE
feat: expression builder in Actual assertion field

### DIFF
--- a/designer/client/src/components/graph/node-modal/io/InputOutputContext.tsx
+++ b/designer/client/src/components/graph/node-modal/io/InputOutputContext.tsx
@@ -133,7 +133,7 @@ export const InputOutputContextProvider = memo(function InputOutputContextProvid
     const getAvailableContexts = useCallback(
         (direction: "input" | "output" = "input", filter: string[] = []): [VariableContextType[], number] => {
             const transitionResults = direction === "input" ? inputs : outputs;
-            const contexts: VariableContextType[] = [];
+            const contextMap = new Map<string, VariableContextType>();
             transitionResults
                 .filter(({ sourceNodeId, destinationNodeId }) => {
                     if (!filter.length) return true;
@@ -142,15 +142,16 @@ export const InputOutputContextProvider = memo(function InputOutputContextProvid
                 })
                 .forEach(({ id: contextNodeId, destinationNodeId, results }) => {
                     results?.forEach(({ id, variables, timestamp }) => {
-                        const foundContext = contexts.find((context) => context.id === id && context.timestamp === timestamp);
-                        if (foundContext) {
-                            foundContext.nodeIds.push(contextNodeId);
+                        const key = `${id}_${timestamp}`;
+                        const existing = contextMap.get(key);
+                        if (existing) {
+                            existing.nodeIds.push(contextNodeId);
                             return;
                         }
 
                         const error = direction === "input" && getError(destinationNodeId, id);
 
-                        contexts.push({
+                        contextMap.set(key, {
                             id,
                             variables,
                             disabled: isContextDisabled(id, direction),
@@ -161,7 +162,7 @@ export const InputOutputContextProvider = memo(function InputOutputContextProvid
                     });
                 });
             const count = transitionResults.reduce((sum, { totalCount = 0 }) => sum + totalCount, 0);
-            return [contexts, count];
+            return [Array.from(contextMap.values()), count];
         },
         [inputs, outputs, getError, isContextDisabled],
     );

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -1,22 +1,33 @@
 import { css } from "@emotion/css";
-import { Box } from "@mui/material";
-import React, { useCallback, useMemo, memo } from "react";
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
+import { Box, IconButton } from "@mui/material";
+import React, { useCallback, useMemo, useState, memo } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { AssertionOperator } from "../../../../../../actions/nk/testCasesActions";
+import { useUserSettings } from "../../../../../../common/useUserSettings";
 import type { TestAssertionResult } from "../../../../../../http/resultsWithCountsDto";
+import type { NodeType } from "../../../../../../types/node";
 import type { NodeValidationError, VariableTypes } from "../../../../../../types/validation";
+import type { ContextData } from "../../../../../dataMapper/DataMapper";
+import { SpelExpressionBuilderComponent } from "../../../../../spelExpressionBuilder/SpelExpressionBuilderComponent";
 import { RowFieldLabel } from "../../../aggregate/rowFieldLabel";
 import { EditableEditor } from "../../../editors/EditableEditor";
 import type { ExpressionObj } from "../../../editors/expression/types";
 import { EditorType, ExpressionLang } from "../../../editors/expression/types";
 import { UseRecordsPrefixContext, UseValueInsertContext } from "../../../editors/expression/useAceDndTarget";
 import Input from "../../../editors/field/Input";
+import { InfoTooltip } from "../../../editors/InfoTooltip/InfoTooltip";
 import { ParamKeyProvider } from "../../../editors/ParamKeyProvider";
 import { FieldsRow } from "../../../fragment-input-definition/FieldsRow";
 import { TypeSelect } from "../../../fragment-input-definition/TypeSelect";
 import type { Option } from "../../../fragment-input-definition/TypeSelect";
 import { OverrideKeys } from "../../../parameterHelpers";
 import { AssertionStatus } from "./AssertionStatus";
+
+const RECORDS_HINT_KEY = "editors.spelEditor.additionalInfoText.assertionActual";
+const RECORDS_HINT_DEFAULT =
+    "Use **#records** to access all events that passed through this node.\n\ncount `#records.size()`  \nfield access `#records[0].status`  \nfilter `#records.?[#this.amount > 100].size()`";
 
 export const ASSERTION_SYMBOLS: Record<AssertionOperator, string> = {
     equals: "==",
@@ -46,7 +57,9 @@ interface Props {
     expected: ExpressionObj;
     operator: AssertionOperator;
     actual: ExpressionObj;
+    node: NodeType;
     variableTypes: VariableTypes;
+    contextData?: ContextData;
     onChange: (
         uuid: string,
         updated: Partial<{ description: string; expected: ExpressionObj; operator: AssertionOperator; actual: ExpressionObj }>,
@@ -62,13 +75,18 @@ const AssertionItemComponent = ({
     expected,
     operator,
     actual,
+    node,
+    contextData,
     onChange,
     index,
     testAssertionResult,
     variableTypes,
     errors = [],
 }: Props) => {
+    const { t } = useTranslation();
     const isFirstRow = index === 0;
+    const [showFieldExpressionBuilder] = useUserSettings("node.showAssertionExpressionBuilder");
+    const [builderOpen, setBuilderOpen] = useState(false);
 
     const handleDescriptionChange = useCallback(
         (event) => {
@@ -112,6 +130,20 @@ const AssertionItemComponent = ({
         return errors.filter((error) => error.fieldName === "description") || [];
     }, [errors]);
 
+    const recordsHint = t(RECORDS_HINT_KEY, RECORDS_HINT_DEFAULT);
+
+    const handleOpenBuilder = useCallback(() => setBuilderOpen(true), []);
+    const handleCloseBuilder = useCallback(() => setBuilderOpen(false), []);
+    const handleBuilderInsert = useCallback((spel: string) => handleActualChange({ expression: spel }), [handleActualChange]);
+
+    const actualAdornment = showFieldExpressionBuilder ? (
+        <InfoTooltip variant="hover" title={recordsHint}>
+            <IconButton onClick={handleOpenBuilder} color="primary" sx={{ padding: 0 }}>
+                <AutoFixHighIcon sx={{ width: "1rem", height: "1rem" }} />
+            </IconButton>
+        </InfoTooltip>
+    ) : undefined;
+
     return (
         <Box display={"flex"} alignItems={"flex-start"} data-assertion-uuid={uuid}>
             <FieldsRow key={uuid} index={index} uuid={uuid} className={gridContainerStyle}>
@@ -136,6 +168,7 @@ const AssertionItemComponent = ({
                                 showValidation
                                 fieldErrors={actualErrors}
                                 placeholder="#records.size()"
+                                inputAdornmentEnd={actualAdornment}
                             />
                         </ParamKeyProvider>
                     </UseRecordsPrefixContext.Provider>
@@ -162,6 +195,17 @@ const AssertionItemComponent = ({
                     </UseValueInsertContext.Provider>
                 </RowFieldLabel>
             </FieldsRow>
+            {showFieldExpressionBuilder && (
+                <SpelExpressionBuilderComponent
+                    node={node}
+                    variableTypes={variableTypes}
+                    contextData={contextData}
+                    initialExpression={actual.expression}
+                    onInsert={handleBuilderInsert}
+                    open={builderOpen}
+                    onClose={handleCloseBuilder}
+                />
+            )}
             {testAssertionResult && (
                 <Box ml={1} mt={0.5}>
                     <AssertionStatus

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from "@mui/material";
 import { omit } from "lodash";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { AssertionOperator } from "../../../../../../actions/nk/testCasesActions";
@@ -13,6 +13,8 @@ import { useAppDispatch, useAppSelector } from "../../../../../../store/storeHel
 import type { Edge } from "../../../../../../types/edge";
 import type { NodeType } from "../../../../../../types/node";
 import type { VariableTypes } from "../../../../../../types/validation";
+import type { ContextData } from "../../../../../dataMapper/DataMapper";
+import { useInputOutputContext } from "../../../../../graph/node-modal/io/InputOutputContext";
 import { withUuid } from "../../../appendUuid";
 import { useHelpText } from "../../../editors/expression/helpText";
 import { ExpressionLang } from "../../../editors/expression/types";
@@ -47,6 +49,17 @@ export const Assertions = ({ node, edges }: Props) => {
     const dispatch = useAppDispatch();
     const testCaseAssertions = useAppSelector((state) => getTestCaseAssertionsForNode(state, node.id));
     const testAssertionResults = useAppSelector((state) => getTestAssertionResultsForNode(state, node.id));
+    const ioContext = useInputOutputContext();
+    const getAvailableContexts = ioContext?.getAvailableContexts;
+    const MAX_RECORDS_CONTEXT = 20;
+    const recordsContextData = useMemo<ContextData | undefined>(() => {
+        const [inputContexts] = getAvailableContexts?.("input") ?? [[]];
+        if (!inputContexts.length) return undefined;
+        const records = inputContexts
+            .slice(0, MAX_RECORDS_CONTEXT)
+            .map((ctx) => Object.fromEntries(Object.keys(ctx.variables).map((k) => [k, ctx.variables[k].pretty])));
+        return { records };
+    }, [getAvailableContexts]);
     const testCasesErrors = useGetNodeTestCasesErrors(node);
 
     useValidation({ node, showValidation: true, edges });
@@ -137,7 +150,9 @@ export const Assertions = ({ node, edges }: Props) => {
                                 expected={expected}
                                 operator={operator}
                                 actual={actual}
+                                node={node}
                                 variableTypes={assertionVariableTypes}
+                                contextData={recordsContextData}
                                 testAssertionResult={testAssertionResults?.[index]}
                                 index={index}
                                 errors={testCasesErrors.assertionsErrors[index.toString()]}

--- a/designer/client/src/components/spelExpressionBuilder/SpelExpressionBuilderComponent.tsx
+++ b/designer/client/src/components/spelExpressionBuilder/SpelExpressionBuilderComponent.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from "react";
 import { useUserSettings } from "../../common/useUserSettings";
 import { useAppSelector } from "../../store/storeHelpers";
 import type { NodeType } from "../../types/node";
+import type { VariableTypes } from "../../types/validation";
 import type { ContextData } from "../dataMapper/DataMapper";
 import { DataMapperDialogTitle } from "../dataMapper/DataMapperDialogTitle";
 import { useInputOutputContext } from "../graph/node-modal/io/InputOutputContext";
@@ -18,6 +19,10 @@ interface Props {
     initialExpression?: string;
     paramName?: string;
     targetTypeDisplay?: string;
+    /** Override variable types instead of deriving from node id. */
+    variableTypes?: VariableTypes;
+    /** Override context data (actual values) instead of deriving from InputOutputContext. */
+    contextData?: ContextData;
     /** Controlled mode: open state managed externally. */
     open?: boolean;
     onClose?: () => void;
@@ -31,6 +36,8 @@ export function SpelExpressionBuilderComponent({
     initialExpression,
     paramName,
     targetTypeDisplay,
+    variableTypes: variableTypesProp,
+    contextData: contextDataProp,
     open: openProp,
     onClose,
 }: Props): React.JSX.Element | null {
@@ -40,7 +47,8 @@ export function SpelExpressionBuilderComponent({
     const open = isControlled ? openProp : openInternal;
 
     const findAvailableVariables = useAppSelector(getFindAvailableVariables);
-    const variableTypes = useMemo(() => findAvailableVariables(node.id), [findAvailableVariables, node.id]);
+    const variableTypesFromNode = useMemo(() => findAvailableVariables(node.id), [findAvailableVariables, node.id]);
+    const variableTypes = variableTypesProp ?? variableTypesFromNode;
 
     const buildProbeNode = useMemo(() => {
         if (!paramName) return undefined;
@@ -53,13 +61,15 @@ export function SpelExpressionBuilderComponent({
     }, [node, paramName]);
 
     const ioContext = useInputOutputContext();
-    const contextData = useMemo<ContextData | undefined>(() => {
+    const contextDataFromIo = useMemo<ContextData | undefined>(() => {
+        if (contextDataProp !== undefined) return undefined;
         const [contexts] = ioContext?.getAvailableContexts("input") ?? [[]];
         if (!contexts.length) return undefined;
         const selected = ioContext?.state.inputDataSetId ? contexts.find((c) => c.id === ioContext.state.inputDataSetId) : undefined;
         const vars = (selected ?? contexts[0]).variables;
         return Object.fromEntries(Object.keys(vars).map((k) => [k, vars[k].pretty]));
-    }, [ioContext]);
+    }, [ioContext, contextDataProp]);
+    const contextData = contextDataProp ?? contextDataFromIo;
 
     if (!showDataMapper) return null;
 

--- a/designer/client/src/reducers/userSettings.ts
+++ b/designer/client/src/reducers/userSettings.ts
@@ -49,6 +49,7 @@ export const getDefaultUserSettings = (initialUserFlags?: Record<string, boolean
         createFlag("node.autoApply"),
         createFlag("node.inputsAndOutputs.showBlinkAnimations", true),
         createFlag("node.shortCounts"),
+        createFlag("node.showAssertionExpressionBuilder"),
         createFlag("node.showFieldExpressionBuilder"),
         createFlag("node.showAggregateSwitcher"),
         createFlag("node.showFragmentCreator"),


### PR DESCRIPTION
## Summary
- Adds SpEL expression builder dialog to the **Actual** field in assertion rows, gated by `node.showFieldExpressionBuilder` user setting
- Builds context data from up to 20 incoming test records (`#records`) and passes it to the builder
- Adds `variableTypes` and `contextData` override props to `SpelExpressionBuilderComponent`; skips expensive `getAvailableContexts` call when `contextData` is already provided

## Test plan
- [ ] Enable `node.showFieldExpressionBuilder` in `__settings`
- [ ] Run a test on a scenario with incoming records
- [ ] Open a node with assertions — wand icon should appear next to Actual field
- [ ] Click wand icon — expression builder should open quickly even with many records
- [ ] Insert expression — it should be inserted into the Actual field
- [ ] Verify builder is absent when setting is disabled