### PR TITLE
Don't create duplicate CI jobs in PRs from preview branches

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,9 @@ on:
     tags-ignore:
       - '**'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # head_ref - refs/heads/<branch_name>, declared only in pull_request events
+  # ref - refs/heads/<branch_name> (push) or refs/pull/<pr_number>/merge (pull_request)
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}
 env:
   #we use this variable in ciRunSbt.sh


### PR DESCRIPTION
## Describe your changes

Fixes duplicate job runs e.g. for PRs from `staging/*`, which currently look like this:

<img width="797" height="379" src="https://github.com/user-attachments/assets/9ced11bf-f527-4061-9450-eb6ee79a2bde" />

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
