### PR TITLE
improve: expand dotted param names and Record types into nested DataMapper fields

### DIFF
--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -70,6 +70,19 @@ function findInTree(fields: FieldDef[], id: number): FieldDef | undefined {
     return undefined;
 }
 
+/** Finds a FieldDef by a dotted path (e.g. "combinedState.tool_record"), traversing children. */
+function findFieldByDottedPath(fields: FieldDef[], path: string): FieldDef | undefined {
+    const segments = path.split(".");
+    let current = fields;
+    let match: FieldDef | undefined;
+    for (const seg of segments) {
+        match = current.find((f) => f.name === seg);
+        if (!match) return undefined;
+        current = match.children;
+    }
+    return match;
+}
+
 /** When expr contains an Elvis fallback (e.g. from applyTypeConversion), split it into expression + defaultValue. */
 function splitElvisIntoField(field: FieldDef, expr: string): FieldDef {
     const elvisIdx = expr.lastIndexOf(" ?: ");
@@ -134,7 +147,7 @@ export function useDataMapper({
     const initialFocusFieldsRef = useRef(fields);
     useEffect(() => {
         if (!initialFocusFieldName) return;
-        const match = initialFocusFieldsRef.current.find((f) => f.name === initialFocusFieldName);
+        const match = findFieldByDottedPath(initialFocusFieldsRef.current, initialFocusFieldName);
         if (match) setSelField(match.id);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/designer/client/src/components/graph/node-modal/NamedParamsDataMapper.tsx
+++ b/designer/client/src/components/graph/node-modal/NamedParamsDataMapper.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useMemo } from "react";
 
-import type { UIParameter } from "../../../types/definition";
+import type { TypingResult, UIParameter } from "../../../types/definition";
 import type { NodeType } from "../../../types/node";
-import { makeField, parseSpelToFields, refClazzToNuType } from "../../dataMapper/dataMapperUtils";
-import type { NuType } from "../../dataMapper/dataMapperUtils";
+import { makeField, parseSpelToFields, refClazzToNuType, genSpelFromFields } from "../../dataMapper/dataMapperUtils";
+import type { FieldDef, NuType } from "../../dataMapper/dataMapperUtils";
 import { DataMapperComponent } from "./DataMapperComponent";
 import { EditorType, ExpressionLang } from "./editors/expression/types";
 import { findParameters } from "./NodeDetailsContent/helpers";
@@ -15,6 +15,101 @@ function resolveParamNuType(typ: UIParameter["typ"]): NuType {
         if (types.size === 1) return [...types][0] as NuType;
     }
     return refClazzToNuType(typ?.refClazzName);
+}
+
+function getTypFields(typ: TypingResult): Record<string, TypingResult> | null {
+    if ("fields" in typ && typ.fields && typeof typ.fields === "object") {
+        return typ.fields as Record<string, TypingResult>;
+    }
+    return null;
+}
+
+/** Builds a FieldDef leaf, expanding Record types into isRecord children. */
+function buildLeafField(name: string, typ: TypingResult, expression: string): FieldDef {
+    const recordFields = getTypFields(typ);
+    if (recordFields) {
+        const field = makeField(name, "Map");
+        field.isRecord = true;
+        const existingChildren = expression ? parseSpelToFields(expression) ?? [] : [];
+        field.children = Object.entries(recordFields).map(([childName, childTyp]) => {
+            const childField = makeField(childName, refClazzToNuType((childTyp as { refClazzName?: string }).refClazzName));
+            const existing = existingChildren.find((c) => c.name === childName);
+            childField.expression = existing?.expression ?? "";
+            return childField;
+        });
+        return field;
+    }
+    const field = makeField(name, resolveParamNuType(typ));
+    field.expression = expression;
+    return field;
+}
+
+/** Inserts a leaf parameter into a nested FieldDef tree at the given remaining path segments. */
+function insertNestedParam(parent: FieldDef, segments: string[], typ: TypingResult, expression: string): void {
+    const [first, ...rest] = segments;
+    if (rest.length === 0) {
+        parent.children.push(buildLeafField(first, typ, expression));
+        return;
+    }
+    let intermediate = parent.children.find((c) => c.name === first);
+    if (!intermediate) {
+        intermediate = makeField(first, "Map");
+        intermediate.isRecord = true;
+        parent.children.push(intermediate);
+    }
+    insertNestedParam(intermediate, rest, typ, expression);
+}
+
+/**
+ * Groups flat params (possibly with dotted names like "combinedState.tool_record") into a nested
+ * FieldDef tree. Parameters with a Record type are expanded into children using typ.fields.
+ */
+function groupByDottedPrefix(params: UIParameter[], currentParams: ReturnType<typeof findParameters>): FieldDef[] {
+    const rootMap = new Map<string, FieldDef>();
+
+    for (const p of params) {
+        const expression = currentParams.find((np) => np.name === p.name)?.expression?.expression?.trim() ?? "";
+        const segments = p.name.split(".");
+
+        if (segments.length === 1) {
+            rootMap.set(p.name, buildLeafField(p.name, p.typ, expression));
+        } else {
+            const [first, ...rest] = segments;
+            if (!rootMap.has(first)) {
+                const intermediate = makeField(first, "Map");
+                intermediate.isRecord = true;
+                rootMap.set(first, intermediate);
+            }
+            insertNestedParam(rootMap.get(first)!, rest, p.typ, expression);
+        }
+    }
+
+    return Array.from(rootMap.values());
+}
+
+/**
+ * Flattens a nested FieldDef tree back to a map of { dottedParamName → expression }.
+ * When a node's dotted path matches a known parameter, its expression (or its children's
+ * SpEL record) is collected. Intermediate nodes without a matching parameter are traversed.
+ */
+function flattenToParams(fields: FieldDef[], knownParamNames: Set<string>, prefix = ""): Map<string, string> {
+    const result = new Map<string, string>();
+    for (const f of fields) {
+        const key = prefix ? `${prefix}.${f.name}` : f.name;
+        if (knownParamNames.has(key)) {
+            let expr: string;
+            if (f.isRecord) {
+                expr = genSpelFromFields(f.children);
+            } else {
+                expr = f.defaultValue !== undefined ? `${f.expression} ?: ${f.defaultValue}` : f.expression;
+            }
+            result.set(key, expr);
+        } else if (f.isRecord && f.children.length > 0) {
+            const nested = flattenToParams(f.children, knownParamNames, key);
+            nested.forEach((v, k) => result.set(k, v));
+        }
+    }
+    return result;
 }
 
 interface Props {
@@ -46,12 +141,7 @@ export function NamedParamsDataMapper({
     const initialFields = useMemo(() => {
         if (mappableParams.length === 0) return undefined;
         const currentParams = findParameters(node);
-        return mappableParams.map((p) => {
-            const field = makeField(p.name, resolveParamNuType(p.typ));
-            const current = currentParams.find((np) => np.name === p.name);
-            field.expression = current?.expression?.expression?.trim() ?? "";
-            return field;
-        });
+        return groupByDottedPrefix(mappableParams, currentParams);
     }, [mappableParams, node]);
 
     const handleInsert = useCallback(
@@ -59,18 +149,19 @@ export function NamedParamsDataMapper({
             const parsed = parseSpelToFields(spel);
             if (!parsed) return;
             const currentParams = findParameters(node);
-            for (const field of parsed) {
-                const paramIndex = currentParams.findIndex((p) => p.name === field.name);
-                if (paramIndex >= 0 && field.expression) {
-                    const fullExpr = field.defaultValue !== undefined ? `${field.expression} ?: ${field.defaultValue}` : field.expression;
-                    setProperty(`${parametersBasePath}[${paramIndex}].expression`, {
-                        expression: fullExpr,
-                        language: ExpressionLang.SpEL,
-                    });
-                }
+            const knownParamNames = new Set(mappableParams.map((p) => p.name));
+            const exprByParam = flattenToParams(parsed, knownParamNames);
+            for (const [paramName, expr] of exprByParam) {
+                if (!expr) continue;
+                const paramIndex = currentParams.findIndex((p) => p.name === paramName);
+                if (paramIndex < 0) continue;
+                setProperty(`${parametersBasePath}[${paramIndex}].expression`, {
+                    expression: expr,
+                    language: ExpressionLang.SpEL,
+                });
             }
         },
-        [node, parametersBasePath, setProperty],
+        [node, mappableParams, parametersBasePath, setProperty],
     );
 
     if (mappableParams.length === 0) return null;


### PR DESCRIPTION
## Summary
- Kafka sink parameters with dotted names (e.g. `combinedState.tool_record`) are now shown as a nested hierarchy in the DataMapper instead of flat fields
- Parameters with a Record type (e.g. `Record{toolId: Integer, ts: Long, wear: Double}`) are expanded into child fields using the schema from `typ.fields`
- Existing expressions are parsed and distributed to the correct child fields on open
- On insert, the nested tree is flattened back to dotted parameter names with correct SpEL record expressions

## Test plan
- [ ] Open a Kafka sink node with parameters that use dotted names (e.g. `combinedState.tool_record`)
- [ ] Verify the DataMapper shows a nested tree: `combinedState → tool_record → { toolId, ts, wear }`
- [ ] Fill in expressions for leaf fields and click Insert — verify the correct SpEL is written back to each parameter
- [ ] Open a node with an existing expression in a Record field — verify child fields are pre-populated correctly