### PR TITLE
improve: DataMapper schema mode — hide field controls for schema-driven fields

### DIFF
--- a/designer/client/src/components/dataMapper/FieldRow.tsx
+++ b/designer/client/src/components/dataMapper/FieldRow.tsx
@@ -217,18 +217,21 @@ export function FieldRow({
                     />
                 )}
                 {!field.isRecord && field.expression && (
-                    <Chip
-                        label={field.expression.length > 30 ? field.expression.slice(0, 30) + "…" : field.expression}
-                        size="small"
-                        sx={{
-                            height: 18,
-                            fontSize: 10,
-                            fontFamily: "monospace",
-                            color: theme.palette.primary.light,
-                            backgroundColor: alpha(theme.palette.primary.main, 0.12),
-                            "& .MuiChip-label": { px: "6px" },
-                        }}
-                    />
+                    <Tooltip title={field.expression} placement="top">
+                        <Chip
+                            label={field.expression}
+                            size="small"
+                            sx={{
+                                height: 18,
+                                fontSize: 10,
+                                fontFamily: "monospace",
+                                color: theme.palette.primary.light,
+                                backgroundColor: alpha(theme.palette.primary.main, 0.12),
+                                maxWidth: 300,
+                                "& .MuiChip-label": { px: "6px" },
+                            }}
+                        />
+                    </Tooltip>
                 )}
                 <Box sx={{ flex: 1 }} />
                 {!hideFieldControls && (
@@ -286,59 +289,65 @@ export function FieldRow({
                     }}
                 >
                     {/* Name */}
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
-                        <Typography sx={{ fontSize: 11, color: "text.secondary", width: 70 }}>Name</Typography>
-                        <TextField
-                            value={field.name}
-                            onChange={(e) => onChange(field.id, "name", e.target.value)}
-                            size="small"
-                            variant="outlined"
-                            sx={{ flex: 1, "& .MuiInputBase-input": { fontSize: 12, fontFamily: "monospace", py: "5px" } }}
-                        />
-                    </Box>
+                    {!hideFieldControls && (
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
+                            <Typography sx={{ fontSize: 11, color: "text.secondary", width: 70 }}>Name</Typography>
+                            <TextField
+                                value={field.name}
+                                onChange={(e) => onChange(field.id, "name", e.target.value)}
+                                size="small"
+                                variant="outlined"
+                                sx={{ flex: 1, "& .MuiInputBase-input": { fontSize: 12, fontFamily: "monospace", py: "5px" } }}
+                            />
+                        </Box>
+                    )}
 
                     {/* Type */}
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
-                        <Typography sx={{ fontSize: 11, color: "text.secondary", width: 70 }}>Type</Typography>
-                        {field.isRecord ? (
-                            <>
-                                <Typography sx={{ fontSize: 12, color: "text.secondary", flex: 1 }}>Nested record</Typography>
-                                <Button
-                                    size="small"
-                                    variant="outlined"
-                                    color="inherit"
-                                    onClick={() => onChange(field.id, "isRecord", false)}
-                                    sx={{ fontSize: 11, py: "2px", textTransform: "none", flexShrink: 0 }}
-                                >
-                                    Switch to expression
-                                </Button>
-                            </>
-                        ) : (
-                            <>
-                                <Select
-                                    value={field.type === "Map" ? "Any" : field.type}
-                                    onChange={(e) => onChange(field.id, "type", e.target.value as NuType)}
-                                    size="small"
-                                    sx={{ flex: 1, fontSize: 12, "& .MuiSelect-select": { py: "5px" } }}
-                                >
-                                    {NU_TYPES.filter((t) => t !== "Map").map((t) => (
-                                        <MenuItem key={t} value={t} sx={{ fontSize: 12 }}>
-                                            {t}
-                                        </MenuItem>
-                                    ))}
-                                </Select>
-                                <Button
-                                    size="small"
-                                    variant="outlined"
-                                    color="inherit"
-                                    onClick={() => onChange(field.id, "isRecord", true)}
-                                    sx={{ fontSize: 11, py: "2px", textTransform: "none", flexShrink: 0 }}
-                                >
-                                    Build Record
-                                </Button>
-                            </>
-                        )}
-                    </Box>
+                    {!hideFieldControls && (
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
+                            <Typography sx={{ fontSize: 11, color: "text.secondary", width: 70 }}>Type</Typography>
+                            {field.isRecord ? (
+                                <>
+                                    <Typography sx={{ fontSize: 12, color: "text.secondary", flex: 1 }}>Nested record</Typography>
+                                    <Button
+                                        size="small"
+                                        variant="outlined"
+                                        color="inherit"
+                                        onClick={() => onChange(field.id, "isRecord", false)}
+                                        sx={{ fontSize: 11, py: "2px", textTransform: "none", flexShrink: 0 }}
+                                    >
+                                        Switch to expression
+                                    </Button>
+                                </>
+                            ) : (
+                                <>
+                                    <Select
+                                        value={field.type === "Map" ? "Any" : field.type}
+                                        onChange={(e) => onChange(field.id, "type", e.target.value as NuType)}
+                                        size="small"
+                                        sx={{ flex: 1, fontSize: 12, "& .MuiSelect-select": { py: "5px" } }}
+                                    >
+                                        {NU_TYPES.filter((t) => t !== "Map").map((t) => (
+                                            <MenuItem key={t} value={t} sx={{ fontSize: 12 }}>
+                                                {t}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                    {field.type === "Map" && (
+                                        <Button
+                                            size="small"
+                                            variant="outlined"
+                                            color="inherit"
+                                            onClick={() => onChange(field.id, "isRecord", true)}
+                                            sx={{ fontSize: 11, py: "2px", textTransform: "none", flexShrink: 0 }}
+                                        >
+                                            Build Record
+                                        </Button>
+                                    )}
+                                </>
+                            )}
+                        </Box>
+                    )}
 
                     {/* SpEL expression (leaf only) */}
                     {!field.isRecord && (
@@ -433,14 +442,16 @@ export function FieldRow({
                             onValidateExpression={onValidateExpression}
                         />
                     ))}
-                    <Button
-                        size="small"
-                        startIcon={<AddIcon />}
-                        onClick={() => onAddChild(field.id)}
-                        sx={{ fontSize: 11, textTransform: "none", mt: 0.5, py: "2px" }}
-                    >
-                        Add field
-                    </Button>
+                    {!hideFieldControls && (
+                        <Button
+                            size="small"
+                            startIcon={<AddIcon />}
+                            onClick={() => onAddChild(field.id)}
+                            sx={{ fontSize: 11, textTransform: "none", mt: 0.5, py: "2px" }}
+                        >
+                            Add field
+                        </Button>
+                    )}
                 </Box>
             )}
         </Box>

--- a/designer/client/src/components/dataMapper/FieldRow.tsx
+++ b/designer/client/src/components/dataMapper/FieldRow.tsx
@@ -276,8 +276,8 @@ export function FieldRow({
                 )}
             </Box>
 
-            {/* Expanded editor */}
-            <Collapse in={isSelected}>
+            {/* Expanded editor — skip for record fields in schema mode (nothing to show) */}
+            <Collapse in={isSelected && !(hideFieldControls && field.isRecord)}>
                 <Box
                     sx={{
                         mx: 1.5,


### PR DESCRIPTION
## Summary

When DataMapper is opened with `hideFieldControls=true` (Kafka sink with a topic schema):
- **Name** and **Type** fields are hidden — fixed by schema
- **Build Record** button hidden (also restricted to `Map`-typed fields in free mode)
- **Add field** button inside nested records hidden
- Record fields no longer open an empty expanded panel when clicked
- Expression chip shows full expression (up to `maxWidth: 300`) with tooltip instead of truncating at 30 chars

Depends on #9237.

## Test plan
- [ ] Open DataMapper on a Kafka sink with a topic schema
- [ ] Click a leaf field (e.g. `x: Double`) — only value + default value, no Name/Type/Build Record
- [ ] Click a record field (e.g. `axis_snapshot`) — no empty panel
- [ ] Expression chip shows full SpEL with hover tooltip
- [ ] In free mode, Name/Type/Build Record/Add field controls are still present