### PR TITLE
fix: DataMapper automap handles default values and Record-typed primitive context variables

### DIFF
--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -171,8 +171,16 @@ export function useDataMapper({
         for (const [key, typingResult] of Object.entries(variableTypes)) {
             const existing = merged[key];
             const elem0 = Array.isArray(existing) ? existing[0] : undefined;
+            const typingHasFields =
+                typingResult !== null &&
+                typeof typingResult === "object" &&
+                "fields" in typingResult &&
+                typingResult.fields !== null &&
+                typeof typingResult.fields === "object" &&
+                Object.keys(typingResult.fields as object).length > 0;
             const lacksStructure =
                 existing === undefined ||
+                (typingHasFields && (existing === null || typeof existing !== "object")) ||
                 (Array.isArray(existing) && existing.length === 0) ||
                 (Array.isArray(existing) &&
                     existing.length > 0 &&
@@ -293,10 +301,15 @@ export function useDataMapper({
             traverse(val, key, variableTypes?.[key] as { fields?: Record<string, unknown> } | undefined),
         );
 
+        function isTrivialExpression(expr: string): boolean {
+            const t = expr.trim();
+            return !t || t === "null" || t === "''" || t === '""' || t === "false" || t === "true" || /^-?\d+(\.\d+)?$/.test(t);
+        }
+
         function autoMap(fs: FieldDef[]): FieldDef[] {
             return fs.map((f) => {
                 if (f.isRecord) return { ...f, children: autoMap(f.children) };
-                if (f.expression) return f;
+                if (f.expression && !isTrivialExpression(f.expression)) return f;
                 const normalized = f.name.toLowerCase().replace(/[_\s]/g, "");
                 const match = pathMap.get(normalized);
                 const expr = `#${match}`;

--- a/designer/client/src/components/graph/node-modal/ParametersUtils.ts
+++ b/designer/client/src/components/graph/node-modal/ParametersUtils.ts
@@ -50,8 +50,14 @@ function splitTopLevelParts(inner: string): string[] {
     return parts.filter(Boolean);
 }
 
-/** Parse a top-level SpEL record `{ k1: expr1, k2: expr2 }` into a name→expression map. */
-function parseSpelRecord(expression: string): Record<string, string> | null {
+/**
+ * Flatten a SpEL record into a name→expression map.
+ * When `knownParamNames` is provided, recursion stops at keys matching known params,
+ * allowing nested `{combinedState: {key: ..., tool_record: {...}}}` to be distributed
+ * back to individual dotted params like `combinedState.key`, `combinedState.tool_record`.
+ * Without `knownParamNames`, only the top level is parsed (legacy flat format).
+ */
+function flattenSpelRecord(expression: string, knownParamNames?: Set<string>, prefix = ""): Record<string, string> | null {
     const trimmed = expression.trim();
     if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
     const inner = trimmed.slice(1, -1).trim();
@@ -62,9 +68,70 @@ function parseSpelRecord(expression: string): Record<string, string> | null {
         const rawName = part.slice(0, colonIdx).trim();
         const name = rawName.replace(/^["'](.*)["']$/, "$1");
         const val = part.slice(colonIdx + 1).trim();
-        if (name) result[name] = val;
+        if (!name) continue;
+        const fullKey = prefix ? `${prefix}.${name}` : name;
+        if (!knownParamNames || knownParamNames.has(fullKey)) {
+            result[fullKey] = reformatIfSpelRecord(val, 0);
+        } else if (val.startsWith("{") && val.endsWith("}")) {
+            const nested = flattenSpelRecord(val, knownParamNames, fullKey);
+            if (nested) Object.assign(result, nested);
+            else result[fullKey] = val;
+        } else {
+            result[fullKey] = val;
+        }
     }
     return Object.keys(result).length > 0 ? result : null;
+}
+
+/** Re-indent a SpEL record expression string to match the given nesting depth. */
+function reformatIfSpelRecord(expr: string, depth: number): string {
+    const trimmed = expr.trim();
+    if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return expr;
+    const inner = trimmed.slice(1, -1).trim();
+    if (!inner) return "{}";
+    const parts = splitTopLevelParts(inner);
+    if (parts.length === 0) return "{}";
+    const indent = "  ".repeat(depth + 1);
+    const closing = "  ".repeat(depth);
+    const lines = parts.map((part) => {
+        const colonIdx = part.indexOf(":");
+        if (colonIdx === -1) return `${indent}${part.trim()}`;
+        const key = part.slice(0, colonIdx).trim();
+        const val = part.slice(colonIdx + 1).trim();
+        return `${indent}${key}: ${reformatIfSpelRecord(val, depth + 1)}`;
+    });
+    return `{\n${lines.join(",\n")}\n${closing}}`;
+}
+
+/** Recursively build a nested SpEL record from a tree of `{key: string|nested}` objects. */
+function serializeSpelRecord(obj: Record<string, unknown>, depth = 0): string {
+    const indent = "  ".repeat(depth + 1);
+    const closing = "  ".repeat(depth);
+    const lines = Object.entries(obj).map(([k, v]) => {
+        const value =
+            typeof v === "object" && v !== null
+                ? serializeSpelRecord(v as Record<string, unknown>, depth + 1)
+                : reformatIfSpelRecord(v as string, depth + 1);
+        return `${indent}${k}: ${value}`;
+    });
+    return `{\n${lines.join(",\n")}\n${closing}}`;
+}
+
+/** Group dotted param names (e.g. "combinedState.key") into a nested SpEL record expression. */
+function buildNestedSpelRecord(params: Parameter[]): string {
+    const root: Record<string, unknown> = {};
+    for (const p of params) {
+        const expr = p.expression?.expression ?? "null";
+        const segments = p.name.split(".");
+        let current = root;
+        for (let i = 0; i < segments.length - 1; i++) {
+            const seg = segments[i];
+            if (typeof current[seg] !== "object" || current[seg] === null) current[seg] = {};
+            current = current[seg] as Record<string, unknown>;
+        }
+        current[segments[segments.length - 1]] = expr;
+    }
+    return serializeSpelRecord(root);
 }
 
 function migrateKafkaParams(currentParameters: Parameter[], parameterDefinitions: Readonly<UIParameter[]>): Parameter[] | null {
@@ -78,8 +145,10 @@ function migrateKafkaParams(currentParameters: Parameter[], parameterDefinitions
     };
 
     // raw editor → dynamic: distribute Value record to individual params
+    // Handles both old flat format { "combinedState.key": expr } and new nested { combinedState: { key: expr } }
     if (oldValueParam && newIndividualDefs.length > 0) {
-        const parsed = parseSpelRecord(oldValueParam.expression?.expression ?? "");
+        const knownParamNames = new Set(newIndividualDefs.map((d) => d.name));
+        const parsed = flattenSpelRecord(oldValueParam.expression?.expression ?? "", knownParamNames);
         if (parsed) {
             return parameterDefinitions
                 .filter((def) => !def.branchParam)
@@ -95,11 +164,11 @@ function migrateKafkaParams(currentParameters: Parameter[], parameterDefinitions
         }
     }
 
-    // dynamic → raw editor: combine individual params into Value record
+    // dynamic → raw editor: combine individual params into a nested Value record
     if (!oldValueParam && newValueDef) {
         const oldIndividualParams = currentParameters.filter((p) => !KAFKA_SYSTEM_PARAMS.has(p.name));
         if (oldIndividualParams.length > 0) {
-            const record = `{\n${oldIndividualParams.map((p) => `  ${p.name}: ${p.expression?.expression ?? "null"}`).join(",\n")}\n}`;
+            const record = buildNestedSpelRecord(oldIndividualParams);
             return parameterDefinitions
                 .filter((def) => !def.branchParam)
                 .map((def) => {


### PR DESCRIPTION
## Summary

Two related fixes to the DataMapper automap button:

**1. Overwrite trivial/default expressions**
`autoMap` previously skipped any field with a non-empty `expression`. Fields initialized from schema defaults (`''`, `0`, `null`, `false`) were silently skipped. Now automap overwrites trivial literals and only preserves real expressions.

**2. Traverse Record-typed variables even when context value is primitive/null**
`enrichedContext` built from test-record `pretty` values sometimes contains primitive values (string, number, null) for variables whose typing declares them as Records. The traversal was skipping these, so `pathMap` never got entries for their sub-fields. Now when the typing has `fields`, the variable is replaced by `typingResultToSample` to enable traversal.

Depends on #9238.

## Test plan
- [ ] Open DataMapper on a Kafka sink with schema params (e.g. `combinedState.key`, `modelOutput.value`)
- [ ] Click Automap — all fields including top-level ones (`key`, `value`) should be filled
- [ ] Fields that already have a real expression (e.g. `#combinedState?.key`) should NOT be overwritten
- [ ] Fields with default values (`''`, `0`, `null`) should be overwritten by automap