### PR TITLE
fix: hide DataMapper field controls for Kafka sink with schema

### DIFF
--- a/designer/client/src/components/graph/node-modal/ParametersUtils.ts
+++ b/designer/client/src/components/graph/node-modal/ParametersUtils.ts
@@ -50,8 +50,14 @@ function splitTopLevelParts(inner: string): string[] {
     return parts.filter(Boolean);
 }
 
-/** Parse a top-level SpEL record `{ k1: expr1, k2: expr2 }` into a name→expression map. */
-function parseSpelRecord(expression: string): Record<string, string> | null {
+/**
+ * Flatten a SpEL record into a name→expression map.
+ * When `knownParamNames` is provided, recursion stops at keys matching known params,
+ * allowing nested `{combinedState: {key: ..., tool_record: {...}}}` to be distributed
+ * back to individual dotted params like `combinedState.key`, `combinedState.tool_record`.
+ * Without `knownParamNames`, only the top level is parsed (legacy flat format).
+ */
+function flattenSpelRecord(expression: string, knownParamNames?: Set<string>, prefix = ""): Record<string, string> | null {
     const trimmed = expression.trim();
     if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
     const inner = trimmed.slice(1, -1).trim();
@@ -62,9 +68,70 @@ function parseSpelRecord(expression: string): Record<string, string> | null {
         const rawName = part.slice(0, colonIdx).trim();
         const name = rawName.replace(/^["'](.*)["']$/, "$1");
         const val = part.slice(colonIdx + 1).trim();
-        if (name) result[name] = val;
+        if (!name) continue;
+        const fullKey = prefix ? `${prefix}.${name}` : name;
+        if (!knownParamNames || knownParamNames.has(fullKey)) {
+            result[fullKey] = reformatIfSpelRecord(val, 0);
+        } else if (val.startsWith("{") && val.endsWith("}")) {
+            const nested = flattenSpelRecord(val, knownParamNames, fullKey);
+            if (nested) Object.assign(result, nested);
+            else result[fullKey] = val;
+        } else {
+            result[fullKey] = val;
+        }
     }
     return Object.keys(result).length > 0 ? result : null;
+}
+
+/** Re-indent a SpEL record expression string to match the given nesting depth. */
+function reformatIfSpelRecord(expr: string, depth: number): string {
+    const trimmed = expr.trim();
+    if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return expr;
+    const inner = trimmed.slice(1, -1).trim();
+    if (!inner) return "{}";
+    const parts = splitTopLevelParts(inner);
+    if (parts.length === 0) return "{}";
+    const indent = "  ".repeat(depth + 1);
+    const closing = "  ".repeat(depth);
+    const lines = parts.map((part) => {
+        const colonIdx = part.indexOf(":");
+        if (colonIdx === -1) return `${indent}${part.trim()}`;
+        const key = part.slice(0, colonIdx).trim();
+        const val = part.slice(colonIdx + 1).trim();
+        return `${indent}${key}: ${reformatIfSpelRecord(val, depth + 1)}`;
+    });
+    return `{\n${lines.join(",\n")}\n${closing}}`;
+}
+
+/** Recursively build a nested SpEL record from a tree of `{key: string|nested}` objects. */
+function serializeSpelRecord(obj: Record<string, unknown>, depth = 0): string {
+    const indent = "  ".repeat(depth + 1);
+    const closing = "  ".repeat(depth);
+    const lines = Object.entries(obj).map(([k, v]) => {
+        const value =
+            typeof v === "object" && v !== null
+                ? serializeSpelRecord(v as Record<string, unknown>, depth + 1)
+                : reformatIfSpelRecord(v as string, depth + 1);
+        return `${indent}${k}: ${value}`;
+    });
+    return `{\n${lines.join(",\n")}\n${closing}}`;
+}
+
+/** Group dotted param names (e.g. "combinedState.key") into a nested SpEL record expression. */
+function buildNestedSpelRecord(params: Parameter[]): string {
+    const root: Record<string, unknown> = {};
+    for (const p of params) {
+        const expr = p.expression?.expression ?? "null";
+        const segments = p.name.split(".");
+        let current = root;
+        for (let i = 0; i < segments.length - 1; i++) {
+            const seg = segments[i];
+            if (typeof current[seg] !== "object" || current[seg] === null) current[seg] = {};
+            current = current[seg] as Record<string, unknown>;
+        }
+        current[segments[segments.length - 1]] = expr;
+    }
+    return serializeSpelRecord(root);
 }
 
 function migrateKafkaParams(currentParameters: Parameter[], parameterDefinitions: Readonly<UIParameter[]>): Parameter[] | null {
@@ -78,8 +145,10 @@ function migrateKafkaParams(currentParameters: Parameter[], parameterDefinitions
     };
 
     // raw editor → dynamic: distribute Value record to individual params
+    // Handles both old flat format { "combinedState.key": expr } and new nested { combinedState: { key: expr } }
     if (oldValueParam && newIndividualDefs.length > 0) {
-        const parsed = parseSpelRecord(oldValueParam.expression?.expression ?? "");
+        const knownParamNames = new Set(newIndividualDefs.map((d) => d.name));
+        const parsed = flattenSpelRecord(oldValueParam.expression?.expression ?? "", knownParamNames);
         if (parsed) {
             return parameterDefinitions
                 .filter((def) => !def.branchParam)
@@ -95,11 +164,11 @@ function migrateKafkaParams(currentParameters: Parameter[], parameterDefinitions
         }
     }
 
-    // dynamic → raw editor: combine individual params into Value record
+    // dynamic → raw editor: combine individual params into a nested Value record
     if (!oldValueParam && newValueDef) {
         const oldIndividualParams = currentParameters.filter((p) => !KAFKA_SYSTEM_PARAMS.has(p.name));
         if (oldIndividualParams.length > 0) {
-            const record = `{\n${oldIndividualParams.map((p) => `  ${p.name}: ${p.expression?.expression ?? "null"}`).join(",\n")}\n}`;
+            const record = buildNestedSpelRecord(oldIndividualParams);
             return parameterDefinitions
                 .filter((def) => !def.branchParam)
                 .map((def) => {

--- a/designer/client/src/components/graph/node-modal/dataMapperFieldWrapper.tsx
+++ b/designer/client/src/components/graph/node-modal/dataMapperFieldWrapper.tsx
@@ -11,7 +11,9 @@ export function DataMapperFieldWrapper({ parameter, parameterDefinitions, ...res
         const paramDef = parameterDefinitions?.find((p) => p.name === parameter.name);
         const fields = paramDef?.typ ? fieldsFromSample(typingResultToSample(paramDef.typ)) : undefined;
         if (fields?.length) return fields;
-        // Fallback: derive from individual field params (avro/json schema dynamic mode)
+        // Fallback: derive schema from individual field params — only for Kafka sinks (avro/json schema dynamic mode).
+        // Other components (HTTP Callback, Webhook etc.) use free-form fields.
+        if (!parameterDefinitions?.some((p) => p.name === "Raw editor")) return undefined;
         const KAFKA_SYSTEM_PARAMS = new Set([
             "Topic",
             "Schema version",

--- a/designer/client/src/components/graph/node-modal/dataMapperFieldWrapper.tsx
+++ b/designer/client/src/components/graph/node-modal/dataMapperFieldWrapper.tsx
@@ -42,6 +42,7 @@ export function DataMapperFieldWrapper({ parameter, parameterDefinitions, ...res
                     onInsert={onInsert}
                     initialExpression={initialExpression}
                     initialFields={initialFields}
+                    hideFieldControls={!!initialFields || parameterDefinitions?.some((p) => p.name === "Schema version")}
                     open={open}
                     onClose={onClose}
                 />

--- a/designer/client/src/components/graph/node-modal/parametersListField.tsx
+++ b/designer/client/src/components/graph/node-modal/parametersListField.tsx
@@ -44,7 +44,17 @@ export const ParametersListField = ({ getListFieldPath, paramWithIndex, ...props
 
     const listFieldPath = useMemo(() => getListFieldPath(index), [getListFieldPath, index]);
 
-    const FieldWrapper = useMemo(() => pickFieldWrapper(paramKey) || NamedParamsMapperFieldWrapper, [paramKey]);
+    const isKafkaValueParam = useMemo(
+        () =>
+            param.name === "Value" &&
+            props.parameterDefinitions?.some((p) => p.name === "Raw editor") &&
+            props.parameterDefinitions?.some((p) => p.name === "Schema version"),
+        [param.name, props.parameterDefinitions],
+    );
+    const FieldWrapper = useMemo(
+        () => pickFieldWrapper(paramKey) || (isKafkaValueParam ? DataMapperFieldWrapper : NamedParamsMapperFieldWrapper),
+        [isKafkaValueParam, paramKey],
+    );
 
     const endAdornment = useMemo(() => {
         switch (paramKey) {


### PR DESCRIPTION
## Summary
- Passes `hideFieldControls` to DataMapper when the Kafka sink schema is known
- In **structured mode**: `initialFields` is derived from parameterDefinitions → controls hidden
- In **raw editor mode with schema**: `"Schema version"` param is present → controls hidden
- In **raw editor mode without schema** or non-Kafka components (HttpBody etc.): controls remain visible

## Test plan
- [ ] Kafka Avro sink, raw editor OFF → open DataMapper: no Add Field / Name / Type controls
- [ ] Kafka Avro sink, raw editor ON → open DataMapper: no Add Field / Name / Type controls
- [ ] Kafka sink without schema, raw editor ON → open DataMapper: Add Field visible