### PR TITLE
feat: expand Record-typed DnD into nested isRecord fields in DataMapper

### DIFF
--- a/designer/client/src/components/dataMapper/DataMapper.tsx
+++ b/designer/client/src/components/dataMapper/DataMapper.tsx
@@ -323,6 +323,7 @@ export function DataMapper({
                                         onDragOverId={dm.setDragOverId}
                                         onChange={dm.updateField}
                                         onAddChild={dm.addChildField}
+                                        onAddChildFromDrop={dm.addChildFromDrop}
                                         onRemove={dm.removeField}
                                         onMove={dm.moveField}
                                         onDrop={dm.onDrop}

--- a/designer/client/src/components/dataMapper/FieldRow.tsx
+++ b/designer/client/src/components/dataMapper/FieldRow.tsx
@@ -19,7 +19,7 @@ import {
     Typography,
     useTheme,
 } from "@mui/material";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import type { VariableTypes } from "../../types/validation";
 import { clearAceSelectionAfterDrop } from "../builderComponents/aceUtils";
@@ -78,6 +78,7 @@ export interface FieldRowProps {
     onDragOverId: (id: number | null) => void;
     onChange: (id: number, key: keyof FieldDef, val: unknown) => void;
     onAddChild: (parentId: number) => void;
+    onAddChildFromDrop: (parentId: number, path: string) => void;
     onRemove: (id: number) => void;
     onMove: (id: number, dir: 1 | -1) => void;
     onDrop: (path: string, fieldId: number) => void;
@@ -98,6 +99,7 @@ export function FieldRow({
     onDragOverId,
     onChange,
     onAddChild,
+    onAddChildFromDrop,
     onRemove,
     onMove,
     onDrop,
@@ -108,6 +110,8 @@ export function FieldRow({
     const isDragOver = dragOverFieldId === field.id;
     const hasSrc = !field.isRecord && !!field.expression;
     const errors = fieldErrors[field.id] ?? [];
+
+    const [childDropActive, setChildDropActive] = useState(false);
 
     const onExpressionChangeRef = useRef<(val: string) => void>(null!);
     const onExpressionChange = useCallback((val: string) => onChange(field.id, "expression", val), [field.id, onChange]);
@@ -411,16 +415,35 @@ export function FieldRow({
             {/* Nested children — sibling of the summary row, so background never stacks */}
             {field.isRecord && (
                 <Box
+                    onDragOver={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setChildDropActive(true);
+                    }}
+                    onDragLeave={() => setChildDropActive(false)}
+                    onDrop={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        const path = e.dataTransfer.getData("text/plain");
+                        if (path) onAddChildFromDrop(field.id, path);
+                        setChildDropActive(false);
+                    }}
                     sx={{
                         mt: 0.5,
                         ml: 1,
                         pl: 1.5,
                         pb: 0.5,
-                        borderLeft: `2px solid ${alpha(theme.palette.primary.main, 0.25)}`,
+                        borderLeft: `2px solid ${childDropActive ? theme.palette.primary.main : alpha(theme.palette.primary.main, 0.25)}`,
+                        borderRadius: childDropActive ? 1 : 0,
+                        backgroundColor: childDropActive ? alpha(theme.palette.primary.main, 0.06) : "transparent",
+                        transition: "border-color 0.15s, background-color 0.15s",
                     }}
                 >
-                    {field.children.length === 0 && (
+                    {field.children.length === 0 && !childDropActive && (
                         <Typography sx={{ fontSize: 11, color: "text.disabled", py: 0.5 }}>No fields yet — click Add field</Typography>
+                    )}
+                    {childDropActive && field.children.length === 0 && (
+                        <Typography sx={{ fontSize: 11, color: "primary.main", py: 0.5 }}>Drop to add field</Typography>
                     )}
                     {field.children.map((child) => (
                         <FieldRow
@@ -436,6 +459,7 @@ export function FieldRow({
                             onDragOverId={onDragOverId}
                             onChange={onChange}
                             onAddChild={onAddChild}
+                            onAddChildFromDrop={onAddChildFromDrop}
                             onRemove={onRemove}
                             onMove={onMove}
                             onDrop={onDrop}

--- a/designer/client/src/components/dataMapper/dataMapperUtils.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.ts
@@ -218,6 +218,29 @@ export function applyTypeConversion(expr: string, sourceType: NuType | undefined
 }
 
 /** Get the NuType of a value at a dotted path within variableTypes (strips leading # and ? from path). */
+export function getTypingResultAtPath(variableTypes: Record<string, TypingResult>, path: string): TypingResult | undefined {
+    const segments =
+        path
+            .replace(/^#/, "")
+            .replace(/\?/g, "")
+            .match(/[^.[]+|\[\d+\]|\['[^']+'\]/g) ?? [];
+    if (segments.length === 0) return undefined;
+    let current: TypingResult | undefined = variableTypes[segments[0]];
+    if (!current) return undefined;
+    for (let i = 1; i < segments.length; i++) {
+        const seg = segments[i];
+        if (seg.startsWith("[")) {
+            const params = (current as { params?: TypingResult[] }).params;
+            if (!params?.length) return undefined;
+            current = params[0];
+        } else {
+            current = (current as { fields?: Record<string, TypingResult> }).fields?.[seg];
+        }
+        if (!current) return undefined;
+    }
+    return current;
+}
+
 export function getNuTypeAtPath(variableTypes: Record<string, TypingResult>, path: string): NuType | undefined {
     // Tokenize: split by "." and also extract "[N]" / "['key']" index segments
     const segments =

--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import HttpService from "../../http/HttpService/instance";
 import { getProcessDefinitionData } from "../../reducers/selectors/getProcessDefinitionData";
 import { useAppSelector } from "../../store/storeHelpers";
+import type { TypingResult } from "../../types/definition";
 import type { VariableTypes } from "../../types/validation";
 import { toNullSafe, typingResultToSample } from "../builderComponents/typeUtils";
 import type { FieldError } from "../graph/node-modal/editors/Validators";
@@ -15,6 +16,7 @@ import {
     fieldsFromSample,
     genSpelFromFields,
     getNuTypeAtPath,
+    getTypingResultAtPath,
     INITIAL_FIELDS,
     makeField,
     nextId,
@@ -41,6 +43,33 @@ function updateInTree(fields: FieldDef[], id: number, updater: (f: FieldDef) => 
         if (f.children.length > 0) return { ...f, children: updateInTree(f.children, id, updater) };
         return f;
     });
+}
+
+/**
+ * Recursively build a FieldDef from the typing result at the given source path.
+ * If the typing result is a Record (has fields), creates an isRecord FieldDef with children.
+ * Otherwise creates a leaf FieldDef with the appropriate expression and type.
+ */
+function buildFieldFromTyping(
+    name: string,
+    sourcePath: string,
+    variableTypes: Record<string, TypingResult> | null | undefined,
+    nullSafe: boolean,
+): FieldDef {
+    const typing = variableTypes ? getTypingResultAtPath(variableTypes, sourcePath) : undefined;
+    const recordFields = (typing as { fields?: Record<string, TypingResult> } | undefined)?.fields;
+    if (recordFields && Object.keys(recordFields).length > 0) {
+        const f = makeField(name, "Map");
+        f.isRecord = true;
+        f.children = Object.keys(recordFields).map((childName) =>
+            buildFieldFromTyping(childName, `${sourcePath}.${childName}`, variableTypes, nullSafe),
+        );
+        return f;
+    }
+    const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, sourcePath) : undefined;
+    const f = makeField(name, sourceType ?? "Any");
+    f.expression = nullSafe ? toNullSafe(`#${sourcePath}`) : `#${sourcePath}`;
+    return f;
 }
 
 function removeFromTree(fields: FieldDef[], id: number): FieldDef[] {
@@ -203,12 +232,21 @@ export function useDataMapper({
             const rawPath = path.replace(/^#/, "").replace(/\?/g, "");
             const bracketMatch = rawPath.match(/\['([^']+)'\]$/);
             const lastSegment = bracketMatch ? bracketMatch[1] : rawPath.split(".").pop() ?? "";
-            const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, rawPath) : undefined;
-            const field = makeField(lastSegment, sourceType ?? "Any");
-            field.expression = nullSafe ? toNullSafe(`#${rawPath}`) : `#${rawPath}`;
-            setFields((f) => [...f, field]);
+            setFields((f) => [...f, buildFieldFromTyping(lastSegment, rawPath, variableTypes, nullSafe)]);
             setDragOverId(null);
             setDropZoneActive(false);
+        },
+        [nullSafe, variableTypes],
+    );
+
+    const addChildFromDrop = useCallback(
+        (parentId: number, path: string) => {
+            const rawPath = path.replace(/^#/, "").replace(/\?/g, "");
+            const bracketMatch = rawPath.match(/\['([^']+)'\]$/);
+            const lastSegment = bracketMatch ? bracketMatch[1] : rawPath.split(".").pop() ?? "";
+            const newChild = buildFieldFromTyping(lastSegment, rawPath, variableTypes, nullSafe);
+            setFields((fs) => updateInTree(fs, parentId, (f) => ({ ...f, children: [...f.children, newChild] })));
+            setDragOverId(null);
         },
         [nullSafe, variableTypes],
     );
@@ -340,16 +378,30 @@ export function useDataMapper({
             const rawPath = path.replace(/^#/, "").replace(/\?/g, "");
             const bracketMatch = rawPath.match(/\['([^']+)'\]$/);
             const lastSegment = bracketMatch ? bracketMatch[1] : rawPath.split(".").pop() ?? "";
-            const baseExpr = nullSafe ? toNullSafe(`#${rawPath}`) : `#${rawPath}`;
-            const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, rawPath) : undefined;
-            setFields((prev) => {
-                const targetField = findInTree(prev, fieldId);
-                const expr = applyTypeConversion(baseExpr, sourceType, targetField?.type ?? "Any", targetField?.defaultValue);
-                return updateInTree(prev, fieldId, (x) => {
-                    const nameUpdate = !x.name?.trim() && lastSegment ? { name: lastSegment } : {};
-                    return { ...splitElvisIntoField(x, expr), ...nameUpdate };
+            const typing = variableTypes ? getTypingResultAtPath(variableTypes, rawPath) : undefined;
+            const recordFields = (typing as { fields?: Record<string, TypingResult> } | undefined)?.fields;
+            if (recordFields && Object.keys(recordFields).length > 0) {
+                // Source is a Record — replace the target field with a nested isRecord structure
+                const built = buildFieldFromTyping(lastSegment, rawPath, variableTypes, nullSafe);
+                setFields((prev) =>
+                    updateInTree(prev, fieldId, (x) => ({
+                        ...built,
+                        id: x.id,
+                        name: x.name?.trim() ? x.name : built.name,
+                    })),
+                );
+            } else {
+                const baseExpr = nullSafe ? toNullSafe(`#${rawPath}`) : `#${rawPath}`;
+                const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, rawPath) : undefined;
+                setFields((prev) => {
+                    const targetField = findInTree(prev, fieldId);
+                    const expr = applyTypeConversion(baseExpr, sourceType, targetField?.type ?? "Any", targetField?.defaultValue);
+                    return updateInTree(prev, fieldId, (x) => {
+                        const nameUpdate = !x.name?.trim() && lastSegment ? { name: lastSegment } : {};
+                        return { ...splitElvisIntoField(x, expr), ...nameUpdate };
+                    });
                 });
-            });
+            }
             setDragOverId(null);
         },
         [nullSafe, variableTypes],
@@ -568,6 +620,7 @@ export function useDataMapper({
         updateField,
         moveField,
         addChildField,
+        addChildFromDrop,
         validateExpression,
         clearFieldErrors,
         handleAutoMap,


### PR DESCRIPTION
## Summary
- When dragging a Record-typed variable onto the DataMapper drop zone, recursively builds a nested `isRecord` FieldDef tree with children instead of a flat leaf with `toString()` expression
- When dragging a Record onto an **existing field**, replaces it with the nested isRecord structure (preserving the field's ID and name)
- Adds `addChildFromDrop` callback: dragging onto the nested children area (or **Add field** zone of a record) adds a child field, also with recursive Record expansion
- Extracts `buildFieldFromTyping` as a shared module-level helper used by all three drop handlers

## Test plan
- [ ] In DataMapper (free-form mode), drag a Record-typed variable from the context tree onto the drop zone — should create a nested isRecord field with all children pre-filled
- [ ] Drag a Record-typed variable onto an existing empty leaf field — should convert it to an isRecord structure
- [ ] Drag a non-Record variable onto an existing field — should behave as before (set expression)
- [ ] Drag any variable onto the nested children area of a record field — should add a new child (recursively expanding if it's a Record)
- [ ] Verify nested isRecord correctly generates SpEL output