### PR TITLE
fix: expand dotted keys in fieldsFromSample for From Schema in DataMapper

### DIFF
--- a/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
@@ -337,4 +337,32 @@ describe("fieldsFromSample", () => {
         expect(result[0].children[0]).toMatchObject({ name: "city", type: "String" });
         expect(result[0].children[1]).toMatchObject({ name: "zip", type: "String" });
     });
+
+    it("expands flat dotted keys into nested record fields", () => {
+        const result = fieldsFromSample({
+            "state.key": null,
+            "state.value": "abc",
+            other: 1,
+        });
+        expect(result).toHaveLength(2);
+        const state = result.find((f) => f.name === "state");
+        expect(state).toMatchObject({ name: "state", type: "Map", isRecord: true });
+        expect(state?.children).toHaveLength(2);
+        expect(state?.children[0]).toMatchObject({ name: "key" });
+        expect(state?.children[1]).toMatchObject({ name: "value", type: "String" });
+        expect(result.find((f) => f.name === "other")).toMatchObject({ type: "Integer" });
+    });
+
+    it("merges dotted key leaf with sibling nested object under same prefix", () => {
+        // schema: { "a.b": null, "a.c": { d: null } }  →  a: { b: null, c: { d: null } }
+        const result = fieldsFromSample({ "a.b": null, "a.c": { d: null } });
+        expect(result).toHaveLength(1);
+        const a = result[0];
+        expect(a).toMatchObject({ name: "a", isRecord: true });
+        expect(a.children).toHaveLength(2);
+        expect(a.children.find((c) => c.name === "b")).toBeDefined();
+        const c = a.children.find((ch) => ch.name === "c");
+        expect(c).toMatchObject({ isRecord: true });
+        expect(c?.children[0]).toMatchObject({ name: "d" });
+    });
 });

--- a/designer/client/src/components/dataMapper/dataMapperUtils.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.ts
@@ -294,9 +294,39 @@ export function inferNuType(val: unknown): NuType {
     return "Any";
 }
 
+/**
+ * Convert a flat object with dotted keys (e.g. `{"a.b": null, "a.c": {d: null}}`)
+ * into a nested object (`{a: {b: null, c: {d: null}}}`).
+ * Keys without dots and nested object values are preserved as-is.
+ */
+function expandDottedKeys(obj: Record<string, unknown>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+        const parts = key.split(".");
+        let current = result;
+        for (let i = 0; i < parts.length - 1; i++) {
+            const part = parts[i];
+            if (typeof current[part] !== "object" || current[part] === null) current[part] = {};
+            current = current[part] as Record<string, unknown>;
+        }
+        const last = parts[parts.length - 1];
+        if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+            if (typeof current[last] === "object" && current[last] !== null) {
+                Object.assign(current[last] as object, value);
+            } else {
+                current[last] = value;
+            }
+        } else {
+            current[last] = value;
+        }
+    }
+    return result;
+}
+
 export function fieldsFromSample(obj: unknown): FieldDef[] {
     if (typeof obj !== "object" || obj === null || Array.isArray(obj)) return [];
-    return Object.entries(obj as Record<string, unknown>).map(([k, v]) => {
+    const expanded = expandDottedKeys(obj as Record<string, unknown>);
+    return Object.entries(expanded).map(([k, v]) => {
         if (typeof v === "object" && v !== null && !Array.isArray(v)) {
             const children = fieldsFromSample(v);
             return { ...makeField(k, "Map"), isRecord: true, children };


### PR DESCRIPTION
## Summary
- Kafka topic schema responses use flat dotted notation (`"combinedState.key": null`) rather than nested objects
- `fieldsFromSample` now pre-processes input with `expandDottedKeys`, converting flat dotted keys into a nested structure before building `FieldDef`s
- **From Schema** now produces nested `isRecord` fields (e.g. `combinedState` with children `key`, `tool_record`, …) instead of flat leaf fields with dotted names
- Mixed schemas (some dotted leaf keys + some nested object siblings under the same prefix) are correctly merged under the same parent record

## Test plan
- [ ] Open DataMapper on a Kafka sink without a schema (free-form mode)
- [ ] Click **From Schema**, select a topic that has dotted field names in its schema
- [ ] Fields should appear as nested isRecord tree, not flat dotted names
- [ ] Verify SpEL output is properly nested (`{combinedState: {key: ..., tool_record: {...}}}`)