### PR TITLE
Update Kafka image, use light Schema Registry image in `WithSchemaRegistryContainer` tests

### DIFF
--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithKafkaContainer.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithKafkaContainer.scala
@@ -12,10 +12,11 @@ trait WithKafkaContainer { self: Suite with WithDockerContainers =>
   protected val kafkaNetworkAlias = "kafka"
 
   protected val kafkaContainer: KafkaContainer =
-    KafkaContainer(DockerImageName.parse("apache/kafka-native:4.1.1")).configure { self =>
+    KafkaContainer(DockerImageName.parse("apache/kafka-native:4.1.2")).configure { self =>
       // can segfault on startup, we need retries - https://issues.apache.org/jira/browse/KAFKA-20314
       self.withStartupAttempts(3)
       self.setNetwork(network)
+      self.withLogConsumer(logConsumer(prefix = "kafka"))
       self.setNetworkAliases(asList(kafkaNetworkAlias))
     }
 

--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithSchemaRegistryContainer.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithSchemaRegistryContainer.scala
@@ -1,15 +1,29 @@
 package pl.touk.nussknacker.engine.flink.test.docker
 
-import com.dimafeng.testcontainers.SchemaRegistryContainer
+import com.dimafeng.testcontainers.GenericContainer
 import org.scalatest.Suite
 import pl.touk.nussknacker.test.containers.WithDockerContainers
 
+import java.util.Arrays.asList
+
 trait WithSchemaRegistryContainer { self: Suite with WithDockerContainers with WithKafkaContainer =>
 
-  protected val schemaRegistryContainer: SchemaRegistryContainer =
-    SchemaRegistryContainer(network, kafkaNetworkAlias)
+  private val schemaRegistryPort         = 8081
+  private val schemaRegistryNetworkAlias = "schema-registry"
+
+  protected val schemaRegistryContainer: GenericContainer =
+    new GenericContainer(
+      "ghcr.io/axonops/axonops-schema-registry:0.2.1",
+      exposedPorts = Seq(schemaRegistryPort),
+    ).configure { self =>
+      self.setNetwork(network)
+      self.setNetworkAliases(asList(schemaRegistryNetworkAlias))
+      self.withLogConsumer(logConsumer(prefix = "schema-registry"))
+    }
 
   // testcontainers exposes schema registry via mapped port on host network, it will be used for kafkaClient in tests, signal sending etc.
-  protected def hostSchemaRegistryUrl: String = schemaRegistryContainer.schemaUrl
+  protected def hostSchemaRegistryUrl: String =
+    s"http://${schemaRegistryContainer.host}:${schemaRegistryContainer.mappedPort(schemaRegistryPort)}"
+  protected def containerSchemaRegistryUrl: String = s"http://$schemaRegistryNetworkAlias:$schemaRegistryPort"
 
 }

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/BaseNuKafkaRuntimeDockerTest.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/kafka/BaseNuKafkaRuntimeDockerTest.scala
@@ -45,7 +45,7 @@ trait BaseNuKafkaRuntimeDockerTest
   protected lazy val schemaRegistryClient = new CachedSchemaRegistryClient(mappedSchemaRegistryAddress, 10)
 
   protected val kafkaContainer: KafkaContainer = {
-    KafkaContainer(DockerImageName.parse("apache/kafka-native:4.1.1")).configure { self =>
+    KafkaContainer(DockerImageName.parse("apache/kafka-native:4.1.2")).configure { self =>
       self.withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
       // can segfault on startup, we need retries - https://issues.apache.org/jira/browse/KAFKA-20314
       self.withStartupAttempts(3)

--- a/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupport.scala
+++ b/engine/lite/k8sDeploymentManager/src/test/scala/pl/touk/nussknacker/k8s/manager/KafkaK8sSupport.scala
@@ -42,7 +42,7 @@ class KafkaK8sSupport(k8s: KubernetesClient)(private implicit val system: ActorS
   def start()(implicit ec: ExecutionContext): Unit = if (k8s.getOption[Pod](kafkaPodName).futureValue.isEmpty) {
     val kafkaContainer = Container(
       name = kafkaPodName,
-      image = "apache/kafka-native:4.1.1",
+      image = "apache/kafka-native:4.1.2",
       ports = List(
         Container.Port(9092, Protocol.TCP, "kafka-internal"),
         Container.Port(kafkaPodExposedPort, Protocol.TCP, "kafka-localhost"),

--- a/utils/kafka-components-utils/src/it/scala/pl/touk/nussknacker/engine/kafka/validator/CachedTopicsExistenceValidatorTest.scala
+++ b/utils/kafka-components-utils/src/it/scala/pl/touk/nussknacker/engine/kafka/validator/CachedTopicsExistenceValidatorTest.scala
@@ -121,7 +121,7 @@ abstract class BaseCachedTopicsExistenceValidatorTest(kafkaAutoCreateEnabled: Bo
     with Matchers {
 
   override val container: KafkaContainer =
-    KafkaContainer(DockerImageName.parse("apache/kafka-native:4.1.1")).configure { self =>
+    KafkaContainer(DockerImageName.parse("apache/kafka-native:4.1.2")).configure { self =>
       // can segfault on startup, we need retries - https://issues.apache.org/jira/browse/KAFKA-20314
       self.withStartupAttempts(3)
       self.withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", kafkaAutoCreateEnabled.toString.toLowerCase)


### PR DESCRIPTION
## Describe your changes

Use lighter and faster Schema Registry image in `WithSchemaRegistryContainer`. I missed this in #8942.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
