### PR TITLE
fix: guard against null testCapabilities in InputDataRecords

### DIFF
--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
@@ -39,10 +39,10 @@ export const InputDataRecords = ({ node, sourceId }: Props) => {
     const testCapabilities = useAppSelector(getTestCapabilities);
     const scenarioProperties = useAppSelector(getProcessProperties);
 
-    const testCapabilitiesParameters = testCapabilities.testWithParameters;
+    const testCapabilitiesParameters = testCapabilities?.testWithParameters;
 
     const defaultParameter: TestFormParameters | undefined =
-        testCapabilitiesParameters.status === TestCapabilityStatus.AVAILABLE
+        testCapabilitiesParameters?.status === TestCapabilityStatus.AVAILABLE
             ? testCapabilitiesParameters.sourceParameters.find((sourceParameter) => sourceParameter.sourceId === sourceId)
             : undefined;
 
@@ -89,7 +89,7 @@ export const InputDataRecords = ({ node, sourceId }: Props) => {
                         data={testingDataRecordsForSource}
                         sourceOptions={[sourceId]}
                         sourceParameters={
-                            testCapabilitiesParameters.status === TestCapabilityStatus.AVAILABLE
+                            testCapabilitiesParameters?.status === TestCapabilityStatus.AVAILABLE
                                 ? testCapabilitiesParameters.sourceParameters
                                 : []
                         }


### PR DESCRIPTION
## Summary

- `testCapabilities` is initialized as `null` in the graph reducer and populated asynchronously after capabilities are fetched
- Accessing `.testWithParameters` before capabilities load causes a crash when the node modal opens during the loading window
- Added optional chaining (`?.`) on `testCapabilities` and `testCapabilitiesParameters` accesses

## Test plan

- [ ] Open a node modal immediately after page load (before capabilities are fetched) — should no longer crash
- [ ] Verify test data records tab works normally when capabilities are available