### PR TITLE
fix: remove assertions section from source nodes in testing tab

### DIFF
--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContent.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContent.tsx
@@ -29,12 +29,7 @@ export function useTestingContentRenderer() {
     const CONFIG: { when: (node: TestingContentProps["node"]) => boolean; render: (props: TestingContentProps) => React.JSX.Element }[] = [
         {
             when: (node) => node.type === "Source",
-            render: ({ node, edges }) => (
-                <>
-                    <InputDataRecords sourceId={node.id} node={node} />
-                    <Assertions node={node} edges={edges} />
-                </>
-            ),
+            render: ({ node }) => <InputDataRecords sourceId={node.id} node={node} />,
         },
         {
             when: (node) => showMockFieldOnEnrichers && node.type === "Enricher" && node.service.id !== "decision-table",


### PR DESCRIPTION
## Summary

- Source nodes have their own test data records view in the Testing tab
- Assertions section was incorrectly shown for Source nodes alongside the test data records
- Removed the `<Assertions>` component from the Source node render path

## Test plan

- [ ] Open a scenario with a Source node, go to Testing tab — verify only test data records are shown (no Assertions section)
- [ ] Open a non-Source node (e.g. Enricher, Filter) — verify Assertions section still appears normally