### PR TITLE
feat: redesign test records table UI in node modal

### DIFF
--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
@@ -1,7 +1,9 @@
 import AddIcon from "@mui/icons-material/Add";
+import CheckIcon from "@mui/icons-material/Check";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { Box, Button, Divider, Tooltip, Typography } from "@mui/material";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { usePromise } from "rooks";
 import { useTranslation } from "react-i18next";
 
@@ -84,6 +86,19 @@ export const InputDataRecords = ({ node }: Props) => {
         handleRowsDeleted(indices);
     }, [handleRowsDeleted, testingDataRecordsForSource]);
 
+    const [copied, setCopied] = useState(false);
+    const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const handleCopyAll = useCallback(() => {
+        const records = testingDataRecordsForSource ?? [];
+        const text = records.map((r) => r.variables).join("\n");
+        navigator.clipboard.writeText(text).then(() => {
+            setCopied(true);
+            if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+            copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+        });
+    }, [testingDataRecordsForSource]);
+
     const hasRecords = (testingDataRecordsForSource ?? []).length > 0;
     const addRecordDisabled = recordsToAddLimitExceeded;
 
@@ -162,6 +177,17 @@ export const InputDataRecords = ({ node }: Props) => {
                                 </Tooltip>
                                 <Box flex={1} />
                                 <Divider orientation="vertical" flexItem sx={{ mx: 1, borderColor: "text.disabled" }} />
+                                <Tooltip title={t("testRecords.copyAll.hint", "Copy all records as JSON lines to clipboard")}>
+                                    <Button
+                                        size="small"
+                                        variant="text"
+                                        startIcon={copied ? <CheckIcon /> : <ContentCopyIcon />}
+                                        onClick={handleCopyAll}
+                                        sx={{ textTransform: "none", color: "text.disabled" }}
+                                    >
+                                        {copied ? t("testRecords.copyAll.copied", "Copied!") : t("testRecords.copyAll", "Copy all")}
+                                    </Button>
+                                </Tooltip>
                                 <Tooltip title={t("testRecords.clearAll.hint", "Remove all test records")}>
                                     <Button
                                         size="small"

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
@@ -91,7 +91,15 @@ export const InputDataRecords = ({ node }: Props) => {
 
     const handleCopyAll = useCallback(() => {
         const records = testingDataRecordsForSource ?? [];
-        const text = records.map((r) => r.variables).join("\n");
+        const text = records
+            .map((r) => {
+                try {
+                    return JSON.stringify(JSON.parse(r.variables));
+                } catch {
+                    return r.variables;
+                }
+            })
+            .join("\n");
         navigator.clipboard.writeText(text).then(() => {
             setCopied(true);
             if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
@@ -1,3 +1,4 @@
+import { Box } from "@mui/material";
 import React, { useCallback, useMemo, useState } from "react";
 import { usePromise } from "rooks";
 
@@ -9,6 +10,7 @@ import { useAppSelector } from "../../../../../../store/storeHelpers";
 import type { NodeType } from "../../../../../../types/node";
 import { AppendFromLiveDataButton } from "../../../../../modals/TestingDataRecords/AppendFromLiveDataButton";
 import { LimitExceededWarning } from "../../../../../modals/TestingDataRecords/LimitExceededWarning";
+import { PasteRecordsButton } from "../../../../../modals/TestingDataRecords/PasteRecordsButton";
 import { Table } from "../../../../../modals/TestingDataRecords/Table";
 import type { TestingDataRecords } from "../../../../../modals/TestingDataRecords/types";
 import { useDataRecordsActions } from "../../../../../modals/TestingDataRecords/useDataRecordsActions";
@@ -40,6 +42,7 @@ export const InputDataRecords = ({ node }: Props) => {
         cellErrors,
         recordsErrors,
         handleRowAdded,
+        handleRowsAdded,
         handleRowMoved,
         handleRowsDeleted,
         handleRowUpdated,
@@ -96,11 +99,19 @@ export const InputDataRecords = ({ node }: Props) => {
                 </ContentSize>
                 {recordsToAddLimitExceeded ? <LimitExceededWarning maxTestingRecords={maxTestingRecords} /> : null}
 
-                <AppendFromLiveDataButton
-                    handleGenerateTestData={handleGenerateTestDataForSingleSource}
-                    maxTestingRecords={maxTestingRecords}
-                    recordsToAddLimitExceeded={recordsToAddLimitExceeded}
-                />
+                <Box display="flex" alignItems="center">
+                    <PasteRecordsButton
+                        sourceId={sourceId}
+                        onRowsAdded={handleRowsAdded}
+                        defaultVariables={defaultDataRecord?.variables}
+                        disabled={recordsToAddLimitExceeded}
+                    />
+                    <AppendFromLiveDataButton
+                        handleGenerateTestData={handleGenerateTestDataForSingleSource}
+                        maxTestingRecords={maxTestingRecords}
+                        recordsToAddLimitExceeded={recordsToAddLimitExceeded}
+                    />
+                </Box>
             </TestingExpandable>
         </StyledStack>
     );

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
@@ -46,7 +46,6 @@ export const InputDataRecords = ({ node }: Props) => {
     const {
         cellErrors,
         recordsErrors,
-        handleRowAdded,
         handleRowsAdded,
         handleRowMoved,
         handleRowsDeleted,
@@ -73,12 +72,13 @@ export const InputDataRecords = ({ node }: Props) => {
     );
 
     const handleAddRecord = useCallback(() => {
-        const records = testingDataRecordsForSource ?? [];
-        handleRowAdded(records.length, {
-            sourceId: defaultDataRecord.sourceId ?? node.id,
-            variables: defaultDataRecord.variables ?? "",
-        });
-    }, [handleRowAdded, testingDataRecordsForSource, defaultDataRecord, node.id]);
+        handleRowsAdded([
+            {
+                sourceId: defaultDataRecord.sourceId ?? node.id,
+                variables: defaultDataRecord.variables ?? "",
+            },
+        ]);
+    }, [handleRowsAdded, defaultDataRecord.sourceId, defaultDataRecord.variables, node.id]);
 
     const handleClearAll = useCallback(() => {
         const indices = (testingDataRecordsForSource ?? []).map((_, i) => i);

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
@@ -1,6 +1,9 @@
-import { Box } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { Box, Button, Divider, Typography } from "@mui/material";
 import React, { useCallback, useMemo, useState } from "react";
 import { usePromise } from "rooks";
+import { useTranslation } from "react-i18next";
 
 import { TestCapabilityStatus } from "../../../../../../common/TestResultUtils";
 import HttpService from "../../../../../../http/HttpService/instance";
@@ -17,7 +20,6 @@ import { useDataRecordsActions } from "../../../../../modals/TestingDataRecords/
 import { buildDefaultVariables } from "../../../../../modals/TestingDataRecords/utils";
 import { getProcessName, getProcessProperties } from "../../../NodeDetailsContent/selectors";
 import { cleanProperties } from "../../../requestSourceAddons";
-import { ContentSize } from "../../ContentSize";
 import { StyledStack } from "./components/Styled";
 import { TestingExpandable } from "./components/TestingExpandable";
 
@@ -26,6 +28,7 @@ interface Props {
 }
 
 export const InputDataRecords = ({ node }: Props) => {
+    const { t } = useTranslation();
     const [isExpanded, setIsExpanded] = useState(true);
     const maxTestingRecords = useAppSelector(getMaxTestingRecords);
     const testingDataRecordsForSource = useAppSelector((state) => getInputDataRecordsForSingleSource(state, node.id));
@@ -58,15 +61,7 @@ export const InputDataRecords = ({ node }: Props) => {
         [node.id, sourceParameters],
     );
 
-    const onValidateVariables = useCallback(
-        (row: TestingDataRecords) => HttpService.validateSourceNodeTestData(scenarioName, scenarioProperties, cleanProperties(node), row),
-        [scenarioName, scenarioProperties, node],
-    );
-
-    const recordsToAddLimitExceeded = useMemo(
-        () => recordsErrors.some((recordsErrors) => recordsErrors.type === "TEST_DATA_LIMIT_EXCEEDED"),
-        [recordsErrors],
-    );
+    const recordsToAddLimitExceeded = useMemo(() => recordsErrors.some((e) => e.type === "TEST_DATA_LIMIT_EXCEEDED"), [recordsErrors]);
 
     const handleGenerateTestDataForSingleSource = useCallback(
         async (numberOfSamples: number) => {
@@ -74,6 +69,23 @@ export const InputDataRecords = ({ node }: Props) => {
         },
         [generateTestDataForSingleSource, node, scenarioProperties],
     );
+
+    const handleAddRecord = useCallback(() => {
+        const records = testingDataRecordsForSource ?? [];
+        handleRowAdded(records.length, {
+            sourceId: defaultDataRecord.sourceId ?? node.id,
+            variables: defaultDataRecord.variables ?? "",
+        });
+    }, [handleRowAdded, testingDataRecordsForSource, defaultDataRecord, node.id]);
+
+    const handleClearAll = useCallback(() => {
+        const indices = (testingDataRecordsForSource ?? []).map((_, i) => i);
+        if (indices.length === 0) return;
+        handleRowsDeleted(indices);
+    }, [handleRowsDeleted, testingDataRecordsForSource]);
+
+    const hasRecords = (testingDataRecordsForSource ?? []).length > 0;
+    const addRecordDisabled = recordsToAddLimitExceeded;
 
     return (
         <StyledStack>
@@ -83,35 +95,98 @@ export const InputDataRecords = ({ node }: Props) => {
                 expanded={isExpanded}
                 onChange={setIsExpanded}
             >
-                <ContentSize sx={{ padding: 0, maxHeight: "45cqh", mb: 2 }}>
+                {hasRecords ? (
                     <Table
-                        data={testingDataRecordsForSource}
-                        onRowAdded={handleRowAdded}
-                        onRowUpdated={handleRowUpdated}
-                        onRowsDeleted={handleRowsDeleted}
-                        onRowMoved={handleRowMoved}
-                        defaultDataRecord={defaultDataRecord}
-                        sourceId={node.id}
-                        sourceName={node.name}
                         cellErrors={cellErrors}
-                        onValidateVariables={onValidateVariables}
+                        defaultDataRecord={defaultDataRecord}
+                        onRowMoved={handleRowMoved}
+                        onRowsDeleted={handleRowsDeleted}
+                        onRowUpdated={handleRowUpdated}
+                        data={testingDataRecordsForSource}
+                        toolbar={
+                            <Box
+                                display="flex"
+                                alignItems="center"
+                                sx={(theme) => ({
+                                    pl: 2,
+                                    pr: 1,
+                                    py: 0.5,
+                                    borderBottom: `1px solid ${theme.palette.divider}`,
+                                })}
+                            >
+                                <Box display="flex" alignItems="center" gap={1.5}>
+                                    <Button
+                                        size="small"
+                                        variant="text"
+                                        startIcon={<AddIcon />}
+                                        onClick={handleAddRecord}
+                                        disabled={addRecordDisabled}
+                                        sx={{ textTransform: "none" }}
+                                    >
+                                        {t("testRecords.addRecord", "Add record")}
+                                    </Button>
+                                    <PasteRecordsButton
+                                        sourceId={node.id}
+                                        onRowsAdded={handleRowsAdded}
+                                        defaultVariables={defaultDataRecord?.variables}
+                                        disabled={recordsToAddLimitExceeded}
+                                    />
+                                </Box>
+                                <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+                                <AppendFromLiveDataButton
+                                    handleGenerateTestData={handleGenerateTestDataForSingleSource}
+                                    maxTestingRecords={maxTestingRecords}
+                                    recordsToAddLimitExceeded={recordsToAddLimitExceeded}
+                                />
+                                <Box flex={1} />
+                                <Divider orientation="vertical" flexItem sx={{ mx: 1, borderColor: "text.disabled" }} />
+                                <Button
+                                    size="small"
+                                    variant="text"
+                                    startIcon={<DeleteOutlineIcon />}
+                                    onClick={handleClearAll}
+                                    sx={{ textTransform: "none", color: "text.disabled" }}
+                                >
+                                    {t("testRecords.clearAll", "Clear all")}
+                                </Button>
+                            </Box>
+                        }
                     />
-                </ContentSize>
+                ) : (
+                    <Box display="flex" flexDirection="column" alignItems="center" py={5} px={3} gap={2}>
+                        <Typography variant="body2" color="textSecondary" align="center" sx={{ whiteSpace: "pre-line" }}>
+                            {t(
+                                "testRecords.empty",
+                                "No test records yet.\nAdd records manually, paste JSON lines, or append from a live topic.",
+                            )}
+                        </Typography>
+                        <Box display="flex" flexWrap="wrap" gap={1} justifyContent="center" alignItems="center">
+                            <Button
+                                size="small"
+                                variant="outlined"
+                                startIcon={<AddIcon />}
+                                onClick={handleAddRecord}
+                                disabled={addRecordDisabled}
+                                sx={{ textTransform: "none" }}
+                            >
+                                {t("testRecords.addRecord", "Add record")}
+                            </Button>
+                            <PasteRecordsButton
+                                sourceId={node.id}
+                                onRowsAdded={handleRowsAdded}
+                                defaultVariables={defaultDataRecord?.variables}
+                                disabled={recordsToAddLimitExceeded}
+                                variant="outlined"
+                            />
+                            <AppendFromLiveDataButton
+                                handleGenerateTestData={handleGenerateTestDataForSingleSource}
+                                maxTestingRecords={maxTestingRecords}
+                                recordsToAddLimitExceeded={recordsToAddLimitExceeded}
+                            />
+                        </Box>
+                    </Box>
+                )}
                 {recordsToAddLimitExceeded ? <LimitExceededWarning maxTestingRecords={maxTestingRecords} /> : null}
-
-                <Box display="flex" alignItems="center">
-                    <PasteRecordsButton
-                        sourceId={sourceId}
-                        onRowsAdded={handleRowsAdded}
-                        defaultVariables={defaultDataRecord?.variables}
-                        disabled={recordsToAddLimitExceeded}
-                    />
-                    <AppendFromLiveDataButton
-                        handleGenerateTestData={handleGenerateTestDataForSingleSource}
-                        maxTestingRecords={maxTestingRecords}
-                        recordsToAddLimitExceeded={recordsToAddLimitExceeded}
-                    />
-                </Box>
             </TestingExpandable>
         </StyledStack>
     );

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
@@ -2,7 +2,7 @@ import AddIcon from "@mui/icons-material/Add";
 import CheckIcon from "@mui/icons-material/Check";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import { Box, Button, Divider, Tooltip, Typography } from "@mui/material";
+import { Box, Button, Divider, Typography } from "@mui/material";
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { usePromise } from "rooks";
 import { useTranslation } from "react-i18next";
@@ -20,6 +20,7 @@ import { Table } from "../../../../../modals/TestingDataRecords/Table";
 import type { TestingDataRecords } from "../../../../../modals/TestingDataRecords/types";
 import { useDataRecordsActions } from "../../../../../modals/TestingDataRecords/useDataRecordsActions";
 import { buildDefaultVariables } from "../../../../../modals/TestingDataRecords/utils";
+import { InfoTooltip } from "../../../../editors/InfoTooltip/InfoTooltip";
 import { getProcessName, getProcessProperties } from "../../../NodeDetailsContent/selectors";
 import { cleanProperties } from "../../../requestSourceAddons";
 import { StyledStack } from "./components/Styled";
@@ -138,7 +139,10 @@ export const InputDataRecords = ({ node }: Props) => {
                                 })}
                             >
                                 <Box display="flex" alignItems="center" gap={1.5}>
-                                    <Tooltip title={t("testRecords.addRecord.hint", "Add a new empty record to edit manually")}>
+                                    <InfoTooltip
+                                        variant="hover"
+                                        title={t("testRecords.addRecord.hint", "Add a new empty record to edit manually")}
+                                    >
                                         <span>
                                             <Button
                                                 size="small"
@@ -151,8 +155,9 @@ export const InputDataRecords = ({ node }: Props) => {
                                                 {t("testRecords.addRecord", "Add record")}
                                             </Button>
                                         </span>
-                                    </Tooltip>
-                                    <Tooltip
+                                    </InfoTooltip>
+                                    <InfoTooltip
+                                        variant="hover"
                                         title={t(
                                             "testRecords.pasteRecords.hint",
                                             "Paste one or more records as JSON (single object, array, or one object per line)",
@@ -166,10 +171,11 @@ export const InputDataRecords = ({ node }: Props) => {
                                                 disabled={recordsToAddLimitExceeded}
                                             />
                                         </span>
-                                    </Tooltip>
+                                    </InfoTooltip>
                                 </Box>
                                 <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
-                                <Tooltip
+                                <InfoTooltip
+                                    variant="hover"
                                     title={t(
                                         "testRecords.appendFromLiveData.hint",
                                         "Capture records from a live topic and append them to the list",
@@ -182,10 +188,13 @@ export const InputDataRecords = ({ node }: Props) => {
                                             recordsToAddLimitExceeded={recordsToAddLimitExceeded}
                                         />
                                     </span>
-                                </Tooltip>
+                                </InfoTooltip>
                                 <Box flex={1} />
                                 <Divider orientation="vertical" flexItem sx={{ mx: 1, borderColor: "text.disabled" }} />
-                                <Tooltip title={t("testRecords.copyAll.hint", "Copy all records as JSON lines to clipboard")}>
+                                <InfoTooltip
+                                    variant="hover"
+                                    title={t("testRecords.copyAll.hint", "Copy all records as JSON lines to clipboard")}
+                                >
                                     <Button
                                         size="small"
                                         variant="text"
@@ -195,8 +204,8 @@ export const InputDataRecords = ({ node }: Props) => {
                                     >
                                         {copied ? t("testRecords.copyAll.copied", "Copied!") : t("testRecords.copyAll", "Copy all")}
                                     </Button>
-                                </Tooltip>
-                                <Tooltip title={t("testRecords.clearAll.hint", "Remove all test records")}>
+                                </InfoTooltip>
+                                <InfoTooltip variant="hover" title={t("testRecords.clearAll.hint", "Remove all test records")}>
                                     <Button
                                         size="small"
                                         variant="text"
@@ -206,7 +215,7 @@ export const InputDataRecords = ({ node }: Props) => {
                                     >
                                         {t("testRecords.clearAll", "Clear all")}
                                     </Button>
-                                </Tooltip>
+                                </InfoTooltip>
                             </Box>
                         }
                     />

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
@@ -20,7 +20,7 @@ import { Table } from "../../../../../modals/TestingDataRecords/Table";
 import type { TestingDataRecords } from "../../../../../modals/TestingDataRecords/types";
 import { useDataRecordsActions } from "../../../../../modals/TestingDataRecords/useDataRecordsActions";
 import { buildDefaultVariables } from "../../../../../modals/TestingDataRecords/utils";
-import { InfoTooltip } from "../../../../editors/InfoTooltip/InfoTooltip";
+import { InfoTooltip } from "../../../editors/InfoTooltip/InfoTooltip";
 import { getProcessName, getProcessProperties } from "../../../NodeDetailsContent/selectors";
 import { cleanProperties } from "../../../requestSourceAddons";
 import { StyledStack } from "./components/Styled";

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/InputDataRecords.tsx
@@ -1,6 +1,6 @@
 import AddIcon from "@mui/icons-material/Add";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import { Box, Button, Divider, Typography } from "@mui/material";
+import { Box, Button, Divider, Tooltip, Typography } from "@mui/material";
 import React, { useCallback, useMemo, useState } from "react";
 import { usePromise } from "rooks";
 import { useTranslation } from "react-i18next";
@@ -115,40 +115,64 @@ export const InputDataRecords = ({ node }: Props) => {
                                 })}
                             >
                                 <Box display="flex" alignItems="center" gap={1.5}>
+                                    <Tooltip title={t("testRecords.addRecord.hint", "Add a new empty record to edit manually")}>
+                                        <span>
+                                            <Button
+                                                size="small"
+                                                variant="text"
+                                                startIcon={<AddIcon />}
+                                                onClick={handleAddRecord}
+                                                disabled={addRecordDisabled}
+                                                sx={{ textTransform: "none" }}
+                                            >
+                                                {t("testRecords.addRecord", "Add record")}
+                                            </Button>
+                                        </span>
+                                    </Tooltip>
+                                    <Tooltip
+                                        title={t(
+                                            "testRecords.pasteRecords.hint",
+                                            "Paste one or more records as JSON (single object, array, or one object per line)",
+                                        )}
+                                    >
+                                        <span>
+                                            <PasteRecordsButton
+                                                sourceId={node.id}
+                                                onRowsAdded={handleRowsAdded}
+                                                defaultVariables={defaultDataRecord?.variables}
+                                                disabled={recordsToAddLimitExceeded}
+                                            />
+                                        </span>
+                                    </Tooltip>
+                                </Box>
+                                <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+                                <Tooltip
+                                    title={t(
+                                        "testRecords.appendFromLiveData.hint",
+                                        "Capture records from a live topic and append them to the list",
+                                    )}
+                                >
+                                    <span>
+                                        <AppendFromLiveDataButton
+                                            handleGenerateTestData={handleGenerateTestDataForSingleSource}
+                                            maxTestingRecords={maxTestingRecords}
+                                            recordsToAddLimitExceeded={recordsToAddLimitExceeded}
+                                        />
+                                    </span>
+                                </Tooltip>
+                                <Box flex={1} />
+                                <Divider orientation="vertical" flexItem sx={{ mx: 1, borderColor: "text.disabled" }} />
+                                <Tooltip title={t("testRecords.clearAll.hint", "Remove all test records")}>
                                     <Button
                                         size="small"
                                         variant="text"
-                                        startIcon={<AddIcon />}
-                                        onClick={handleAddRecord}
-                                        disabled={addRecordDisabled}
-                                        sx={{ textTransform: "none" }}
+                                        startIcon={<DeleteOutlineIcon />}
+                                        onClick={handleClearAll}
+                                        sx={{ textTransform: "none", color: "text.disabled" }}
                                     >
-                                        {t("testRecords.addRecord", "Add record")}
+                                        {t("testRecords.clearAll", "Clear all")}
                                     </Button>
-                                    <PasteRecordsButton
-                                        sourceId={node.id}
-                                        onRowsAdded={handleRowsAdded}
-                                        defaultVariables={defaultDataRecord?.variables}
-                                        disabled={recordsToAddLimitExceeded}
-                                    />
-                                </Box>
-                                <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
-                                <AppendFromLiveDataButton
-                                    handleGenerateTestData={handleGenerateTestDataForSingleSource}
-                                    maxTestingRecords={maxTestingRecords}
-                                    recordsToAddLimitExceeded={recordsToAddLimitExceeded}
-                                />
-                                <Box flex={1} />
-                                <Divider orientation="vertical" flexItem sx={{ mx: 1, borderColor: "text.disabled" }} />
-                                <Button
-                                    size="small"
-                                    variant="text"
-                                    startIcon={<DeleteOutlineIcon />}
-                                    onClick={handleClearAll}
-                                    sx={{ textTransform: "none", color: "text.disabled" }}
-                                >
-                                    {t("testRecords.clearAll", "Clear all")}
-                                </Button>
+                                </Tooltip>
                             </Box>
                         }
                     />

--- a/designer/client/src/components/modals/TestingDataRecords/AppendFromLiveDataButton.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/AppendFromLiveDataButton.tsx
@@ -1,11 +1,8 @@
-import { Box } from "@mui/material";
-import React, { useState } from "react";
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+import { LoadingButton } from "@mui/lab";
+import { Box, inputBaseClasses, TextField } from "@mui/material";
+import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-
-import { NumericInput } from "../../graph/node-modal/editors/expression/NumericInput";
-import { FormLabel } from "../../graph/node-modal/editors/FormControl";
-import { InfoTooltip } from "../../graph/node-modal/editors/InfoTooltip/InfoTooltip";
-import { StyledLoadingButton } from "../../graph/node-modal/node-action-buttons/StyledLoadingButton";
 
 interface Props {
     handleGenerateTestData: (numberOfSamples: number) => void;
@@ -15,35 +12,57 @@ interface Props {
 
 const DEFAULT_APPEND_COUNT = 10;
 const APPEND_MIN = 0;
-const TOOLTIP_APPEND_LIVE_DATA = "The table will be appended with live data from the data sources.";
 
 export const AppendFromLiveDataButton = ({ handleGenerateTestData, maxTestingRecords, recordsToAddLimitExceeded }: Props) => {
     const { t } = useTranslation();
     const [recordsToAppend, setRecordsToAppend] = useState<number>(DEFAULT_APPEND_COUNT);
+    const [loading, setLoading] = useState(false);
+
+    const handleClick = useCallback(async () => {
+        setLoading(true);
+        try {
+            await handleGenerateTestData(recordsToAppend ?? APPEND_MIN);
+        } finally {
+            setLoading(false);
+        }
+    }, [handleGenerateTestData, recordsToAppend]);
+
+    const handleChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const num = Number(e.target.value);
+            if (!Number.isFinite(num)) return;
+            setRecordsToAppend(Math.max(APPEND_MIN, Math.min(maxTestingRecords, num)));
+        },
+        [maxTestingRecords],
+    );
 
     return (
-        <Box display={"flex"} justifyContent={"flex-start"}>
-            <Box display={"flex"} justifyContent={"center"} alignItems={"center"} gap={0.5}>
-                <StyledLoadingButton
-                    sx={{ mr: 2, fontSize: "14px" }}
-                    title={t("testingDialog.appendRecordsButton", "Append from live data")}
-                    action={() => handleGenerateTestData(recordsToAppend ?? APPEND_MIN)}
-                    disabled={recordsToAddLimitExceeded}
-                />
-            </Box>
-            <NumericInput
-                onChange={(_, value: unknown) => {
-                    const num = typeof value === "number" ? value : Number(value);
-                    if (!Number.isFinite(num)) return;
-                    setRecordsToAppend(Math.max(APPEND_MIN, Math.min(maxTestingRecords, num)));
-                }}
+        <Box display="flex" alignItems="center" gap={0.5}>
+            <LoadingButton
+                variant="text"
+                size="small"
+                startIcon={<AddCircleOutlineIcon />}
+                onClick={handleClick}
+                disabled={recordsToAddLimitExceeded}
+                loading={loading}
+                sx={{ textTransform: "none", fontSize: "14px" }}
+            >
+                {t("testingDialog.appendRecordsButton", "Append from live data")}
+            </LoadingButton>
+            <TextField
+                type="number"
                 value={recordsToAppend}
-                data-testid={"numberOfRecords"}
+                onChange={handleChange}
+                inputProps={{ min: APPEND_MIN, max: maxTestingRecords, "data-testid": "numberOfRecords" }}
+                size="small"
+                variant="filled"
+                InputProps={{ disableUnderline: true }}
+                sx={{
+                    width: 52,
+                    [`& .${inputBaseClasses.root}`]: { fontSize: "13px", borderRadius: 1 },
+                    [`& .${inputBaseClasses.input}`]: { py: 0.375, px: 0.75, textAlign: "center" },
+                }}
             />
-            <FormLabel sx={{ display: "flex", alignItems: "center", ml: 1 }}>{t("testingDialog.labels.records", "Records")}</FormLabel>
-            <Box display={"flex"} alignItems={"center"} ml={1}>
-                <InfoTooltip title={TOOLTIP_APPEND_LIVE_DATA} variant={"hover"} />
-            </Box>
         </Box>
     );
 };

--- a/designer/client/src/components/modals/TestingDataRecords/AppendFromLiveDataButton.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/AppendFromLiveDataButton.tsx
@@ -1,9 +1,7 @@
 import { Box } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { getTestData } from "../../../reducers/selectors/testCases";
-import { useAppSelector } from "../../../store/storeHelpers";
 import { NumericInput } from "../../graph/node-modal/editors/expression/NumericInput";
 import { FormLabel } from "../../graph/node-modal/editors/FormControl";
 import { InfoTooltip } from "../../graph/node-modal/editors/InfoTooltip/InfoTooltip";
@@ -22,15 +20,6 @@ const TOOLTIP_APPEND_LIVE_DATA = "The table will be appended with live data from
 export const AppendFromLiveDataButton = ({ handleGenerateTestData, maxTestingRecords, recordsToAddLimitExceeded }: Props) => {
     const { t } = useTranslation();
     const [recordsToAppend, setRecordsToAppend] = useState<number>(DEFAULT_APPEND_COUNT);
-    const allTestingDataRecords = useAppSelector(getTestData);
-    const currentRecordsNumber = allTestingDataRecords.length;
-    const maxLiveDataToAppend = maxTestingRecords - currentRecordsNumber;
-
-    useEffect(() => {
-        if (maxLiveDataToAppend <= DEFAULT_APPEND_COUNT) {
-            setRecordsToAppend(maxLiveDataToAppend > 0 ? maxLiveDataToAppend : APPEND_MIN);
-        }
-    }, [maxLiveDataToAppend]);
 
     return (
         <Box display={"flex"} justifyContent={"flex-start"}>
@@ -45,10 +34,8 @@ export const AppendFromLiveDataButton = ({ handleGenerateTestData, maxTestingRec
             <NumericInput
                 onChange={(_, value: unknown) => {
                     const num = typeof value === "number" ? value : Number(value);
-                    if (!Number.isFinite(num)) return; // ignore non-numeric input
-
-                    const clamped = Math.max(APPEND_MIN, Math.min(maxLiveDataToAppend, num));
-                    setRecordsToAppend(clamped);
+                    if (!Number.isFinite(num)) return;
+                    setRecordsToAppend(Math.max(APPEND_MIN, Math.min(maxTestingRecords, num)));
                 }}
                 value={recordsToAppend}
                 data-testid={"numberOfRecords"}

--- a/designer/client/src/components/modals/TestingDataRecords/CellContent.ts
+++ b/designer/client/src/components/modals/TestingDataRecords/CellContent.ts
@@ -3,43 +3,17 @@ import { GridCellKind } from "@glideapps/glide-data-grid";
 
 import type { TestingDataRecords } from "./types";
 
-type SourceSelectCellData = {
-    kind: "source-select-cell";
-    value: string;
-    displayValue: string;
-    options: string[];
-    optionLabels: string[];
-};
-type SourceSelectCell = CustomCell<SourceSelectCellData>;
-export const isSourceSelectCell = (c: GridCell): c is SourceSelectCell =>
-    c.kind === GridCellKind.Custom && (c as SourceSelectCell).data?.kind === "source-select-cell";
-
 type VariablesCellData = { kind: "variables-cell"; value: string; sourceId: string };
 export type VariablesCell = CustomCell<VariablesCellData>;
 export const isVariablesCell = (c: GridCell): c is VariablesCell =>
     c.kind === GridCellKind.Custom && (c as VariablesCell).data?.kind === "variables-cell";
 
-export function getTestingCellContent(item: Item, data: TestingDataRecords[], sourceId: string, sourceName: string): GridCell {
+export function getTestingCellContent(item: Item, data: TestingDataRecords[]): GridCell {
     const [columnIndex, rowIndex] = item;
     const rowData = data[rowIndex];
     if (!rowData) return { kind: GridCellKind.Text, displayData: "", data: "", allowOverlay: true, readonly: false };
-    if (columnIndex === 0)
-        return {
-            kind: GridCellKind.Custom,
-            allowOverlay: true,
-            copyData: rowData.sourceId || "",
-            data: {
-                kind: "source-select-cell",
-                value: rowData.sourceId || "",
-                displayValue: sourceName,
-                options: [sourceId],
-                optionLabels: [sourceName],
-            },
-            readonly: false,
-        } as SourceSelectCell;
-    if (columnIndex === 1) {
+    if (columnIndex === 0) {
         const raw = rowData.variables || "";
-
         return {
             kind: GridCellKind.Custom,
             allowOverlay: true,

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsButton.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsButton.tsx
@@ -1,8 +1,11 @@
 import ContentPasteIcon from "@mui/icons-material/ContentPaste";
-import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from "@mui/material";
-import React, { useCallback, useState } from "react";
+import { Button } from "@mui/material";
+import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
+import { useWindows } from "../../../windowManager/useWindows";
+import { WindowKind } from "../../../windowManager/WindowKind";
+import type { PasteRecordsDialogData } from "./PasteRecordsDialog";
 import type { TestingDataRecords } from "./Table";
 
 interface Props {
@@ -13,168 +16,30 @@ interface Props {
     variant?: "text" | "outlined";
 }
 
-function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta: unknown } {
-    return typeof obj === "object" && obj !== null && "input" in obj && "inputMeta" in obj;
-}
-
-function toRecord(parsed: unknown, defaultTemplate: Record<string, unknown> | null): unknown {
-    return isNkFormat(parsed) ? parsed : { ...defaultTemplate, input: parsed };
-}
-
-function parseRecords(text: string, sourceId: string, defaultVariables?: string): { rows: TestingDataRecords[]; errorCount: number } {
-    let defaultTemplate: Record<string, unknown> | null = null;
-    if (defaultVariables) {
-        try {
-            const parsed = JSON.parse(defaultVariables);
-            if (typeof parsed === "object" && parsed !== null) {
-                defaultTemplate = parsed as Record<string, unknown>;
-            }
-        } catch {
-            // ignore
-        }
-    }
-
-    const trimmed = text.trim();
-
-    // Try whole text as JSON first (handles pretty-printed single object or array)
-    try {
-        const parsed = JSON.parse(trimmed);
-        if (Array.isArray(parsed)) {
-            return {
-                rows: parsed.map((item) => ({ sourceId, variables: JSON.stringify(toRecord(item, defaultTemplate), null, 2) })),
-                errorCount: 0,
-            };
-        }
-        if (typeof parsed === "object" && parsed !== null) {
-            return {
-                rows: [{ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) }],
-                errorCount: 0,
-            };
-        }
-    } catch {
-        // not a single JSON — fall through to NDJSON
-    }
-
-    // NDJSON: one JSON object per line
-    const lines = trimmed
-        .split("\n")
-        .map((l) => l.trim())
-        .filter(Boolean);
-    let errorCount = 0;
-    const rows: TestingDataRecords[] = [];
-    for (const line of lines) {
-        try {
-            const parsed = JSON.parse(line);
-            rows.push({ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) });
-        } catch {
-            errorCount++;
-        }
-    }
-    return { rows, errorCount };
-}
-
 export const PasteRecordsButton = ({ sourceId, onRowsAdded, defaultVariables, disabled, variant = "text" }: Props) => {
     const { t } = useTranslation();
-    const [open, setOpen] = useState(false);
-    const [text, setText] = useState("");
-    const [parseError, setParseError] = useState<string | null>(null);
+    const { open } = useWindows();
 
     const handleOpen = useCallback(() => {
-        setText("");
-        setParseError(null);
-        setOpen(true);
-    }, []);
-
-    const handleClose = useCallback(() => setOpen(false), []);
-
-    const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        setText(e.target.value);
-        setParseError(null);
-    }, []);
-
-    const handleConfirm = useCallback(() => {
-        const { rows, errorCount } = parseRecords(text, sourceId, defaultVariables);
-
-        if (rows.length === 0) {
-            setParseError(t("pasteRecords.noValidLines", "No valid JSON lines found."));
-            return;
-        }
-
-        if (errorCount > 0) {
-            setParseError(t("pasteRecords.someInvalid", "{{errorCount}} line(s) could not be parsed and were skipped.", { errorCount }));
-        }
-
-        onRowsAdded(rows);
-        if (errorCount === 0) {
-            setOpen(false);
-        }
-    }, [text, sourceId, defaultVariables, onRowsAdded, t]);
-
-    const recordCount = React.useMemo(() => {
-        const trimmed = text.trim();
-        if (!trimmed) return 0;
-        try {
-            const parsed = JSON.parse(trimmed);
-            return Array.isArray(parsed) ? parsed.length : 1;
-        } catch {
-            return trimmed
-                .split("\n")
-                .map((l) => l.trim())
-                .filter(Boolean).length;
-        }
-    }, [text]);
+        open<PasteRecordsDialogData>({
+            title: t("pasteRecords.title", "Paste JSON records"),
+            kind: WindowKind.pasteRecords,
+            isModal: true,
+            meta: { sourceId, onRowsAdded, defaultVariables },
+            layoutData: { width: 640 },
+        });
+    }, [open, t, sourceId, onRowsAdded, defaultVariables]);
 
     return (
-        <>
-            <Button
-                size="small"
-                variant={variant}
-                startIcon={<ContentPasteIcon fontSize="small" />}
-                onClick={handleOpen}
-                disabled={disabled}
-                sx={{ textTransform: "none" }}
-            >
-                {t("pasteRecords.button", "Paste JSON lines")}
-            </Button>
-
-            <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
-                <DialogTitle>{t("pasteRecords.title", "Paste JSON records")}</DialogTitle>
-                <DialogContent>
-                    <Typography variant="body2" color="text.secondary" mb={1}>
-                        {t(
-                            "pasteRecords.hint",
-                            "Accepts: a single JSON object (pretty-printed or compact), a JSON array, or one JSON object per line (NDJSON). Raw events without input/inputMeta will be wrapped automatically.",
-                        )}
-                    </Typography>
-                    <TextField
-                        multiline
-                        fullWidth
-                        minRows={8}
-                        maxRows={20}
-                        value={text}
-                        onChange={handleChange}
-                        placeholder={'{"input": {...}, "inputMeta": {...}}\n{"input": {...}, "inputMeta": {...}}'}
-                        inputProps={{ style: { fontFamily: "monospace", fontSize: 12 } }}
-                        autoFocus
-                    />
-                    <Box mt={1} display="flex" justifyContent="space-between" alignItems="center">
-                        <Typography variant="caption" color="text.secondary">
-                            {recordCount > 0 ? t("pasteRecords.recordCount", "{{count}} line(s) detected", { count: recordCount }) : ""}
-                        </Typography>
-                        {parseError && (
-                            <Typography variant="caption" color="warning.main">
-                                {parseError}
-                            </Typography>
-                        )}
-                    </Box>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={handleClose}>{t("dialog.button.cancel", "Cancel")}</Button>
-                    <Button onClick={handleConfirm} variant="contained" disabled={!text.trim()}>
-                        {t("pasteRecords.confirm", "Add {{count}} record(s)", { count: recordCount })}
-                    </Button>
-                </DialogActions>
-            </Dialog>
-        </>
+        <Button
+            size="small"
+            variant={variant}
+            startIcon={<ContentPasteIcon fontSize="small" />}
+            onClick={handleOpen}
+            disabled={disabled}
+            sx={{ textTransform: "none" }}
+        >
+            {t("pasteRecords.button", "Paste JSON lines")}
+        </Button>
     );
 };

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsButton.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsButton.tsx
@@ -1,0 +1,177 @@
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from "@mui/material";
+import React, { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { TestingDataRecords } from "./Table";
+
+interface Props {
+    sourceId: string;
+    onRowsAdded: (rows: TestingDataRecords[]) => void;
+    defaultVariables?: string;
+    disabled?: boolean;
+}
+
+function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta: unknown } {
+    return typeof obj === "object" && obj !== null && "input" in obj && "inputMeta" in obj;
+}
+
+function toRecord(parsed: unknown, defaultTemplate: Record<string, unknown> | null): unknown {
+    return isNkFormat(parsed) ? parsed : { ...defaultTemplate, input: parsed };
+}
+
+function parseRecords(text: string, sourceId: string, defaultVariables?: string): { rows: TestingDataRecords[]; errorCount: number } {
+    let defaultTemplate: Record<string, unknown> | null = null;
+    if (defaultVariables) {
+        try {
+            const parsed = JSON.parse(defaultVariables);
+            if (typeof parsed === "object" && parsed !== null) {
+                defaultTemplate = parsed as Record<string, unknown>;
+            }
+        } catch {
+            // ignore
+        }
+    }
+
+    const trimmed = text.trim();
+
+    // Try whole text as JSON first (handles pretty-printed single object or array)
+    try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+            return {
+                rows: parsed.map((item) => ({ sourceId, variables: JSON.stringify(toRecord(item, defaultTemplate), null, 2) })),
+                errorCount: 0,
+            };
+        }
+        if (typeof parsed === "object" && parsed !== null) {
+            return {
+                rows: [{ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) }],
+                errorCount: 0,
+            };
+        }
+    } catch {
+        // not a single JSON — fall through to NDJSON
+    }
+
+    // NDJSON: one JSON object per line
+    const lines = trimmed
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+    let errorCount = 0;
+    const rows: TestingDataRecords[] = [];
+    for (const line of lines) {
+        try {
+            const parsed = JSON.parse(line);
+            rows.push({ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) });
+        } catch {
+            errorCount++;
+        }
+    }
+    return { rows, errorCount };
+}
+
+export const PasteRecordsButton = ({ sourceId, onRowsAdded, defaultVariables, disabled }: Props) => {
+    const { t } = useTranslation();
+    const [open, setOpen] = useState(false);
+    const [text, setText] = useState("");
+    const [parseError, setParseError] = useState<string | null>(null);
+
+    const handleOpen = useCallback(() => {
+        setText("");
+        setParseError(null);
+        setOpen(true);
+    }, []);
+
+    const handleClose = useCallback(() => setOpen(false), []);
+
+    const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setText(e.target.value);
+        setParseError(null);
+    }, []);
+
+    const handleConfirm = useCallback(() => {
+        const { rows, errorCount } = parseRecords(text, sourceId, defaultVariables);
+
+        if (rows.length === 0) {
+            setParseError(t("pasteRecords.noValidLines", "No valid JSON lines found."));
+            return;
+        }
+
+        if (errorCount > 0) {
+            setParseError(t("pasteRecords.someInvalid", "{{errorCount}} line(s) could not be parsed and were skipped.", { errorCount }));
+        }
+
+        onRowsAdded(rows);
+        if (errorCount === 0) {
+            setOpen(false);
+        }
+    }, [text, sourceId, defaultVariables, onRowsAdded, t]);
+
+    const recordCount = React.useMemo(() => {
+        const trimmed = text.trim();
+        if (!trimmed) return 0;
+        try {
+            const parsed = JSON.parse(trimmed);
+            return Array.isArray(parsed) ? parsed.length : 1;
+        } catch {
+            return trimmed
+                .split("\n")
+                .map((l) => l.trim())
+                .filter(Boolean).length;
+        }
+    }, [text]);
+
+    return (
+        <>
+            <Button
+                size="small"
+                variant="text"
+                onClick={handleOpen}
+                disabled={disabled}
+                sx={{ fontSize: "14px", mr: 2, textTransform: "none" }}
+            >
+                {t("pasteRecords.button", "Paste JSON lines")}
+            </Button>
+
+            <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
+                <DialogTitle>{t("pasteRecords.title", "Paste JSON records")}</DialogTitle>
+                <DialogContent>
+                    <Typography variant="body2" color="text.secondary" mb={1}>
+                        {t(
+                            "pasteRecords.hint",
+                            "Accepts: a single JSON object (pretty-printed or compact), a JSON array, or one JSON object per line (NDJSON). Raw events without input/inputMeta will be wrapped automatically.",
+                        )}
+                    </Typography>
+                    <TextField
+                        multiline
+                        fullWidth
+                        minRows={8}
+                        maxRows={20}
+                        value={text}
+                        onChange={handleChange}
+                        placeholder={'{"input": {...}, "inputMeta": {...}}\n{"input": {...}, "inputMeta": {...}}'}
+                        inputProps={{ style: { fontFamily: "monospace", fontSize: 12 } }}
+                        autoFocus
+                    />
+                    <Box mt={1} display="flex" justifyContent="space-between" alignItems="center">
+                        <Typography variant="caption" color="text.secondary">
+                            {recordCount > 0 ? t("pasteRecords.recordCount", "{{count}} line(s) detected", { count: recordCount }) : ""}
+                        </Typography>
+                        {parseError && (
+                            <Typography variant="caption" color="warning.main">
+                                {parseError}
+                            </Typography>
+                        )}
+                    </Box>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose}>{t("dialog.button.cancel", "Cancel")}</Button>
+                    <Button onClick={handleConfirm} variant="contained" disabled={!text.trim()}>
+                        {t("pasteRecords.confirm", "Add {{count}} record(s)", { count: recordCount })}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+};

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsButton.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsButton.tsx
@@ -1,3 +1,4 @@
+import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from "@mui/material";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -9,6 +10,7 @@ interface Props {
     onRowsAdded: (rows: TestingDataRecords[]) => void;
     defaultVariables?: string;
     disabled?: boolean;
+    variant?: "text" | "outlined";
 }
 
 function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta: unknown } {
@@ -71,7 +73,7 @@ function parseRecords(text: string, sourceId: string, defaultVariables?: string)
     return { rows, errorCount };
 }
 
-export const PasteRecordsButton = ({ sourceId, onRowsAdded, defaultVariables, disabled }: Props) => {
+export const PasteRecordsButton = ({ sourceId, onRowsAdded, defaultVariables, disabled, variant = "text" }: Props) => {
     const { t } = useTranslation();
     const [open, setOpen] = useState(false);
     const [text, setText] = useState("");
@@ -126,10 +128,11 @@ export const PasteRecordsButton = ({ sourceId, onRowsAdded, defaultVariables, di
         <>
             <Button
                 size="small"
-                variant="text"
+                variant={variant}
+                startIcon={<ContentPasteIcon fontSize="small" />}
                 onClick={handleOpen}
                 disabled={disabled}
-                sx={{ fontSize: "14px", mr: 2, textTransform: "none" }}
+                sx={{ textTransform: "none" }}
             >
                 {t("pasteRecords.button", "Paste JSON lines")}
             </Button>

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsButton.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsButton.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useWindows } from "../../../windowManager/useWindows";
 import { WindowKind } from "../../../windowManager/WindowKind";
 import type { PasteRecordsDialogData } from "./PasteRecordsDialog";
-import type { TestingDataRecords } from "./Table";
+import type { TestingDataRecords } from "./types";
 
 interface Props {
     sourceId: string;

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.test.ts
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.test.ts
@@ -1,0 +1,146 @@
+import { parseRecords } from "./parseRecords";
+
+const SOURCE_ID = "test-source";
+
+describe("parseRecords", () => {
+    describe("single compact JSON object", () => {
+        it("wraps raw event in input field", () => {
+            const { rows, errorCount } = parseRecords('{"value": 1}', SOURCE_ID);
+            expect(errorCount).toBe(0);
+            expect(rows).toHaveLength(1);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 } });
+        });
+
+        it("passes through object that already has input key", () => {
+            const { rows, errorCount } = parseRecords('{"input": {"value": 1}}', SOURCE_ID);
+            expect(errorCount).toBe(0);
+            expect(rows).toHaveLength(1);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 } });
+        });
+
+        it("passes through object with both input and inputMeta", () => {
+            const { rows } = parseRecords('{"input": {"value": 1}, "inputMeta": {"offset": 0}}', SOURCE_ID);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 }, inputMeta: { offset: 0 } });
+        });
+    });
+
+    describe("pretty-printed single JSON object", () => {
+        it("wraps multi-line raw event", () => {
+            const text = JSON.stringify({ value: 1 }, null, 2);
+            const { rows, errorCount } = parseRecords(text, SOURCE_ID);
+            expect(errorCount).toBe(0);
+            expect(rows).toHaveLength(1);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 } });
+        });
+
+        it("passes through multi-line NK format object", () => {
+            const text = JSON.stringify({ input: { value: 1 }, inputMeta: { offset: 5 } }, null, 2);
+            const { rows } = parseRecords(text, SOURCE_ID);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 }, inputMeta: { offset: 5 } });
+        });
+    });
+
+    describe("JSON array", () => {
+        it("splits array of raw events into separate records", () => {
+            const { rows, errorCount } = parseRecords('[{"value": 1}, {"value": 2}]', SOURCE_ID);
+            expect(errorCount).toBe(0);
+            expect(rows).toHaveLength(2);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 } });
+            expect(JSON.parse(rows[1].variables)).toEqual({ input: { value: 2 } });
+        });
+
+        it("splits array of NK format objects into separate records", () => {
+            const text = JSON.stringify([{ input: { value: 1 } }, { input: { value: 2 } }]);
+            const { rows, errorCount } = parseRecords(text, SOURCE_ID);
+            expect(errorCount).toBe(0);
+            expect(rows).toHaveLength(2);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 } });
+        });
+
+        it("splits pretty-printed array into separate records", () => {
+            const text = JSON.stringify([{ input: { value: 1 } }, { input: { value: 2 } }], null, 2);
+            const { rows } = parseRecords(text, SOURCE_ID);
+            expect(rows).toHaveLength(2);
+        });
+    });
+
+    describe("NDJSON (one compact object per line)", () => {
+        it("parses multiple lines as separate records", () => {
+            const text = '{"value": 1}\n{"value": 2}\n{"value": 3}';
+            const { rows, errorCount } = parseRecords(text, SOURCE_ID);
+            expect(errorCount).toBe(0);
+            expect(rows).toHaveLength(3);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 } });
+            expect(JSON.parse(rows[2].variables)).toEqual({ input: { value: 3 } });
+        });
+
+        it("skips blank lines", () => {
+            const text = '{"value": 1}\n\n{"value": 2}';
+            const { rows } = parseRecords(text, SOURCE_ID);
+            expect(rows).toHaveLength(2);
+        });
+
+        it("counts invalid lines as errors", () => {
+            const text = '{"value": 1}\nnot-json\n{"value": 2}';
+            const { rows, errorCount } = parseRecords(text, SOURCE_ID);
+            expect(errorCount).toBe(1);
+            expect(rows).toHaveLength(2);
+        });
+    });
+
+    describe("defaultVariables template", () => {
+        const defaultVariables = JSON.stringify({ input: {}, inputMeta: { partition: 0 } });
+
+        it("wraps raw event using template fields", () => {
+            const { rows } = parseRecords('{"value": 1}', SOURCE_ID, defaultVariables);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 }, inputMeta: { partition: 0 } });
+        });
+
+        it("fills missing inputMeta when object has input but no inputMeta", () => {
+            const { rows } = parseRecords('{"input": {"value": 1}}', SOURCE_ID, defaultVariables);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 }, inputMeta: { partition: 0 } });
+        });
+
+        it("preserves provided inputMeta over template default", () => {
+            const { rows } = parseRecords('{"input": {"value": 1}, "inputMeta": {"partition": 99}}', SOURCE_ID, defaultVariables);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 }, inputMeta: { partition: 99 } });
+        });
+
+        it("applies template to each item in array", () => {
+            const { rows } = parseRecords('[{"value": 1}, {"value": 2}]', SOURCE_ID, defaultVariables);
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 }, inputMeta: { partition: 0 } });
+            expect(JSON.parse(rows[1].variables)).toEqual({ input: { value: 2 }, inputMeta: { partition: 0 } });
+        });
+
+        it("ignores invalid defaultVariables", () => {
+            const { rows } = parseRecords('{"value": 1}', SOURCE_ID, "not-json");
+            expect(JSON.parse(rows[0].variables)).toEqual({ input: { value: 1 } });
+        });
+    });
+
+    describe("sourceId", () => {
+        it("sets sourceId on each record", () => {
+            const { rows } = parseRecords('[{"value": 1}, {"value": 2}]', SOURCE_ID);
+            rows.forEach((r) => expect(r.sourceId).toBe(SOURCE_ID));
+        });
+    });
+
+    describe("edge cases", () => {
+        it("returns empty rows for empty input", () => {
+            const { rows, errorCount } = parseRecords("", SOURCE_ID);
+            expect(rows).toHaveLength(0);
+            expect(errorCount).toBe(0);
+        });
+
+        it("returns empty rows for whitespace-only input", () => {
+            const { rows } = parseRecords("   \n  ", SOURCE_ID);
+            expect(rows).toHaveLength(0);
+        });
+
+        it("returns error for entirely invalid input", () => {
+            const { rows, errorCount } = parseRecords("not json at all", SOURCE_ID);
+            expect(rows).toHaveLength(0);
+            expect(errorCount).toBe(1);
+        });
+    });
+});

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -9,79 +9,13 @@ import { useAppSelector } from "../../../store/storeHelpers";
 import { LoadingButtonTypes } from "../../../windowManager/LoadingButton";
 import { WindowContent } from "../../../windowManager/WindowContent";
 import type { WindowKind } from "../../../windowManager/WindowKind";
+import { parseRecords } from "./parseRecords";
 import type { TestingDataRecords } from "./Table";
 
 export interface PasteRecordsDialogData {
     sourceId: string;
     onRowsAdded: (rows: TestingDataRecords[]) => void;
     defaultVariables?: string;
-}
-
-function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta?: unknown } {
-    return typeof obj === "object" && obj !== null && "input" in obj;
-}
-
-function toRecord(parsed: unknown, defaultTemplate: Record<string, unknown> | null): unknown {
-    if (!isNkFormat(parsed)) {
-        return { ...defaultTemplate, input: parsed };
-    }
-    // Already has 'input', but fill in missing fields from template (e.g. inputMeta) as defaults
-    return defaultTemplate ? { ...defaultTemplate, ...parsed } : parsed;
-}
-
-function splitNdjsonLines(text: string): string[] {
-    return text
-        .split("\n")
-        .map((l) => l.trim())
-        .filter(Boolean);
-}
-
-function parseRecords(text: string, sourceId: string, defaultVariables?: string): { rows: TestingDataRecords[]; errorCount: number } {
-    let defaultTemplate: Record<string, unknown> | null = null;
-    if (defaultVariables) {
-        try {
-            const parsed = JSON.parse(defaultVariables);
-            if (typeof parsed === "object" && parsed !== null) {
-                defaultTemplate = parsed as Record<string, unknown>;
-            }
-        } catch {
-            // ignore
-        }
-    }
-
-    const trimmed = text.trim();
-
-    try {
-        const parsed = JSON.parse(trimmed);
-        if (Array.isArray(parsed)) {
-            return {
-                rows: parsed.map((item) => ({ sourceId, variables: JSON.stringify(toRecord(item, defaultTemplate), null, 2) })),
-                errorCount: 0,
-            };
-        }
-        if (typeof parsed === "object" && parsed !== null) {
-            return {
-                rows: [{ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) }],
-                errorCount: 0,
-            };
-        }
-    } catch {
-        // not a single JSON — fall through to NDJSON
-    }
-
-    // Fallback: NDJSON (one compact JSON object per line)
-    const lines = splitNdjsonLines(trimmed);
-    let errorCount = 0;
-    const rows: TestingDataRecords[] = [];
-    for (const line of lines) {
-        try {
-            const parsed = JSON.parse(line);
-            rows.push({ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) });
-        } catch {
-            errorCount++;
-        }
-    }
-    return { rows, errorCount };
 }
 
 export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRecordsDialogData>) => {

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -35,7 +35,7 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
             const parsed = JSON.parse(trimmed);
             return Array.isArray(parsed) ? parsed.length : 1;
         } catch {
-            return splitNdjsonLines(trimmed).length;
+            return trimmed.split("\n").filter((l) => l.trim()).length;
         }
     }, [text]);
 

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -1,0 +1,170 @@
+import { Box, TextField, Typography } from "@mui/material";
+import type { WindowButtonProps, WindowContentProps } from "@touk/window-manager";
+import React, { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { LoadingButtonTypes } from "../../../windowManager/LoadingButton";
+import { WindowContent } from "../../../windowManager/WindowContent";
+import type { WindowKind } from "../../../windowManager/WindowKind";
+import type { TestingDataRecords } from "./Table";
+
+export interface PasteRecordsDialogData {
+    sourceId: string;
+    onRowsAdded: (rows: TestingDataRecords[]) => void;
+    defaultVariables?: string;
+}
+
+function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta: unknown } {
+    return typeof obj === "object" && obj !== null && "input" in obj && "inputMeta" in obj;
+}
+
+function toRecord(parsed: unknown, defaultTemplate: Record<string, unknown> | null): unknown {
+    return isNkFormat(parsed) ? parsed : { ...defaultTemplate, input: parsed };
+}
+
+function parseRecords(text: string, sourceId: string, defaultVariables?: string): { rows: TestingDataRecords[]; errorCount: number } {
+    let defaultTemplate: Record<string, unknown> | null = null;
+    if (defaultVariables) {
+        try {
+            const parsed = JSON.parse(defaultVariables);
+            if (typeof parsed === "object" && parsed !== null) {
+                defaultTemplate = parsed as Record<string, unknown>;
+            }
+        } catch {
+            // ignore
+        }
+    }
+
+    const trimmed = text.trim();
+
+    try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+            return {
+                rows: parsed.map((item) => ({ sourceId, variables: JSON.stringify(toRecord(item, defaultTemplate), null, 2) })),
+                errorCount: 0,
+            };
+        }
+        if (typeof parsed === "object" && parsed !== null) {
+            return {
+                rows: [{ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) }],
+                errorCount: 0,
+            };
+        }
+    } catch {
+        // not a single JSON — fall through to NDJSON
+    }
+
+    const lines = trimmed
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+    let errorCount = 0;
+    const rows: TestingDataRecords[] = [];
+    for (const line of lines) {
+        try {
+            const parsed = JSON.parse(line);
+            rows.push({ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) });
+        } catch {
+            errorCount++;
+        }
+    }
+    return { rows, errorCount };
+}
+
+export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRecordsDialogData>) => {
+    const { t } = useTranslation();
+    const { sourceId, onRowsAdded, defaultVariables } = props.data.meta;
+
+    const [text, setText] = useState("");
+    const [parseError, setParseError] = useState<string | null>(null);
+
+    const recordCount = useMemo(() => {
+        const trimmed = text.trim();
+        if (!trimmed) return 0;
+        try {
+            const parsed = JSON.parse(trimmed);
+            return Array.isArray(parsed) ? parsed.length : 1;
+        } catch {
+            return trimmed
+                .split("\n")
+                .map((l) => l.trim())
+                .filter(Boolean).length;
+        }
+    }, [text]);
+
+    const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setText(e.target.value);
+        setParseError(null);
+    }, []);
+
+    const handleConfirm = useCallback(() => {
+        const { rows, errorCount } = parseRecords(text, sourceId, defaultVariables);
+
+        if (rows.length === 0) {
+            setParseError(t("pasteRecords.noValidLines", "No valid JSON lines found."));
+            return;
+        }
+
+        if (errorCount > 0) {
+            setParseError(t("pasteRecords.someInvalid", "{{errorCount}} line(s) could not be parsed and were skipped.", { errorCount }));
+        }
+
+        onRowsAdded(rows);
+        if (errorCount === 0) {
+            props.close();
+        }
+    }, [text, sourceId, defaultVariables, onRowsAdded, props, t]);
+
+    const buttons = useMemo<WindowButtonProps[]>(
+        () => [
+            {
+                title: t("dialog.button.cancel", "Cancel"),
+                action: () => props.close(),
+                classname: LoadingButtonTypes.secondaryButton,
+            },
+            {
+                title: t("pasteRecords.confirm", "Add {{count}} record(s)", { count: recordCount }),
+                action: handleConfirm,
+                disabled: !text.trim(),
+            },
+        ],
+        [t, props, recordCount, handleConfirm, text],
+    );
+
+    return (
+        <WindowContent {...props} buttons={buttons}>
+            <Box sx={{ p: 2 }}>
+                <Typography variant="body2" color="text.secondary" mb={1}>
+                    {t(
+                        "pasteRecords.hint",
+                        "Accepts: a single JSON object (pretty-printed or compact), a JSON array, or one JSON object per line (NDJSON). Raw events without input/inputMeta will be wrapped automatically.",
+                    )}
+                </Typography>
+                <TextField
+                    multiline
+                    fullWidth
+                    minRows={8}
+                    maxRows={20}
+                    value={text}
+                    onChange={handleChange}
+                    placeholder={'{"input": {...}, "inputMeta": {...}}\n{"input": {...}, "inputMeta": {...}}'}
+                    inputProps={{ style: { fontFamily: "monospace", fontSize: 12 } }}
+                    autoFocus
+                />
+                <Box mt={1} display="flex" justifyContent="space-between" alignItems="center">
+                    <Typography variant="caption" color="text.secondary">
+                        {recordCount > 0 ? t("pasteRecords.recordCount", "{{count}} line(s) detected", { count: recordCount }) : ""}
+                    </Typography>
+                    {parseError && (
+                        <Typography variant="caption" color="warning.main">
+                            {parseError}
+                        </Typography>
+                    )}
+                </Box>
+            </Box>
+        </WindowContent>
+    );
+};
+
+export default PasteRecordsDialog;

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -22,7 +22,11 @@ function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta?: unknown 
 }
 
 function toRecord(parsed: unknown, defaultTemplate: Record<string, unknown> | null): unknown {
-    return isNkFormat(parsed) ? parsed : { ...defaultTemplate, input: parsed };
+    if (!isNkFormat(parsed)) {
+        return { ...defaultTemplate, input: parsed };
+    }
+    // Already has 'input', but fill in missing fields from template (e.g. inputMeta) as defaults
+    return defaultTemplate ? { ...defaultTemplate, ...parsed } : parsed;
 }
 
 function splitNdjsonLines(text: string): string[] {

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -25,6 +25,42 @@ function toRecord(parsed: unknown, defaultTemplate: Record<string, unknown> | nu
     return isNkFormat(parsed) ? parsed : { ...defaultTemplate, input: parsed };
 }
 
+function splitTopLevelJsonObjects(text: string): string[] {
+    const chunks: string[] = [];
+    let depth = 0;
+    let start = 0;
+    let inString = false;
+    let escape = false;
+
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (escape) {
+            escape = false;
+            continue;
+        }
+        if (ch === "\\" && inString) {
+            escape = true;
+            continue;
+        }
+        if (ch === '"') {
+            inString = !inString;
+            continue;
+        }
+        if (inString) continue;
+
+        if (ch === "{" || ch === "[") {
+            if (depth === 0) start = i;
+            depth++;
+        } else if (ch === "}" || ch === "]") {
+            depth--;
+            if (depth === 0) {
+                chunks.push(text.slice(start, i + 1));
+            }
+        }
+    }
+    return chunks;
+}
+
 function parseRecords(text: string, sourceId: string, defaultVariables?: string): { rows: TestingDataRecords[]; errorCount: number } {
     let defaultTemplate: Record<string, unknown> | null = null;
     if (defaultVariables) {
@@ -58,6 +94,23 @@ function parseRecords(text: string, sourceId: string, defaultVariables?: string)
         // not a single JSON — fall through to NDJSON
     }
 
+    // Try splitting into multiple top-level JSON objects (handles pretty-printed multi-line objects)
+    const topLevelChunks = splitTopLevelJsonObjects(trimmed);
+    if (topLevelChunks.length > 1) {
+        let errorCount = 0;
+        const rows: TestingDataRecords[] = [];
+        for (const chunk of topLevelChunks) {
+            try {
+                const parsed = JSON.parse(chunk);
+                rows.push({ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) });
+            } catch {
+                errorCount++;
+            }
+        }
+        return { rows, errorCount };
+    }
+
+    // Fallback: NDJSON (one compact JSON object per line)
     const lines = trimmed
         .split("\n")
         .map((l) => l.trim())
@@ -92,6 +145,8 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
             const parsed = JSON.parse(trimmed);
             return Array.isArray(parsed) ? parsed.length : 1;
         } catch {
+            const topLevel = splitTopLevelJsonObjects(trimmed);
+            if (topLevel.length > 1) return topLevel.length;
             return trimmed
                 .split("\n")
                 .map((l) => l.trim())

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -3,6 +3,9 @@ import type { WindowButtonProps, WindowContentProps } from "@touk/window-manager
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { getMaxTestingRecords } from "../../../reducers/selectors/settings";
+import { getTestData } from "../../../reducers/selectors/testCases";
+import { useAppSelector } from "../../../store/storeHelpers";
 import { LoadingButtonTypes } from "../../../windowManager/LoadingButton";
 import { WindowContent } from "../../../windowManager/WindowContent";
 import type { WindowKind } from "../../../windowManager/WindowKind";
@@ -76,6 +79,9 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
     const { t } = useTranslation();
     const { sourceId, onRowsAdded, defaultVariables } = props.data.meta;
 
+    const maxTestingRecords = useAppSelector(getMaxTestingRecords);
+    const currentRecordsCount = useAppSelector(getTestData).length;
+
     const [text, setText] = useState("");
     const [parseError, setParseError] = useState<string | null>(null);
 
@@ -116,6 +122,8 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
         }
     }, [text, sourceId, defaultVariables, onRowsAdded, props, t]);
 
+    const limitExceeded = currentRecordsCount + recordCount > maxTestingRecords;
+
     const buttons = useMemo<WindowButtonProps[]>(
         () => [
             {
@@ -126,10 +134,10 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
             {
                 title: t("pasteRecords.confirm", "Add {{count}} record(s)", { count: recordCount }),
                 action: handleConfirm,
-                disabled: !text.trim(),
+                disabled: !text.trim() || limitExceeded,
             },
         ],
-        [t, props, recordCount, handleConfirm, text],
+        [t, props, recordCount, handleConfirm, text, limitExceeded],
     );
 
     return (
@@ -156,10 +164,16 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
                     <Typography variant="caption" color="text.secondary">
                         {recordCount > 0 ? t("pasteRecords.recordCount", "{{count}} line(s) detected", { count: recordCount }) : ""}
                     </Typography>
-                    {parseError && (
-                        <Typography variant="caption" color="warning.main">
-                            {parseError}
+                    {limitExceeded ? (
+                        <Typography variant="caption" color="error.main">
+                            {t("pasteRecords.limitExceeded", "Limit of {{max}} records would be exceeded.", { max: maxTestingRecords })}
                         </Typography>
+                    ) : (
+                        parseError && (
+                            <Typography variant="caption" color="warning.main">
+                                {parseError}
+                            </Typography>
+                        )
                     )}
                 </Box>
             </Box>

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -132,7 +132,11 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
                 classname: LoadingButtonTypes.secondaryButton,
             },
             {
-                title: t("pasteRecords.confirm", "Add {{count}} record(s)", { count: recordCount }),
+                title: t("pasteRecords.confirm", {
+                    count: recordCount,
+                    defaultValue_one: "Add {{count}} record",
+                    defaultValue_other: "Add {{count}} records",
+                }),
                 action: handleConfirm,
                 disabled: !text.trim() || limitExceeded,
             },
@@ -162,7 +166,13 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
                 />
                 <Box mt={1} display="flex" justifyContent="space-between" alignItems="center">
                     <Typography variant="caption" color="text.secondary">
-                        {recordCount > 0 ? t("pasteRecords.recordCount", "{{count}} line(s) detected", { count: recordCount }) : ""}
+                        {recordCount > 0
+                            ? t("pasteRecords.recordCount", {
+                                  count: recordCount,
+                                  defaultValue_one: "{{count}} line detected",
+                                  defaultValue_other: "{{count}} lines detected",
+                              })
+                            : ""}
                     </Typography>
                     {limitExceeded ? (
                         <Typography variant="caption" color="error.main">

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -10,7 +10,7 @@ import { LoadingButtonTypes } from "../../../windowManager/LoadingButton";
 import { WindowContent } from "../../../windowManager/WindowContent";
 import type { WindowKind } from "../../../windowManager/WindowKind";
 import { parseRecords } from "./parseRecords";
-import type { TestingDataRecords } from "./Table";
+import type { TestingDataRecords } from "./types";
 
 export interface PasteRecordsDialogData {
     sourceId: string;

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -17,48 +17,12 @@ export interface PasteRecordsDialogData {
     defaultVariables?: string;
 }
 
-function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta: unknown } {
-    return typeof obj === "object" && obj !== null && "input" in obj && "inputMeta" in obj;
+function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta?: unknown } {
+    return typeof obj === "object" && obj !== null && "input" in obj;
 }
 
 function toRecord(parsed: unknown, defaultTemplate: Record<string, unknown> | null): unknown {
     return isNkFormat(parsed) ? parsed : { ...defaultTemplate, input: parsed };
-}
-
-function splitTopLevelJsonObjects(text: string): string[] {
-    const chunks: string[] = [];
-    let depth = 0;
-    let start = 0;
-    let inString = false;
-    let escape = false;
-
-    for (let i = 0; i < text.length; i++) {
-        const ch = text[i];
-        if (escape) {
-            escape = false;
-            continue;
-        }
-        if (ch === "\\" && inString) {
-            escape = true;
-            continue;
-        }
-        if (ch === '"') {
-            inString = !inString;
-            continue;
-        }
-        if (inString) continue;
-
-        if (ch === "{" || ch === "[") {
-            if (depth === 0) start = i;
-            depth++;
-        } else if (ch === "}" || ch === "]") {
-            depth--;
-            if (depth === 0) {
-                chunks.push(text.slice(start, i + 1));
-            }
-        }
-    }
-    return chunks;
 }
 
 function splitNdjsonLines(text: string): string[] {
@@ -101,22 +65,6 @@ function parseRecords(text: string, sourceId: string, defaultVariables?: string)
         // not a single JSON — fall through to NDJSON
     }
 
-    // Try splitting into multiple top-level JSON objects (handles pretty-printed multi-line objects)
-    const topLevelChunks = splitTopLevelJsonObjects(trimmed);
-    if (topLevelChunks.length > 1) {
-        let errorCount = 0;
-        const rows: TestingDataRecords[] = [];
-        for (const chunk of topLevelChunks) {
-            try {
-                const parsed = JSON.parse(chunk);
-                rows.push({ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) });
-            } catch {
-                errorCount++;
-            }
-        }
-        return { rows, errorCount };
-    }
-
     // Fallback: NDJSON (one compact JSON object per line)
     const lines = splitNdjsonLines(trimmed);
     let errorCount = 0;
@@ -149,8 +97,6 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
             const parsed = JSON.parse(trimmed);
             return Array.isArray(parsed) ? parsed.length : 1;
         } catch {
-            const topLevel = splitTopLevelJsonObjects(trimmed);
-            if (topLevel.length > 1) return topLevel.length;
             return splitNdjsonLines(trimmed).length;
         }
     }, [text]);

--- a/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/PasteRecordsDialog.tsx
@@ -61,6 +61,13 @@ function splitTopLevelJsonObjects(text: string): string[] {
     return chunks;
 }
 
+function splitNdjsonLines(text: string): string[] {
+    return text
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+}
+
 function parseRecords(text: string, sourceId: string, defaultVariables?: string): { rows: TestingDataRecords[]; errorCount: number } {
     let defaultTemplate: Record<string, unknown> | null = null;
     if (defaultVariables) {
@@ -111,10 +118,7 @@ function parseRecords(text: string, sourceId: string, defaultVariables?: string)
     }
 
     // Fallback: NDJSON (one compact JSON object per line)
-    const lines = trimmed
-        .split("\n")
-        .map((l) => l.trim())
-        .filter(Boolean);
+    const lines = splitNdjsonLines(trimmed);
     let errorCount = 0;
     const rows: TestingDataRecords[] = [];
     for (const line of lines) {
@@ -147,10 +151,7 @@ export const PasteRecordsDialog = (props: WindowContentProps<WindowKind, PasteRe
         } catch {
             const topLevel = splitTopLevelJsonObjects(trimmed);
             if (topLevel.length > 1) return topLevel.length;
-            return trimmed
-                .split("\n")
-                .map((l) => l.trim())
-                .filter(Boolean).length;
+            return splitNdjsonLines(trimmed).length;
         }
     }, [text]);
 

--- a/designer/client/src/components/modals/TestingDataRecords/Table.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/Table.tsx
@@ -165,6 +165,9 @@ export const Table: React.FC<TableProps> = ({
     );
 
     const clearSelection = useCallback((): void => setSelection({ rows: CompactSelection.empty(), columns: CompactSelection.empty() }), []);
+    const selectAllRows = useCallback((): void => {
+        setSelection({ rows: CompactSelection.fromSingleSelection([0, data.length]), columns: CompactSelection.empty() });
+    }, [data.length]);
     const closeCellMenu = (): void => setCellMenuData((c) => ({ ...c, position: null }));
     const onDataEditorCellContextMenu = useCallback<NonNullable<DataEditorProps["onCellContextMenu"]>>(([, row], e): void => {
         e.preventDefault();
@@ -363,6 +366,7 @@ export const Table: React.FC<TableProps> = ({
                         selectedCount={selectedRowsCount}
                         allRowsNumber={data.length}
                         handleRemoveRows={handleRemoveSelectedRows}
+                        handleSelectAll={selectedRowsCount < data.length ? selectAllRows : undefined}
                     />
                 )}
             </Sizer>

--- a/designer/client/src/components/modals/TestingDataRecords/Table.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/Table.tsx
@@ -46,7 +46,7 @@ interface TableProps {
 export const TABLE_HEIGHT = "100vh";
 export const TABLE_WIDTH = "100%";
 const COLUMN_VARIABLES_ID = "variables";
-const COLUMN_VARIABLES_TITLE = "Input variables";
+const COLUMN_VARIABLES_TITLE = "Records";
 
 const emptySelection: GridSelection = { columns: CompactSelection.empty(), rows: CompactSelection.empty() };
 const tableColumns: GridColumn[] = [{ id: COLUMN_VARIABLES_ID, title: COLUMN_VARIABLES_TITLE, grow: 1, hasMenu: false }];

--- a/designer/client/src/components/modals/TestingDataRecords/Table.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/Table.tsx
@@ -9,25 +9,22 @@ import type {
     GridMouseCellEventArgs,
     GridSelection,
     Item,
-    ProvideEditorComponent,
     Theme,
 } from "@glideapps/glide-data-grid";
 import DataEditor, { CompactSelection, type CustomRenderer, drawTextCell, GridCellKind } from "@glideapps/glide-data-grid";
 import { Box, useTheme } from "@mui/material";
 import type { PopoverPosition } from "@mui/material/Popover/Popover";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { NodeValidationError } from "../../../types/validation";
+import { useSize } from "../../../containers/hooks/useSize";
 import { CellMenu, DeleteRowMenuItem } from "../../graph/node-modal/editors/expression/Table/CellMenu";
 import type { CellError } from "../../graph/node-modal/editors/expression/Table/errorHighlights";
 import { useErrorHighlights } from "../../graph/node-modal/editors/expression/Table/errorHighlights";
 import { Sizer } from "../../graph/node-modal/editors/expression/Table/Sizer";
 import { useTableTheme } from "../../graph/node-modal/editors/expression/Table/tableTheme";
 import type { VariablesCell } from "./CellContent";
-import { getTestingCellContent, isSourceSelectCell, isVariablesCell } from "./CellContent";
+import { getTestingCellContent, isVariablesCell } from "./CellContent";
 import { DEFAULT_ROW_HEADER_HEIGHT, drawFieldForDisplay } from "./drawText";
-import type { SourceSelectCell } from "./SourceEditor";
-import { SourceEditor } from "./SourceEditor";
 import "@glideapps/glide-data-grid/dist/index.css";
 import { TableFooter } from "./TableFooter";
 import type { TestingDataRecords } from "./types";
@@ -37,49 +34,34 @@ import { VariablesEditor } from "./VariablesEditor";
 
 interface TableProps {
     data?: TestingDataRecords[];
-    onRowAdded: (rowIndex: number, row: TestingDataRecords) => void;
     onRowUpdated: (rowIndex: number, row: TestingDataRecords) => void;
     onRowsDeleted: (deletedRows: number[]) => void;
     onRowMoved: (fromIndex: number, toIndex: number) => void;
     defaultDataRecord: TestingDataRecords;
-    sourceId: string;
-    sourceName: string;
     className?: string;
     cellErrors: CellError[];
-    recordsToAddLimitExceeded?: boolean;
-    onValidateVariables: (row: TestingDataRecords) => Promise<{ data: { validationErrors: NodeValidationError[] } }>;
+    toolbar?: React.ReactNode;
 }
 
-const TABLE_WIDTH = "100%";
-const TRAILING_ROW_HINT = "Add record";
-const COLUMN_SOURCE_ID = "sourceId";
+export const TABLE_HEIGHT = "100vh";
+export const TABLE_WIDTH = "100%";
 const COLUMN_VARIABLES_ID = "variables";
-const COLUMN_SOURCE_TITLE = "Source";
 const COLUMN_VARIABLES_TITLE = "Input variables";
-const COLUMN_SOURCE_WIDTH = 150;
-const COLUMN_VARIABLES_WIDTH = 300;
 
 const emptySelection: GridSelection = { columns: CompactSelection.empty(), rows: CompactSelection.empty() };
-const tableColumns: GridColumn[] = [
-    { id: COLUMN_SOURCE_ID, title: COLUMN_SOURCE_TITLE, width: COLUMN_SOURCE_WIDTH, hasMenu: false },
-    { id: COLUMN_VARIABLES_ID, title: COLUMN_VARIABLES_TITLE, width: COLUMN_VARIABLES_WIDTH, grow: 1, hasMenu: false },
-];
+const tableColumns: GridColumn[] = [{ id: COLUMN_VARIABLES_ID, title: COLUMN_VARIABLES_TITLE, grow: 1, hasMenu: false }];
 
 type HeaderRenderArgs = { columnIndex: number; theme: Theme; rect: { width: number } };
 
 export const Table: React.FC<TableProps> = ({
     data = [],
-    onRowAdded,
     onRowUpdated,
     onRowsDeleted,
     onRowMoved,
-    defaultDataRecord,
-    sourceId,
-    sourceName,
     className,
+    defaultDataRecord,
     cellErrors,
-    recordsToAddLimitExceeded,
-    onValidateVariables,
+    toolbar,
 }) => {
     const [draggingRow, setDraggingRow] = useState<number | null>(null);
     const lastDraggingRowRef = useRef<number | null>(null);
@@ -89,27 +71,32 @@ export const Table: React.FC<TableProps> = ({
     const ref = useRef<DataEditorRef | null>(null);
     const [cellMenuData, setCellMenuData] = useState<{ position: PopoverPosition | null; row?: number }>({ position: null });
 
-    const { toggleTooltip, highlightRegions, drawCell, tooltipElement } = useErrorHighlights(cellErrors, ref);
+    // Scroll to the last row when a new record is added
+    const prevDataLengthRef = useRef(data.length);
+    useEffect(() => {
+        if (data.length > prevDataLengthRef.current) {
+            ref.current?.scrollTo(0, data.length - 1, "vertical");
+        }
+        prevDataLengthRef.current = data.length;
+    }, [data.length]);
 
-    const sourceSelectRenderer = useMemo<CustomRenderer<SourceSelectCell>>(
-        () => ({
-            kind: GridCellKind.Custom,
-            isMatch: isSourceSelectCell,
-            draw: (drawArgs, cell) => {
-                drawTextCell(drawArgs, cell.data.displayValue || cell.data.value, cell.contentAlign);
-                return true;
-            },
-            provideEditor: () => ({
-                editor: SourceEditor as ProvideEditorComponent<SourceSelectCell>,
-                deletedValue: (sourceSelectCell) => ({
-                    ...sourceSelectCell,
-                    copyData: "",
-                    data: { ...(sourceSelectCell as unknown as SourceSelectCell).data, value: "", displayValue: "" },
-                }),
-            }),
-        }),
-        [],
-    );
+    // Observe the modal section ancestor to compute available height for DataEditor
+    const { observe: observeSection, height: sectionHeight } = useSize();
+    const outerBoxRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        let el: HTMLElement | null = outerBoxRef.current;
+        while (el) {
+            if (el.tagName === "SECTION" && el.closest('[data-testid="window"]')) {
+                observeSection(el);
+                return;
+            }
+            el = el.parentElement;
+        }
+    }, [observeSection]);
+    const SECTION_CUTOUT = 220; // toolbar (inside table) + accordion header + GENERAL/TESTING tabs + test case row + padding
+    const dataEditorHeight = sectionHeight > 0 ? Math.max(100, sectionHeight - SECTION_CUTOUT) : undefined;
+
+    const { toggleTooltip, highlightRegions, drawCell, tooltipElement } = useErrorHighlights(cellErrors, ref);
 
     const variablesRenderer = useMemo<CustomRenderer<VariablesCell>>(
         () => ({
@@ -123,36 +110,32 @@ export const Table: React.FC<TableProps> = ({
                 editor: (props) => {
                     const { onChange, value } = props;
 
-                    return <VariablesEditor value={value} onChange={onChange} onValidate={onValidateVariables} />;
+                    return <VariablesEditor value={value} onChange={onChange} />;
                 },
                 deletedValue: (v) => ({ ...v, copyData: "", data: { ...(v as VariablesCell).data, value: "" } }),
             }),
         }),
-        [theme, onValidateVariables],
+        [theme],
     );
 
-    const getCellContent = useCallback(
-        (item: Item): GridCell => getTestingCellContent(item, data, sourceId, sourceName),
-        [data, sourceId, sourceName],
+    const getCellContent = useCallback((item: Item): GridCell => getTestingCellContent(item, data), [data]);
+    const buildRowUpdates = useCallback(
+        (changes: readonly EditListItem[]): Record<number, TestingDataRecords> => buildInputDataRecordUpdates(changes, data),
+        [data],
     );
 
     const onCellEdited = useCallback<NonNullable<DataEditorProps["onCellsEdited"]>>(
         (changes): void => {
             if (!changes.length) return;
-            const rowUpdates = buildInputDataRecordUpdates(changes, data, defaultDataRecord.variables);
+            const rowUpdates = buildRowUpdates(changes);
             if (!Object.keys(rowUpdates).length) return;
             Object.entries(rowUpdates).forEach(([rowIndexStr, value]) => {
-                onRowUpdated(Number(rowIndexStr), value);
+                const rowIndex = Number(rowIndexStr);
+                onRowUpdated(rowIndex, value);
             });
         },
-        [data, defaultDataRecord.variables, onRowUpdated],
+        [buildRowUpdates, onRowUpdated],
     );
-
-    const onCellAdded = useCallback((): void => {
-        const newRow: TestingDataRecords = { ...defaultDataRecord };
-        const rowIndex = data.length;
-        onRowAdded(rowIndex, newRow);
-    }, [data.length, defaultDataRecord, onRowAdded]);
 
     const onCellDeleted = useCallback(
         (rows: number[]): number[] => {
@@ -206,8 +189,7 @@ export const Table: React.FC<TableProps> = ({
         [data, variablesColumnWidth],
     );
 
-    const customRenderers = useMemo(() => [sourceSelectRenderer, variablesRenderer], [sourceSelectRenderer, variablesRenderer]);
-    const trailingRowOptions = useMemo(() => ({ sticky: true, hint: TRAILING_ROW_HINT }), []);
+    const customRenderers = useMemo(() => [variablesRenderer], [variablesRenderer]);
     const highlightedRegions = useMemo(() => highlightRegions(), [highlightRegions]);
     const handleGridSelectionChange = useCallback(
         (selection: GridSelection): void => {
@@ -219,7 +201,7 @@ export const Table: React.FC<TableProps> = ({
     const renderHeaderCell = useCallback((args: HeaderRenderArgs & { [key: string]: unknown }): void => {
         const { columnIndex, theme } = args;
         dataEditorThemeRef.current = theme;
-        if (columnIndex === 1) {
+        if (columnIndex === 0) {
             setVariablesColumnWidth(args.rect.width);
         }
         const col = tableColumns[columnIndex];
@@ -227,7 +209,7 @@ export const Table: React.FC<TableProps> = ({
         drawTextCell(args as unknown as BaseDrawArgs, col.title);
     }, []);
     const { tableHeight } = useTableHeight(data, getRowHeight);
-    const sizerSx = useMemo(() => ({ border: "1px solid", borderColor: tableTheme.borderColor }), [tableTheme.borderColor]);
+
     const deleteMenuIndexes = useMemo<number[]>(() => {
         if (selection.rows.toArray().length > 0) return selection.rows.toArray();
         if (selection.current?.range) {
@@ -275,29 +257,8 @@ export const Table: React.FC<TableProps> = ({
 
     const selectedRowsCount = rowsFromSelection.length;
 
-    const getDeletedColumn = useCallback(({ current }: GridSelection) => {
-        const currentCell = current?.cell;
-        if (!currentCell) {
-            return { removedCellColumnId: undefined, removedCellRowIndex: undefined };
-        }
-        const columnIndex = currentCell[0];
-        const columnRowIndex = currentCell[1];
-
-        const col = tableColumns[columnIndex];
-
-        return { removedCellColumnId: col.id, removedCellRowIndex: columnRowIndex };
-    }, []);
-
     const onDeleteTableRow = useCallback(
         (selection: GridSelection) => {
-            const { removedCellColumnId, removedCellRowIndex } = getDeletedColumn(selection);
-
-            // Remove whole row when sourceId column value removed
-            if (removedCellColumnId === COLUMN_SOURCE_ID) {
-                onCellDeleted([removedCellRowIndex]);
-                return false;
-            }
-
             if (selectedRowsCount > 0) {
                 handleRemoveSelectedRows();
                 return false;
@@ -306,22 +267,25 @@ export const Table: React.FC<TableProps> = ({
             // keep native behaviour when no rows selected
             return true;
         },
-        [getDeletedColumn, handleRemoveSelectedRows, onCellDeleted, selectedRowsCount],
+        [handleRemoveSelectedRows, selectedRowsCount],
     );
 
     return (
         <Box
+            ref={outerBoxRef}
             sx={{
-                "--sizer-height-cutout": "140px",
                 display: "flex",
+                flexDirection: "column",
+                border: "1px solid",
+                borderColor: tableTheme.borderColor,
             }}
         >
+            {toolbar}
             <Sizer
                 offsetParent={`[data-testid="window"] section`}
                 overflowY={false}
                 data-testid="data-records-table-container"
                 className={className}
-                sx={sizerSx}
                 onBlur={(e) => {
                     if (e.currentTarget.contains(e.relatedTarget)) return;
                 }}
@@ -334,7 +298,6 @@ export const Table: React.FC<TableProps> = ({
                     customRenderers={customRenderers}
                     getCellsForSelection
                     onCellsEdited={onCellEdited}
-                    onRowAppended={recordsToAddLimitExceeded ? undefined : onCellAdded}
                     rowMarkers="both"
                     rows={data.length}
                     smoothScrollX
@@ -344,13 +307,12 @@ export const Table: React.FC<TableProps> = ({
                     gridSelection={selection}
                     onCellContextMenu={onDataEditorCellContextMenu}
                     getRowThemeOverride={getRowThemeOverride}
-                    trailingRowOptions={trailingRowOptions}
                     highlightRegions={highlightedRegions}
                     onGridSelectionChange={handleGridSelectionChange}
                     onItemHovered={toggleTooltip}
                     drawCell={drawCell}
                     drawHeader={renderHeaderCell}
-                    height={tableHeight}
+                    height={dataEditorHeight ?? tableHeight}
                     rowHeight={getRowHeight}
                     onRowMoved={handleRowReorder}
                     rowSelectionMode="multi"
@@ -361,15 +323,15 @@ export const Table: React.FC<TableProps> = ({
                         <DeleteRowMenuItem indexes={deleteMenuIndexes} onClick={handleDeleteRows} />
                     )}
                 </CellMenu>
-                {selection.rows.length > 0 && (
-                    <TableFooter
-                        selectedCount={selectedRowsCount}
-                        allRowsNumber={data.length}
-                        handleRemoveRows={handleRemoveSelectedRows}
-                        handleSelectAll={selectedRowsCount < data.length ? selectAllRows : undefined}
-                    />
-                )}
             </Sizer>
+            {selection.rows.length > 0 && (
+                <TableFooter
+                    selectedCount={selectedRowsCount}
+                    allRowsNumber={data.length}
+                    handleRemoveRows={handleRemoveSelectedRows}
+                    handleSelectAll={selectedRowsCount < data.length ? selectAllRows : undefined}
+                />
+            )}
             {tooltipElement}
         </Box>
     );

--- a/designer/client/src/components/modals/TestingDataRecords/TableFooter.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/TableFooter.tsx
@@ -43,6 +43,7 @@ export const TableFooter: React.FC<TableFooterProps> = ({ selectedCount, allRows
                         <Button
                             variant="text"
                             size="small"
+                            onMouseDown={(e) => e.preventDefault()}
                             onClick={handleSelectAll}
                             sx={{
                                 p: 0,
@@ -64,6 +65,7 @@ export const TableFooter: React.FC<TableFooterProps> = ({ selectedCount, allRows
                 size="small"
                 color="error"
                 startIcon={<DeleteOutlineIcon fontSize="small" />}
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={handleRemoveRows}
                 sx={{ textTransform: "none" }}
             >

--- a/designer/client/src/components/modals/TestingDataRecords/TableFooter.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/TableFooter.tsx
@@ -1,9 +1,7 @@
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { alpha, Box, Button, Typography } from "@mui/material";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
-
-import Remove from "../../../assets/img/toolbarButtons/archive.svg";
-import { getBorderColor } from "../../../containers/theme/helpers";
 
 interface TableFooterProps {
     selectedCount: number;
@@ -18,21 +16,13 @@ export const TableFooter: React.FC<TableFooterProps> = ({ selectedCount, allRows
     return (
         <Box
             sx={(theme) => ({
-                position: "absolute",
-                bottom: "20px",
-                left: 0,
-                right: 0,
-                margin: "0 auto",
-                width: "320px",
                 display: "flex",
                 alignItems: "center",
-                justifyContent: "space-between",
                 px: 2,
-                py: 1,
-                background: alpha(theme.palette.primary.main, 0.25),
-                border: `1px solid ${getBorderColor(theme)}`,
-                boxShadow: "0 0 2px rgba(0,0,0,0.8),0 0 20px rgba(0,0,0,0.8)",
-                backdropFilter: "blur(20px)",
+                py: 0.5,
+                flexShrink: 0,
+                background: alpha(theme.palette.primary.main, 0.12),
+                borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.25)}`,
             })}
             data-testid="table-footer"
         >
@@ -67,22 +57,18 @@ export const TableFooter: React.FC<TableFooterProps> = ({ selectedCount, allRows
                         </Button>
                     </>
                 )}
-                <Typography variant="body2" color="textSecondary" sx={{ opacity: 0.4 }}>
-                    ·
-                </Typography>
             </Box>
-            <Box display="flex" alignItems="center">
-                <Button
-                    variant={"text"}
-                    sx={(theme) => ({ color: theme.palette.text.primary, textTransform: "capitalize" })}
-                    onClick={handleRemoveRows}
-                >
-                    <Box width={"24px"} height={"24px"}>
-                        <Remove />
-                    </Box>
-                    {t("testingDataRecords.tableFooter.remove", "Remove")}
-                </Button>
-            </Box>
+            <Box flex={1} />
+            <Button
+                variant="text"
+                size="small"
+                color="error"
+                startIcon={<DeleteOutlineIcon fontSize="small" />}
+                onClick={handleRemoveRows}
+                sx={{ textTransform: "none" }}
+            >
+                {t("testingDataRecords.tableFooter.remove", "Remove selected")}
+            </Button>
         </Box>
     );
 };

--- a/designer/client/src/components/modals/TestingDataRecords/TableFooter.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/TableFooter.tsx
@@ -1,5 +1,5 @@
 import { alpha, Box, Button, Typography } from "@mui/material";
-import React, { useCallback } from "react";
+import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 import Remove from "../../../assets/img/toolbarButtons/archive.svg";
@@ -9,9 +9,10 @@ interface TableFooterProps {
     selectedCount: number;
     allRowsNumber: number;
     handleRemoveRows: () => void;
+    handleSelectAll?: () => void;
 }
 
-export const TableFooter: React.FC<TableFooterProps> = ({ selectedCount, allRowsNumber, handleRemoveRows }) => {
+export const TableFooter: React.FC<TableFooterProps> = ({ selectedCount, allRowsNumber, handleRemoveRows, handleSelectAll }) => {
     const { t } = useTranslation();
 
     return (
@@ -35,24 +36,53 @@ export const TableFooter: React.FC<TableFooterProps> = ({ selectedCount, allRows
             })}
             data-testid="table-footer"
         >
-            <Typography variant="body2" color="textPrimary">
-                <Trans
-                    i18nKey="tableFooter.selected"
-                    defaults="<strong>{{selectedCount}}</strong> of <strong>{{allRowsNumber}}</strong> selected"
-                    values={{ selectedCount, allRowsNumber }}
-                    components={{ strong: <strong /> }}
-                />
-            </Typography>
-            <Button
-                variant={"text"}
-                sx={(theme) => ({ color: theme.palette.text.primary, textTransform: "capitalize" })}
-                onClick={handleRemoveRows}
-            >
-                <Box width={"24px"} height={"24px"}>
-                    <Remove />
-                </Box>
-                {t("testingDataRecords.tableFooter.remove", "Remove")}
-            </Button>
+            <Box display="flex" alignItems="center" gap={1} sx={{ flexWrap: "nowrap", whiteSpace: "nowrap" }}>
+                <Typography variant="body2" color="textPrimary">
+                    <Trans
+                        i18nKey="tableFooter.selected"
+                        defaults="<strong>{{selectedCount}}</strong> of <strong>{{allRowsNumber}}</strong> selected"
+                        values={{ selectedCount, allRowsNumber }}
+                        components={{ strong: <strong /> }}
+                    />
+                </Typography>
+                {handleSelectAll && (
+                    <>
+                        <Typography variant="body2" color="textSecondary" sx={{ opacity: 0.4 }}>
+                            ·
+                        </Typography>
+                        <Button
+                            variant="text"
+                            size="small"
+                            onClick={handleSelectAll}
+                            sx={{
+                                p: 0,
+                                minWidth: 0,
+                                fontSize: "inherit",
+                                textTransform: "none",
+                                color: "text.primary",
+                                textDecoration: "underline",
+                            }}
+                        >
+                            {t("tableFooter.selectAll", "Select all")}
+                        </Button>
+                    </>
+                )}
+                <Typography variant="body2" color="textSecondary" sx={{ opacity: 0.4 }}>
+                    ·
+                </Typography>
+            </Box>
+            <Box display="flex" alignItems="center">
+                <Button
+                    variant={"text"}
+                    sx={(theme) => ({ color: theme.palette.text.primary, textTransform: "capitalize" })}
+                    onClick={handleRemoveRows}
+                >
+                    <Box width={"24px"} height={"24px"}>
+                        <Remove />
+                    </Box>
+                    {t("testingDataRecords.tableFooter.remove", "Remove")}
+                </Button>
+            </Box>
         </Box>
     );
 };

--- a/designer/client/src/components/modals/TestingDataRecords/VariablesEditor.tsx
+++ b/designer/client/src/components/modals/TestingDataRecords/VariablesEditor.tsx
@@ -9,7 +9,7 @@ import type { TestingDataRecords } from "./types";
 interface VariablesEditorProps {
     value: VariablesCell;
     onChange: (cell: VariablesCell) => void;
-    onValidate: (row: TestingDataRecords) => Promise<{ data: { validationErrors: NodeValidationError[] } }>;
+    onValidate?: (row: TestingDataRecords) => Promise<{ data: { validationErrors: NodeValidationError[] } }>;
 }
 
 export const VariablesEditor = ({ value, onChange, onValidate }: VariablesEditorProps) => {
@@ -17,7 +17,7 @@ export const VariablesEditor = ({ value, onChange, onValidate }: VariablesEditor
 
     const handleValidateData = useCallback(
         (row: TestingDataRecords) => {
-            onValidate(row).then(({ data }) => setValidationErrors(data.validationErrors));
+            onValidate?.(row).then(({ data }) => setValidationErrors(data.validationErrors));
         },
         [onValidate],
     );

--- a/designer/client/src/components/modals/TestingDataRecords/parseRecords.ts
+++ b/designer/client/src/components/modals/TestingDataRecords/parseRecords.ts
@@ -1,0 +1,72 @@
+import type { TestingDataRecords } from "./Table";
+
+function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta?: unknown } {
+    return typeof obj === "object" && obj !== null && "input" in obj;
+}
+
+function toRecord(parsed: unknown, defaultTemplate: Record<string, unknown> | null): unknown {
+    if (!isNkFormat(parsed)) {
+        return { ...defaultTemplate, input: parsed };
+    }
+    // Already has 'input', but fill in missing fields from template (e.g. inputMeta) as defaults
+    return defaultTemplate ? { ...defaultTemplate, ...parsed } : parsed;
+}
+
+function splitNdjsonLines(text: string): string[] {
+    return text
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+}
+
+export function parseRecords(
+    text: string,
+    sourceId: string,
+    defaultVariables?: string,
+): { rows: TestingDataRecords[]; errorCount: number } {
+    let defaultTemplate: Record<string, unknown> | null = null;
+    if (defaultVariables) {
+        try {
+            const parsed = JSON.parse(defaultVariables);
+            if (typeof parsed === "object" && parsed !== null) {
+                defaultTemplate = parsed as Record<string, unknown>;
+            }
+        } catch {
+            // ignore
+        }
+    }
+
+    const trimmed = text.trim();
+
+    try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+            return {
+                rows: parsed.map((item) => ({ sourceId, variables: JSON.stringify(toRecord(item, defaultTemplate), null, 2) })),
+                errorCount: 0,
+            };
+        }
+        if (typeof parsed === "object" && parsed !== null) {
+            return {
+                rows: [{ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) }],
+                errorCount: 0,
+            };
+        }
+    } catch {
+        // not a single JSON — fall through to NDJSON
+    }
+
+    // Fallback: NDJSON (one compact JSON object per line)
+    const lines = splitNdjsonLines(trimmed);
+    let errorCount = 0;
+    const rows: TestingDataRecords[] = [];
+    for (const line of lines) {
+        try {
+            const parsed = JSON.parse(line);
+            rows.push({ sourceId, variables: JSON.stringify(toRecord(parsed, defaultTemplate), null, 2) });
+        } catch {
+            errorCount++;
+        }
+    }
+    return { rows, errorCount };
+}

--- a/designer/client/src/components/modals/TestingDataRecords/parseRecords.ts
+++ b/designer/client/src/components/modals/TestingDataRecords/parseRecords.ts
@@ -1,4 +1,4 @@
-import type { TestingDataRecords } from "./Table";
+import type { TestingDataRecords } from "./types";
 
 function isNkFormat(obj: unknown): obj is { input: unknown; inputMeta?: unknown } {
     return typeof obj === "object" && obj !== null && "input" in obj;

--- a/designer/client/src/components/modals/TestingDataRecords/useDataRecordsActions.ts
+++ b/designer/client/src/components/modals/TestingDataRecords/useDataRecordsActions.ts
@@ -142,6 +142,21 @@ export const useDataRecordsActions = (node: NodeType, scenarioProperties: Proper
         [dispatch, validateForCount],
     );
 
+    const handleRowsAdded = React.useCallback(
+        (rows: TestingDataRecords[]) => {
+            if (!rows.length) return;
+            if (
+                !validateForCount((currentCount) => {
+                    return currentCount + rows.length;
+                })
+            )
+                return;
+
+            dispatch(setTestCaseInputs((prev) => [...prev, ...rows]));
+        },
+        [dispatch, validateForCount],
+    );
+
     const handleRowMoved = React.useCallback(
         (fromIndex: number, toIndex: number) => {
             dispatch(
@@ -161,6 +176,7 @@ export const useDataRecordsActions = (node: NodeType, scenarioProperties: Proper
         cellErrors,
         recordsErrors,
         handleRowAdded,
+        handleRowsAdded,
         handleRowUpdated,
         handleRowsDeleted,
         handleGenerateTestData,

--- a/designer/client/src/components/modals/TestingDataRecords/useDataRecordsActions.ts
+++ b/designer/client/src/components/modals/TestingDataRecords/useDataRecordsActions.ts
@@ -76,29 +76,6 @@ export const useDataRecordsActions = (node: NodeType, scenarioProperties: Proper
         [scenarioName, node, scenarioProperties],
     );
 
-    const handleRowAdded = React.useCallback(
-        (rowIndex: number, row: TestingDataRecords) => {
-            if (
-                !validateForCount((currentCount) => {
-                    return currentCount + 1;
-                })
-            )
-                return;
-
-            dispatch(
-                setTestCaseInputs((prev) => {
-                    const next = [...prev];
-                    if (rowIndex === next.length) next.push(row);
-                    else next.splice(rowIndex, 0, row);
-                    return next;
-                }),
-            );
-
-            setCellErrors((prev) => prev.map((e) => (e.y >= rowIndex ? { ...e, y: e.y + 1 } : e)));
-        },
-        [dispatch, validateForCount],
-    );
-
     const handleRowUpdated = React.useCallback(
         (rowIndex: number, row: TestingDataRecords) => {
             dispatch(
@@ -175,7 +152,6 @@ export const useDataRecordsActions = (node: NodeType, scenarioProperties: Proper
     return {
         cellErrors,
         recordsErrors,
-        handleRowAdded,
         handleRowsAdded,
         handleRowUpdated,
         handleRowsDeleted,

--- a/designer/client/src/components/modals/TestingDataRecords/useTableHeight.ts
+++ b/designer/client/src/components/modals/TestingDataRecords/useTableHeight.ts
@@ -1,7 +1,7 @@
 import { sum, values } from "lodash";
 import { useMemo } from "react";
 
-import { DEFAULT_ROW_HEADER_HEIGHT, DEFAULT_TRAILING_ROW_HEIGHT, paddingY } from "./drawText";
+import { DEFAULT_ROW_HEADER_HEIGHT, paddingY } from "./drawText";
 import type { TestingDataRecords } from "./types";
 
 export const useTableHeight = (data: TestingDataRecords[], getRowHeight: (rowIndex: number) => number) => {
@@ -13,7 +13,7 @@ export const useTableHeight = (data: TestingDataRecords[], getRowHeight: (rowInd
         });
 
         const sumOfRowsHeight = sum(values(rowsHeight));
-        return sumOfRowsHeight + DEFAULT_ROW_HEADER_HEIGHT + paddingY + DEFAULT_TRAILING_ROW_HEIGHT + paddingY;
+        return sumOfRowsHeight + DEFAULT_ROW_HEADER_HEIGHT + paddingY;
     }, [data, getRowHeight]);
 
     return { tableHeight };

--- a/designer/client/src/components/modals/TestingDataRecords/utils.ts
+++ b/designer/client/src/components/modals/TestingDataRecords/utils.ts
@@ -1,11 +1,9 @@
 import type { Item } from "@glideapps/glide-data-grid";
 import { type EditListItem } from "@glideapps/glide-data-grid";
 
-import type { TestFormParameters } from "../../../common/TestResultUtils";
 import type { UIParameter } from "../../../types/definition";
-import { isSourceSelectCell, isVariablesCell } from "./CellContent";
+import { isVariablesCell } from "./CellContent";
 import { formatDataRecordsVariablesForDisplay, getRowLines, LINE_HEIGHT, paddingX, paddingY, SPLIT_SEPARATOR } from "./drawText";
-import type { SourceSelectCell } from "./SourceEditor";
 import type { TestingDataRecords } from "./types";
 
 export const mapInputDataRecordsToRunTestsFormat = (dataRecords: TestingDataRecords) => {
@@ -56,9 +54,8 @@ export function computeVariablesRowHeight(variables: string, columnInnerWidth: n
 }
 
 export function buildInputDataRecordUpdates(
-    changes: readonly (EditListItem | { location: Item; value: SourceSelectCell })[],
+    changes: readonly EditListItem[],
     data: TestingDataRecords[],
-    defaultVariables: string,
 ): Record<number, TestingDataRecords> {
     const rowUpdates: Record<number, TestingDataRecords> = {};
     changes.forEach(({ location, value }) => {
@@ -67,9 +64,7 @@ export function buildInputDataRecordUpdates(
         const base = rowUpdates[row] || { ...(prevRow || { sourceId: "", timestamp: "", variables: "" }) };
 
         let cellValue: string;
-        if (isSourceSelectCell(value)) {
-            cellValue = value.data.value;
-        } else if (isVariablesCell(value as any)) {
+        if (isVariablesCell(value as any)) {
             cellValue = (value as any).data?.value ?? "";
         } else {
             const maybeData = (value as unknown as { data?: unknown }).data;
@@ -79,12 +74,6 @@ export function buildInputDataRecordUpdates(
         }
 
         if (col === 0) {
-            if (prevRow?.sourceId !== cellValue) {
-                rowUpdates[row] = { ...base, sourceId: cellValue, variables: cellValue ? defaultVariables : "" };
-            } else {
-                rowUpdates[row] = { ...base, sourceId: cellValue };
-            }
-        } else if (col === 1) {
             rowUpdates[row] = { ...base, variables: cellValue };
         }
     });

--- a/designer/client/src/windowManager/ContentGetter.tsx
+++ b/designer/client/src/windowManager/ContentGetter.tsx
@@ -83,6 +83,10 @@ const SaveAsTestCaseDialog = loadable(() => import("../components/modals/saveAsT
     fallback: <LoaderSpinner show />,
 });
 
+const PasteRecordsDialog = loadable(() => import("../components/modals/TestingDataRecords/PasteRecordsDialog"), {
+    fallback: <LoaderSpinner show />,
+});
+
 const contentGetter = (props: WindowContentProps<WindowKind>) => {
     switch (props.data.kind) {
         case WindowKind.addFragment:
@@ -139,6 +143,8 @@ const contentGetter = (props: WindowContentProps<WindowKind>) => {
             return <EnterpriseFeatureInfo {...props} />;
         case WindowKind.saveAsTestCase:
             return <SaveAsTestCaseDialog {...props} />;
+        case WindowKind.pasteRecords:
+            return <PasteRecordsDialog {...props} />;
         default:
             return (
                 <WindowContent {...props}>

--- a/designer/client/src/windowManager/WindowKind.tsx
+++ b/designer/client/src/windowManager/WindowKind.tsx
@@ -27,4 +27,5 @@ export enum WindowKind {
     aiAssistant,
     enterpriseFeatureInfo,
     saveAsTestCase,
+    pasteRecords,
 }


### PR DESCRIPTION
## Summary

- Remove Source column from test records DataGrid (single-source context makes it redundant)
- Remove trailing add-record row from DataGrid footer
- Scroll to newly added record after add action
- Table fills available section height and scrolls internally when content exceeds it
- AppendFromLiveDataButton: remove 'records' label and info icon, use filled TextField for count input
- Empty state: newline after 'No test records yet.' for better readability
- First toolbar divider (before Append) uses default subtle color
- Add paste JSON lines button for bulk record insertion
- Add select-all to TableFooter selection bar
- Fix: remove assertions section from source nodes in testing tab
- Remove dead code: SourceEditor, sourceSelectRenderer, buildDefaultVariablesMap, isSourceSelectCell

## Test plan

- [ ] Open a node with a Kafka source and switch to Testing tab
- [ ] Verify Source column is gone from the test records table
- [ ] Add a record — verify scroll goes to the new row
- [ ] Add enough records to overflow — verify table scrolls internally
- [ ] Verify 'Append from live data' count input shows filled background style
- [ ] Verify empty state shows two lines
- [ ] Verify paste JSON lines works
- [ ] Open a Source node — verify no assertions section appears in testing tab