### PR TITLE
improve: DataMapper enhancements and expression builder in assertions

### DIFF
--- a/designer/client/src/components/builderComponents/ContextTreeNode.tsx
+++ b/designer/client/src/components/builderComponents/ContextTreeNode.tsx
@@ -181,7 +181,7 @@ export function ContextTreeNode({
                     </Typography>
                 )}
             </Box>
-            <Collapse in={forceOpen || open}>
+            <Collapse in={forceOpen || open} unmountOnExit>
                 {isExpandable &&
                     visibleChildren.map(([k, v]) => {
                         const childPath = isArr

--- a/designer/client/src/components/dataMapper/DataMapper.tsx
+++ b/designer/client/src/components/dataMapper/DataMapper.tsx
@@ -323,6 +323,7 @@ export function DataMapper({
                                         onDragOverId={dm.setDragOverId}
                                         onChange={dm.updateField}
                                         onAddChild={dm.addChildField}
+                                        onAddChildFromDrop={dm.addChildFromDrop}
                                         onRemove={dm.removeField}
                                         onMove={dm.moveField}
                                         onDrop={dm.onDrop}

--- a/designer/client/src/components/dataMapper/DataMapper.tsx
+++ b/designer/client/src/components/dataMapper/DataMapper.tsx
@@ -94,15 +94,17 @@ export function DataMapper({
         prevFieldsLengthRef.current = dm.fields.length;
     }, [dm.fields.length]);
     useEffect(() => {
-        if (dm.selField == null || !fieldsScrollRef.current) return;
+        const id = dm.selField ?? dm.initialScrollFieldId;
+        if (id == null || !fieldsScrollRef.current) return;
         const container = fieldsScrollRef.current;
-        const id = dm.selField;
-        // Wait for MUI Collapse animation to finish before scrolling
+        // When selField changes, wait for MUI Collapse animation before scrolling.
+        // When only scrolling without expanding (initialScrollFieldId), a short delay suffices.
+        const delay = dm.selField != null ? 320 : 50;
         const timer = setTimeout(() => {
             container.querySelector(`[data-field-id="${id}"]`)?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-        }, 320);
+        }, delay);
         return () => clearTimeout(timer);
-    }, [dm.selField]);
+    }, [dm.selField, dm.initialScrollFieldId]);
 
     return (
         <RootBox embedded={!!onInsert}>

--- a/designer/client/src/components/dataMapper/DataMapper.tsx
+++ b/designer/client/src/components/dataMapper/DataMapper.tsx
@@ -94,17 +94,15 @@ export function DataMapper({
         prevFieldsLengthRef.current = dm.fields.length;
     }, [dm.fields.length]);
     useEffect(() => {
-        const id = dm.selField ?? dm.initialScrollFieldId;
-        if (id == null || !fieldsScrollRef.current) return;
+        if (dm.selField == null || !fieldsScrollRef.current) return;
         const container = fieldsScrollRef.current;
-        // When selField changes, wait for MUI Collapse animation before scrolling.
-        // When only scrolling without expanding (initialScrollFieldId), a short delay suffices.
-        const delay = dm.selField != null ? 320 : 50;
+        const id = dm.selField;
+        // Wait for MUI Collapse animation to finish before scrolling
         const timer = setTimeout(() => {
             container.querySelector(`[data-field-id="${id}"]`)?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-        }, delay);
+        }, 320);
         return () => clearTimeout(timer);
-    }, [dm.selField, dm.initialScrollFieldId]);
+    }, [dm.selField]);
 
     return (
         <RootBox embedded={!!onInsert}>

--- a/designer/client/src/components/dataMapper/FieldRow.tsx
+++ b/designer/client/src/components/dataMapper/FieldRow.tsx
@@ -217,18 +217,21 @@ export function FieldRow({
                     />
                 )}
                 {!field.isRecord && field.expression && (
-                    <Chip
-                        label={field.expression.length > 30 ? field.expression.slice(0, 30) + "…" : field.expression}
-                        size="small"
-                        sx={{
-                            height: 18,
-                            fontSize: 10,
-                            fontFamily: "monospace",
-                            color: theme.palette.primary.light,
-                            backgroundColor: alpha(theme.palette.primary.main, 0.12),
-                            "& .MuiChip-label": { px: "6px" },
-                        }}
-                    />
+                    <Tooltip title={field.expression} placement="top">
+                        <Chip
+                            label={field.expression}
+                            size="small"
+                            sx={{
+                                height: 18,
+                                fontSize: 10,
+                                fontFamily: "monospace",
+                                color: theme.palette.primary.light,
+                                backgroundColor: alpha(theme.palette.primary.main, 0.12),
+                                maxWidth: 300,
+                                "& .MuiChip-label": { px: "6px" },
+                            }}
+                        />
+                    </Tooltip>
                 )}
                 <Box sx={{ flex: 1 }} />
                 {!hideFieldControls && (
@@ -286,59 +289,65 @@ export function FieldRow({
                     }}
                 >
                     {/* Name */}
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
-                        <Typography sx={{ fontSize: 11, color: "text.secondary", width: 70 }}>Name</Typography>
-                        <TextField
-                            value={field.name}
-                            onChange={(e) => onChange(field.id, "name", e.target.value)}
-                            size="small"
-                            variant="outlined"
-                            sx={{ flex: 1, "& .MuiInputBase-input": { fontSize: 12, fontFamily: "monospace", py: "5px" } }}
-                        />
-                    </Box>
+                    {!hideFieldControls && (
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
+                            <Typography sx={{ fontSize: 11, color: "text.secondary", width: 70 }}>Name</Typography>
+                            <TextField
+                                value={field.name}
+                                onChange={(e) => onChange(field.id, "name", e.target.value)}
+                                size="small"
+                                variant="outlined"
+                                sx={{ flex: 1, "& .MuiInputBase-input": { fontSize: 12, fontFamily: "monospace", py: "5px" } }}
+                            />
+                        </Box>
+                    )}
 
                     {/* Type */}
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
-                        <Typography sx={{ fontSize: 11, color: "text.secondary", width: 70 }}>Type</Typography>
-                        {field.isRecord ? (
-                            <>
-                                <Typography sx={{ fontSize: 12, color: "text.secondary", flex: 1 }}>Nested record</Typography>
-                                <Button
-                                    size="small"
-                                    variant="outlined"
-                                    color="inherit"
-                                    onClick={() => onChange(field.id, "isRecord", false)}
-                                    sx={{ fontSize: 11, py: "2px", textTransform: "none", flexShrink: 0 }}
-                                >
-                                    Switch to expression
-                                </Button>
-                            </>
-                        ) : (
-                            <>
-                                <Select
-                                    value={field.type === "Map" ? "Any" : field.type}
-                                    onChange={(e) => onChange(field.id, "type", e.target.value as NuType)}
-                                    size="small"
-                                    sx={{ flex: 1, fontSize: 12, "& .MuiSelect-select": { py: "5px" } }}
-                                >
-                                    {NU_TYPES.filter((t) => t !== "Map").map((t) => (
-                                        <MenuItem key={t} value={t} sx={{ fontSize: 12 }}>
-                                            {t}
-                                        </MenuItem>
-                                    ))}
-                                </Select>
-                                <Button
-                                    size="small"
-                                    variant="outlined"
-                                    color="inherit"
-                                    onClick={() => onChange(field.id, "isRecord", true)}
-                                    sx={{ fontSize: 11, py: "2px", textTransform: "none", flexShrink: 0 }}
-                                >
-                                    Build Record
-                                </Button>
-                            </>
-                        )}
-                    </Box>
+                    {!hideFieldControls && (
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
+                            <Typography sx={{ fontSize: 11, color: "text.secondary", width: 70 }}>Type</Typography>
+                            {field.isRecord ? (
+                                <>
+                                    <Typography sx={{ fontSize: 12, color: "text.secondary", flex: 1 }}>Nested record</Typography>
+                                    <Button
+                                        size="small"
+                                        variant="outlined"
+                                        color="inherit"
+                                        onClick={() => onChange(field.id, "isRecord", false)}
+                                        sx={{ fontSize: 11, py: "2px", textTransform: "none", flexShrink: 0 }}
+                                    >
+                                        Switch to expression
+                                    </Button>
+                                </>
+                            ) : (
+                                <>
+                                    <Select
+                                        value={field.type === "Map" ? "Any" : field.type}
+                                        onChange={(e) => onChange(field.id, "type", e.target.value as NuType)}
+                                        size="small"
+                                        sx={{ flex: 1, fontSize: 12, "& .MuiSelect-select": { py: "5px" } }}
+                                    >
+                                        {NU_TYPES.filter((t) => t !== "Map").map((t) => (
+                                            <MenuItem key={t} value={t} sx={{ fontSize: 12 }}>
+                                                {t}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                    {field.type === "Map" && (
+                                        <Button
+                                            size="small"
+                                            variant="outlined"
+                                            color="inherit"
+                                            onClick={() => onChange(field.id, "isRecord", true)}
+                                            sx={{ fontSize: 11, py: "2px", textTransform: "none", flexShrink: 0 }}
+                                        >
+                                            Build Record
+                                        </Button>
+                                    )}
+                                </>
+                            )}
+                        </Box>
+                    )}
 
                     {/* SpEL expression (leaf only) */}
                     {!field.isRecord && (
@@ -433,14 +442,16 @@ export function FieldRow({
                             onValidateExpression={onValidateExpression}
                         />
                     ))}
-                    <Button
-                        size="small"
-                        startIcon={<AddIcon />}
-                        onClick={() => onAddChild(field.id)}
-                        sx={{ fontSize: 11, textTransform: "none", mt: 0.5, py: "2px" }}
-                    >
-                        Add field
-                    </Button>
+                    {!hideFieldControls && (
+                        <Button
+                            size="small"
+                            startIcon={<AddIcon />}
+                            onClick={() => onAddChild(field.id)}
+                            sx={{ fontSize: 11, textTransform: "none", mt: 0.5, py: "2px" }}
+                        >
+                            Add field
+                        </Button>
+                    )}
                 </Box>
             )}
         </Box>

--- a/designer/client/src/components/dataMapper/FieldRow.tsx
+++ b/designer/client/src/components/dataMapper/FieldRow.tsx
@@ -19,7 +19,7 @@ import {
     Typography,
     useTheme,
 } from "@mui/material";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import type { VariableTypes } from "../../types/validation";
 import { clearAceSelectionAfterDrop } from "../builderComponents/aceUtils";
@@ -78,6 +78,7 @@ export interface FieldRowProps {
     onDragOverId: (id: number | null) => void;
     onChange: (id: number, key: keyof FieldDef, val: unknown) => void;
     onAddChild: (parentId: number) => void;
+    onAddChildFromDrop: (parentId: number, path: string) => void;
     onRemove: (id: number) => void;
     onMove: (id: number, dir: 1 | -1) => void;
     onDrop: (path: string, fieldId: number) => void;
@@ -98,6 +99,7 @@ export function FieldRow({
     onDragOverId,
     onChange,
     onAddChild,
+    onAddChildFromDrop,
     onRemove,
     onMove,
     onDrop,
@@ -108,6 +110,8 @@ export function FieldRow({
     const isDragOver = dragOverFieldId === field.id;
     const hasSrc = !field.isRecord && !!field.expression;
     const errors = fieldErrors[field.id] ?? [];
+
+    const [childDropActive, setChildDropActive] = useState(false);
 
     const onExpressionChangeRef = useRef<(val: string) => void>(null!);
     const onExpressionChange = useCallback((val: string) => onChange(field.id, "expression", val), [field.id, onChange]);
@@ -411,16 +415,35 @@ export function FieldRow({
             {/* Nested children — sibling of the summary row, so background never stacks */}
             {field.isRecord && (
                 <Box
+                    onDragOver={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setChildDropActive(true);
+                    }}
+                    onDragLeave={() => setChildDropActive(false)}
+                    onDrop={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        const path = e.dataTransfer.getData("text/plain");
+                        if (path) onAddChildFromDrop(field.id, path);
+                        setChildDropActive(false);
+                    }}
                     sx={{
                         mt: 0.5,
                         ml: 1,
                         pl: 1.5,
                         pb: 0.5,
-                        borderLeft: `2px solid ${alpha(theme.palette.primary.main, 0.25)}`,
+                        borderLeft: `2px solid ${childDropActive ? theme.palette.primary.main : alpha(theme.palette.primary.main, 0.25)}`,
+                        borderRadius: childDropActive ? 1 : 0,
+                        backgroundColor: childDropActive ? alpha(theme.palette.primary.main, 0.06) : "transparent",
+                        transition: "border-color 0.15s, background-color 0.15s",
                     }}
                 >
-                    {field.children.length === 0 && (
+                    {field.children.length === 0 && !childDropActive && (
                         <Typography sx={{ fontSize: 11, color: "text.disabled", py: 0.5 }}>No fields yet — click Add field</Typography>
+                    )}
+                    {childDropActive && field.children.length === 0 && (
+                        <Typography sx={{ fontSize: 11, color: "primary.main", py: 0.5 }}>Drop to add field</Typography>
                     )}
                     {field.children.map((child) => (
                         <FieldRow
@@ -436,6 +459,7 @@ export function FieldRow({
                             onDragOverId={onDragOverId}
                             onChange={onChange}
                             onAddChild={onAddChild}
+                            onAddChildFromDrop={onAddChildFromDrop}
                             onRemove={onRemove}
                             onMove={onMove}
                             onDrop={onDrop}

--- a/designer/client/src/components/dataMapper/FieldRow.tsx
+++ b/designer/client/src/components/dataMapper/FieldRow.tsx
@@ -276,8 +276,8 @@ export function FieldRow({
                 )}
             </Box>
 
-            {/* Expanded editor */}
-            <Collapse in={isSelected}>
+            {/* Expanded editor — skip for record fields in schema mode (nothing to show) */}
+            <Collapse in={isSelected && !(hideFieldControls && field.isRecord)}>
                 <Box
                     sx={{
                         mx: 1.5,

--- a/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.test.ts
@@ -337,4 +337,32 @@ describe("fieldsFromSample", () => {
         expect(result[0].children[0]).toMatchObject({ name: "city", type: "String" });
         expect(result[0].children[1]).toMatchObject({ name: "zip", type: "String" });
     });
+
+    it("expands flat dotted keys into nested record fields", () => {
+        const result = fieldsFromSample({
+            "state.key": null,
+            "state.value": "abc",
+            other: 1,
+        });
+        expect(result).toHaveLength(2);
+        const state = result.find((f) => f.name === "state");
+        expect(state).toMatchObject({ name: "state", type: "Map", isRecord: true });
+        expect(state?.children).toHaveLength(2);
+        expect(state?.children[0]).toMatchObject({ name: "key" });
+        expect(state?.children[1]).toMatchObject({ name: "value", type: "String" });
+        expect(result.find((f) => f.name === "other")).toMatchObject({ type: "Integer" });
+    });
+
+    it("merges dotted key leaf with sibling nested object under same prefix", () => {
+        // schema: { "a.b": null, "a.c": { d: null } }  →  a: { b: null, c: { d: null } }
+        const result = fieldsFromSample({ "a.b": null, "a.c": { d: null } });
+        expect(result).toHaveLength(1);
+        const a = result[0];
+        expect(a).toMatchObject({ name: "a", isRecord: true });
+        expect(a.children).toHaveLength(2);
+        expect(a.children.find((c) => c.name === "b")).toBeDefined();
+        const c = a.children.find((ch) => ch.name === "c");
+        expect(c).toMatchObject({ isRecord: true });
+        expect(c?.children[0]).toMatchObject({ name: "d" });
+    });
 });

--- a/designer/client/src/components/dataMapper/dataMapperUtils.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.ts
@@ -218,6 +218,29 @@ export function applyTypeConversion(expr: string, sourceType: NuType | undefined
 }
 
 /** Get the NuType of a value at a dotted path within variableTypes (strips leading # and ? from path). */
+export function getTypingResultAtPath(variableTypes: Record<string, TypingResult>, path: string): TypingResult | undefined {
+    const segments =
+        path
+            .replace(/^#/, "")
+            .replace(/\?/g, "")
+            .match(/[^.[]+|\[\d+\]|\['[^']+'\]/g) ?? [];
+    if (segments.length === 0) return undefined;
+    let current: TypingResult | undefined = variableTypes[segments[0]];
+    if (!current) return undefined;
+    for (let i = 1; i < segments.length; i++) {
+        const seg = segments[i];
+        if (seg.startsWith("[")) {
+            const params = (current as { params?: TypingResult[] }).params;
+            if (!params?.length) return undefined;
+            current = params[0];
+        } else {
+            current = (current as { fields?: Record<string, TypingResult> }).fields?.[seg];
+        }
+        if (!current) return undefined;
+    }
+    return current;
+}
+
 export function getNuTypeAtPath(variableTypes: Record<string, TypingResult>, path: string): NuType | undefined {
     // Tokenize: split by "." and also extract "[N]" / "['key']" index segments
     const segments =

--- a/designer/client/src/components/dataMapper/dataMapperUtils.ts
+++ b/designer/client/src/components/dataMapper/dataMapperUtils.ts
@@ -294,9 +294,39 @@ export function inferNuType(val: unknown): NuType {
     return "Any";
 }
 
+/**
+ * Convert a flat object with dotted keys (e.g. `{"a.b": null, "a.c": {d: null}}`)
+ * into a nested object (`{a: {b: null, c: {d: null}}}`).
+ * Keys without dots and nested object values are preserved as-is.
+ */
+function expandDottedKeys(obj: Record<string, unknown>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+        const parts = key.split(".");
+        let current = result;
+        for (let i = 0; i < parts.length - 1; i++) {
+            const part = parts[i];
+            if (typeof current[part] !== "object" || current[part] === null) current[part] = {};
+            current = current[part] as Record<string, unknown>;
+        }
+        const last = parts[parts.length - 1];
+        if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+            if (typeof current[last] === "object" && current[last] !== null) {
+                Object.assign(current[last] as object, value);
+            } else {
+                current[last] = value;
+            }
+        } else {
+            current[last] = value;
+        }
+    }
+    return result;
+}
+
 export function fieldsFromSample(obj: unknown): FieldDef[] {
     if (typeof obj !== "object" || obj === null || Array.isArray(obj)) return [];
-    return Object.entries(obj as Record<string, unknown>).map(([k, v]) => {
+    const expanded = expandDottedKeys(obj as Record<string, unknown>);
+    return Object.entries(expanded).map(([k, v]) => {
         if (typeof v === "object" && v !== null && !Array.isArray(v)) {
             const children = fieldsFromSample(v);
             return { ...makeField(k, "Map"), isRecord: true, children };

--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -70,19 +70,6 @@ function findInTree(fields: FieldDef[], id: number): FieldDef | undefined {
     return undefined;
 }
 
-/** Finds a FieldDef by a dotted path (e.g. "combinedState.tool_record"), traversing children. */
-function findFieldByDottedPath(fields: FieldDef[], path: string): FieldDef | undefined {
-    const segments = path.split(".");
-    let current = fields;
-    let match: FieldDef | undefined;
-    for (const seg of segments) {
-        match = current.find((f) => f.name === seg);
-        if (!match) return undefined;
-        current = match.children;
-    }
-    return match;
-}
-
 /** When expr contains an Elvis fallback (e.g. from applyTypeConversion), split it into expression + defaultValue. */
 function splitElvisIntoField(field: FieldDef, expr: string): FieldDef {
     const elvisIdx = expr.lastIndexOf(" ?: ");
@@ -143,13 +130,12 @@ export function useDataMapper({
         return isEmbedded ? [] : INITIAL_FIELDS.map((f) => ({ ...f, id: nextId() }));
     });
     const [selField, setSelField] = useState<number | null>(null);
-    const [initialScrollFieldId, setInitialScrollFieldId] = useState<number | null>(null);
 
     const initialFocusFieldsRef = useRef(fields);
     useEffect(() => {
         if (!initialFocusFieldName) return;
-        const match = findFieldByDottedPath(initialFocusFieldsRef.current, initialFocusFieldName);
-        if (match) setInitialScrollFieldId(match.id);
+        const match = initialFocusFieldsRef.current.find((f) => f.name === initialFocusFieldName);
+        if (match) setSelField(match.id);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -525,7 +511,6 @@ export function useDataMapper({
         enrichedContext,
         fields,
         selField,
-        initialScrollFieldId,
         selPath,
         dragOverId,
         showTargetSample,

--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import HttpService from "../../http/HttpService/instance";
 import { getProcessDefinitionData } from "../../reducers/selectors/getProcessDefinitionData";
 import { useAppSelector } from "../../store/storeHelpers";
+import type { TypingResult } from "../../types/definition";
 import type { VariableTypes } from "../../types/validation";
 import { toNullSafe, typingResultToSample } from "../builderComponents/typeUtils";
 import type { FieldError } from "../graph/node-modal/editors/Validators";
@@ -15,6 +16,7 @@ import {
     fieldsFromSample,
     genSpelFromFields,
     getNuTypeAtPath,
+    getTypingResultAtPath,
     INITIAL_FIELDS,
     makeField,
     nextId,
@@ -41,6 +43,33 @@ function updateInTree(fields: FieldDef[], id: number, updater: (f: FieldDef) => 
         if (f.children.length > 0) return { ...f, children: updateInTree(f.children, id, updater) };
         return f;
     });
+}
+
+/**
+ * Recursively build a FieldDef from the typing result at the given source path.
+ * If the typing result is a Record (has fields), creates an isRecord FieldDef with children.
+ * Otherwise creates a leaf FieldDef with the appropriate expression and type.
+ */
+function buildFieldFromTyping(
+    name: string,
+    sourcePath: string,
+    variableTypes: Record<string, TypingResult> | null | undefined,
+    nullSafe: boolean,
+): FieldDef {
+    const typing = variableTypes ? getTypingResultAtPath(variableTypes, sourcePath) : undefined;
+    const recordFields = (typing as { fields?: Record<string, TypingResult> } | undefined)?.fields;
+    if (recordFields && Object.keys(recordFields).length > 0) {
+        const f = makeField(name, "Map");
+        f.isRecord = true;
+        f.children = Object.keys(recordFields).map((childName) =>
+            buildFieldFromTyping(childName, `${sourcePath}.${childName}`, variableTypes, nullSafe),
+        );
+        return f;
+    }
+    const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, sourcePath) : undefined;
+    const f = makeField(name, sourceType ?? "Any");
+    f.expression = nullSafe ? toNullSafe(`#${sourcePath}`) : `#${sourcePath}`;
+    return f;
 }
 
 function removeFromTree(fields: FieldDef[], id: number): FieldDef[] {
@@ -203,12 +232,21 @@ export function useDataMapper({
             const rawPath = path.replace(/^#/, "").replace(/\?/g, "");
             const bracketMatch = rawPath.match(/\['([^']+)'\]$/);
             const lastSegment = bracketMatch ? bracketMatch[1] : rawPath.split(".").pop() ?? "";
-            const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, rawPath) : undefined;
-            const field = makeField(lastSegment, sourceType ?? "Any");
-            field.expression = nullSafe ? toNullSafe(`#${rawPath}`) : `#${rawPath}`;
-            setFields((f) => [...f, field]);
+            setFields((f) => [...f, buildFieldFromTyping(lastSegment, rawPath, variableTypes, nullSafe)]);
             setDragOverId(null);
             setDropZoneActive(false);
+        },
+        [nullSafe, variableTypes],
+    );
+
+    const addChildFromDrop = useCallback(
+        (parentId: number, path: string) => {
+            const rawPath = path.replace(/^#/, "").replace(/\?/g, "");
+            const bracketMatch = rawPath.match(/\['([^']+)'\]$/);
+            const lastSegment = bracketMatch ? bracketMatch[1] : rawPath.split(".").pop() ?? "";
+            const newChild = buildFieldFromTyping(lastSegment, rawPath, variableTypes, nullSafe);
+            setFields((fs) => updateInTree(fs, parentId, (f) => ({ ...f, children: [...f.children, newChild] })));
+            setDragOverId(null);
         },
         [nullSafe, variableTypes],
     );
@@ -340,16 +378,30 @@ export function useDataMapper({
             const rawPath = path.replace(/^#/, "").replace(/\?/g, "");
             const bracketMatch = rawPath.match(/\['([^']+)'\]$/);
             const lastSegment = bracketMatch ? bracketMatch[1] : rawPath.split(".").pop() ?? "";
-            const baseExpr = nullSafe ? toNullSafe(`#${rawPath}`) : `#${rawPath}`;
-            const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, rawPath) : undefined;
-            setFields((prev) => {
-                const targetField = findInTree(prev, fieldId);
-                const expr = applyTypeConversion(baseExpr, sourceType, targetField?.type ?? "Any", targetField?.defaultValue);
-                return updateInTree(prev, fieldId, (x) => {
-                    const nameUpdate = !x.name?.trim() && lastSegment ? { name: lastSegment } : {};
-                    return { ...splitElvisIntoField(x, expr), ...nameUpdate };
+            const typing = variableTypes ? getTypingResultAtPath(variableTypes, rawPath) : undefined;
+            const recordFields = (typing as { fields?: Record<string, TypingResult> } | undefined)?.fields;
+            if (recordFields && Object.keys(recordFields).length > 0) {
+                // Source is a Record — replace the target field with a nested isRecord structure
+                const built = buildFieldFromTyping(lastSegment, rawPath, variableTypes, nullSafe);
+                setFields((prev) =>
+                    updateInTree(prev, fieldId, (x) => ({
+                        ...built,
+                        id: x.id,
+                        name: x.name?.trim() ? x.name : built.name,
+                    })),
+                );
+            } else {
+                const baseExpr = nullSafe ? toNullSafe(`#${rawPath}`) : `#${rawPath}`;
+                const sourceType = variableTypes ? getNuTypeAtPath(variableTypes, rawPath) : undefined;
+                setFields((prev) => {
+                    const targetField = findInTree(prev, fieldId);
+                    const expr = applyTypeConversion(baseExpr, sourceType, targetField?.type ?? "Any", targetField?.defaultValue);
+                    return updateInTree(prev, fieldId, (x) => {
+                        const nameUpdate = !x.name?.trim() && lastSegment ? { name: lastSegment } : {};
+                        return { ...splitElvisIntoField(x, expr), ...nameUpdate };
+                    });
                 });
-            });
+            }
             setDragOverId(null);
         },
         [nullSafe, variableTypes],
@@ -568,6 +620,7 @@ export function useDataMapper({
         updateField,
         moveField,
         addChildField,
+        addChildFromDrop,
         validateExpression,
         clearFieldErrors,
         handleAutoMap,

--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -70,6 +70,19 @@ function findInTree(fields: FieldDef[], id: number): FieldDef | undefined {
     return undefined;
 }
 
+/** Finds a FieldDef by a dotted path (e.g. "combinedState.tool_record"), traversing children. */
+function findFieldByDottedPath(fields: FieldDef[], path: string): FieldDef | undefined {
+    const segments = path.split(".");
+    let current = fields;
+    let match: FieldDef | undefined;
+    for (const seg of segments) {
+        match = current.find((f) => f.name === seg);
+        if (!match) return undefined;
+        current = match.children;
+    }
+    return match;
+}
+
 /** When expr contains an Elvis fallback (e.g. from applyTypeConversion), split it into expression + defaultValue. */
 function splitElvisIntoField(field: FieldDef, expr: string): FieldDef {
     const elvisIdx = expr.lastIndexOf(" ?: ");
@@ -130,12 +143,13 @@ export function useDataMapper({
         return isEmbedded ? [] : INITIAL_FIELDS.map((f) => ({ ...f, id: nextId() }));
     });
     const [selField, setSelField] = useState<number | null>(null);
+    const [initialScrollFieldId, setInitialScrollFieldId] = useState<number | null>(null);
 
     const initialFocusFieldsRef = useRef(fields);
     useEffect(() => {
         if (!initialFocusFieldName) return;
-        const match = initialFocusFieldsRef.current.find((f) => f.name === initialFocusFieldName);
-        if (match) setSelField(match.id);
+        const match = findFieldByDottedPath(initialFocusFieldsRef.current, initialFocusFieldName);
+        if (match) setInitialScrollFieldId(match.id);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -511,6 +525,7 @@ export function useDataMapper({
         enrichedContext,
         fields,
         selField,
+        initialScrollFieldId,
         selPath,
         dragOverId,
         showTargetSample,

--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -171,8 +171,16 @@ export function useDataMapper({
         for (const [key, typingResult] of Object.entries(variableTypes)) {
             const existing = merged[key];
             const elem0 = Array.isArray(existing) ? existing[0] : undefined;
+            const typingHasFields =
+                typingResult !== null &&
+                typeof typingResult === "object" &&
+                "fields" in typingResult &&
+                typingResult.fields !== null &&
+                typeof typingResult.fields === "object" &&
+                Object.keys(typingResult.fields as object).length > 0;
             const lacksStructure =
                 existing === undefined ||
+                (typingHasFields && (existing === null || typeof existing !== "object")) ||
                 (Array.isArray(existing) && existing.length === 0) ||
                 (Array.isArray(existing) &&
                     existing.length > 0 &&
@@ -293,10 +301,15 @@ export function useDataMapper({
             traverse(val, key, variableTypes?.[key] as { fields?: Record<string, unknown> } | undefined),
         );
 
+        function isTrivialExpression(expr: string): boolean {
+            const t = expr.trim();
+            return !t || t === "null" || t === "''" || t === '""' || t === "false" || t === "true" || /^-?\d+(\.\d+)?$/.test(t);
+        }
+
         function autoMap(fs: FieldDef[]): FieldDef[] {
             return fs.map((f) => {
                 if (f.isRecord) return { ...f, children: autoMap(f.children) };
-                if (f.expression) return f;
+                if (f.expression && !isTrivialExpression(f.expression)) return f;
                 const normalized = f.name.toLowerCase().replace(/[_\s]/g, "");
                 const match = pathMap.get(normalized);
                 const expr = `#${match}`;

--- a/designer/client/src/components/graph/node-modal/NamedParamsDataMapper.tsx
+++ b/designer/client/src/components/graph/node-modal/NamedParamsDataMapper.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useMemo } from "react";
 
-import type { UIParameter } from "../../../types/definition";
+import type { TypingResult, UIParameter } from "../../../types/definition";
 import type { NodeType } from "../../../types/node";
-import { makeField, parseSpelToFields, refClazzToNuType } from "../../dataMapper/dataMapperUtils";
-import type { NuType } from "../../dataMapper/dataMapperUtils";
+import { makeField, parseSpelToFields, refClazzToNuType, genSpelFromFields } from "../../dataMapper/dataMapperUtils";
+import type { FieldDef, NuType } from "../../dataMapper/dataMapperUtils";
 import { DataMapperComponent } from "./DataMapperComponent";
 import { EditorType, ExpressionLang } from "./editors/expression/types";
 import { findParameters } from "./NodeDetailsContent/helpers";
@@ -15,6 +15,101 @@ function resolveParamNuType(typ: UIParameter["typ"]): NuType {
         if (types.size === 1) return [...types][0] as NuType;
     }
     return refClazzToNuType(typ?.refClazzName);
+}
+
+function getTypFields(typ: TypingResult): Record<string, TypingResult> | null {
+    if ("fields" in typ && typ.fields && typeof typ.fields === "object") {
+        return typ.fields as Record<string, TypingResult>;
+    }
+    return null;
+}
+
+/** Builds a FieldDef leaf, expanding Record types into isRecord children. */
+function buildLeafField(name: string, typ: TypingResult, expression: string): FieldDef {
+    const recordFields = getTypFields(typ);
+    if (recordFields) {
+        const field = makeField(name, "Map");
+        field.isRecord = true;
+        const existingChildren = expression ? parseSpelToFields(expression) ?? [] : [];
+        field.children = Object.entries(recordFields).map(([childName, childTyp]) => {
+            const childField = makeField(childName, refClazzToNuType((childTyp as { refClazzName?: string }).refClazzName));
+            const existing = existingChildren.find((c) => c.name === childName);
+            childField.expression = existing?.expression ?? "";
+            return childField;
+        });
+        return field;
+    }
+    const field = makeField(name, resolveParamNuType(typ));
+    field.expression = expression;
+    return field;
+}
+
+/** Inserts a leaf parameter into a nested FieldDef tree at the given remaining path segments. */
+function insertNestedParam(parent: FieldDef, segments: string[], typ: TypingResult, expression: string): void {
+    const [first, ...rest] = segments;
+    if (rest.length === 0) {
+        parent.children.push(buildLeafField(first, typ, expression));
+        return;
+    }
+    let intermediate = parent.children.find((c) => c.name === first);
+    if (!intermediate) {
+        intermediate = makeField(first, "Map");
+        intermediate.isRecord = true;
+        parent.children.push(intermediate);
+    }
+    insertNestedParam(intermediate, rest, typ, expression);
+}
+
+/**
+ * Groups flat params (possibly with dotted names like "combinedState.tool_record") into a nested
+ * FieldDef tree. Parameters with a Record type are expanded into children using typ.fields.
+ */
+function groupByDottedPrefix(params: UIParameter[], currentParams: ReturnType<typeof findParameters>): FieldDef[] {
+    const rootMap = new Map<string, FieldDef>();
+
+    for (const p of params) {
+        const expression = currentParams.find((np) => np.name === p.name)?.expression?.expression?.trim() ?? "";
+        const segments = p.name.split(".");
+
+        if (segments.length === 1) {
+            rootMap.set(p.name, buildLeafField(p.name, p.typ, expression));
+        } else {
+            const [first, ...rest] = segments;
+            if (!rootMap.has(first)) {
+                const intermediate = makeField(first, "Map");
+                intermediate.isRecord = true;
+                rootMap.set(first, intermediate);
+            }
+            insertNestedParam(rootMap.get(first)!, rest, p.typ, expression);
+        }
+    }
+
+    return Array.from(rootMap.values());
+}
+
+/**
+ * Flattens a nested FieldDef tree back to a map of { dottedParamName → expression }.
+ * When a node's dotted path matches a known parameter, its expression (or its children's
+ * SpEL record) is collected. Intermediate nodes without a matching parameter are traversed.
+ */
+function flattenToParams(fields: FieldDef[], knownParamNames: Set<string>, prefix = ""): Map<string, string> {
+    const result = new Map<string, string>();
+    for (const f of fields) {
+        const key = prefix ? `${prefix}.${f.name}` : f.name;
+        if (knownParamNames.has(key)) {
+            let expr: string;
+            if (f.isRecord) {
+                expr = genSpelFromFields(f.children);
+            } else {
+                expr = f.defaultValue !== undefined ? `${f.expression} ?: ${f.defaultValue}` : f.expression;
+            }
+            result.set(key, expr);
+        } else if (f.isRecord && f.children.length > 0) {
+            const nested = flattenToParams(f.children, knownParamNames, key);
+            nested.forEach((v, k) => result.set(k, v));
+        }
+    }
+    return result;
 }
 
 interface Props {
@@ -46,12 +141,7 @@ export function NamedParamsDataMapper({
     const initialFields = useMemo(() => {
         if (mappableParams.length === 0) return undefined;
         const currentParams = findParameters(node);
-        return mappableParams.map((p) => {
-            const field = makeField(p.name, resolveParamNuType(p.typ));
-            const current = currentParams.find((np) => np.name === p.name);
-            field.expression = current?.expression?.expression?.trim() ?? "";
-            return field;
-        });
+        return groupByDottedPrefix(mappableParams, currentParams);
     }, [mappableParams, node]);
 
     const handleInsert = useCallback(
@@ -59,18 +149,19 @@ export function NamedParamsDataMapper({
             const parsed = parseSpelToFields(spel);
             if (!parsed) return;
             const currentParams = findParameters(node);
-            for (const field of parsed) {
-                const paramIndex = currentParams.findIndex((p) => p.name === field.name);
-                if (paramIndex >= 0 && field.expression) {
-                    const fullExpr = field.defaultValue !== undefined ? `${field.expression} ?: ${field.defaultValue}` : field.expression;
-                    setProperty(`${parametersBasePath}[${paramIndex}].expression`, {
-                        expression: fullExpr,
-                        language: ExpressionLang.SpEL,
-                    });
-                }
+            const knownParamNames = new Set(mappableParams.map((p) => p.name));
+            const exprByParam = flattenToParams(parsed, knownParamNames);
+            for (const [paramName, expr] of exprByParam) {
+                if (!expr) continue;
+                const paramIndex = currentParams.findIndex((p) => p.name === paramName);
+                if (paramIndex < 0) continue;
+                setProperty(`${parametersBasePath}[${paramIndex}].expression`, {
+                    expression: expr,
+                    language: ExpressionLang.SpEL,
+                });
             }
         },
-        [node, parametersBasePath, setProperty],
+        [node, mappableParams, parametersBasePath, setProperty],
     );
 
     if (mappableParams.length === 0) return null;

--- a/designer/client/src/components/graph/node-modal/ParametersUtils.ts
+++ b/designer/client/src/components/graph/node-modal/ParametersUtils.ts
@@ -50,8 +50,14 @@ function splitTopLevelParts(inner: string): string[] {
     return parts.filter(Boolean);
 }
 
-/** Parse a top-level SpEL record `{ k1: expr1, k2: expr2 }` into a name→expression map. */
-function parseSpelRecord(expression: string): Record<string, string> | null {
+/**
+ * Flatten a SpEL record into a name→expression map.
+ * When `knownParamNames` is provided, recursion stops at keys matching known params,
+ * allowing nested `{combinedState: {key: ..., tool_record: {...}}}` to be distributed
+ * back to individual dotted params like `combinedState.key`, `combinedState.tool_record`.
+ * Without `knownParamNames`, only the top level is parsed (legacy flat format).
+ */
+function flattenSpelRecord(expression: string, knownParamNames?: Set<string>, prefix = ""): Record<string, string> | null {
     const trimmed = expression.trim();
     if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
     const inner = trimmed.slice(1, -1).trim();
@@ -62,9 +68,70 @@ function parseSpelRecord(expression: string): Record<string, string> | null {
         const rawName = part.slice(0, colonIdx).trim();
         const name = rawName.replace(/^["'](.*)["']$/, "$1");
         const val = part.slice(colonIdx + 1).trim();
-        if (name) result[name] = val;
+        if (!name) continue;
+        const fullKey = prefix ? `${prefix}.${name}` : name;
+        if (!knownParamNames || knownParamNames.has(fullKey)) {
+            result[fullKey] = reformatIfSpelRecord(val, 0);
+        } else if (val.startsWith("{") && val.endsWith("}")) {
+            const nested = flattenSpelRecord(val, knownParamNames, fullKey);
+            if (nested) Object.assign(result, nested);
+            else result[fullKey] = val;
+        } else {
+            result[fullKey] = val;
+        }
     }
     return Object.keys(result).length > 0 ? result : null;
+}
+
+/** Re-indent a SpEL record expression string to match the given nesting depth. */
+function reformatIfSpelRecord(expr: string, depth: number): string {
+    const trimmed = expr.trim();
+    if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return expr;
+    const inner = trimmed.slice(1, -1).trim();
+    if (!inner) return "{}";
+    const parts = splitTopLevelParts(inner);
+    if (parts.length === 0) return "{}";
+    const indent = "  ".repeat(depth + 1);
+    const closing = "  ".repeat(depth);
+    const lines = parts.map((part) => {
+        const colonIdx = part.indexOf(":");
+        if (colonIdx === -1) return `${indent}${part.trim()}`;
+        const key = part.slice(0, colonIdx).trim();
+        const val = part.slice(colonIdx + 1).trim();
+        return `${indent}${key}: ${reformatIfSpelRecord(val, depth + 1)}`;
+    });
+    return `{\n${lines.join(",\n")}\n${closing}}`;
+}
+
+/** Recursively build a nested SpEL record from a tree of `{key: string|nested}` objects. */
+function serializeSpelRecord(obj: Record<string, unknown>, depth = 0): string {
+    const indent = "  ".repeat(depth + 1);
+    const closing = "  ".repeat(depth);
+    const lines = Object.entries(obj).map(([k, v]) => {
+        const value =
+            typeof v === "object" && v !== null
+                ? serializeSpelRecord(v as Record<string, unknown>, depth + 1)
+                : reformatIfSpelRecord(v as string, depth + 1);
+        return `${indent}${k}: ${value}`;
+    });
+    return `{\n${lines.join(",\n")}\n${closing}}`;
+}
+
+/** Group dotted param names (e.g. "combinedState.key") into a nested SpEL record expression. */
+function buildNestedSpelRecord(params: Parameter[]): string {
+    const root: Record<string, unknown> = {};
+    for (const p of params) {
+        const expr = p.expression?.expression ?? "null";
+        const segments = p.name.split(".");
+        let current = root;
+        for (let i = 0; i < segments.length - 1; i++) {
+            const seg = segments[i];
+            if (typeof current[seg] !== "object" || current[seg] === null) current[seg] = {};
+            current = current[seg] as Record<string, unknown>;
+        }
+        current[segments[segments.length - 1]] = expr;
+    }
+    return serializeSpelRecord(root);
 }
 
 function migrateKafkaParams(currentParameters: Parameter[], parameterDefinitions: Readonly<UIParameter[]>): Parameter[] | null {
@@ -78,8 +145,10 @@ function migrateKafkaParams(currentParameters: Parameter[], parameterDefinitions
     };
 
     // raw editor → dynamic: distribute Value record to individual params
+    // Handles both old flat format { "combinedState.key": expr } and new nested { combinedState: { key: expr } }
     if (oldValueParam && newIndividualDefs.length > 0) {
-        const parsed = parseSpelRecord(oldValueParam.expression?.expression ?? "");
+        const knownParamNames = new Set(newIndividualDefs.map((d) => d.name));
+        const parsed = flattenSpelRecord(oldValueParam.expression?.expression ?? "", knownParamNames);
         if (parsed) {
             return parameterDefinitions
                 .filter((def) => !def.branchParam)
@@ -95,11 +164,11 @@ function migrateKafkaParams(currentParameters: Parameter[], parameterDefinitions
         }
     }
 
-    // dynamic → raw editor: combine individual params into Value record
+    // dynamic → raw editor: combine individual params into a nested Value record
     if (!oldValueParam && newValueDef) {
         const oldIndividualParams = currentParameters.filter((p) => !KAFKA_SYSTEM_PARAMS.has(p.name));
         if (oldIndividualParams.length > 0) {
-            const record = `{\n${oldIndividualParams.map((p) => `  ${p.name}: ${p.expression?.expression ?? "null"}`).join(",\n")}\n}`;
+            const record = buildNestedSpelRecord(oldIndividualParams);
             return parameterDefinitions
                 .filter((def) => !def.branchParam)
                 .map((def) => {

--- a/designer/client/src/components/graph/node-modal/dataMapperFieldWrapper.tsx
+++ b/designer/client/src/components/graph/node-modal/dataMapperFieldWrapper.tsx
@@ -11,7 +11,9 @@ export function DataMapperFieldWrapper({ parameter, parameterDefinitions, ...res
         const paramDef = parameterDefinitions?.find((p) => p.name === parameter.name);
         const fields = paramDef?.typ ? fieldsFromSample(typingResultToSample(paramDef.typ)) : undefined;
         if (fields?.length) return fields;
-        // Fallback: derive from individual field params (avro/json schema dynamic mode)
+        // Fallback: derive schema from individual field params — only for Kafka sinks (avro/json schema dynamic mode).
+        // Other components (HTTP Callback, Webhook etc.) use free-form fields.
+        if (!parameterDefinitions?.some((p) => p.name === "Raw editor")) return undefined;
         const KAFKA_SYSTEM_PARAMS = new Set([
             "Topic",
             "Schema version",

--- a/designer/client/src/components/graph/node-modal/dataMapperFieldWrapper.tsx
+++ b/designer/client/src/components/graph/node-modal/dataMapperFieldWrapper.tsx
@@ -42,6 +42,7 @@ export function DataMapperFieldWrapper({ parameter, parameterDefinitions, ...res
                     onInsert={onInsert}
                     initialExpression={initialExpression}
                     initialFields={initialFields}
+                    hideFieldControls={!!initialFields || parameterDefinitions?.some((p) => p.name === "Schema version")}
                     open={open}
                     onClose={onClose}
                 />

--- a/designer/client/src/components/graph/node-modal/editors/expression/useAceDndTarget.test.ts
+++ b/designer/client/src/components/graph/node-modal/editors/expression/useAceDndTarget.test.ts
@@ -1,0 +1,100 @@
+import type { SpelDndContext } from "../../io/ContextTree";
+import { ExpressionLang } from "./types";
+import { getInsertText, jsonToSpelString } from "./useAceDndTarget";
+
+describe("jsonToSpelString", () => {
+    it("converts null", () => {
+        expect(jsonToSpelString(null)).toBe("null");
+    });
+
+    it("converts string with escaping", () => {
+        expect(jsonToSpelString("hello")).toBe('"hello"');
+        expect(jsonToSpelString('say "hi"')).toBe('"say \\"hi\\""');
+    });
+
+    it("converts number", () => {
+        expect(jsonToSpelString(42)).toBe("42");
+        expect(jsonToSpelString(3.14)).toBe("3.14");
+    });
+
+    it("converts boolean", () => {
+        expect(jsonToSpelString(true)).toBe("true");
+        expect(jsonToSpelString(false)).toBe("false");
+    });
+
+    it("converts array", () => {
+        expect(jsonToSpelString([1, "a"])).toBe('{1,"a"}');
+    });
+
+    it("converts object", () => {
+        expect(jsonToSpelString({ a: 1 })).toBe("{ a: 1 }");
+    });
+
+    it("quotes object keys with spaces", () => {
+        expect(jsonToSpelString({ "my key": 1 })).toBe('{ "my key": 1 }');
+    });
+});
+
+describe("getInsertText", () => {
+    const noOverrides = { recordsPrefix: false, valueInsert: false };
+
+    describe("recordsPrefix=true — Actual field DnD", () => {
+        const opts = { recordsPrefix: true, valueInsert: false };
+
+        it("produces #records[N].path for SpEL", () => {
+            const item: SpelDndContext = { type: "key", path: ["status"], value: "active", recordIndex: 2 };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("#records[2].status");
+        });
+
+        it("uses recordIndex from first record", () => {
+            const item: SpelDndContext = { type: "key", path: ["amount"], value: 100, recordIndex: 0 };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("#records[0].amount");
+        });
+
+        it("falls back to standard path when recordIndex is undefined", () => {
+            const item: SpelDndContext = { type: "key", path: ["status"], value: "active" };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("#status");
+        });
+    });
+
+    describe("valueInsert=true — Expected field DnD", () => {
+        const opts = { recordsPrefix: false, valueInsert: true };
+
+        it("inserts string value as SpEL string literal", () => {
+            const item: SpelDndContext = { type: "value", path: ["status"], value: "active" };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe('"active"');
+        });
+
+        it("inserts numeric value as-is", () => {
+            const item: SpelDndContext = { type: "value", path: ["amount"], value: 42 };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("42");
+        });
+
+        it("inserts boolean value", () => {
+            const item: SpelDndContext = { type: "value", path: ["active"], value: true };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("true");
+        });
+
+        it("inserts null value", () => {
+            const item: SpelDndContext = { type: "value", path: ["field"], value: null };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe("null");
+        });
+
+        it("ignores recordIndex — always inserts value", () => {
+            const item: SpelDndContext = { type: "value", path: ["status"], value: "done", recordIndex: 5 };
+            expect(getInsertText(item, ExpressionLang.SpEL, opts)).toBe('"done"');
+        });
+    });
+
+    describe("no overrides — standard behaviour", () => {
+        it("inserts #path for key type in SpEL", () => {
+            const item: SpelDndContext = { type: "key", path: ["input", "status"], value: "active" };
+            expect(getInsertText(item, ExpressionLang.SpEL, noOverrides)).toBe('#input["status"]');
+        });
+
+        it("inserts value for value type in SpEL", () => {
+            const item: SpelDndContext = { type: "value", path: ["amount"], value: 99 };
+            expect(getInsertText(item, ExpressionLang.SpEL, noOverrides)).toBe("99");
+        });
+    });
+});

--- a/designer/client/src/components/graph/node-modal/editors/expression/useAceDndTarget.tsx
+++ b/designer/client/src/components/graph/node-modal/editors/expression/useAceDndTarget.tsx
@@ -1,5 +1,4 @@
-import type React from "react";
-import { useCallback, useContext, useEffect } from "react";
+import React, { useCallback, useContext, useEffect } from "react";
 import type ReactAce from "react-ace/lib/ace";
 import type { XYCoord } from "react-dnd";
 import { useDragLayer, useDrop } from "react-dnd";
@@ -11,7 +10,10 @@ import { AcceptedLangCtx } from "../../../../ValueDragPreview";
 import type { SpelDndContext } from "../../io/ContextTree";
 import { ExpressionLang } from "./types";
 
-function jsonToSpelString(value: any): string {
+export const UseRecordsPrefixContext = React.createContext(false);
+export const UseValueInsertContext = React.createContext(false);
+
+export function jsonToSpelString(value: any): string {
     if (value === null) return "null";
     if (typeof value === "string") return `"${value.replace(/"/g, '\\"')}"`;
     if (typeof value === "number" || typeof value === "boolean") return String(value);
@@ -69,6 +71,20 @@ const getTextToInsert = memoizeByArgsWithTTL((item: SpelDndContext, language: Ex
     return JSON.stringify(item?.value);
 });
 
+export function getInsertText(
+    item: SpelDndContext,
+    language: ExpressionLang,
+    { recordsPrefix, valueInsert }: { recordsPrefix: boolean; valueInsert: boolean },
+): string {
+    if (recordsPrefix && item.recordIndex !== undefined) {
+        return `#records[${item.recordIndex}].${getPathString(item.path)}`;
+    }
+    if (valueInsert) {
+        return jsonToSpelString(item.value);
+    }
+    return getTextToInsert(item, language);
+}
+
 export function useAceDndTarget(editorRef: React.MutableRefObject<ReactAce>, language: ExpressionLang) {
     const getEditor = useCallback(() => editorRef?.current?.editor, [editorRef]);
 
@@ -76,7 +92,13 @@ export function useAceDndTarget(editorRef: React.MutableRefObject<ReactAce>, lan
         getEditor()?.removeGhostText();
     }, [getEditor]);
 
-    const getText = useCallback((item: SpelDndContext) => getTextToInsert(item, language), [language]);
+    const useRecordsPrefix = useContext(UseRecordsPrefixContext);
+    const useValueInsert = useContext(UseValueInsertContext);
+
+    const getText = useCallback(
+        (item: SpelDndContext) => getInsertText(item, language, { recordsPrefix: useRecordsPrefix, valueInsert: useValueInsert }),
+        [language, useRecordsPrefix, useValueInsert],
+    );
 
     const addPlaceholder = useCallback(
         (clientOffset: XYCoord, item: SpelDndContext) => {

--- a/designer/client/src/components/graph/node-modal/io/ContextData.tsx
+++ b/designer/client/src/components/graph/node-modal/io/ContextData.tsx
@@ -7,6 +7,7 @@ import { getIsLiveDataWorking } from "../../../../reducers/selectors/getLiveData
 import { useAppSelector } from "../../../../store/storeHelpers";
 import { ContextAccordion } from "./ContextAccordion";
 import { ContextDataDisplay } from "./ContextDataDisplay";
+import { RecordIndexContext } from "./ContextTree";
 import type { Direction, VariableContextType } from "./VariableContextTree";
 
 export const ContextData = memo(function Data({
@@ -81,8 +82,10 @@ export const ContextData = memo(function Data({
                             locked={index >= availableContexts}
                             showNodes={showNodes}
                         >
-                            {direction === "output" ? <>{r.error}</> : null}
-                            <ContextDataDisplay direction={direction} context={r} inputVariables={inputVariables} />
+                            <RecordIndexContext.Provider value={data.length - 1 - index}>
+                                {direction === "output" ? <>{r.error}</> : null}
+                                <ContextDataDisplay direction={direction} context={r} inputVariables={inputVariables} />
+                            </RecordIndexContext.Provider>
                         </ContextAccordion>
                     </Slide>
                 ))}

--- a/designer/client/src/components/graph/node-modal/io/ContextTree.tsx
+++ b/designer/client/src/components/graph/node-modal/io/ContextTree.tsx
@@ -22,10 +22,13 @@ function normalizePath(keyPath: KeyPath | (string | number)[]) {
     return [...keyPath].reverse();
 }
 
+export const RecordIndexContext = React.createContext<number | undefined>(undefined);
+
 export type SpelDndContext = {
     value: any;
     path: KeyPath;
     type: "key" | "value";
+    recordIndex?: number;
 };
 
 function DraggableValue({
@@ -40,13 +43,17 @@ function DraggableValue({
     value: unknown;
     type?: SpelDndContext["type"];
 }>) {
-    const [{ isActive }, drag, preview] = useDrag<SpelDndContext, void, { isActive: boolean }>(() => ({
-        type: DndTypes.VALUE,
-        item: { path, type, value },
-        options: { dropEffect: "copy" },
-        canDrag: !disabled,
-        collect: (monitor) => ({ isActive: monitor.isDragging() }),
-    }));
+    const recordIndex = React.useContext(RecordIndexContext);
+    const [{ isActive }, drag, preview] = useDrag<SpelDndContext, void, { isActive: boolean }>(
+        () => ({
+            type: DndTypes.VALUE,
+            item: { path, type, value, recordIndex },
+            options: { dropEffect: "copy" },
+            canDrag: !disabled,
+            collect: (monitor) => ({ isActive: monitor.isDragging() }),
+        }),
+        [path, type, value, recordIndex, disabled],
+    );
 
     useEffect(() => {
         preview(getEmptyImage());

--- a/designer/client/src/components/graph/node-modal/io/InputOutputContext.tsx
+++ b/designer/client/src/components/graph/node-modal/io/InputOutputContext.tsx
@@ -133,7 +133,7 @@ export const InputOutputContextProvider = memo(function InputOutputContextProvid
     const getAvailableContexts = useCallback(
         (direction: "input" | "output" = "input", filter: string[] = []): [VariableContextType[], number] => {
             const transitionResults = direction === "input" ? inputs : outputs;
-            const contexts: VariableContextType[] = [];
+            const contextMap = new Map<string, VariableContextType>();
             transitionResults
                 .filter(({ sourceNodeId, destinationNodeId }) => {
                     if (!filter.length) return true;
@@ -142,15 +142,16 @@ export const InputOutputContextProvider = memo(function InputOutputContextProvid
                 })
                 .forEach(({ id: contextNodeId, destinationNodeId, results }) => {
                     results?.forEach(({ id, variables, timestamp }) => {
-                        const foundContext = contexts.find((context) => context.id === id && context.timestamp === timestamp);
-                        if (foundContext) {
-                            foundContext.nodeIds.push(contextNodeId);
+                        const key = `${id}_${timestamp}`;
+                        const existing = contextMap.get(key);
+                        if (existing) {
+                            existing.nodeIds.push(contextNodeId);
                             return;
                         }
 
                         const error = direction === "input" && getError(destinationNodeId, id);
 
-                        contexts.push({
+                        contextMap.set(key, {
                             id,
                             variables,
                             disabled: isContextDisabled(id, direction),
@@ -161,7 +162,7 @@ export const InputOutputContextProvider = memo(function InputOutputContextProvid
                     });
                 });
             const count = transitionResults.reduce((sum, { totalCount = 0 }) => sum + totalCount, 0);
-            return [contexts, count];
+            return [Array.from(contextMap.values()), count];
         },
         [inputs, outputs, getError, isContextDisabled],
     );

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -1,22 +1,33 @@
 import { css } from "@emotion/css";
-import { Box } from "@mui/material";
-import React, { useCallback, useMemo, memo } from "react";
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
+import { Box, IconButton } from "@mui/material";
+import React, { useCallback, useMemo, useState, memo } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { AssertionOperator } from "../../../../../../actions/nk/testCasesActions";
+import { useUserSettings } from "../../../../../../common/useUserSettings";
 import type { TestAssertionResult } from "../../../../../../http/resultsWithCountsDto";
+import type { NodeType } from "../../../../../../types/node";
 import type { NodeValidationError, VariableTypes } from "../../../../../../types/validation";
+import type { ContextData } from "../../../../../dataMapper/DataMapper";
+import { SpelExpressionBuilderComponent } from "../../../../../spelExpressionBuilder/SpelExpressionBuilderComponent";
 import { RowFieldLabel } from "../../../aggregate/rowFieldLabel";
 import { EditableEditor } from "../../../editors/EditableEditor";
 import type { ExpressionObj } from "../../../editors/expression/types";
 import { EditorType, ExpressionLang } from "../../../editors/expression/types";
 import { UseRecordsPrefixContext, UseValueInsertContext } from "../../../editors/expression/useAceDndTarget";
 import Input from "../../../editors/field/Input";
+import { InfoTooltip } from "../../../editors/InfoTooltip/InfoTooltip";
 import { ParamKeyProvider } from "../../../editors/ParamKeyProvider";
 import { FieldsRow } from "../../../fragment-input-definition/FieldsRow";
 import { TypeSelect } from "../../../fragment-input-definition/TypeSelect";
 import type { Option } from "../../../fragment-input-definition/TypeSelect";
 import { OverrideKeys } from "../../../parameterHelpers";
 import { AssertionStatus } from "./AssertionStatus";
+
+const RECORDS_HINT_KEY = "editors.spelEditor.additionalInfoText.assertionActual";
+const RECORDS_HINT_DEFAULT =
+    "Use **#records** to access all events that passed through this node.\n\ncount `#records.size()`  \nfield access `#records[0].status`  \nfilter `#records.?[#this.amount > 100].size()`";
 
 export const ASSERTION_SYMBOLS: Record<AssertionOperator, string> = {
     equals: "==",
@@ -46,7 +57,9 @@ interface Props {
     expected: ExpressionObj;
     operator: AssertionOperator;
     actual: ExpressionObj;
+    node: NodeType;
     variableTypes: VariableTypes;
+    contextData?: ContextData;
     onChange: (
         uuid: string,
         updated: Partial<{ description: string; expected: ExpressionObj; operator: AssertionOperator; actual: ExpressionObj }>,
@@ -62,13 +75,18 @@ const AssertionItemComponent = ({
     expected,
     operator,
     actual,
+    node,
+    contextData,
     onChange,
     index,
     testAssertionResult,
     variableTypes,
     errors = [],
 }: Props) => {
+    const { t } = useTranslation();
     const isFirstRow = index === 0;
+    const [showFieldExpressionBuilder] = useUserSettings("node.showAssertionExpressionBuilder");
+    const [builderOpen, setBuilderOpen] = useState(false);
 
     const handleDescriptionChange = useCallback(
         (event) => {
@@ -112,6 +130,20 @@ const AssertionItemComponent = ({
         return errors.filter((error) => error.fieldName === "description") || [];
     }, [errors]);
 
+    const recordsHint = t(RECORDS_HINT_KEY, RECORDS_HINT_DEFAULT);
+
+    const handleOpenBuilder = useCallback(() => setBuilderOpen(true), []);
+    const handleCloseBuilder = useCallback(() => setBuilderOpen(false), []);
+    const handleBuilderInsert = useCallback((spel: string) => handleActualChange({ expression: spel }), [handleActualChange]);
+
+    const actualAdornment = showFieldExpressionBuilder ? (
+        <InfoTooltip variant="hover" title={recordsHint}>
+            <IconButton onClick={handleOpenBuilder} color="primary" sx={{ padding: 0 }}>
+                <AutoFixHighIcon sx={{ width: "1rem", height: "1rem" }} />
+            </IconButton>
+        </InfoTooltip>
+    ) : undefined;
+
     return (
         <Box display={"flex"} alignItems={"flex-start"} data-assertion-uuid={uuid}>
             <FieldsRow key={uuid} index={index} uuid={uuid} className={gridContainerStyle}>
@@ -136,6 +168,7 @@ const AssertionItemComponent = ({
                                 showValidation
                                 fieldErrors={actualErrors}
                                 placeholder="#records.size()"
+                                inputAdornmentEnd={actualAdornment}
                             />
                         </ParamKeyProvider>
                     </UseRecordsPrefixContext.Provider>
@@ -162,6 +195,17 @@ const AssertionItemComponent = ({
                     </UseValueInsertContext.Provider>
                 </RowFieldLabel>
             </FieldsRow>
+            {showFieldExpressionBuilder && (
+                <SpelExpressionBuilderComponent
+                    node={node}
+                    variableTypes={variableTypes}
+                    contextData={contextData}
+                    initialExpression={actual.expression}
+                    onInsert={handleBuilderInsert}
+                    open={builderOpen}
+                    onClose={handleCloseBuilder}
+                />
+            )}
             {testAssertionResult && (
                 <Box ml={1} mt={0.5}>
                     <AssertionStatus

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/AssertionItem.tsx
@@ -9,6 +9,7 @@ import { RowFieldLabel } from "../../../aggregate/rowFieldLabel";
 import { EditableEditor } from "../../../editors/EditableEditor";
 import type { ExpressionObj } from "../../../editors/expression/types";
 import { EditorType, ExpressionLang } from "../../../editors/expression/types";
+import { UseRecordsPrefixContext, UseValueInsertContext } from "../../../editors/expression/useAceDndTarget";
 import Input from "../../../editors/field/Input";
 import { ParamKeyProvider } from "../../../editors/ParamKeyProvider";
 import { FieldsRow } from "../../../fragment-input-definition/FieldsRow";
@@ -124,18 +125,20 @@ const AssertionItemComponent = ({
                     />
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Actual" data-testid={`assertion-actual-${index}`}>
-                    <ParamKeyProvider custom={OverrideKeys.AssertionActual}>
-                        <EditableEditor
-                            showSwitch={false}
-                            editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
-                            expressionObj={actual}
-                            variableTypes={variableTypes}
-                            onValueChange={handleActualChange}
-                            showValidation
-                            fieldErrors={actualErrors}
-                            placeholder="#records.size()"
-                        />
-                    </ParamKeyProvider>
+                    <UseRecordsPrefixContext.Provider value={true}>
+                        <ParamKeyProvider custom={OverrideKeys.AssertionActual}>
+                            <EditableEditor
+                                showSwitch={false}
+                                editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
+                                expressionObj={actual}
+                                variableTypes={variableTypes}
+                                onValueChange={handleActualChange}
+                                showValidation
+                                fieldErrors={actualErrors}
+                                placeholder="#records.size()"
+                            />
+                        </ParamKeyProvider>
+                    </UseRecordsPrefixContext.Provider>
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Assertion" data-testid={`assertion-operator-${index}`}>
                     <TypeSelect
@@ -145,16 +148,18 @@ const AssertionItemComponent = ({
                     />
                 </RowFieldLabel>
                 <RowFieldLabel showLabel={isFirstRow} label="Expected" data-testid={`assertion-expected-${index}`}>
-                    <EditableEditor
-                        showSwitch={false}
-                        editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
-                        expressionObj={expected}
-                        variableTypes={variableTypes}
-                        onValueChange={handleExpectedChange}
-                        showValidation
-                        fieldErrors={expectedErrors}
-                        placeholder="true, 12, 'xxxx'"
-                    />
+                    <UseValueInsertContext.Provider value={true}>
+                        <EditableEditor
+                            showSwitch={false}
+                            editors={[{ type: EditorType.SPEL_PARAMETER_EDITOR }]}
+                            expressionObj={expected}
+                            variableTypes={variableTypes}
+                            onValueChange={handleExpectedChange}
+                            showValidation
+                            fieldErrors={expectedErrors}
+                            placeholder="true, 12, 'xxxx'"
+                        />
+                    </UseValueInsertContext.Provider>
                 </RowFieldLabel>
             </FieldsRow>
             {testAssertionResult && (

--- a/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
+++ b/designer/client/src/components/graph/node-modal/node/NodeContent/TestingContentElements/Assertions.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from "@mui/material";
 import { omit } from "lodash";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { AssertionOperator } from "../../../../../../actions/nk/testCasesActions";
@@ -13,6 +13,8 @@ import { useAppDispatch, useAppSelector } from "../../../../../../store/storeHel
 import type { Edge } from "../../../../../../types/edge";
 import type { NodeType } from "../../../../../../types/node";
 import type { VariableTypes } from "../../../../../../types/validation";
+import type { ContextData } from "../../../../../dataMapper/DataMapper";
+import { useInputOutputContext } from "../../../../../graph/node-modal/io/InputOutputContext";
 import { withUuid } from "../../../appendUuid";
 import { useHelpText } from "../../../editors/expression/helpText";
 import { ExpressionLang } from "../../../editors/expression/types";
@@ -47,6 +49,17 @@ export const Assertions = ({ node, edges }: Props) => {
     const dispatch = useAppDispatch();
     const testCaseAssertions = useAppSelector((state) => getTestCaseAssertionsForNode(state, node.id));
     const testAssertionResults = useAppSelector((state) => getTestAssertionResultsForNode(state, node.id));
+    const ioContext = useInputOutputContext();
+    const getAvailableContexts = ioContext?.getAvailableContexts;
+    const MAX_RECORDS_CONTEXT = 20;
+    const recordsContextData = useMemo<ContextData | undefined>(() => {
+        const [inputContexts] = getAvailableContexts?.("input") ?? [[]];
+        if (!inputContexts.length) return undefined;
+        const records = inputContexts
+            .slice(0, MAX_RECORDS_CONTEXT)
+            .map((ctx) => Object.fromEntries(Object.keys(ctx.variables).map((k) => [k, ctx.variables[k].pretty])));
+        return { records };
+    }, [getAvailableContexts]);
     const testCasesErrors = useGetNodeTestCasesErrors(node);
 
     useValidation({ node, showValidation: true, edges });
@@ -137,7 +150,9 @@ export const Assertions = ({ node, edges }: Props) => {
                                 expected={expected}
                                 operator={operator}
                                 actual={actual}
+                                node={node}
                                 variableTypes={assertionVariableTypes}
+                                contextData={recordsContextData}
                                 testAssertionResult={testAssertionResults?.[index]}
                                 index={index}
                                 errors={testCasesErrors.assertionsErrors[index.toString()]}

--- a/designer/client/src/components/graph/node-modal/parametersListField.tsx
+++ b/designer/client/src/components/graph/node-modal/parametersListField.tsx
@@ -44,7 +44,17 @@ export const ParametersListField = ({ getListFieldPath, paramWithIndex, ...props
 
     const listFieldPath = useMemo(() => getListFieldPath(index), [getListFieldPath, index]);
 
-    const FieldWrapper = useMemo(() => pickFieldWrapper(paramKey) || NamedParamsMapperFieldWrapper, [paramKey]);
+    const isKafkaValueParam = useMemo(
+        () =>
+            param.name === "Value" &&
+            props.parameterDefinitions?.some((p) => p.name === "Raw editor") &&
+            props.parameterDefinitions?.some((p) => p.name === "Schema version"),
+        [param.name, props.parameterDefinitions],
+    );
+    const FieldWrapper = useMemo(
+        () => pickFieldWrapper(paramKey) || (isKafkaValueParam ? DataMapperFieldWrapper : NamedParamsMapperFieldWrapper),
+        [isKafkaValueParam, paramKey],
+    );
 
     const endAdornment = useMemo(() => {
         switch (paramKey) {

--- a/designer/client/src/components/spelExpressionBuilder/SpelExpressionBuilderComponent.tsx
+++ b/designer/client/src/components/spelExpressionBuilder/SpelExpressionBuilderComponent.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from "react";
 import { useUserSettings } from "../../common/useUserSettings";
 import { useAppSelector } from "../../store/storeHelpers";
 import type { NodeType } from "../../types/node";
+import type { VariableTypes } from "../../types/validation";
 import type { ContextData } from "../dataMapper/DataMapper";
 import { DataMapperDialogTitle } from "../dataMapper/DataMapperDialogTitle";
 import { useInputOutputContext } from "../graph/node-modal/io/InputOutputContext";
@@ -18,6 +19,10 @@ interface Props {
     initialExpression?: string;
     paramName?: string;
     targetTypeDisplay?: string;
+    /** Override variable types instead of deriving from node id. */
+    variableTypes?: VariableTypes;
+    /** Override context data (actual values) instead of deriving from InputOutputContext. */
+    contextData?: ContextData;
     /** Controlled mode: open state managed externally. */
     open?: boolean;
     onClose?: () => void;
@@ -31,6 +36,8 @@ export function SpelExpressionBuilderComponent({
     initialExpression,
     paramName,
     targetTypeDisplay,
+    variableTypes: variableTypesProp,
+    contextData: contextDataProp,
     open: openProp,
     onClose,
 }: Props): React.JSX.Element | null {
@@ -40,7 +47,8 @@ export function SpelExpressionBuilderComponent({
     const open = isControlled ? openProp : openInternal;
 
     const findAvailableVariables = useAppSelector(getFindAvailableVariables);
-    const variableTypes = useMemo(() => findAvailableVariables(node.id), [findAvailableVariables, node.id]);
+    const variableTypesFromNode = useMemo(() => findAvailableVariables(node.id), [findAvailableVariables, node.id]);
+    const variableTypes = variableTypesProp ?? variableTypesFromNode;
 
     const buildProbeNode = useMemo(() => {
         if (!paramName) return undefined;
@@ -53,13 +61,15 @@ export function SpelExpressionBuilderComponent({
     }, [node, paramName]);
 
     const ioContext = useInputOutputContext();
-    const contextData = useMemo<ContextData | undefined>(() => {
+    const contextDataFromIo = useMemo<ContextData | undefined>(() => {
+        if (contextDataProp !== undefined) return undefined;
         const [contexts] = ioContext?.getAvailableContexts("input") ?? [[]];
         if (!contexts.length) return undefined;
         const selected = ioContext?.state.inputDataSetId ? contexts.find((c) => c.id === ioContext.state.inputDataSetId) : undefined;
         const vars = (selected ?? contexts[0]).variables;
         return Object.fromEntries(Object.keys(vars).map((k) => [k, vars[k].pretty]));
-    }, [ioContext]);
+    }, [ioContext, contextDataProp]);
+    const contextData = contextDataProp ?? contextDataFromIo;
 
     if (!showDataMapper) return null;
 

--- a/designer/client/src/reducers/userSettings.ts
+++ b/designer/client/src/reducers/userSettings.ts
@@ -49,6 +49,7 @@ export const getDefaultUserSettings = (initialUserFlags?: Record<string, boolean
         createFlag("node.autoApply"),
         createFlag("node.inputsAndOutputs.showBlinkAnimations", true),
         createFlag("node.shortCounts"),
+        createFlag("node.showAssertionExpressionBuilder"),
         createFlag("node.showFieldExpressionBuilder"),
         createFlag("node.showAggregateSwitcher"),
         createFlag("node.showFragmentCreator"),


### PR DESCRIPTION
Combines improvements from 10 PRs (#9232, #9237, #9238, #9239, #9241, #9242, #9244, #9249, #9158, #9161) into a single PR.

## DataMapper improvements

- Do not auto-expand target field definition when opening DataMapper
- Expand dotted param names and Record types into nested DataMapper fields
- Schema mode: hide name/type/add-field controls, show full expression in chip
- Automap fills fields with default/trivial values and traverses Record-typed primitive context vars
- Fix nested SpEL record when switching Kafka sink to raw editor mode
- Fix DataMapper for custom Kafka sinks and correct hideFieldControls
- Expand Record-typed DnD into nested isRecord fields
- Expand dotted keys in fieldsFromSample for From Schema

## Assertions / expression builder improvements

- Improve DnD in assertion Expected and Actual fields
- Expression builder in Actual assertion field

## Test plan

- [ ] Open DataMapper on a Kafka sink with schema — verify field controls are hidden, expression shown in chip
- [ ] DnD a Record-typed variable into DataMapper — verify it expands into nested fields
- [ ] Use automap — verify Record-typed context vars are traversed and default values filled
- [ ] Switch Kafka sink to raw editor and back — verify nested SpEL record generated correctly
- [ ] Drag variable from context tree to assertion Expected/Actual field — verify DnD works
- [ ] Open expression builder in Actual assertion field — verify it works