### PR TITLE
fix: show Unknown-type variables in DataMapper context panel

### DIFF
--- a/designer/client/src/components/dataMapper/useDataMapper.ts
+++ b/designer/client/src/components/dataMapper/useDataMapper.ts
@@ -165,7 +165,12 @@ export function useDataMapper({
                     (elem0 === null || typeof elem0 !== "object" || Object.keys(elem0 as object).length === 0));
             if (lacksStructure) {
                 const sample = typingResultToSample(typingResult);
-                if (sample !== null) merged[key] = sample;
+                if (sample !== null) {
+                    merged[key] = sample;
+                } else if (!(key in merged)) {
+                    // Variable has Unknown type and no live data yet — add as empty object so it appears in the context tree
+                    merged[key] = {};
+                }
             }
         }
         return merged;


### PR DESCRIPTION
## Summary
- Variables with Unknown TypingResult (e.g. for-each output with unknown element type) were silently skipped in `enrichedContext` because `typingResultToSample` returns `null` for Unknown types
- Such variables never appeared in the DataMapper context tree panel
- Fix: when sample is `null` and the variable has no existing value in merged context, fall back to `{}` so the variable is visible in the tree
- When live data is present, `existing` is already populated → fallback is never applied → live data is preserved

## Test plan
- [ ] Open DataMapper on a node downstream of a for-each node (no test run)
- [ ] Verify the for-each output variable appears in the context panel (previously missing)
- [ ] Run tests with sample data, verify the variable shows real fields from live data (not empty `{}`)
- [ ] Verify other typed variables still show their correct structure from typing info