### PR TITLE
Generalize devModel's `StatefulTransformer`

### DIFF
--- a/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/StatefulTransformer.scala
+++ b/engine/flink/management/dev-model/src/main/scala/pl/touk/nussknacker/engine/management/sample/transformer/StatefulTransformer.scala
@@ -14,6 +14,7 @@ import pl.touk.nussknacker.engine.api.{
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.flink.api.datastream.DataStreamImplicits.DataStreamExtension
 import pl.touk.nussknacker.engine.flink.api.process.{FlinkCustomNodeContext, FlinkCustomStreamTransformation}
+import pl.touk.nussknacker.engine.flink.api.typeinformation.TypeInformationDetection
 
 import java.util
 
@@ -28,20 +29,17 @@ case object StatefulTransformer extends CustomStreamTransformer with LazyLogging
     FlinkCustomStreamTransformation((start: DataStream[Context], ctx: FlinkCustomNodeContext) => {
       start
         .groupBy(groupBy, groupByParameterName)(ctx)
-        .mapWithState[ValueWithContext[AnyRef], util.List[String]] {
-          case (StringFromIr(ir, sr), oldState) =>
-            logger.info(s"received: $sr, current state: $oldState")
-            val nList = oldState.getOrElse(new util.ArrayList[String]())
-            nList.add(sr)
+        .mapWithState[ValueWithContext[AnyRef], util.List[AnyRef]] { (valueWithContext, oldState) =>
+          val input = valueWithContext.context.apply[AnyRef]("input")
+          logger.info(s"received: $input, current state: $oldState")
+          val nList = oldState.getOrElse(new util.ArrayList[AnyRef]())
+          nList.add(input)
 
-            (ValueWithContext(nList, ir.context), Some(nList))
-          case _ => throw new IllegalStateException()
-        }(ctx.valueWithContextInfo.forUnknown, Types.LIST(Types.STRING))
+          (ValueWithContext(nList, valueWithContext.context), Some(nList))
+        }(
+          ctx.valueWithContextInfo.forUnknown,
+          Types.LIST(TypeInformationDetection.instance.forType(ctx.asOneOutputContext("input")))
+        )
     })
-
-  object StringFromIr {
-    def unapply(ir: ValueWithContext[_]): Option[(ValueWithContext[_], String)] =
-      Some(ir, ir.context.apply[String]("input"))
-  }
 
 }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
@@ -265,7 +265,7 @@ trait BaseFlinkDeploymentManagerSpec
   test("cancel of not existing job should not fail") {
     deploymentManager
       .processCommand(DMCancelScenarioCommand(ProcessName("not existing job"), user = userToAct))
-      .futureValue shouldBe (())
+      .futureValue shouldBe ()
   }
 
   test("save state when redeploying") {
@@ -385,14 +385,14 @@ trait BaseFlinkDeploymentManagerSpec
 
       logger.info("Starting to redeploy")
 
-      val statefullProcess = StatefulSampleProcess.prepareProcessWithLongState(processName)
+      val statefulProcess = StatefulSampleProcess.prepareProcessWithLongState(processName)
       val exception =
         deploymentManager
           .processCommand(
             DMRunDeploymentCommand(
               empty(process.name),
               defaultDeploymentData,
-              statefullProcess,
+              statefulProcess,
               DeploymentUpdateStrategy.ReplaceDeploymentWithSameScenarioName(
                 StateRestoringStrategy.RestoreStateFromReplacedJobSavepoint
               )


### PR DESCRIPTION
## Describe your changes

Makes `StatefulTransformer` useful for non-String inputs

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
