### PR TITLE
Better validation error message for UnknownHostException from Schema Registry client

### DIFF
--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/SchemaRegistryError.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/SchemaRegistryError.scala
@@ -5,6 +5,10 @@ final case class SchemaTopicError(message: String)   extends RuntimeException(me
 final case class SchemaVersionError(message: String) extends RuntimeException(message) with SchemaRegistryError
 final case class SchemaError(message: String)        extends RuntimeException(message) with SchemaRegistryError
 
+final case class UnknownHostError(message: String, cause: Throwable)
+    extends RuntimeException(message, cause)
+    with SchemaRegistryError
+
 final case class SchemaRegistryUnknownError(message: String, cause: Throwable)
     extends RuntimeException(message, cause)
     with SchemaRegistryError

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/confluent/client/ConfluentSchemaRegistryClient.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/confluent/client/ConfluentSchemaRegistryClient.scala
@@ -16,6 +16,7 @@ import pl.touk.nussknacker.engine.kafka.{SchemaRegistryClientKafkaConfig, Unspec
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry._
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.ConfluentUtils
 
+import java.net.UnknownHostException
 import scala.jdk.CollectionConverters._
 
 trait ConfluentSchemaRegistryClient extends SchemaRegistryClient with LazyLogging {
@@ -34,6 +35,9 @@ trait ConfluentSchemaRegistryClient extends SchemaRegistryClient with LazyLoggin
         invalid(SchemaVersionError("Schema version doesn't exist."))
       case exc: RestClientException if exc.getErrorCode == schemaNotFoundCode =>
         invalid(SchemaError("Schema doesn't exist."))
+      case exc: UnknownHostException =>
+        logger.error(s"Cannot resolve Schema Registry host: ${exc.getMessage}", exc)
+        invalid(UnknownHostError(s"Cannot resolve Schema Registry host: ${exc.getMessage}.", exc))
       case exc: Throwable =>
         logger.error("Unknown error on fetching schema data.", exc)
         invalid(SchemaRegistryUnknownError("Unknown error on fetching schema data.", exc))


### PR DESCRIPTION
## Describe your changes

Show a readable error message on name resolution failure instead of a generic "Unknown error on fetching schema data.". It's easy to encounter this when developing tests.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
