### PR TITLE
Add `MockAzureSchemaRegistryClient`

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -360,6 +360,7 @@ description: Stay informed with detailed changelogs covering new features, impro
   Can be configured by implementing TypingConfigurationProvider and registering it as SPI.
   By default, the existing permissive behavior is preserved.
 * [#9286](https://github.com/TouK/nussknacker/pull/9286) Fixed handling of Avro records in Flink SQL component.
+* [#9322](https://github.com/TouK/nussknacker/pull/9322) Added mockable Azure Schema Registry client
 
 ## 1.18
 

--- a/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/AzureSchemaRegistryKafkaAvroTest.scala
+++ b/engine/lite/components/kafka-tests/src/test/scala/pl/touk/nussknacker/engine/lite/components/AzureSchemaRegistryKafkaAvroTest.scala
@@ -28,11 +28,8 @@ import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransforme
   topicParamName
 }
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{SchemaId, SchemaVersionOption}
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.{
-  AzureSchemaRegistryClientFactory,
-  AzureUtils,
-  SchemaNameTopicMatchStrategy
-}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.{AzureUtils, SchemaNameTopicMatchStrategy}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client.AzureSchemaRegistryClientFactory
 import pl.touk.nussknacker.engine.spel.SpelExtension._
 import pl.touk.nussknacker.engine.util.test.TestScenarioRunner
 import pl.touk.nussknacker.engine.util.test.TestScenarioRunner.RunnerListResult

--- a/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaComponentsConfig.scala
+++ b/utils/kafka-utils/src/main/scala/pl/touk/nussknacker/engine/kafka/KafkaComponentsConfig.scala
@@ -11,8 +11,8 @@ import scala.concurrent.duration._
 
 case class SchemaRegistryClientKafkaConfig(
     kafkaProperties: Map[String, String],
-    cacheConfig: SchemaRegistryCacheConfig,
-    avroAsJsonSerialization: Option[Boolean]
+    cacheConfig: SchemaRegistryCacheConfig = SchemaRegistryCacheConfig(),
+    avroAsJsonSerialization: Option[Boolean] = None
 )
 
 case class KafkaComponentsConfig(

--- a/utils/lite-components-testkit/src/main/scala/pl/touk/nussknacker/engine/lite/util/test/LiteKafkaTestScenarioRunner.scala
+++ b/utils/lite-components-testkit/src/main/scala/pl/touk/nussknacker/engine/lite/util/test/LiteKafkaTestScenarioRunner.scala
@@ -26,7 +26,7 @@ import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{
   SchemaRegistryClientFactoryWithRegistration,
   SchemaRegistryClientWithRegistration
 }
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.AzureSchemaRegistryClient
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client.AzureSchemaRegistryClient
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.ConfluentUtils
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.{
   ConfluentSchemaRegistryClient,

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/SchemaRegistryClient.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/SchemaRegistryClient.scala
@@ -17,10 +17,6 @@ trait SchemaRegistryClient {
 
   /**
     * Latest fresh schema by topic - it should be always fresh schema
-    *
-    * @param topic
-    * @param isKey
-    * @return
     */
   protected def getLatestFreshSchema(
       topic: UnspecializedTopicName,
@@ -53,9 +49,9 @@ trait SchemaRegistryClient {
 
 }
 
-object EmptySchemaRegistry extends SchemaRegistryClient {
+object EmptySchemaRegistry extends SchemaRegistryClientWithRegistration {
 
-  private val errorMessage = "There is no schema in empty schema registry";
+  private val errorMessage = "There is no schema in empty schema registry"
   private val error        = SchemaError(errorMessage)
 
   override def getSchemaById(id: SchemaId): SchemaWithMetadata = throw new IllegalStateException(errorMessage)
@@ -77,6 +73,9 @@ object EmptySchemaRegistry extends SchemaRegistryClient {
       topic: UnspecializedTopicName,
       isKey: Boolean
   ): Validated[SchemaRegistryError, List[Integer]] = Validated.Invalid(error)
+
+  override def registerSchema(topic: UnspecializedTopicName, isKey: Boolean, schema: ParsedSchema): SchemaId =
+    throw new IllegalStateException(errorMessage)
 
 }
 

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/AzureSchemaRegistryClient.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/AzureSchemaRegistryClient.scala
@@ -1,0 +1,74 @@
+package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client
+
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
+import com.azure.data.schemaregistry.models.SchemaProperties
+import com.typesafe.scalalogging.LazyLogging
+import io.confluent.kafka.schemaregistry.ParsedSchema
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import org.apache.avro.Schema
+import pl.touk.nussknacker.engine.kafka.UnspecializedTopicName
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{
+  SchemaId,
+  SchemaRegistryClientWithRegistration,
+  SchemaRegistryError,
+  SchemaTopicError
+}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.SchemaNameTopicMatchStrategy
+
+trait AzureSchemaRegistryClient extends SchemaRegistryClientWithRegistration with LazyLogging {
+
+  protected def checkAvroSchema(schema: ParsedSchema): AvroSchema = {
+    schema match {
+      case avroSchema: AvroSchema => avroSchema
+      case _ => throw new IllegalArgumentException("Currently only avro schema is supported for Azure implementation")
+    }
+  }
+
+  protected def getOneMatchingSchemaName(
+      topicName: UnspecializedTopicName,
+      isKey: Boolean
+  ): Validated[SchemaRegistryError, String] = {
+    getAllFullSchemaNames.andThen { fullSchemaNames =>
+      val matchingFullSchemaNames = SchemaNameTopicMatchStrategy.getMatchingSchemas(topicName, fullSchemaNames, isKey)
+      matchingFullSchemaNames match {
+        case one :: Nil =>
+          Valid(one)
+        case Nil =>
+          Invalid(SchemaTopicError(s"Schema for topic: $topicName not found"))
+        case moreThenOnce =>
+          // We can't pick one in this case because there is no option to recognize which one is newer.
+          // I've tried to parse schemaId to UUID but it is saved in Version 4 UUID format (random) and has no timestamp
+          Invalid(SchemaTopicError(s"Ambiguous schemas: ${moreThenOnce.mkString(", ")} for topic: $topicName"))
+      }
+    }
+  }
+
+  protected def getAllFullSchemaNames: Validated[SchemaRegistryError, List[String]]
+
+  override def registerSchema(topicName: UnspecializedTopicName, isKey: Boolean, schema: ParsedSchema): SchemaId = {
+    val schemaNameBasedOnTopic = SchemaNameTopicMatchStrategy.schemaNameFromTopicName(topicName, isKey)
+    val avroSchema             = checkAvroSchema(schema).rawSchema()
+    if (avroSchema.getType == Schema.Type.RECORD) {
+      require(
+        avroSchema.getName == schemaNameBasedOnTopic,
+        s"Invalid record schema name ${avroSchema.getName} Should be: $schemaNameBasedOnTopic."
+      )
+    } else {
+      // for primitive types we have to register schema on two names - one for listing of topics purpose and second one based on name, to be possible to serialize such object
+      // by KafkaAvroSerializer - it just lookup into schema registry based on schema's full name. Can be tricky which one id is returned - in most cases it easy better
+      // to return this based on name
+      registerSchemaVersionIfNotExists(schema, Some(schemaNameBasedOnTopic))
+    }
+    SchemaId.fromString(registerSchemaVersionIfNotExists(schema).getId)
+  }
+
+  // forceSchemaNameOpt is for special purposes like primitive schemas when there is no name
+  def registerSchemaVersionIfNotExists(
+      schema: ParsedSchema,
+      forceSchemaNameOpt: Option[String] = None
+  ): SchemaProperties
+
+  def getSchemaIdByContent(schema: AvroSchema): SchemaId
+
+}

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/AzureSchemaRegistryClientFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/AzureSchemaRegistryClientFactory.scala
@@ -1,0 +1,14 @@
+package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client
+
+import pl.touk.nussknacker.engine.kafka._
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry._
+
+object AzureSchemaRegistryClientFactory extends SchemaRegistryClientFactoryWithRegistration {
+
+  override type SchemaRegistryClientT = AzureSchemaRegistryClient
+
+  override def create(config: SchemaRegistryClientKafkaConfig): SchemaRegistryClientT = {
+    new DefaultAzureSchemaRegistryClient(config)
+  }
+
+}

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/DefaultAzureSchemaRegistryClient.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/DefaultAzureSchemaRegistryClient.scala
@@ -10,10 +10,27 @@ import com.azure.data.schemaregistry.models.{SchemaFormat, SchemaProperties, Sch
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import org.apache.commons.io.IOUtils
-import pl.touk.nussknacker.engine.kafka.{KafkaComponentsConfig, KafkaUtils, SchemaRegistryClientKafkaConfig, UnspecializedTopicName}
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{SchemaId, SchemaRegistryError, SchemaRegistryUnknownError, SchemaVersionError, SchemaWithMetadata}
+import pl.touk.nussknacker.engine.kafka.{
+  KafkaComponentsConfig,
+  KafkaUtils,
+  SchemaRegistryClientKafkaConfig,
+  UnspecializedTopicName
+}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{
+  SchemaId,
+  SchemaRegistryError,
+  SchemaRegistryUnknownError,
+  SchemaVersionError,
+  SchemaWithMetadata
+}
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.SchemaNameTopicMatchStrategy
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.internal.{AzureConfigurationFactory, AzureHttpPipelineFactory, AzureTokenCredentialFactory, EnhancedSchemasImpl, SchemaRegistryJsonSerializer}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.internal.{
+  AzureConfigurationFactory,
+  AzureHttpPipelineFactory,
+  AzureTokenCredentialFactory,
+  EnhancedSchemasImpl,
+  SchemaRegistryJsonSerializer
+}
 import reactor.core.publisher.Mono
 
 import java.nio.charset.StandardCharsets
@@ -69,9 +86,9 @@ class DefaultAzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) 
   }
 
   override protected def getLatestFreshSchema(
-                                               topicName: UnspecializedTopicName,
-                                               isKey: Boolean
-                                             ): Validated[SchemaRegistryError, SchemaWithMetadata] = {
+      topicName: UnspecializedTopicName,
+      isKey: Boolean
+  ): Validated[SchemaRegistryError, SchemaWithMetadata] = {
     getOneMatchingSchemaName(topicName, isKey).andThen { fullSchemaName =>
       try {
         FluxUtil
@@ -101,9 +118,9 @@ class DefaultAzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) 
   }
 
   override def getAllVersions(
-                               topicName: UnspecializedTopicName,
-                               isKey: Boolean
-                             ): Validated[SchemaRegistryError, List[Integer]] = {
+      topicName: UnspecializedTopicName,
+      isKey: Boolean
+  ): Validated[SchemaRegistryError, List[Integer]] = {
     getOneMatchingSchemaName(topicName, isKey).andThen(getVersions)
   }
 
@@ -126,9 +143,9 @@ class DefaultAzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) 
   }
 
   override def registerSchemaVersionIfNotExists(
-                                        schema: ParsedSchema,
-                                        forceSchemaNameOpt: Option[String] = None
-                                      ): SchemaProperties = {
+      schema: ParsedSchema,
+      forceSchemaNameOpt: Option[String] = None
+  ): SchemaProperties = {
     val avroSchema   = checkAvroSchema(schema).rawSchema()
     val schemaString = schema.canonicalString()
     val name         = forceSchemaNameOpt.getOrElse(avroSchema.getFullName)

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/DefaultAzureSchemaRegistryClient.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/DefaultAzureSchemaRegistryClient.scala
@@ -1,4 +1,4 @@
-package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure
+package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client
 
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
@@ -9,29 +9,19 @@ import com.azure.data.schemaregistry.implementation.models.SchemasGetByIdRespons
 import com.azure.data.schemaregistry.models.{SchemaFormat, SchemaProperties, SchemaRegistrySchema}
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import org.apache.avro.Schema
 import org.apache.commons.io.IOUtils
-import pl.touk.nussknacker.engine.kafka._
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry._
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.internal._
+import pl.touk.nussknacker.engine.kafka.{KafkaComponentsConfig, KafkaUtils, SchemaRegistryClientKafkaConfig, UnspecializedTopicName}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{SchemaId, SchemaRegistryError, SchemaRegistryUnknownError, SchemaVersionError, SchemaWithMetadata}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.SchemaNameTopicMatchStrategy
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.internal.{AzureConfigurationFactory, AzureHttpPipelineFactory, AzureTokenCredentialFactory, EnhancedSchemasImpl, SchemaRegistryJsonSerializer}
 import reactor.core.publisher.Mono
 
 import java.nio.charset.StandardCharsets
-import scala.compat.java8.FunctionConverters._
+import scala.compat.java8.FunctionConverters.asJavaFunction
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
-object AzureSchemaRegistryClientFactory extends SchemaRegistryClientFactoryWithRegistration {
-
-  override type SchemaRegistryClientT = AzureSchemaRegistryClient
-
-  override def create(config: SchemaRegistryClientKafkaConfig): SchemaRegistryClientT = {
-    new AzureSchemaRegistryClient(config)
-  }
-
-}
-
-class AzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) extends SchemaRegistryClientWithRegistration {
+class DefaultAzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) extends AzureSchemaRegistryClient {
 
   private val azureConfiguration      = AzureConfigurationFactory.createFromKafkaProperties(config.kafkaProperties)
   private val credential              = AzureTokenCredentialFactory.createCredential(azureConfiguration)
@@ -54,7 +44,7 @@ class AzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) extends
   )
 
   override def getSchemaById(id: SchemaId): SchemaWithMetadata = {
-    toSchemaWithMetada(schemaRegistryClient.getSchema(id.asString))
+    toSchemaWithMetadata(schemaRegistryClient.getSchema(id.asString))
   }
 
   override protected def getByTopicAndVersion(
@@ -70,18 +60,18 @@ class AzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) extends
           case NonFatal(ex) => Invalid(SchemaVersionError(ex.getMessage))
         }
       }
-      .map(toSchemaWithMetada)
+      .map(toSchemaWithMetadata)
 
   }
 
-  private def toSchemaWithMetada(result: SchemaRegistrySchema) = {
+  private def toSchemaWithMetadata(result: SchemaRegistrySchema) = {
     SchemaWithMetadata(new AvroSchema(result.getDefinition), SchemaId.fromString(result.getProperties.getId))
   }
 
   override protected def getLatestFreshSchema(
-      topicName: UnspecializedTopicName,
-      isKey: Boolean
-  ): Validated[SchemaRegistryError, SchemaWithMetadata] = {
+                                               topicName: UnspecializedTopicName,
+                                               isKey: Boolean
+                                             ): Validated[SchemaRegistryError, SchemaWithMetadata] = {
     getOneMatchingSchemaName(topicName, isKey).andThen { fullSchemaName =>
       try {
         FluxUtil
@@ -111,9 +101,9 @@ class AzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) extends
   }
 
   override def getAllVersions(
-      topicName: UnspecializedTopicName,
-      isKey: Boolean
-  ): Validated[SchemaRegistryError, List[Integer]] = {
+                               topicName: UnspecializedTopicName,
+                               isKey: Boolean
+                             ): Validated[SchemaRegistryError, List[Integer]] = {
     getOneMatchingSchemaName(topicName, isKey).andThen(getVersions)
   }
 
@@ -125,59 +115,20 @@ class AzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) extends
       .map(UnspecializedTopicName.apply)
   }
 
-  private def getOneMatchingSchemaName(
-      topicName: UnspecializedTopicName,
-      isKey: Boolean
-  ): Validated[SchemaRegistryError, String] = {
-    getAllFullSchemaNames.andThen { fullSchemaNames =>
-      val matchingFullSchemaNames = SchemaNameTopicMatchStrategy.getMatchingSchemas(topicName, fullSchemaNames, isKey)
-      matchingFullSchemaNames match {
-        case one :: Nil =>
-          Valid(one)
-        case Nil =>
-          Invalid(SchemaTopicError(s"Schema for topic: $topicName not found"))
-        case moreThenOnce =>
-          // We can't pick one in this case because there is no option to recognize which one is newer.
-          // I've tried to parse schemaId to UUID but it is saved in Version 4 UUID format (random) and has no timestamp
-          Invalid(SchemaTopicError(s"Ambiguous schemas: ${moreThenOnce.mkString(", ")} for topic: $topicName"))
-      }
-    }
-  }
-
   private def getVersions(fullSchemaName: String): Validated[SchemaRegistryError, List[Integer]] = {
     invokeBlocking(enhancedSchemasService.getVersionsWithResponseAsync(schemaGroup, fullSchemaName, _))
       .map(_.getValue.getSchemaVersions().asScala.toList)
   }
 
-  private def getAllFullSchemaNames: Validated[SchemaRegistryError, List[String]] = {
+  override protected def getAllFullSchemaNames: Validated[SchemaRegistryError, List[String]] = {
     invokeBlocking(enhancedSchemasService.getSchemasWithResponseAsync(schemaGroup, _))
       .map(_.getValue.getSchemas().asScala.toList)
   }
 
-  override def registerSchema(topicName: UnspecializedTopicName, isKey: Boolean, schema: ParsedSchema): SchemaId = {
-    val schemaNameBasedOnTopic = SchemaNameTopicMatchStrategy.schemaNameFromTopicName(topicName, isKey)
-    val avroSchema             = checkAvroSchema(schema).rawSchema()
-    if (avroSchema.getType == Schema.Type.RECORD) {
-      require(
-        avroSchema.getName == schemaNameBasedOnTopic,
-        s"Invalid record schema name ${avroSchema.getName} Should be: $schemaNameBasedOnTopic."
-      )
-      SchemaId.fromString(registerSchemaVersionIfNotExists(schema).getId)
-    } else {
-      // for primitive types we have to register schema on two names - one for listing of topics purpose and second one based on name, to be possible to serialize such object
-      // by KafkaAvroSerializer - it just lookup into schema registry based on schema's full name. Can be tricky which one id is returned - in most cases it easy better
-      // to return this based on name
-      registerSchemaVersionIfNotExists(schema, Some(schemaNameBasedOnTopic))
-      SchemaId.fromString(registerSchemaVersionIfNotExists(schema).getId)
-    }
-
-  }
-
-  // forceSchemaNameOpt is for special purposes like primitive schemas when there is no name
-  def registerSchemaVersionIfNotExists(
-      schema: ParsedSchema,
-      forceSchemaNameOpt: Option[String] = None
-  ): SchemaProperties = {
+  override def registerSchemaVersionIfNotExists(
+                                        schema: ParsedSchema,
+                                        forceSchemaNameOpt: Option[String] = None
+                                      ): SchemaProperties = {
     val avroSchema   = checkAvroSchema(schema).rawSchema()
     val schemaString = schema.canonicalString()
     val name         = forceSchemaNameOpt.getOrElse(avroSchema.getFullName)
@@ -189,19 +140,12 @@ class AzureSchemaRegistryClient(config: SchemaRegistryClientKafkaConfig) extends
     }
   }
 
-  def getSchemaIdByContent(schema: AvroSchema): SchemaId = {
+  override def getSchemaIdByContent(schema: AvroSchema): SchemaId = {
     SchemaId.fromString(
       schemaRegistryClient
         .getSchemaProperties(schemaGroup, schema.rawSchema().getFullName, schema.canonicalString(), SchemaFormat.AVRO)
         .getId
     )
-  }
-
-  private def checkAvroSchema(schema: ParsedSchema): AvroSchema = {
-    schema match {
-      case avroSchema: AvroSchema => avroSchema
-      case _ => throw new IllegalArgumentException("Currently only avro schema is supported for Azure implementation")
-    }
   }
 
   private def invokeBlocking[T](f: Context => Mono[T]): Validated[SchemaRegistryError, T] = {

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/MockAzureSchemaRegistryClient.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/MockAzureSchemaRegistryClient.scala
@@ -1,0 +1,166 @@
+package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client
+
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
+import com.azure.core.exception.ResourceNotFoundException
+import com.azure.data.schemaregistry.models.{SchemaFormat, SchemaProperties}
+import io.confluent.kafka.schemaregistry.ParsedSchema
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import org.apache.avro.Schema
+import pl.touk.nussknacker.engine.kafka.UnspecializedTopicName
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{
+  SchemaId,
+  SchemaRegistryError,
+  SchemaTopicError,
+  SchemaVersionError,
+  SchemaWithMetadata
+}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.SchemaNameTopicMatchStrategy
+
+import java.lang.reflect.Constructor
+import java.util.UUID
+import scala.collection.mutable
+
+/**
+ * Mock implementation of Schema Registry client for Azure that can be used for tests. This version is NOT thread safe.
+ * Schema data is stored in memory and is not persistent or shared across instances.
+ */
+class MockAzureSchemaRegistryClient extends AzureSchemaRegistryClient {
+
+  private val schemasById          = mutable.Map.empty[String, ParsedSchema]
+  private val versionsBySchemaName = mutable.Map.empty[String, mutable.ArrayBuffer[StoredSchema]]
+  private val registeredTopics     = mutable.Set.empty[UnspecializedTopicName]
+
+  override def getSchemaById(id: SchemaId): SchemaWithMetadata = {
+    val schema = schemasById.getOrElse(id.asString, throw new IllegalArgumentException(s"Schema with id $id not found"))
+    SchemaWithMetadata(schema, id)
+  }
+
+  override protected def getByTopicAndVersion(
+      topic: UnspecializedTopicName,
+      version: Int,
+      isKey: Boolean
+  ): Validated[SchemaRegistryError, SchemaWithMetadata] =
+    getOneMatchingSchemaName(topic, isKey).andThen { name =>
+      versionsBySchemaName.getOrElse(name, mutable.ArrayBuffer.empty).find(_.version == version) match {
+        case Some(stored) => Valid(SchemaWithMetadata(stored.schema, SchemaId.fromString(stored.id)))
+        case None         => Invalid(SchemaVersionError(s"Version $version of schema $name not found"))
+      }
+    }
+
+  override protected def getLatestFreshSchema(
+      topic: UnspecializedTopicName,
+      isKey: Boolean
+  ): Validated[SchemaRegistryError, SchemaWithMetadata] =
+    getOneMatchingSchemaName(topic, isKey).andThen { name =>
+      versionsBySchemaName.getOrElse(name, mutable.ArrayBuffer.empty).maxByOption(_.version) match {
+        case Some(stored) => Valid(SchemaWithMetadata(stored.schema, SchemaId.fromString(stored.id)))
+        case None         => Invalid(SchemaTopicError(s"Schema for topic: $topic not found"))
+      }
+    }
+
+  override def getAllTopics: Validated[SchemaRegistryError, List[UnspecializedTopicName]] = {
+    val matchStrategy = SchemaNameTopicMatchStrategy(registeredTopics.toList)
+    getAllFullSchemaNames.map(matchStrategy.getAllMatchingTopics(_, isKey = false))
+  }
+
+  override def getAllVersions(
+      topic: UnspecializedTopicName,
+      isKey: Boolean
+  ): Validated[SchemaRegistryError, List[Integer]] =
+    getOneMatchingSchemaName(topic, isKey).map { name =>
+      versionsBySchemaName
+        .getOrElse(name, mutable.ArrayBuffer.empty)
+        .map(_.version)
+        .map(Integer.valueOf)
+        .toList
+    }
+
+  def register(
+      topic: UnspecializedTopicName,
+      isKey: Boolean,
+      schema: ParsedSchema,
+      version: Integer = null,
+      id: String = null
+  ): SchemaId = {
+    val schemaNameBasedOnTopic = SchemaNameTopicMatchStrategy.schemaNameFromTopicName(topic, isKey)
+    val avroSchema             = checkAvroSchema(schema).rawSchema()
+    if (avroSchema.getType != Schema.Type.RECORD) {
+      storeIfAbsent(schema, Some(schemaNameBasedOnTopic), Option(version), Option(id))
+    }
+    registeredTopics.add(topic)
+    SchemaId.fromString(storeIfAbsent(schema, Some(avroSchema.getFullName), Option(version), Option(id)).getId)
+  }
+
+  override protected def getAllFullSchemaNames: Validated[SchemaRegistryError, List[String]] =
+    Valid(versionsBySchemaName.keys.toList)
+
+  override def registerSchema(topicName: UnspecializedTopicName, isKey: Boolean, schema: ParsedSchema): SchemaId = {
+    val schemaId = super.registerSchema(topicName, isKey, schema)
+    registeredTopics.add(topicName)
+    schemaId
+  }
+
+  override def registerSchemaVersionIfNotExists(
+      schema: ParsedSchema,
+      forceSchemaNameOpt: Option[String] = None
+  ): SchemaProperties = {
+    storeIfAbsent(schema, forceSchemaNameOpt)
+  }
+
+  private def storeIfAbsent(
+      schema: ParsedSchema,
+      fullName: Option[String] = None,
+      version: Option[Int] = None,
+      id: Option[String] = None
+  ): SchemaProperties = synchronized {
+    val normalizedSchema = schema.normalize()
+
+    val storedId = id
+      .orElse(schemasById.find({ case (_, schema) => schema == normalizedSchema }).map(_._1))
+      .getOrElse(UUID.randomUUID().toString)
+    val storedName = fullName.getOrElse(checkAvroSchema(schema).rawSchema().getFullName)
+
+    val buf = versionsBySchemaName.getOrElseUpdate(storedName, mutable.ArrayBuffer.empty)
+    val storedSchema = buf.find(_.schema == normalizedSchema) match {
+      case Some(existing) =>
+        existing
+      case None =>
+        val newVersion = version.orElse(buf.maxByOption(_.version).map(_.version + 1)).getOrElse(1)
+        val stored     = StoredSchema(storedId, newVersion, storedName, normalizedSchema)
+        buf.append(stored)
+        if (!schemasById.contains(storedId)) {
+          schemasById.put(storedId, normalizedSchema)
+        }
+        stored
+    }
+
+    createSchemaProperties(storedSchema, storedName)
+  }
+
+  override def getSchemaIdByContent(schema: AvroSchema): SchemaId = {
+    val fullName         = schema.rawSchema().getFullName
+    val normalizedSchema = schema.normalize()
+    versionsBySchemaName
+      .get(fullName)
+      .orElse(throw new ResourceNotFoundException(s"Cannot find a matching schema for $fullName", null))
+      .flatMap(_.find(_.schema == normalizedSchema))
+      .map(_.id)
+      .map(SchemaId.fromString)
+      .getOrElse(throw new ResourceNotFoundException(s"Cannot find a matching schema version for $fullName", null))
+  }
+
+  private def createSchemaProperties(storedSchema: StoredSchema, fullName: String): SchemaProperties = {
+    val constructor = classOf[SchemaProperties].getDeclaredConstructors
+      .find(_.getParameterCount == 5)
+      .get
+      .asInstanceOf[Constructor[SchemaProperties]]
+    constructor.setAccessible(true)
+    // call private constructor - doing it the normal way would require manual construction of HTTP response objects
+    // SchemaProperties(String id, SchemaFormat format, String groupName, String name, int version) constructor
+    constructor.newInstance(storedSchema.id, SchemaFormat.AVRO, "mockGroup", fullName, storedSchema.version)
+  }
+
+}
+
+private[client] case class StoredSchema(id: String, version: Int, name: String, schema: ParsedSchema)

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/MockAzureSchemaRegistryClientBuilder.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/MockAzureSchemaRegistryClientBuilder.scala
@@ -1,0 +1,37 @@
+package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client
+
+import io.confluent.kafka.schemaregistry.ParsedSchema
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import org.apache.avro.Schema
+import pl.touk.nussknacker.engine.kafka.UnspecializedTopicName
+
+import scala.collection.mutable.ListBuffer
+
+class MockAzureSchemaRegistryClientBuilder {
+
+  private val registry: ListBuffer[RegistryItem] = ListBuffer()
+
+  def register(
+      topic: String,
+      schema: Schema,
+      version: Int,
+      isKey: Boolean,
+      schemaId: String = null
+  ): MockAzureSchemaRegistryClientBuilder = {
+    registry.append(RegistryItem(topic, new AvroSchema(schema), version, isKey, schemaId))
+    this
+  }
+
+  def build: MockAzureSchemaRegistryClient = {
+    val client = new MockAzureSchemaRegistryClient
+    registry.foreach(reg => register(client, reg))
+    client
+  }
+
+  private def register(mockSchemaRegistry: MockAzureSchemaRegistryClient, item: RegistryItem): Unit = {
+    mockSchemaRegistry.register(UnspecializedTopicName(item.topic), item.isKey, item.schema, item.version, item.id)
+  }
+
+}
+
+private[client] case class RegistryItem(topic: String, schema: ParsedSchema, version: Int, isKey: Boolean, id: String)

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/MockAzureSchemaRegistryClientFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/MockAzureSchemaRegistryClientFactory.scala
@@ -1,0 +1,15 @@
+package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client
+
+import pl.touk.nussknacker.engine.kafka.SchemaRegistryClientKafkaConfig
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.SchemaRegistryClientFactoryWithRegistration
+
+class MockAzureSchemaRegistryClientFactory(schemaRegistryMockClient: => AzureSchemaRegistryClient)
+    extends SchemaRegistryClientFactoryWithRegistration {
+
+  override type SchemaRegistryClientT = AzureSchemaRegistryClient
+
+  override def create(config: SchemaRegistryClientKafkaConfig): SchemaRegistryClientT = {
+    schemaRegistryMockClient
+  }
+
+}

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/serialization/AzureAvroSerializerFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/serialization/AzureAvroSerializerFactory.scala
@@ -9,7 +9,8 @@ import pl.touk.nussknacker.engine.kafka.KafkaComponentsConfig
 import pl.touk.nussknacker.engine.kafka.serialization.DelegatingKafkaSerializer
 import pl.touk.nussknacker.engine.schemedkafka.schema.DefaultAvroSchemaEvolution
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.SchemaId
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.{AzureSchemaRegistryClient, AzureUtils}
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.AzureUtils
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client.AzureSchemaRegistryClient
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.internal.AzureConfigurationFactory
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.DefaultConfluentSchemaRegistryClient
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.serialization.jsonpayload.ConfluentJsonPayloadKafkaSerializer

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/confluent/client/MockSchemaRegistryClient.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/confluent/client/MockSchemaRegistryClient.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client
 import com.typesafe.scalalogging.LazyLogging
 import io.confluent.kafka.schemaregistry.client.{MockSchemaRegistryClient => CMockSchemaRegistryClient, SchemaMetadata}
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.SchemaRegistryClient
 
 import java.util
 

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/confluent/client/MockSchemaRegistryClientBuilder.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/confluent/client/MockSchemaRegistryClientBuilder.scala
@@ -20,9 +20,17 @@ class MockConfluentSchemaRegistryClientBuilder {
       schema: Schema,
       version: Int,
       isKey: Boolean
+  ): MockConfluentSchemaRegistryClientBuilder = registerWithId(topic, schema, version, isKey, AutoIncId)
+
+  def registerWithId(
+      topic: String,
+      schema: Schema,
+      version: Int,
+      isKey: Boolean,
+      schemaId: Int
   ): MockConfluentSchemaRegistryClientBuilder = {
     val avroSchema = ConfluentUtils.convertToAvroSchema(schema)
-    registry.append(RegistryItem(topic, avroSchema, version, isKey, AutoIncId))
+    registry.append(RegistryItem(topic, avroSchema, version, isKey, schemaId))
     this
   }
 
@@ -31,9 +39,17 @@ class MockConfluentSchemaRegistryClientBuilder {
       schema: JsonSchema,
       version: Int,
       isKey: Boolean
+  ): MockConfluentSchemaRegistryClientBuilder = registerWithId(topic, schema, version, isKey, AutoIncId)
+
+  def registerWithId(
+      topic: String,
+      schema: JsonSchema,
+      version: Int,
+      isKey: Boolean,
+      schemaId: Int
   ): MockConfluentSchemaRegistryClientBuilder = {
     val avroSchema = ConfluentUtils.convertToJsonSchema(schema)
-    registry.append(RegistryItem(topic, avroSchema, version, isKey, AutoIncId))
+    registry.append(RegistryItem(topic, avroSchema, version, isKey, schemaId))
     this
   }
 

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/MockSchemaRegistryClientFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/MockSchemaRegistryClientFactory.scala
@@ -2,11 +2,18 @@ package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal
 
 import io.confluent.kafka.schemaregistry.client.{SchemaRegistryClient => CSchemaRegistryClient}
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.SchemaRegistryClientFactoryWithRegistration
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client.{
+  AzureSchemaRegistryClient,
+  MockAzureSchemaRegistryClientFactory
+}
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.MockConfluentSchemaRegistryClientFactory
 
 object MockSchemaRegistryClientFactory {
 
   def confluentBased(schemaRegistryMockClient: => CSchemaRegistryClient): SchemaRegistryClientFactoryWithRegistration =
     new MockConfluentSchemaRegistryClientFactory(schemaRegistryMockClient)
+
+  def azureBased(schemaRegistryMockClient: => AzureSchemaRegistryClient): SchemaRegistryClientFactoryWithRegistration =
+    new MockAzureSchemaRegistryClientFactory(schemaRegistryMockClient)
 
 }

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/ParsedSchemaSupport.scala
@@ -28,7 +28,7 @@ import pl.touk.nussknacker.engine.schemedkafka.KafkaUniversalComponentTransforme
 import pl.touk.nussknacker.engine.schemedkafka.encode._
 import pl.touk.nussknacker.engine.schemedkafka.schema.{AvroSchemaBasedParameter, DefaultAvroSchemaEvolution}
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.SchemaRegistryClient
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.AzureSchemaRegistryClient
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client.AzureSchemaRegistryClient
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.serialization.AzureAvroSerializerFactory
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.{
   ConfluentSchemaRegistryClient,

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaBasedSerdeProvider.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaBasedSerdeProvider.scala
@@ -6,7 +6,7 @@ import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{
   SchemaRegistryClient,
   SchemaRegistryClientFactory
 }
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.AzureSchemaRegistryClient
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client.AzureSchemaRegistryClient
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.schemaid.SchemaIdFromAzureHeader
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.ConfluentSchemaRegistryClient
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.schemaid.{

--- a/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaRegistryClientFactory.scala
+++ b/utils/schemed-kafka-components-utils/src/main/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/universal/UniversalSchemaRegistryClientFactory.scala
@@ -6,7 +6,7 @@ import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{
   SchemaRegistryClient,
   SchemaRegistryClientFactory
 }
-import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.AzureSchemaRegistryClientFactory
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client.AzureSchemaRegistryClientFactory
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.confluent.client.CachedConfluentSchemaRegistryClientFactory
 
 object UniversalSchemaRegistryClientFactory extends UniversalSchemaRegistryClientFactory

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/AzureTestsFromFileIntegrationTest.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/AzureTestsFromFileIntegrationTest.scala
@@ -17,6 +17,7 @@ import pl.touk.nussknacker.engine.kafka.{KafkaComponentsConfig, UnspecializedTop
 import pl.touk.nussknacker.engine.kafka.UnspecializedTopicName.ToUnspecializedTopicName
 import pl.touk.nussknacker.engine.schemedkafka.AvroUtils
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.SchemaId
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client.AzureSchemaRegistryClientFactory
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.universal.{
   UniversalSchemaBasedSerdeProvider,
   UniversalSchemaRegistryClientFactory

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/AzureSchemaRegistryClientIntegrationTest.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/AzureSchemaRegistryClientIntegrationTest.scala
@@ -1,21 +1,16 @@
-package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure
+package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.avro.reflect.ReflectData
+import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.kafka.clients.admin.NewTopic
 import org.scalatest.OptionValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.tags.Network
-import pl.touk.nussknacker.engine.kafka.{
-  KafkaComponentsConfig,
-  KafkaUtils,
-  SchemaRegistryCacheConfig,
-  SchemaRegistryClientKafkaConfig,
-  UnspecializedTopicName
-}
+import pl.touk.nussknacker.engine.kafka._
 import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.ExistingSchemaVersion
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.SchemaNameTopicMatchStrategy
 import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage
 
 import java.util.Collections
@@ -45,8 +40,7 @@ class AzureSchemaRegistryClientIntegrationTest
       "schema.group"        -> "test-group",
     )
 
-  private val schemaRegistryConfig =
-    SchemaRegistryClientKafkaConfig(kafkaPropertiesConfigMap, SchemaRegistryCacheConfig(), None)
+  private val schemaRegistryConfig = SchemaRegistryClientKafkaConfig(kafkaPropertiesConfigMap)
   private val schemaRegistryClient = AzureSchemaRegistryClientFactory.create(schemaRegistryConfig)
 
   test("getAllTopics should return topic for corresponding schema based on schema name") {

--- a/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/MockAzureSchemaRegistryClientTest.scala
+++ b/utils/schemed-kafka-components-utils/src/test/scala/pl/touk/nussknacker/engine/schemedkafka/schemaregistry/azure/client/MockAzureSchemaRegistryClientTest.scala
@@ -1,0 +1,161 @@
+package pl.touk.nussknacker.engine.schemedkafka.schemaregistry.azure.client
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import org.apache.avro.SchemaBuilder
+import org.scalatest.OptionValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pl.touk.nussknacker.engine.kafka.UnspecializedTopicName
+import pl.touk.nussknacker.engine.schemedkafka.schemaregistry.{
+  ExistingSchemaVersion,
+  LatestSchemaVersion,
+  SchemaId,
+  SchemaTopicError,
+  SchemaVersionError
+}
+import pl.touk.nussknacker.test.ValidatedValuesDetailedMessage
+
+class MockAzureSchemaRegistryClientTest
+    extends AnyFunSuite
+    with Matchers
+    with ValidatedValuesDetailedMessage
+    with OptionValues {
+
+  private val topic = UnspecializedTopicName("foo-bar")
+
+  test("registerSchema + getSchemaById round trip") {
+    val client = new MockAzureSchemaRegistryClient
+    val schema = createRecordSchema("a")
+
+    val id = client.registerSchema(topic, isKey = false, schema)
+
+    val stored = client.getSchemaById(id)
+    stored.schema shouldEqual schema
+    stored.id shouldEqual id
+
+    client.getAllTopics.validValue shouldEqual List(topic)
+  }
+
+  test("registering the same schema content twice returns the same id and keeps one version") {
+    val client = new MockAzureSchemaRegistryClient
+    val schema = createRecordSchema("a")
+
+    val id1 = client.registerSchema(topic, isKey = false, schema)
+    val id2 = client.registerSchema(topic, isKey = false, schema)
+
+    id1 shouldEqual id2
+    client.getAllVersions(topic, isKey = false).validValue shouldEqual List(Integer.valueOf(1))
+    client.getAllTopics.validValue shouldEqual List(topic)
+  }
+
+  test("registering different schemas creates subsequent versions") {
+    val client = new MockAzureSchemaRegistryClient
+    val v1     = createRecordSchema("a")
+    val v2     = createRecordSchema("b")
+
+    client.registerSchema(topic, isKey = false, v1)
+    client.registerSchema(topic, isKey = false, v2)
+
+    client.getAllVersions(topic, isKey = false).validValue shouldEqual List(
+      Integer.valueOf(1),
+      Integer.valueOf(2)
+    )
+  }
+
+  test("getLatestFreshSchema returns the highest-version registration") {
+    val client = new MockAzureSchemaRegistryClient
+    val v1     = createRecordSchema("a")
+    val v2     = createRecordSchema("b")
+
+    client.registerSchema(topic, isKey = false, v1)
+    val v2Id = client.registerSchema(topic, isKey = false, v2)
+
+    val result = client.getFreshSchema(topic, LatestSchemaVersion, isKey = false).validValue
+    result.schema shouldEqual v2
+    result.id shouldEqual v2Id
+  }
+
+  test("getByTopicAndVersion returns schema for the given version") {
+    val client = new MockAzureSchemaRegistryClient
+    val v1     = createRecordSchema("a")
+    val v2     = createRecordSchema("b")
+
+    val v1Id = client.registerSchema(topic, isKey = false, v1)
+    client.registerSchema(topic, isKey = false, v2)
+
+    val result = client.getFreshSchema(topic, ExistingSchemaVersion(1), isKey = false).validValue
+    result.schema shouldEqual v1
+    result.id shouldEqual v1Id
+  }
+
+  test("getAllTopics lists topics whose schemas have been registered") {
+    val client = new MockAzureSchemaRegistryClient
+    client.registerSchema(topic, isKey = false, createRecordSchema("a"))
+
+    client.getAllTopics.validValue should contain(topic)
+  }
+
+  test("record schema name must match topic-derived naming convention") {
+    val client = new MockAzureSchemaRegistryClient
+    val wrongName = new AvroSchema(
+      SchemaBuilder.record("UnrelatedName").fields().requiredString("a").endRecord()
+    )
+
+    assertThrows[IllegalArgumentException] {
+      client.registerSchema(topic, isKey = false, wrongName)
+    }
+  }
+
+  test("getFreshSchema returns SchemaTopicError when no schema is registered for the topic") {
+    val client       = new MockAzureSchemaRegistryClient
+    val unknownTopic = UnspecializedTopicName("missing")
+
+    client
+      .getFreshSchema(unknownTopic, LatestSchemaVersion, isKey = false)
+      .invalidValue shouldBe a[SchemaTopicError]
+  }
+
+  test("getFreshSchema returns SchemaVersionError when the version does not exist") {
+    val client = new MockAzureSchemaRegistryClient
+    client.registerSchema(topic, isKey = false, createRecordSchema("a"))
+
+    client
+      .getFreshSchema(topic, ExistingSchemaVersion(42), isKey = false)
+      .invalidValue shouldBe a[SchemaVersionError]
+  }
+
+  test("getSchemaById throws when id is unknown") {
+    val client = new MockAzureSchemaRegistryClient
+
+    assertThrows[IllegalArgumentException] {
+      client.getSchemaById(SchemaId.fromString("does-not-exist"))
+    }
+  }
+
+  test("register allows providing an explicit schema id and version") {
+    val client = new MockAzureSchemaRegistryClient
+    val schema = createRecordSchema("a")
+
+    val id = client.register(topic, isKey = false, schema, version = 7, id = "explicit-id")
+
+    id shouldEqual SchemaId.fromString("explicit-id")
+    client.getAllVersions(topic, isKey = false).validValue shouldEqual List(Integer.valueOf(7))
+    client.getSchemaById(SchemaId.fromString("explicit-id")).schema shouldEqual schema
+  }
+
+  test("builder registers schemas and build returns a populated client") {
+    val schema = SchemaBuilder.record("FooBarValue").fields().requiredString("a").endRecord()
+
+    val client = new MockAzureSchemaRegistryClientBuilder()
+      .register(topic.name, schema, version = 1, isKey = false, schemaId = "schema-1")
+      .build
+
+    client.getSchemaById(SchemaId.fromString("schema-1")).schema shouldEqual new AvroSchema(schema)
+    client.getAllVersions(topic, isKey = false).validValue shouldEqual List(Integer.valueOf(1))
+    client.getAllTopics.validValue shouldEqual List(topic)
+  }
+
+  private def createRecordSchema(fieldName: String): AvroSchema =
+    new AvroSchema(SchemaBuilder.record("FooBarValue").fields().requiredString(fieldName).endRecord())
+
+}


### PR DESCRIPTION
## Describe your changes

Add `MockAzureSchemaRegistryClient` so that we can use String schema identifiers in tests.
Implementation is made to mirror Confluent SR mocks where possible.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [x] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [x] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [x] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
