### PR TITLE
Remove bind mounts from Docker tests

### DIFF
--- a/components/sql/src/test/scala/pl/touk/nussknacker/sql/utils/BaseHsqlQueryEnricherTest.scala
+++ b/components/sql/src/test/scala/pl/touk/nussknacker/sql/utils/BaseHsqlQueryEnricherTest.scala
@@ -1,10 +1,7 @@
 package pl.touk.nussknacker.sql.utils
 
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import pl.touk.nussknacker.engine.lite.api.runtimecontext.LiteEngineRuntimeContextPreparer
 import pl.touk.nussknacker.sql.db.pool.DBPoolConfig
-
-import scala.jdk.CollectionConverters._
 
 trait BaseHsqlQueryEnricherTest extends BaseDatabaseQueryEnricherTest with WithHsqlDB {
 
@@ -14,16 +11,6 @@ trait BaseHsqlQueryEnricherTest extends BaseDatabaseQueryEnricherTest with WithH
     username = hsqlConfigValues("username"),
     password = hsqlConfigValues("password")
   )
-
-  val dbEnricherConfig: Config = ConfigFactory
-    .load()
-    .withValue("name", ConfigValueFactory.fromAnyRef("db-enricher"))
-    .withValue(
-      "dbPool",
-      ConfigValueFactory.fromMap(
-        hsqlConfigValues.asJava
-      )
-    )
 
   override def beforeAll(): Unit = {
     service.open(LiteEngineRuntimeContextPreparer.noOp.prepare(jobData))

--- a/components/sql/src/test/scala/pl/touk/nussknacker/sql/utils/BasePostgresqlQueryEnricherTest.scala
+++ b/components/sql/src/test/scala/pl/touk/nussknacker/sql/utils/BasePostgresqlQueryEnricherTest.scala
@@ -1,14 +1,11 @@
 package pl.touk.nussknacker.sql.utils
 
 import com.dimafeng.testcontainers.ForAllTestContainer
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.time.{Second, Seconds, Span}
 import pl.touk.nussknacker.engine.lite.api.runtimecontext.LiteEngineRuntimeContextPreparer
 import pl.touk.nussknacker.sql.db.pool.DBPoolConfig
 import pl.touk.nussknacker.test.PatientScalaFutures
-
-import scala.jdk.CollectionConverters._
 
 trait BasePostgresqlQueryEnricherTest
     extends BaseDatabaseQueryEnricherTest
@@ -19,22 +16,12 @@ trait BasePostgresqlQueryEnricherTest
 
   val pc: PatienceConfig = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
-  val postgresqlDbPoolConfig: DBPoolConfig = DBPoolConfig(
+  lazy val postgresqlDbPoolConfig: DBPoolConfig = DBPoolConfig(
     driverClassName = postgresqlConfigValues("driverClassName"),
     url = postgresqlConfigValues("url"),
     username = postgresqlConfigValues("username"),
     password = postgresqlConfigValues("password")
   )
-
-  val dbEnricherConfig: Config = ConfigFactory
-    .load()
-    .withValue("name", ConfigValueFactory.fromAnyRef("db-enricher"))
-    .withValue(
-      "dbPool",
-      ConfigValueFactory.fromMap(
-        postgresqlConfigValues.asJava
-      )
-    )
 
   override def beforeAll(): Unit = {
     service.open(LiteEngineRuntimeContextPreparer.noOp.prepare(jobData))

--- a/components/sql/src/test/scala/pl/touk/nussknacker/sql/utils/WithPostgresqlDB.scala
+++ b/components/sql/src/test/scala/pl/touk/nussknacker/sql/utils/WithPostgresqlDB.scala
@@ -5,7 +5,6 @@ import org.scalatest.BeforeAndAfterAll
 import org.testcontainers.utility.DockerImageName
 
 import java.sql.{Connection, DriverManager}
-import scala.jdk.CollectionConverters._
 
 trait WithPostgresqlDB {
   self: BeforeAndAfterAll with ForAllTestContainer =>
@@ -14,17 +13,16 @@ trait WithPostgresqlDB {
 
   override val container: PostgreSQLContainer = {
     val container = PostgreSQLContainer(DockerImageName.parse("postgres:18-alpine"))
-    container.container.setPortBindings(List("5432:5432").asJava)
+    container.container.withUrlParam("loggerLevel", "OFF")
     container
   }
 
   private val driverClassName = "org.postgresql.Driver"
   private val username        = container.username
   private val password        = container.password
-  // this url can be read as container.jdbcUrl when service is started, but it is hard to postpone this step until this service is started
-  private val url = "jdbc:postgresql://localhost:5432/test?loggerLevel=OFF"
+  private lazy val url        = container.jdbcUrl
 
-  val postgresqlConfigValues: Map[String, String] = Map(
+  lazy val postgresqlConfigValues: Map[String, String] = Map(
     "driverClassName" -> driverClassName,
     "username"        -> username,
     "password"        -> password,

--- a/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/test/mock/MockDeploymentManager.scala
@@ -19,6 +19,7 @@ import pl.touk.nussknacker.engine.flink.minicluster.scenariotesting.ScenarioStat
 import pl.touk.nussknacker.engine.management.{FlinkConfig, FlinkDeploymentManager, FlinkDeploymentManagerProvider}
 import pl.touk.nussknacker.engine.management.jobrunner.FlinkScenarioJobRunner
 import pl.touk.nussknacker.engine.management.rest.flinkRestModel.{JobOverview, JobTasksOverview}
+import pl.touk.nussknacker.engine.management.savepoint.IdentitySavepointLocator
 import pl.touk.nussknacker.test.mock.MockDeploymentManager.{sampleDeploymentId, sampleDeploymentStatusDetails}
 import pl.touk.nussknacker.test.utils.domain.TestFactory
 import pl.touk.nussknacker.ui.process.periodic.flink.FlinkClientStub
@@ -48,6 +49,7 @@ class MockDeploymentManager private (
       FlinkMiniClusterFactory.createMiniClusterWithServices(modelData.modelClassLoader, new Configuration),
       FlinkClientStub,
       FlinkScenarioJobRunnerStub,
+      new IdentitySavepointLocator,
       NoLiveDataPreviewSupport,
     ) {
 

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/BaseDeploymentApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/BaseDeploymentApiHttpServiceBusinessSpec.scala
@@ -3,7 +3,6 @@ package pl.touk.nussknacker.ui.api
 import com.typesafe.scalalogging.StrictLogging
 import io.restassured.RestAssured.`given`
 import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
-import org.apache.commons.io.FileUtils
 import org.hamcrest.Matchers.{anyOf, equalTo}
 import org.scalatest.{LoneElement, Suite}
 import org.scalatest.concurrent.Eventually
@@ -11,6 +10,7 @@ import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
 import org.testcontainers.containers.BindMode
+import org.testcontainers.images.builder.Transferable
 import pl.touk.nussknacker.engine.api.deployment.DeploymentStatusName
 import pl.touk.nussknacker.engine.build.ScenarioBuilder
 import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
@@ -21,10 +21,12 @@ import pl.touk.nussknacker.test.config.{
   WithBusinessCaseRestAssuredUsersExtensions,
   WithFlinkContainersDeploymentManager
 }
-import pl.touk.nussknacker.test.containers.FileSystemBind
+import pl.touk.nussknacker.test.containers.ContainerVolume
 
-import java.io.File
-import java.nio.file.Path
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.UUID
+import scala.jdk.CollectionConverters._
 
 trait BaseDeploymentApiHttpServiceBusinessSpec extends WithFlinkContainersDeploymentManager {
   self: NuItTest
@@ -70,49 +72,43 @@ trait BaseDeploymentApiHttpServiceBusinessSpec extends WithFlinkContainersDeploy
     .fragment(scenarioName)
     .fragmentOutput("out", "out")
 
-  private lazy val inputDirectory = {
-    val directory =
-      createMountableTempDirectory(s"nusssknacker-${getClass.getSimpleName}-transactions-", BindMode.READ_ONLY)
-    populateInputTransactionsDirectory(directory)
-    directory
-  }
+  protected def inputTransactionsFiles: Map[String, String]
 
-  protected def populateInputTransactionsDirectory(rootDirectory: Path): Unit
+  private val inputContainerPath  = "/transactions"
+  private val outputContainerPath = "/output/transactions_summary"
 
-  private lazy val outputDirectory =
-    createMountableTempDirectory(s"nusssknacker-${getClass.getSimpleName}-transactions_summary-", BindMode.READ_WRITE)
+  private val volumeNameSuffix = s"${getClass.getSimpleName}-${UUID.randomUUID()}"
+  private val inputVolumeName  = s"nussknacker-test-transactions-$volumeNameSuffix"
+  private val outputVolumeName = s"nussknacker-test-transactions-summary-$volumeNameSuffix"
 
-  private lazy val inputTransactionsBind = FileSystemBind(
-    inputDirectory,
-    "/transactions",
-    BindMode.READ_ONLY
+  private val sharedVolumeMounts: List[ContainerVolume] = List(
+    ContainerVolume(inputVolumeName, inputContainerPath, BindMode.READ_WRITE),
+    ContainerVolume(outputVolumeName, outputContainerPath, BindMode.READ_WRITE)
   )
 
-  private lazy val outputTransactionsSummaryBind = FileSystemBind(
-    outputDirectory,
-    "/output/transactions_summary",
-    BindMode.READ_WRITE
-  )
+  override protected def jobManagerExtraVolumes: List[ContainerVolume]  = sharedVolumeMounts
+  override protected def taskManagerExtraVolumes: List[ContainerVolume] = sharedVolumeMounts
 
-  override protected def jobManagerExtraFSBinds: List[FileSystemBind] =
-    List(
-      // input must be also available on the JM side to allow their to split work into multiple subtasks
-      inputTransactionsBind,
-      // output directory has to be available on JM to allow writing the final output file and deleting the temp files
-      outputTransactionsSummaryBind
-    )
-
-  override protected def taskManagerExtraFSBinds: List[FileSystemBind] = {
-    List(
-      inputTransactionsBind,
-      outputTransactionsSummaryBind
-    )
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    seedInputTransactionsFiles()
   }
 
-  override protected def afterAll(): Unit = {
-    FileUtils.deleteQuietly(inputDirectory.toFile)
-    FileUtils.deleteQuietly(outputDirectory.toFile) // it might not work because docker user can has other uid
-    super.afterAll()
+  private def seedInputTransactionsFiles(): Unit = {
+    inputTransactionsFiles.foreach { case (relativePath, content) =>
+      val targetPath  = s"$inputContainerPath/$relativePath"
+      val parentPath  = targetPath.substring(0, targetPath.lastIndexOf('/'))
+      val mkdirResult = jobManagerContainer.container.execInContainer("mkdir", "-p", parentPath)
+      if (mkdirResult.getExitCode != 0) {
+        throw new IllegalStateException(
+          s"Failed to create directory $parentPath in JobManager container: ${mkdirResult.getStderr}"
+        )
+      }
+      jobManagerContainer.container.copyFileToContainer(
+        Transferable.of(content.getBytes(StandardCharsets.UTF_8)),
+        targetPath
+      )
+    }
   }
 
   protected def waitForDeploymentStatusNameMatches(
@@ -140,15 +136,21 @@ trait BaseDeploymentApiHttpServiceBusinessSpec extends WithFlinkContainersDeploy
       .body("name", anyOf(expectedStatusNames.map(statusName => equalTo[String](statusName.value)): _*))
   }
 
-  protected def getLoneFileFromLoneOutputTransactionsSummaryPartitionWithGivenName(
-      expectedLonePartitionName: String
-  ): File = {
-    val transactionSummaryDirectories = Option(outputDirectory.toFile.listFiles(!_.isHidden)).toList.flatten
-    val matchingPartitionDirectory    = transactionSummaryDirectories.loneElement
-    matchingPartitionDirectory.getName shouldEqual expectedLonePartitionName
+  protected def readLinesFromLoneOutputTransactionsSummaryPartition(expectedLonePartitionName: String): List[String] = {
+    val partitionName = listJobManagerFiles(outputContainerPath).loneElement
+    partitionName shouldEqual expectedLonePartitionName
 
-    val partitionFiles = Option(matchingPartitionDirectory.listFiles(!_.isHidden)).toList.flatten
-    partitionFiles.loneElement
+    val partitionPath     = s"$outputContainerPath/$partitionName"
+    val fileName          = listJobManagerFiles(partitionPath).loneElement
+    val containerFilePath = s"$partitionPath/$fileName"
+
+    val localTempFile = Files.createTempFile(s"nussknacker-${getClass.getSimpleName}-output-", ".csv")
+    try {
+      jobManagerContainer.container.copyFileFromContainer(containerFilePath, localTempFile.toString)
+      Files.readAllLines(localTempFile, StandardCharsets.UTF_8).asScala.toList
+    } finally {
+      Files.deleteIfExists(localTempFile)
+    }
   }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/BaseDeploymentApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/BaseDeploymentApiHttpServiceBusinessSpec.scala
@@ -154,7 +154,7 @@ trait BaseDeploymentApiHttpServiceBusinessSpec extends WithFlinkContainersDeploy
   }
 
   protected def listJobManagerFiles(containerPath: String): List[String] = {
-    val result = jobManagerContainer.container.execInContainer("ls", "-Atr1p", containerPath)
+    val result = jobManagerContainer.container.execInContainer("ls", "-A1", containerPath)
     if (result.getExitCode != 0) {
       throw new IllegalStateException(
         s"Failed to list $containerPath in JobManager container: ${result.getStderr}"

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/BaseDeploymentApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/BaseDeploymentApiHttpServiceBusinessSpec.scala
@@ -153,4 +153,14 @@ trait BaseDeploymentApiHttpServiceBusinessSpec extends WithFlinkContainersDeploy
     }
   }
 
+  protected def listJobManagerFiles(containerPath: String): List[String] = {
+    val result = jobManagerContainer.container.execInContainer("ls", "-Atr1p", containerPath)
+    if (result.getExitCode != 0) {
+      throw new IllegalStateException(
+        s"Failed to list $containerPath in JobManager container: ${result.getStderr}"
+      )
+    }
+    result.getStdout.split("\n").iterator.map(_.trim).filter(_.nonEmpty).toList
+  }
+
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DeploymentApiHttpServiceBusinessSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DeploymentApiHttpServiceBusinessSpec.scala
@@ -4,7 +4,6 @@ import cats.implicits.toTraverseOps
 import com.typesafe.scalalogging.StrictLogging
 import io.restassured.RestAssured.`given`
 import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
-import org.apache.commons.io.FileUtils
 import org.scalatest.LoneElement
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -19,12 +18,9 @@ import pl.touk.nussknacker.test.{
 import pl.touk.nussknacker.test.base.it.{NuItTest, WithBatchConfigScenarioHelper}
 import pl.touk.nussknacker.test.config.{WithBatchDesignerConfig, WithBusinessCaseRestAssuredUsersExtensions}
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.Path
 import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.jdk.CollectionConverters._
 
 class DeploymentApiHttpServiceBusinessSpec
     extends AnyFreeSpecLike
@@ -40,28 +36,20 @@ class DeploymentApiHttpServiceBusinessSpec
     with Matchers
     with LoneElement {
 
-  override protected def populateInputTransactionsDirectory(rootDirectory: Path): Unit = {
-    val firstPartition = rootDirectory.resolve("date=2024-01-01")
-    firstPartition.toFile.mkdir()
-    FileUtils.write(
-      firstPartition.resolve("transaction-1.csv").toFile,
+  override protected def inputTransactionsFiles: Map[String, String] = Map(
+    // first partition
+    "date=2024-01-01/transaction-1.csv" ->
       """"2024-01-01 10:00:00",client1,1.11
         |"2024-01-01 10:01:00",client2,2.22
         |"2024-01-01 10:02:00",client1,3.33
         |""".stripMargin,
-      StandardCharsets.UTF_8
-    )
-    val secondPartition = rootDirectory.resolve("date=2024-01-02")
-    secondPartition.toFile.mkdir()
-    FileUtils.write(
-      secondPartition.resolve("transaction-1.csv").toFile,
+    // second partition
+    "date=2024-01-02/transaction-1.csv" ->
       """"2024-01-02 10:00:00",client1,1.11
         |"2024-01-02 10:01:00",client2,2.22
         |"2024-01-02 10:02:00",client1,3.33
         |""".stripMargin,
-      StandardCharsets.UTF_8
-    )
-  }
+  )
 
   private val correctDeploymentRequest = s"""{
                                             |  "scenarioName": "$scenarioName",
@@ -89,8 +77,7 @@ class DeploymentApiHttpServiceBusinessSpec
               waitForDeploymentStatusNameMatches(requestedDeploymentId, DeploymentStatusName.finishedStatusName)
             }
             .verifyExternalState {
-              val resultFile = getLoneFileFromLoneOutputTransactionsSummaryPartitionWithGivenName("date=2024-01-01")
-              FileUtils.readLines(resultFile, StandardCharsets.UTF_8).asScala.toSet shouldBe Set(
+              readLinesFromLoneOutputTransactionsSummaryPartition("date=2024-01-01").toSet shouldBe Set(
                 "client1,4.44",
                 "client2,2.22"
               )

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DeploymentApiHttpServiceDeploymentCommentSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/api/DeploymentApiHttpServiceDeploymentCommentSpec.scala
@@ -4,11 +4,10 @@ import com.typesafe.config.{Config, ConfigValueFactory}
 import com.typesafe.scalalogging.StrictLogging
 import io.restassured.RestAssured.`given`
 import io.restassured.module.scala.RestAssuredSupport.AddThenToResponse
-import org.apache.commons.io.FileUtils
 import org.scalatest.LoneElement
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.engine.api.deployment.{DeploymentStatus, DeploymentStatusName}
+import pl.touk.nussknacker.engine.api.deployment.DeploymentStatusName
 import pl.touk.nussknacker.engine.newdeployment.DeploymentId
 import pl.touk.nussknacker.test.{
   NuRestAssureMatchers,
@@ -17,10 +16,6 @@ import pl.touk.nussknacker.test.{
 }
 import pl.touk.nussknacker.test.base.it.{NuItTest, WithBatchConfigScenarioHelper}
 import pl.touk.nussknacker.test.config.{WithBatchDesignerConfig, WithBusinessCaseRestAssuredUsersExtensions}
-
-import java.nio.charset.StandardCharsets
-import java.nio.file.Path
-import scala.jdk.CollectionConverters._
 
 class DeploymentApiHttpServiceDeploymentCommentSpec
     extends AnyFreeSpecLike
@@ -43,28 +38,20 @@ class DeploymentApiHttpServiceDeploymentCommentSpec
       .withValue("deploymentCommentSettings.validationPattern", ConfigValueFactory.fromAnyRef(s".*$configuredPhrase.*"))
   }
 
-  override protected def populateInputTransactionsDirectory(rootDirectory: Path): Unit = {
-    val firstPartition = rootDirectory.resolve("date=2024-01-01")
-    firstPartition.toFile.mkdir()
-    FileUtils.write(
-      firstPartition.resolve("transaction-1.csv").toFile,
+  override protected def inputTransactionsFiles: Map[String, String] = Map(
+    // first partition
+    "date=2024-01-01/transaction-1.csv" ->
       """"2024-01-01 10:00:00",client1,1
         |"2024-01-01 10:01:00",client2,2
         |"2024-01-01 10:02:00",client1,3
         |""".stripMargin,
-      StandardCharsets.UTF_8
-    )
-    val secondPartition = rootDirectory.resolve("date=2024-01-02")
-    secondPartition.toFile.mkdir()
-    FileUtils.write(
-      secondPartition.resolve("transaction-1.csv").toFile,
+    // second partition
+    "date=2024-01-02/transaction-1.csv" ->
       """"2024-01-02 10:00:00",client1,1
         |"2024-01-02 10:01:00",client2,2
         |"2024-01-02 10:02:00",client1,3
         |""".stripMargin,
-      StandardCharsets.UTF_8
-    )
-  }
+  )
 
   "The deployment requesting endpoint" - {
     "With validationPattern configured in deploymentCommentSettings" - {
@@ -132,8 +119,7 @@ class DeploymentApiHttpServiceDeploymentCommentSpec
               waitForDeploymentStatusNameMatches(requestedDeploymentId, DeploymentStatusName.finishedStatusName)
             }
             .verifyExternalState {
-              val resultFile = getLoneFileFromLoneOutputTransactionsSummaryPartitionWithGivenName("date=2024-01-01")
-              FileUtils.readLines(resultFile, StandardCharsets.UTF_8).asScala.toSet shouldBe Set(
+              readLinesFromLoneOutputTransactionsSummaryPartition("date=2024-01-01").toSet shouldBe Set(
                 "client1,4",
                 "client2,2"
               )

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -360,6 +360,7 @@ description: Stay informed with detailed changelogs covering new features, impro
   Can be configured by implementing TypingConfigurationProvider and registering it as SPI.
   By default, the existing permissive behavior is preserved.
 * [#9286](https://github.com/TouK/nussknacker/pull/9286) Fixed handling of Avro records in Flink SQL component.
+* [#9327](https://github.com/TouK/nussknacker/pull/9327) Remove bind mounts from Docker tests
 
 ## 1.18
 

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -222,6 +222,8 @@ To see the biggest differences please consult the [changelog](Changelog.md).
   Use `setUidAndNameToNodeId` extension method available in `DataStreamImplicits` instead 
 * [#8786](https://github.com/TouK/nussknacker/pull/8786) `StandardFlinkSource`, `BaseFlinkSource` and `CustomizableWatermarkStrategySource` traits were removed.
   Use `setUidAndNameToNodeId`, `assignTimestampsAndWatermarks` and context initialization (`FlinkContextInitializingFunction`) directly
+* [#9327](https://github.com/TouK/nussknacker/pull/9327) `FileSystemBind` and associated bind mounting helpers in Docker tests were removed.
+  Use `ContainerVolume` instead.
 
 ### Other changes
 

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/BaseFlinkDeploymentManagerSpec.scala
@@ -5,7 +5,6 @@ import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.Json
 import io.circe.syntax.EncoderOps
-import org.apache.commons.lang3.SystemUtils
 import org.apache.flink.api.common.JobID
 import org.scalatest.Inside.inside
 import org.scalatest.Inspectors.forAll
@@ -305,11 +304,10 @@ trait BaseFlinkDeploymentManagerSpec
       // we wait for first element to appear in kafka to be sure it's processed, before we proceed to checkpoint
       messagesFromTopic(outTopic, 1) shouldBe List("[One element]")
 
-      val customSavepointBind = savepointBind.subdirectory("customSavepoint")
-      val customSavepointDir = if (useMiniClusterForDeployment || !SystemUtils.IS_OS_WINDOWS) {
-        customSavepointBind.hostPath.toUri
+      val customSavepointDir = if (useMiniClusterForDeployment) {
+        savepointDir.toUri
       } else {
-        URI.create(s"file:${customSavepointBind.containerPath}")
+        URI.create(s"file:$jobManagerContainerSavepointDir")
       }
       val savepointPath = deploymentManager
         .processCommand(

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkDeploymentManagerProviderHelper.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkDeploymentManagerProviderHelper.scala
@@ -16,12 +16,14 @@ import pl.touk.nussknacker.engine.classloader.{
 }
 import pl.touk.nussknacker.engine.definition.component.Components.ComponentDefinitionExtractionMode
 import pl.touk.nussknacker.engine.management.FlinkDeploymentManagerProvider
+import pl.touk.nussknacker.engine.management.savepoint.{FlinkSavepointLocator, IdentitySavepointLocator}
 
 object FlinkDeploymentManagerProviderHelper {
 
   def createDeploymentManager(
       processingTypeConfig: ConfigWithUnresolvedVersion,
-      deploymentManagerClassLoader: DeploymentManagersClassLoader
+      deploymentManagerClassLoader: DeploymentManagersClassLoader,
+      savepointLocator: FlinkSavepointLocator,
   ): DeploymentManager = {
     val typeConfig       = ProcessingTypeConfig.read(processingTypeConfig)
     val modelClassLoader = ModelClassLoaderFactory.create(typeConfig.classPath, None, deploymentManagerClassLoader)
@@ -49,7 +51,8 @@ object FlinkDeploymentManagerProviderHelper {
         modelData.toModelDataProvider,
         deploymentManagerDependencies,
         typeConfig.deploymentConfig,
-        None
+        None,
+        savepointLocator
       )
       .valueOr(err => throw new IllegalStateException(s"Invalid Deployment Manager: ${err.toList.mkString(", ")}"))
   }
@@ -60,7 +63,7 @@ object FlinkDeploymentManagerProviderHelper {
     DeploymentManagersClassLoaderFactory
       .create(List.empty)
       .map { deploymentManagerClassLoader =>
-        createDeploymentManager(processingTypeConfig, deploymentManagerClassLoader)
+        createDeploymentManager(processingTypeConfig, deploymentManagerClassLoader, new IdentitySavepointLocator)
       }
   }
 

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkKafkaDockerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkKafkaDockerSpec.scala
@@ -22,7 +22,7 @@ import pl.touk.nussknacker.engine.deployment.{DeploymentData, DeploymentId, Exte
 import pl.touk.nussknacker.engine.flink.test.docker.{WithFlinkContainers, WithKafkaContainer}
 import pl.touk.nussknacker.engine.kafka.KafkaClient
 import pl.touk.nussknacker.engine.management.WithProcessingTypeConfig
-import pl.touk.nussknacker.engine.management.savepoint.FlinkSavepointLocator
+import pl.touk.nussknacker.engine.management.savepoint.{FlinkSavepointLocator, IdentitySavepointLocator}
 import pl.touk.nussknacker.engine.management.savepoint.FlinkSavepointLocator.LocalSavepoint
 import pl.touk.nussknacker.test.{ExtremelyPatientScalaFutures, KafkaConfigProperties}
 
@@ -134,7 +134,7 @@ trait FlinkKafkaDockerSpec
     FlinkDeploymentManagerProviderHelper.createDeploymentManager(
       ConfigWithUnresolvedVersion(rawProcessingTypeConfig),
       deploymentManagerClassLoader,
-      new JobManagerSavepointLocator
+      if (useMiniClusterForDeployment) new IdentitySavepointLocator else new JobManagerSavepointLocator
     )
 
   override def afterAll(): Unit = {
@@ -219,9 +219,9 @@ trait FlinkKafkaDockerSpec
       if (uri.getScheme != "file") {
         throw new IllegalArgumentException(s"Invalid savepoint path, expected file URI but got: $path")
       }
-      val targetDir = savepointDir.resolve(uri.getPath.split("/").last)
-      copyDirectoryFromContainer(jobManagerContainer.container, uri.getPath, targetDir)
-      LocalSavepoint(targetDir.toUri.toURL.toString)
+      copyDirectoryFromContainer(jobManagerContainer.container, uri.getPath, savepointDir)
+      val resolvedSavepointDir = savepointDir.resolve(uri.getPath.split("/").last)
+      LocalSavepoint(resolvedSavepointDir.toUri.toURL.toString)
     }
 
   }

--- a/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkKafkaDockerSpec.scala
+++ b/engine/flink/management/src/it/scala/pl/touk/nussknacker/engine/management/streaming/FlinkKafkaDockerSpec.scala
@@ -7,6 +7,7 @@ import com.dimafeng.testcontainers.{Container, ForAllTestContainer, LazyContaine
 import com.typesafe.config.{Config, ConfigValueFactory}
 import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import com.typesafe.scalalogging.StrictLogging
+import org.apache.flink.util.FileUtils
 import org.scalatest.{BeforeAndAfterAll, OptionValues, Suite}
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ConfigWithUnresolvedVersion
@@ -21,10 +22,16 @@ import pl.touk.nussknacker.engine.deployment.{DeploymentData, DeploymentId, Exte
 import pl.touk.nussknacker.engine.flink.test.docker.{WithFlinkContainers, WithKafkaContainer}
 import pl.touk.nussknacker.engine.kafka.KafkaClient
 import pl.touk.nussknacker.engine.management.WithProcessingTypeConfig
+import pl.touk.nussknacker.engine.management.savepoint.FlinkSavepointLocator
+import pl.touk.nussknacker.engine.management.savepoint.FlinkSavepointLocator.LocalSavepoint
 import pl.touk.nussknacker.test.{ExtremelyPatientScalaFutures, KafkaConfigProperties}
 
+import java.net.URI
+import java.nio.file.{Files, Path}
 import java.util.UUID
+import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 trait FlinkKafkaDockerSpec
     extends BeforeAndAfterAll
@@ -45,6 +52,15 @@ trait FlinkKafkaDockerSpec
   override lazy val container: Container = MultipleContainers(
     (kafkaContainer: LazyContainer[_]) :: (if (useMiniClusterForDeployment) Nil else flinkContainers): _*
   )
+
+  private var savepointDirInitialized: Boolean = false
+
+  protected lazy val savepointDir: Path = {
+    savepointDirInitialized = true
+    val tempPath = Files.createTempDirectory(getClass.getSimpleName)
+    tempPath.toFile.deleteOnExit()
+    tempPath
+  }
 
   protected val kafkaComponentsConfigPrefix = "modelConfig.components.kafka.config"
 
@@ -68,7 +84,7 @@ trait FlinkKafkaDockerSpec
         .withValue("deploymentConfig.useMiniClusterForDeployment", fromAnyRef(true))
         .withValue(
           "deploymentConfig.miniCluster.config.\"execution.checkpointing.savepoint-dir\"",
-          fromAnyRef(savepointBind.hostPath.toFile.toURI.toString)
+          fromAnyRef(savepointDir.toFile.toURI.toString)
         )
         .withValue(
           KafkaConfigProperties.bootstrapServersProperty("modelConfig.components.kafka.config"),
@@ -117,13 +133,21 @@ trait FlinkKafkaDockerSpec
   protected lazy val deploymentManager: DeploymentManager =
     FlinkDeploymentManagerProviderHelper.createDeploymentManager(
       ConfigWithUnresolvedVersion(rawProcessingTypeConfig),
-      deploymentManagerClassLoader
+      deploymentManagerClassLoader,
+      new JobManagerSavepointLocator
     )
 
   override def afterAll(): Unit = {
     releaseKafkaClient.unsafeRunSync()
     deploymentManager.close()
     releaseDeploymentManagerClassLoaderResources.unsafeRunSync()
+    if (savepointDirInitialized) {
+      try {
+        FileUtils.deleteDirectory(savepointDir.toFile)
+      } catch {
+        case NonFatal(e) => logger.warn(s"Failed to delete temp savepoint directory $savepointDir (${e.getMessage})")
+      }
+    }
     super.afterAll()
   }
 
@@ -186,6 +210,20 @@ trait FlinkKafkaDockerSpec
         throw new IllegalStateException("Job still exists")
       }
     }
+  }
+
+  private class JobManagerSavepointLocator extends FlinkSavepointLocator {
+
+    override def locateSavepoint(path: String): Future[FlinkSavepointLocator.Savepoint] = Future.successful {
+      val uri = URI.create(path)
+      if (uri.getScheme != "file") {
+        throw new IllegalArgumentException(s"Invalid savepoint path, expected file URI but got: $path")
+      }
+      val targetDir = savepointDir.resolve(uri.getPath.split("/").last)
+      copyDirectoryFromContainer(jobManagerContainer.container, uri.getPath, targetDir)
+      LocalSavepoint(targetDir.toUri.toURL.toString)
+    }
+
   }
 
 }

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManager.scala
@@ -5,7 +5,6 @@ import cats.effect.{Resource, SyncIO}
 import cats.implicits._
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.commons.lang3.SystemUtils
 import org.apache.flink.api.common.{JobID, JobStatus}
 import pl.touk.nussknacker.engine.{newdeployment, BaseModelDataProvider, DeploymentManagerDependencies}
 import pl.touk.nussknacker.engine.api.ProcessVersion
@@ -29,6 +28,7 @@ import pl.touk.nussknacker.engine.management.jobrunner.FlinkScenarioJobRunner
 import pl.touk.nussknacker.engine.management.rest.FlinkClient
 import pl.touk.nussknacker.engine.management.rest.FlinkClient.ExecutionConfigOps
 import pl.touk.nussknacker.engine.management.rest.flinkRestModel.JobOverview
+import pl.touk.nussknacker.engine.management.savepoint.FlinkSavepointLocator
 import pl.touk.nussknacker.engine.util.Implicits.RichScalaMap
 import pl.touk.nussknacker.engine.util.WithDataFreshnessStatusUtils.WithDataFreshnessStatusMapOps
 
@@ -36,6 +36,7 @@ import java.net.URI
 import java.nio.file.{Files, Paths}
 import java.time.Instant
 import scala.concurrent.Future
+import scala.util.Using
 
 class FlinkDeploymentManager(
     modelDataProvider: BaseModelDataProvider,
@@ -44,6 +45,7 @@ class FlinkDeploymentManager(
     miniClusterWithServices: FlinkMiniClusterWithServices,
     client: FlinkClient,
     jobRunner: FlinkScenarioJobRunner,
+    savepointLocator: FlinkSavepointLocator,
     override val liveDataPreviewSupport: LiveDataPreviewSupport,
 ) extends DeploymentManager
     with LazyLogging {
@@ -212,26 +214,21 @@ class FlinkDeploymentManager(
       processVersion: ProcessVersion
   ): Future[Unit] =
     if (flinkConfig.scenarioStateVerification.enabled) {
-      val adjustedSavepointPath = adjustWindowsTempPath(savepointPath)
-      if (!Files.isDirectory(Paths.get(URI.create(adjustedSavepointPath)))) {
-        return Future.failed(
-          new IllegalArgumentException(
-            s"Cannot run state verification, passed savepoint path '$savepointPath' does not exist"
-          )
-        )
+      savepointLocator.locateSavepoint(savepointPath).flatMap { locatedSavepoint =>
+        Using.resource(locatedSavepoint) { savepoint =>
+          if (!Files.isDirectory(Paths.get(URI.create(savepoint.path)))) {
+            Future.failed(
+              new IllegalArgumentException(
+                s"Cannot run state verification, passed savepoint path '$savepointPath' does not exist locally at '${savepoint.path}'"
+              )
+            )
+          } else {
+            verification.verify(processVersion, canonicalProcess, savepoint.path)
+          }
+        }
       }
-      verification.verify(processVersion, canonicalProcess, adjustedSavepointPath)
     } else {
       Future.successful(())
-    }
-
-  private def adjustWindowsTempPath(path: String): String =
-    if (SystemUtils.IS_OS_WINDOWS && path.startsWith("file:/tmp/") && !Files.isDirectory(Paths.get(URI.create(path)))) {
-      // we don't support running on Windows, but let's at least allow tests to pass
-      val windowsTempDir = SystemUtils.getJavaIoTmpDir.toURI.toURL.toString
-      windowsTempDir + path.stripPrefix("file:/tmp/")
-    } else {
-      path
     }
 
   override def getScenarioDeploymentsStatuses(

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManagerProvider.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManagerProvider.scala
@@ -19,8 +19,8 @@ import pl.touk.nussknacker.engine.flink.minicluster.FlinkMiniClusterFactory
 import pl.touk.nussknacker.engine.management.FlinkConfig.RestUrlPath
 import pl.touk.nussknacker.engine.management.jobrunner.{FlinkMiniClusterScenarioJobRunner, RemoteFlinkScenarioJobRunner}
 import pl.touk.nussknacker.engine.management.rest.FlinkClient
+import pl.touk.nussknacker.engine.management.savepoint.{FlinkSavepointLocator, IdentitySavepointLocator}
 
-import scala.collection.compat._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.FiniteDuration
@@ -41,10 +41,30 @@ class FlinkDeploymentManagerProvider extends DeploymentManagerProvider {
       dependencies: DeploymentManagerDependencies,
       deploymentConfig: Config,
       scenarioStateCacheTTL: Option[FiniteDuration]
+  ): ValidatedNel[String, DeploymentManager] = createDeploymentManager(
+    modelDataProvider,
+    dependencies,
+    deploymentConfig,
+    scenarioStateCacheTTL,
+    new IdentitySavepointLocator,
+  )
+
+  def createDeploymentManager(
+      modelDataProvider: BaseModelDataProvider,
+      dependencies: DeploymentManagerDependencies,
+      deploymentConfig: Config,
+      scenarioStateCacheTTL: Option[FiniteDuration],
+      savepointLocator: FlinkSavepointLocator,
   ): ValidatedNel[String, DeploymentManager] = {
     val flinkConfig = deploymentConfig.rootAs[FlinkConfig]
     FlinkDeploymentManagerProvider
-      .createDeploymentManager(modelDataProvider, dependencies, flinkConfig, scenarioStateCacheTTL)
+      .createDeploymentManager(
+        modelDataProvider,
+        dependencies,
+        flinkConfig,
+        scenarioStateCacheTTL,
+        savepointLocator,
+      )
       .toValidatedNel
   }
 
@@ -77,7 +97,8 @@ object FlinkDeploymentManagerProvider extends LazyLogging {
       modelDataProvider: BaseModelDataProvider,
       dependencies: DeploymentManagerDependencies,
       flinkConfig: FlinkConfig,
-      scenarioStateCacheTTL: Option[FiniteDuration]
+      scenarioStateCacheTTL: Option[FiniteDuration],
+      savepointLocator: FlinkSavepointLocator,
   ): Validated[String, DeploymentManager] = {
     logger.info("Creating FlinkStreamingDeploymentManager")
     import dependencies._
@@ -112,6 +133,7 @@ object FlinkDeploymentManagerProvider extends LazyLogging {
             miniClusterWithServices,
             client,
             jobRunner,
+            savepointLocator,
             liveDataPreviewSupport,
           )
         CachingProcessStateDeploymentManager.wrapWithCachingIfNeeded(underlying, scenarioStateCacheTTL)

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/savepoint/FlinkSavepointLocator.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/savepoint/FlinkSavepointLocator.scala
@@ -1,0 +1,21 @@
+package pl.touk.nussknacker.engine.management.savepoint
+
+import scala.concurrent.Future
+
+trait FlinkSavepointLocator {
+  import FlinkSavepointLocator.Savepoint
+
+  def locateSavepoint(path: String): Future[Savepoint]
+}
+
+object FlinkSavepointLocator {
+
+  sealed trait Savepoint extends AutoCloseable {
+    val path: String
+  }
+
+  case class LocalSavepoint(override val path: String) extends Savepoint {
+    override def close(): Unit = {}
+  }
+
+}

--- a/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/savepoint/IdentitySavepointLocator.scala
+++ b/engine/flink/management/src/main/scala/pl/touk/nussknacker/engine/management/savepoint/IdentitySavepointLocator.scala
@@ -1,0 +1,10 @@
+package pl.touk.nussknacker.engine.management.savepoint
+
+import scala.concurrent.Future
+
+class IdentitySavepointLocator extends FlinkSavepointLocator {
+
+  override def locateSavepoint(path: String): Future[FlinkSavepointLocator.Savepoint] =
+    Future.successful(FlinkSavepointLocator.LocalSavepoint(path))
+
+}

--- a/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManagerSpec.scala
+++ b/engine/flink/management/src/test/scala/pl/touk/nussknacker/engine/management/FlinkDeploymentManagerSpec.scala
@@ -22,6 +22,7 @@ import pl.touk.nussknacker.engine.canonicalgraph.CanonicalProcess
 import pl.touk.nussknacker.engine.deployment._
 import pl.touk.nussknacker.engine.flink.minicluster.scenariotesting.ScenarioStateVerificationConfig
 import pl.touk.nussknacker.engine.management.rest.flinkRestModel._
+import pl.touk.nussknacker.engine.management.savepoint.IdentitySavepointLocator
 import pl.touk.nussknacker.engine.management.utils.JobIdGenerator.generateJobId
 import pl.touk.nussknacker.engine.testing.LocalModelData
 import pl.touk.nussknacker.test.{AvailablePortFinder, PatientScalaFutures}
@@ -467,7 +468,8 @@ class FlinkDeploymentManagerSpec extends AnyFunSuite with Matchers with PatientS
         LocalModelData(ConfigFactory.empty, List.empty).toModelDataProvider,
         deploymentManagerDependencies,
         config,
-        scenarioStateCacheTTL = None
+        scenarioStateCacheTTL = None,
+        savepointLocator = new IdentitySavepointLocator
       )
       .valueOr(message => throw new IllegalStateException(message))
   }

--- a/engine/flink/test-utils/src/main/resources/docker/entrypointWithIP.sh
+++ b/engine/flink/test-utils/src/main/resources/docker/entrypointWithIP.sh
@@ -2,11 +2,11 @@
 set -eu
 
 if [[ -n "${SAVEPOINT_DIR_PATH:-}" ]]; then
-  chmod -R 777 "$SAVEPOINT_DIR_PATH"
+  chown -cR flink:flink "$SAVEPOINT_DIR_PATH"
 fi
 
 if [[ -d /output ]]; then
-  chmod -R 777 /output
+  chown -cR flink:flink /output
 fi
 
 cat /config.overrides.yml >> $FLINK_HOME/conf/config.yaml

--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithFlinkContainers.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithFlinkContainers.scala
@@ -2,16 +2,14 @@ package pl.touk.nussknacker.engine.flink.test.docker
 
 import com.dimafeng.testcontainers.{GenericContainer, LazyContainer}
 import com.typesafe.scalalogging.StrictLogging
-import org.apache.flink.util.FileUtils
 import org.scalatest.{BeforeAndAfterAll, Suite}
-import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
 import org.testcontainers.images.builder.ImageFromDockerfile
 import pl.touk.nussknacker.engine.util.ResourceLoader
 import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
-import pl.touk.nussknacker.test.containers.{FileSystemBind, WithDockerContainers}
+import pl.touk.nussknacker.test.containers.{ContainerVolume, WithDockerContainers}
 
-import scala.util.control.NonFatal
+import java.nio.file.Path
 
 trait WithFlinkContainers extends WithDockerContainers with BeforeAndAfterAll { self: Suite with StrictLogging =>
 
@@ -19,43 +17,34 @@ trait WithFlinkContainers extends WithDockerContainers with BeforeAndAfterAll { 
 
   protected lazy val taskManagerSlotCount = 32
 
-  protected def jobManagerExtraFSBinds: List[FileSystemBind] = List.empty
+  protected def jobManagerExtraVolumes: List[ContainerVolume] = List.empty
 
-  protected def taskManagerExtraFSBinds: List[FileSystemBind] = List.empty
+  protected def taskManagerExtraVolumes: List[ContainerVolume] = List.empty
 
   protected def jobManagerRestUrl =
     s"http://${jobManagerContainer.container.getHost}:${jobManagerContainer.container.getMappedPort(FlinkJobManagerRestPort)}"
 
   protected def flinkContainers: List[LazyContainer[GenericContainer]] = List(jobManagerContainer, taskManagerContainer)
 
-  private var savepointBindInitialized = false
-
-  protected lazy val savepointBind: FileSystemBind = {
-    savepointBindInitialized = true
-    val tempPath = createMountableTempDirectory("nussknackerFlinkSavepointTest", BindMode.READ_WRITE)
-    FileSystemBind(tempPath, s"/tmp/${tempPath.getFileName}", BindMode.READ_WRITE)
-  }
-
   private lazy val flinkImage = prepareFlinkImage()
 
-  private lazy val jobManagerContainer: GenericContainer = {
+  protected val jobManagerContainerSavepointDir = "/tmp/savepoints/"
+
+  protected lazy val jobManagerContainer: GenericContainer = {
     new GenericContainer(
       dockerImage = flinkImage,
       command = "jobmanager" :: Nil,
       exposedPorts = FlinkJobManagerRestPort :: Nil,
       env = Map(
-        "SAVEPOINT_DIR_PATH" -> savepointBind.containerPath,
         "FLINK_PROPERTIES" ->
-          s"""execution.checkpointing.savepoint-dir: file:${savepointBind.containerPath}
+          s"""execution.checkpointing.savepoint-dir: file:$jobManagerContainerSavepointDir
              |""".stripMargin,
       ),
       waitStrategy = Some(new LogMessageWaitStrategy().withRegEx(".*Recover all persisted job graphs.*"))
     ).configure { self =>
       self.withNetwork(network)
       self.withLogConsumer(logConsumer(prefix = "jobmanager"))
-      (savepointBind :: jobManagerExtraFSBinds).foreach { bind =>
-        self.withFileSystemBind(bind.hostPath.toString, bind.containerPath, bind.mode)
-      }
+      taskManagerExtraVolumes.foreach { bindTempVolume(self, _) }
     }
   }
 
@@ -72,21 +61,13 @@ trait WithFlinkContainers extends WithDockerContainers with BeforeAndAfterAll { 
     ).configure { self =>
       self.setNetwork(network)
       self.withLogConsumer(logConsumer(prefix = "taskmanager"))
-      taskManagerExtraFSBinds.foreach { bind =>
-        self.withFileSystemBind(bind.hostPath.toString, bind.containerPath, bind.mode)
-      }
+      taskManagerExtraVolumes.foreach { bindTempVolume(self, _) }
     }
   }
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    if (savepointBindInitialized) {
-      try {
-        FileUtils.deleteDirectory(savepointBind.hostPath.toFile)
-      } catch {
-        case NonFatal(e) => logger.warn(s"Failed to delete temp savepoint directory $savepointBind (${e.getMessage})")
-      }
-    }
+    removeVolumesQuietly((jobManagerExtraVolumes ++ taskManagerExtraVolumes).map(_.volumeName))
   }
 
   private def prepareFlinkImage(): ImageFromDockerfile = {
@@ -99,6 +80,22 @@ trait WithFlinkContainers extends WithDockerContainers with BeforeAndAfterAll { 
 
       image.withFileFromString(file, withFlinkLibTweaks)
     }
+  }
+
+  protected def listJobManagerFiles(containerPath: String): List[String] = {
+    val result = jobManagerContainer.container.execInContainer("ls", "-Atr1p", containerPath)
+    if (result.getExitCode != 0) {
+      throw new IllegalStateException(
+        s"Failed to list $containerPath in JobManager container: ${result.getStderr}"
+      )
+    }
+    result.getStdout.split("\n").iterator.map(_.trim).filter(_.nonEmpty).toList
+  }
+
+  protected def copyLastSavepointFromJobManager(target: Path): Unit = {
+    val savepointDirName = listJobManagerFiles(jobManagerContainerSavepointDir).headOption
+      .getOrElse(throw new IllegalStateException(s"There are no savepoints under $jobManagerContainerSavepointDir"))
+    copyDirectoryFromContainer(jobManagerContainer.container, savepointDirName, target)
   }
 
 }

--- a/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithFlinkContainers.scala
+++ b/engine/flink/test-utils/src/main/scala/pl/touk/nussknacker/engine/flink/test/docker/WithFlinkContainers.scala
@@ -9,8 +9,6 @@ import pl.touk.nussknacker.engine.util.ResourceLoader
 import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
 import pl.touk.nussknacker.test.containers.{ContainerVolume, WithDockerContainers}
 
-import java.nio.file.Path
-
 trait WithFlinkContainers extends WithDockerContainers with BeforeAndAfterAll { self: Suite with StrictLogging =>
 
   private val FlinkJobManagerRestPort = 8081
@@ -80,22 +78,6 @@ trait WithFlinkContainers extends WithDockerContainers with BeforeAndAfterAll { 
 
       image.withFileFromString(file, withFlinkLibTweaks)
     }
-  }
-
-  protected def listJobManagerFiles(containerPath: String): List[String] = {
-    val result = jobManagerContainer.container.execInContainer("ls", "-Atr1p", containerPath)
-    if (result.getExitCode != 0) {
-      throw new IllegalStateException(
-        s"Failed to list $containerPath in JobManager container: ${result.getStderr}"
-      )
-    }
-    result.getStdout.split("\n").iterator.map(_.trim).filter(_.nonEmpty).toList
-  }
-
-  protected def copyLastSavepointFromJobManager(target: Path): Unit = {
-    val savepointDirName = listJobManagerFiles(jobManagerContainerSavepointDir).headOption
-      .getOrElse(throw new IllegalStateException(s"There are no savepoints under $jobManagerContainerSavepointDir"))
-    copyDirectoryFromContainer(jobManagerContainer.container, savepointDirName, target)
   }
 
 }

--- a/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/utils/NuRuntimeDockerTestUtils.scala
+++ b/engine/lite/integration-test/src/it/scala/pl/touk/nussknacker/engine/lite/utils/NuRuntimeDockerTestUtils.scala
@@ -5,6 +5,7 @@ import org.slf4j.Logger
 import org.testcontainers.containers.{BindMode, Network}
 import org.testcontainers.containers.output.{OutputFrame, Slf4jLogConsumer}
 import org.testcontainers.containers.wait.strategy.{Wait, WaitStrategy, WaitStrategyTarget}
+import org.testcontainers.utility.MountableFile
 import pl.touk.nussknacker.engine.util.config.ScalaMajorVersionConfig
 import pl.touk.nussknacker.engine.version.BuildInfo
 
@@ -34,15 +35,13 @@ object NuRuntimeDockerTestUtils {
       env = sys.env.get("NUSSKNACKER_LOG_LEVEL").map("NUSSKNACKER_LOG_LEVEL" -> _).toMap ++ additionalEnvs
     )
     networkOpt.foreach(runtimeContainer.underlyingUnsafeContainer.withNetwork)
-    runtimeContainer.underlyingUnsafeContainer.withFileSystemBind(
-      scenarioFile.toString,
-      "/opt/nussknacker/conf/scenario.json",
-      BindMode.READ_ONLY
+    runtimeContainer.underlyingUnsafeContainer.withCopyFileToContainer(
+      MountableFile.forHostPath(scenarioFile.toPath),
+      "/opt/nussknacker/conf/scenario.json"
     )
-    runtimeContainer.underlyingUnsafeContainer.withFileSystemBind(
-      NuRuntimeTestUtils.deploymentDataFile.toString,
-      "/opt/nussknacker/conf/deploymentData.json",
-      BindMode.READ_ONLY
+    runtimeContainer.underlyingUnsafeContainer.withCopyFileToContainer(
+      MountableFile.forHostPath(NuRuntimeTestUtils.deploymentDataFile.toPath),
+      "/opt/nussknacker/conf/deploymentData.json"
     )
     val waitStrategy = if (checkReady) Wait.forHttp("/ready").forPort(runtimeApiPort) else DummyWaitStrategy
     runtimeContainer.underlyingUnsafeContainer.setWaitStrategy(waitStrategy)

--- a/utils/test-utils/src/main/scala/pl/touk/nussknacker/test/containers/VolumeReaper.scala
+++ b/utils/test-utils/src/main/scala/pl/touk/nussknacker/test/containers/VolumeReaper.scala
@@ -1,0 +1,60 @@
+package pl.touk.nussknacker.test.containers
+
+import com.typesafe.scalalogging.{LazyLogging, Logger}
+import org.testcontainers.DockerClientFactory
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
+
+/**
+ * Like [[org.testcontainers.utility.ResourceReaper]], but for Volumes.
+ *
+ * Ideally we'd use tags and depend on the main `ResourceReaper`, but it works with labels, and that would complicate
+ * volume creation which then would need to happen explicitly via `DockerClient.createVolumeCmd().withLabels(...)`.
+ *
+ * See https://github.com/testcontainers/testcontainers-java/issues/7420 for discussion
+ * about adding volumes to Testcontainers.
+ */
+object VolumeReaper extends LazyLogging {
+
+  Runtime.getRuntime.addShutdownHook(
+    new Thread(DockerClientFactory.TESTCONTAINERS_THREAD_GROUP, () => this.performCleanup(), "volumes-reaper")
+  )
+
+  private val volumes = ConcurrentHashMap.newKeySet[String]
+
+  private def performCleanup(): Unit = {
+    removeVolumesQuietly(volumes.asScala.toSeq)
+  }
+
+  def registerVolume(name: String): Unit = this.synchronized {
+    volumes.add(name)
+  }
+
+  def unregisterVolume(name: String): Unit = this.synchronized {
+    volumes.remove(name)
+  }
+
+  def removeVolumesQuietly(volumeNames: Seq[String], rmLogger: Logger = logger): Unit = this.synchronized {
+    if (volumeNames.nonEmpty) {
+      try {
+        val client              = DockerClientFactory.lazyClient()
+        val existingVolumes     = client.listVolumesCmd().exec().getVolumes.asScala.map(_.getName)
+        val (toRemove, missing) = existingVolumes.partition(volumeNames.contains)
+        missing.foreach(unregisterVolume)
+        toRemove.foreach { volumeName =>
+          try {
+            DockerClientFactory.lazyClient().removeVolumeCmd(volumeName).exec()
+            unregisterVolume(volumeName)
+          } catch {
+            case NonFatal(e) => rmLogger.warn(s"Failed to remove Docker volume $volumeName: ${e.getMessage}")
+          }
+        }
+      } catch {
+        case NonFatal(e) => rmLogger.warn(s"Failed to remove Docker volumes: ${volumeNames.mkString(", ")}", e)
+      }
+    }
+  }
+
+}

--- a/utils/test-utils/src/main/scala/pl/touk/nussknacker/test/containers/WithDockerContainers.scala
+++ b/utils/test-utils/src/main/scala/pl/touk/nussknacker/test/containers/WithDockerContainers.scala
@@ -1,13 +1,17 @@
 package pl.touk.nussknacker.test.containers
 
+import com.github.dockerjava.api.model.{Bind, Volume}
+import com.typesafe.scalalogging.Logger
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.scalatest.Suite
-import org.testcontainers.containers.{BindMode, Network}
+import org.testcontainers.containers.{BindMode, GenericContainer, Network}
 import pl.touk.nussknacker.test.containers.LogLevelConfigurableScalaLoggingConsumer.LoggerLevel
 
-import java.nio.file.{Files, FileSystems, Path}
-import java.nio.file.attribute.PosixFilePermissions
+import java.nio.file.{Files, Path}
 
 trait WithDockerContainers { self: Suite =>
+
+  protected val logger: Logger
 
   // dedicated method because withPrefix is mutable
   protected def logConsumer(prefix: String): LogLevelConfigurableScalaLoggingConsumer =
@@ -18,40 +22,39 @@ trait WithDockerContainers { self: Suite =>
 
   protected val network: Network = Network.newNetwork
 
-  /**
-   * Creates a temporary directory with possibly insecure permissions.
-   * If your directory is writable you may need to also use `chmod` in Docker container.
-   *
-   * Instead of mounting prefer [[com.dimafeng.testcontainers.GenericContainer.copyFileFromContainer()]]
-   * and [[com.dimafeng.testcontainers.GenericContainer.copyFileToContainer()]].
-   */
-  protected def createMountableTempDirectory(prefix: String, mode: BindMode): Path = {
-    val posixPerms = mode match {
-      case BindMode.READ_WRITE => "rwxrwxrwx"
-      case BindMode.READ_ONLY  => "rwxr-xr-x"
-    }
+  protected def bindTempVolume(container: GenericContainer[_], volume: ContainerVolume): Unit = {
+    container.getBinds.add(new Bind(volume.volumeName, new Volume(volume.containerPath), volume.mode.accessMode))
+    VolumeReaper.registerVolume(volume.volumeName)
+  }
 
-    val tempDirectoryAttributes = {
-      if (FileSystems.getDefault.supportedFileAttributeViews().contains("posix")) {
-        val allPermissions = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(posixPerms))
-        List(allPermissions)
-      } else {
-        Nil // Windows
+  protected def removeVolumesQuietly(volumeNames: Seq[String]): Unit =
+    VolumeReaper.removeVolumesQuietly(volumeNames, logger)
+
+  protected def copyDirectoryFromContainer(
+      container: GenericContainer[_],
+      containerPath: String,
+      destinationPath: Path
+  ): Unit = {
+    container.copyFileFromContainer(
+      containerPath,
+      (stream: java.io.InputStream) => {
+        // Leverage the fact that we got a TarArchiveInputStream
+        // Other possible approaches: https://github.com/testcontainers/testcontainers-java/issues/1647
+        val tar = stream.asInstanceOf[TarArchiveInputStream]
+        Iterator.continually(tar.getNextEntry).takeWhile(_ != null).foreach { entry =>
+          val entryPath = destinationPath.resolve(entry.getName)
+          if (entry.isDirectory) {
+            Files.createDirectories(entryPath)
+          } else {
+            Files.createDirectories(entryPath.getParent)
+            Files.copy(tar, entryPath)
+          }
+        }
+        tar.close()
       }
-    }
-    val tempPath = Files.createTempDirectory(prefix, tempDirectoryAttributes: _*)
-    tempPath.toFile.deleteOnExit()
-    tempPath
+    )
   }
 
 }
 
-final case class FileSystemBind(hostPath: Path, containerPath: String, mode: BindMode) {
-
-  def subdirectory(name: String): FileSystemBind = this.copy(
-    hostPath = hostPath.resolve(name),
-    containerPath = containerPath + "/" + name,
-    mode
-  )
-
-}
+final case class ContainerVolume(volumeName: String, containerPath: String, mode: BindMode = BindMode.READ_WRITE)


### PR DESCRIPTION
## Describe your changes

Makes it possible to run tests in environments where it's difficult to have working Docker bind mounts.

Changes are mostly straightforward, except the introduction of `SavepointLocator` - we still require savepoint location to be available for Designer, but tests can override this and fetch savepoint from external location (here - extract from Docker container).

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
