### PR TITLE
Runtime parameter validation (ESP)

### DIFF
--- a/components-api/src/main/java/pl/touk/nussknacker/engine/api/validation/CustomValidator.java
+++ b/components-api/src/main/java/pl/touk/nussknacker/engine/api/validation/CustomValidator.java
@@ -1,0 +1,14 @@
+package pl.touk.nussknacker.engine.api.validation;
+
+import pl.touk.nussknacker.engine.api.definition.CustomParameterValidator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomValidator {
+    Class<? extends CustomParameterValidator> value();
+}

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/component/ComponentConfig.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/component/ComponentConfig.scala
@@ -2,7 +2,8 @@ package pl.touk.nussknacker.engine.api.component
 
 import cats.implicits.catsSyntaxSemigroup
 import cats.kernel.Semigroup
-import io.circe.generic.JsonCodec
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
 import pl.touk.nussknacker.engine.api.definition.{
   ParameterCategory,
   ParameterEditor,
@@ -92,7 +93,7 @@ object ParameterConfig {
   val empty: ParameterConfig = ParameterConfig(None, None, None, None, None, None)
 }
 
-@JsonCodec case class ScenarioPropertyConfig(
+case class ScenarioPropertyConfig(
     defaultValue: Option[String],
     editor: Option[StaticParameterEditor],
     validators: Option[List[ParameterValidator]],
@@ -101,6 +102,9 @@ object ParameterConfig {
 )
 
 object ScenarioPropertyConfig {
+
+  implicit val decoder: Decoder[ScenarioPropertyConfig] = deriveDecoder
+
   val empty: ScenarioPropertyConfig = ScenarioPropertyConfig(None, None, None, None, None)
 
   implicit val semigroup: Semigroup[ScenarioPropertyConfig] = {

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
@@ -477,16 +477,17 @@ object CustomParameterValidatorByClassLoader {
   def apply(clazz: Class[_ <: CustomParameterValidator]): CustomParameterValidatorByClassLoader =
     new CustomParameterValidatorByClassLoader(clazz.getName)
 
-  private val cache: TrieMap[(String, ClassLoader), CustomParameterValidator] = TrieMap.empty
+  private val cache: TrieMap[String, CustomParameterValidator] = TrieMap.empty
 
-  private def getOrLoad(className: String): CustomParameterValidator = {
-    val classLoader = Thread.currentThread().getContextClassLoader
-    cache.getOrElseUpdate((className, classLoader), load(className, classLoader))
-  }
+  private def getOrLoad(className: String): CustomParameterValidator =
+    cache.getOrElseUpdate(className, load(className))
 
-  private def load(className: String, classLoader: ClassLoader): CustomParameterValidator =
+  private def load(className: String): CustomParameterValidator =
     try {
-      Class.forName(className, true, classLoader).getDeclaredConstructor().newInstance() match {
+      Class
+        .forName(className, true, Thread.currentThread().getContextClassLoader)
+        .getDeclaredConstructor()
+        .newInstance() match {
         case v: CustomParameterValidator => v
         case _ => throw new RuntimeException(s"Class $className does not extend CustomParameterValidator")
       }

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/definition/ParameterValidator.scala
@@ -2,12 +2,13 @@ package pl.touk.nussknacker.engine.api.definition
 
 import cats.data.Validated
 import cats.data.Validated.{invalid, valid}
-import io.circe.generic.extras.ConfiguredJsonCodec
+import io.circe._
 import io.circe.parser._
-import pl.touk.nussknacker.engine.api.CirceUtil._
+import io.circe.syntax.EncoderOps
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context.PartSubGraphCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
+import pl.touk.nussknacker.engine.api.definition.CustomParameterValidatorLoader.WithUnderlyingCustomParameterValidator
 import pl.touk.nussknacker.engine.api.parameter.{ParameterName, ParameterValueCompileTimeValidation}
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language
@@ -17,11 +18,23 @@ import java.util.regex.Pattern
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
 
-trait Validator {
+sealed trait Validator
+
+trait CompileTimeValidator extends Validator {
 
   def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
       implicit nodeId: NodeId
   ): Validated[PartSubGraphCompilationError, Unit]
+
+}
+
+final case class ParameterRuntimeValidationError(input: String, message: String)
+
+trait RuntimeValidator extends Validator {
+
+  def isValid(paramName: ParameterName, expression: Expression, value: Any)(
+      implicit nodeId: NodeId
+  ): Validated[ParameterRuntimeValidationError, Unit]
 
 }
 
@@ -35,11 +48,93 @@ trait Validator {
   * TODO: This being sealed also makes the tests of cases that use these validators dependant on the code here -
   * not good/unseal!!
   */
-@ConfiguredJsonCodec sealed trait ParameterValidator extends Validator
+sealed trait ParameterValidator extends Validator
+
+object ParameterValidator {
+
+  def resolveLoaders(validators: List[Validator]): List[Validator] =
+    validators.map { case d: CustomParameterValidatorLoader => d.resolved; case v => v }
+
+  private val fixedValuesCodec: Codec[FixedValuesValidator] =
+    Codec.forProduct1("possibleValues")(FixedValuesValidator.apply)(_.possibleValues)
+
+  private val regExpCodec: Codec[RegExpParameterValidator] =
+    Codec.forProduct3("pattern", "message", "description")(RegExpParameterValidator.apply)(v =>
+      (v.pattern, v.message, v.description)
+    )
+
+  private val minimalNumberCodec: Codec[MinimalNumberValidator] =
+    Codec.forProduct1("minimalNumber")(MinimalNumberValidator.apply)(_.minimalNumber)
+
+  private val maximalNumberCodec: Codec[MaximalNumberValidator] =
+    Codec.forProduct1("maximalNumber")(MaximalNumberValidator.apply)(_.maximalNumber)
+
+  private val validationExpressionCodec: Codec[ValidationExpressionParameterValidatorToCompile] =
+    Codec.forProduct2("validationExpression", "validationFailedMessage")(
+      ValidationExpressionParameterValidatorToCompile.apply
+    )(v => (v.validationExpression, v.validationFailedMessage))
+
+  implicit val decoder: Decoder[ParameterValidator] = Decoder.instance { cursor =>
+    cursor.downField("type").as[String].flatMap {
+      case "MandatoryParameterValidator"        => Right(MandatoryParameterValidator)
+      case "NotNullParameterValidator"          => Right(NotNullParameterValidator)
+      case "CompileTimeEvaluableValueValidator" => Right(CompileTimeEvaluableValueValidator)
+      case "NotBlankParameterValidator"         => Right(NotBlankParameterValidator)
+      case "LiteralIntegerValidator"            => Right(LiteralIntegerValidator)
+      case "JsonValidator"                      => Right(JsonValidator)
+      case "FixedValuesValidator"               => fixedValuesCodec(cursor)
+      case "RegExpParameterValidator"           => regExpCodec(cursor)
+      case "MinimalNumberValidator"             => minimalNumberCodec(cursor)
+      case "MaximalNumberValidator"             => maximalNumberCodec(cursor)
+      case "ValidationExpressionParameterValidatorToCompile" =>
+        validationExpressionCodec(cursor)
+      case "CustomParameterValidatorDelegate" =>
+        cursor
+          .downField("className")
+          .as[String]
+          .map(cn => CustomParameterValidatorByClassLoader(cn))
+          .orElse(cursor.downField("name").as[String].map(name => CustomParameterValidatorByNameLoader(name)))
+      case other =>
+        Left(DecodingFailure(s"Unknown ParameterValidator type: $other", cursor.history))
+    }
+  }
+
+  implicit val encoder: Encoder[ParameterValidator] = Encoder.instance {
+    case MandatoryParameterValidator        => Json.obj("type" -> "MandatoryParameterValidator".asJson)
+    case NotNullParameterValidator          => Json.obj("type" -> "NotNullParameterValidator".asJson)
+    case CompileTimeEvaluableValueValidator => Json.obj("type" -> "CompileTimeEvaluableValueValidator".asJson)
+    case NotBlankParameterValidator         => Json.obj("type" -> "NotBlankParameterValidator".asJson)
+    case LiteralIntegerValidator            => Json.obj("type" -> "LiteralIntegerValidator".asJson)
+    case JsonValidator                      => Json.obj("type" -> "JsonValidator".asJson)
+    case v: FixedValuesValidator =>
+      fixedValuesCodec(v).deepMerge(Json.obj("type" -> "FixedValuesValidator".asJson))
+    case v: RegExpParameterValidator =>
+      regExpCodec(v).deepMerge(Json.obj("type" -> "RegExpParameterValidator".asJson))
+    case v: MinimalNumberValidator =>
+      minimalNumberCodec(v).deepMerge(Json.obj("type" -> "MinimalNumberValidator".asJson))
+    case v: MaximalNumberValidator =>
+      maximalNumberCodec(v).deepMerge(Json.obj("type" -> "MaximalNumberValidator".asJson))
+    case v: ValidationExpressionParameterValidatorToCompile =>
+      validationExpressionCodec(v).deepMerge(
+        Json.obj("type" -> "ValidationExpressionParameterValidatorToCompile".asJson)
+      )
+    case v: CustomParameterValidatorByClassLoader =>
+      Json.obj("type" -> "CustomParameterValidatorDelegate".asJson, "className" -> v.validatorClassName.asJson)
+    case v: CustomParameterValidatorByNameLoader =>
+      Json.obj("type" -> "CustomParameterValidatorDelegate".asJson, "name" -> v.name.asJson)
+    case v =>
+      throw new IllegalArgumentException(s"Cannot encode unknown ParameterValidator type: ${v.getClass.getName}")
+  }
+
+}
+
+trait CompileTimeParameterValidator extends ParameterValidator with CompileTimeValidator
+
+trait RuntimeParameterValidator extends ParameterValidator with RuntimeValidator
 
 //TODO: These validators should be moved to separated module
 
-case object MandatoryParameterValidator extends ParameterValidator {
+case object MandatoryParameterValidator extends CompileTimeParameterValidator {
 
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
       implicit nodeId: NodeId
@@ -63,7 +158,7 @@ case object MandatoryParameterValidator extends ParameterValidator {
 
 }
 
-case object NotNullParameterValidator extends ParameterValidator {
+case object NotNullParameterValidator extends CompileTimeParameterValidator {
 
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
       implicit nodeId: NodeId
@@ -83,7 +178,7 @@ case object NotNullParameterValidator extends ParameterValidator {
 
 }
 
-case object CompileTimeEvaluableValueValidator extends ParameterValidator {
+case object CompileTimeEvaluableValueValidator extends CompileTimeParameterValidator {
 
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
       implicit nodeId: NodeId
@@ -104,7 +199,7 @@ case object CompileTimeEvaluableValueValidator extends ParameterValidator {
 
 }
 
-case object NotBlankParameterValidator extends ParameterValidator {
+case object NotBlankParameterValidator extends CompileTimeParameterValidator {
 
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
       implicit nodeId: NodeId
@@ -125,7 +220,7 @@ case object NotBlankParameterValidator extends ParameterValidator {
 
 }
 
-case class FixedValuesValidator(possibleValues: List[FixedExpressionValue]) extends ParameterValidator {
+case class FixedValuesValidator(possibleValues: List[FixedExpressionValue]) extends CompileTimeParameterValidator {
 
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
       implicit nodeId: NodeId
@@ -143,7 +238,8 @@ case class FixedValuesValidator(possibleValues: List[FixedExpressionValue]) exte
 
 }
 
-case class RegExpParameterValidator(pattern: String, message: String, description: String) extends ParameterValidator {
+case class RegExpParameterValidator(pattern: String, message: String, description: String)
+    extends CompileTimeParameterValidator {
 
   lazy val regexpPattern: Pattern = Pattern.compile(pattern)
 
@@ -163,7 +259,7 @@ case class RegExpParameterValidator(pattern: String, message: String, descriptio
 
 // TODO: we need this validator because scenario properties do not have typing result, so we enforce proper type
 //   here in validator by parsing raw expression to int
-case object LiteralIntegerValidator extends ParameterValidator {
+case object LiteralIntegerValidator extends CompileTimeParameterValidator {
 
   // empty expression should not be validated - we want to chain validators
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
@@ -185,7 +281,7 @@ case object LiteralIntegerValidator extends ParameterValidator {
 
 }
 
-case class MinimalNumberValidator(minimalNumber: BigDecimal) extends ParameterValidator {
+case class MinimalNumberValidator(minimalNumber: BigDecimal) extends CompileTimeParameterValidator {
 
   // null value should not be validated - we want to chain validators
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
@@ -208,7 +304,7 @@ case class MinimalNumberValidator(minimalNumber: BigDecimal) extends ParameterVa
 
 }
 
-case class MaximalNumberValidator(maximalNumber: BigDecimal) extends ParameterValidator {
+case class MaximalNumberValidator(maximalNumber: BigDecimal) extends CompileTimeParameterValidator {
 
   // null value should not be validated - we want to chain validators
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
@@ -234,7 +330,7 @@ case class MaximalNumberValidator(maximalNumber: BigDecimal) extends ParameterVa
 
 // This validator is not determined by default in components based on usage of JsonParameterEditor because someone may want to use only
 // editor for syntax highlight but don't want to use validator e.g. when want user to provide SpEL literal map
-case object JsonValidator extends ParameterValidator {
+case object JsonValidator extends CompileTimeParameterValidator {
 
   // null value should not be validated - we want to chain validators
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
@@ -268,7 +364,7 @@ case object JsonValidator extends ParameterValidator {
 case class ValidationExpressionParameterValidatorToCompile(
     validationExpression: Expression,
     validationFailedMessage: Option[String]
-) extends ParameterValidator {
+) extends CompileTimeParameterValidator {
 
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
       implicit nodeId: NodeId
@@ -290,20 +386,68 @@ object ValidationExpressionParameterValidatorToCompile {
 
 }
 
-trait CustomParameterValidator extends Validator {
+sealed trait CustomParameterValidator {
   def name: String
 }
 
-case class CustomParameterValidatorDelegate(name: String) extends ParameterValidator {
-  import CustomParameterValidatorDelegate._
+trait CustomCompileTimeParameterValidator extends CustomParameterValidator with CompileTimeValidator
 
-  override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
-      implicit nodeId: NodeId
-  ): Validated[PartSubGraphCompilationError, Unit] = getOrLoad(name).isValid(paramName, expression, value, label)
+trait CustomRuntimeParameterValidator extends CustomParameterValidator with RuntimeValidator
+
+sealed trait CustomParameterValidatorLoader extends ParameterValidator {
+  protected def load(): CustomParameterValidator
+
+  lazy val resolved: ParameterValidator with WithUnderlyingCustomParameterValidator = load() match {
+    case validator: CustomCompileTimeParameterValidator with CustomRuntimeParameterValidator =>
+      new CompileTimeParameterValidator with RuntimeParameterValidator with WithUnderlyingCustomParameterValidator {
+        override val underlying: CustomCompileTimeParameterValidator with CustomRuntimeParameterValidator = validator
+        override def isValid(
+            paramName: ParameterName,
+            expression: Expression,
+            value: Option[Any],
+            label: Option[String]
+        )(implicit nodeId: NodeId): Validated[PartSubGraphCompilationError, Unit] =
+          underlying.isValid(paramName, expression, value, label)
+        override def isValid(paramName: ParameterName, expression: Expression, value: Any)(
+            implicit nodeId: NodeId
+        ): Validated[ParameterRuntimeValidationError, Unit] = underlying.isValid(paramName, expression, value)
+      }
+    case validator: CustomCompileTimeParameterValidator =>
+      new CompileTimeParameterValidator with WithUnderlyingCustomParameterValidator {
+        override val underlying: CustomCompileTimeParameterValidator = validator
+        override def isValid(
+            paramName: ParameterName,
+            expression: Expression,
+            value: Option[Any],
+            label: Option[String]
+        )(implicit nodeId: NodeId): Validated[PartSubGraphCompilationError, Unit] =
+          underlying.isValid(paramName, expression, value, label)
+      }
+    case validator: CustomRuntimeParameterValidator =>
+      new RuntimeParameterValidator with WithUnderlyingCustomParameterValidator {
+        override val underlying: CustomRuntimeParameterValidator = validator
+        override def isValid(paramName: ParameterName, expression: Expression, value: Any)(
+            implicit nodeId: NodeId
+        ): Validated[ParameterRuntimeValidationError, Unit] = underlying.isValid(paramName, expression, value)
+      }
+  }
 
 }
 
-object CustomParameterValidatorDelegate {
+object CustomParameterValidatorLoader {
+
+  trait WithUnderlyingCustomParameterValidator {
+    def underlying: CustomParameterValidator
+  }
+
+}
+
+case class CustomParameterValidatorByNameLoader(name: String) extends CustomParameterValidatorLoader {
+  import CustomParameterValidatorByNameLoader._
+  override protected def load(): CustomParameterValidator = getOrLoad(name)
+}
+
+object CustomParameterValidatorByNameLoader {
   import scala.jdk.CollectionConverters._
 
   private val cache: TrieMap[String, CustomParameterValidator] = TrieMap[String, CustomParameterValidator]()
@@ -320,5 +464,35 @@ object CustomParameterValidatorDelegate {
     case Nil      => throw new RuntimeException(s"Cannot load custom validator: $name")
     case _        => throw new RuntimeException(s"Multiple custom validators with name: $name")
   }
+
+}
+
+case class CustomParameterValidatorByClassLoader(validatorClassName: String) extends CustomParameterValidatorLoader {
+  import CustomParameterValidatorByClassLoader._
+  override protected def load(): CustomParameterValidator = getOrLoad(validatorClassName)
+}
+
+object CustomParameterValidatorByClassLoader {
+
+  def apply(clazz: Class[_ <: CustomParameterValidator]): CustomParameterValidatorByClassLoader =
+    new CustomParameterValidatorByClassLoader(clazz.getName)
+
+  private val cache: TrieMap[(String, ClassLoader), CustomParameterValidator] = TrieMap.empty
+
+  private def getOrLoad(className: String): CustomParameterValidator = {
+    val classLoader = Thread.currentThread().getContextClassLoader
+    cache.getOrElseUpdate((className, classLoader), load(className, classLoader))
+  }
+
+  private def load(className: String, classLoader: ClassLoader): CustomParameterValidator =
+    try {
+      Class.forName(className, true, classLoader).getDeclaredConstructor().newInstance() match {
+        case v: CustomParameterValidator => v
+        case _ => throw new RuntimeException(s"Class $className does not extend CustomParameterValidator")
+      }
+    } catch {
+      case e: ReflectiveOperationException =>
+        throw new RuntimeException(s"Failed to instantiate CustomParameterValidator '$className': ${e.getMessage}", e)
+    }
 
 }

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/exception/ParameterRuntimeValidationException.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/exception/ParameterRuntimeValidationException.scala
@@ -1,0 +1,8 @@
+package pl.touk.nussknacker.engine.api.exception
+
+case class ParameterRuntimeValidationException(
+    paramName: pl.touk.nussknacker.engine.api.parameter.ParameterName,
+    override val input: String,
+    message: String,
+    cause: Throwable = null,
+) extends NonTransientException(input, message, cause = cause)

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/exception/ParameterRuntimeValidationException.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/exception/ParameterRuntimeValidationException.scala
@@ -1,7 +1,9 @@
 package pl.touk.nussknacker.engine.api.exception
 
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+
 case class ParameterRuntimeValidationException(
-    paramName: pl.touk.nussknacker.engine.api.parameter.ParameterName,
+    paramName: ParameterName,
     override val input: String,
     message: String,
     cause: Throwable = null,

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/exception/ParameterValidationAtRuntimeException.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/exception/ParameterValidationAtRuntimeException.scala
@@ -1,4 +1,0 @@
-package pl.touk.nussknacker.engine.api.exception
-
-class ParameterValidationAtRuntimeException(input: String, message: String, cause: Throwable = null)
-    extends NonTransientException(input, message, cause = cause)

--- a/components-api/src/main/scala/pl/touk/nussknacker/engine/api/exception/ParameterValidationAtRuntimeException.scala
+++ b/components-api/src/main/scala/pl/touk/nussknacker/engine/api/exception/ParameterValidationAtRuntimeException.scala
@@ -1,0 +1,4 @@
+package pl.touk.nussknacker.engine.api.exception
+
+class ParameterValidationAtRuntimeException(input: String, message: String, cause: Throwable = null)
+    extends NonTransientException(input, message, cause = cause)

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/cron/CronParameterValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/cron/CronParameterValidator.scala
@@ -5,13 +5,13 @@ import cats.data.Validated.{invalid, valid}
 import pl.touk.nussknacker.engine.api
 import pl.touk.nussknacker.engine.api.context.PartSubGraphCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.CustomParameterValidationError
-import pl.touk.nussknacker.engine.api.definition.CustomParameterValidatorDelegate
+import pl.touk.nussknacker.engine.api.definition.CompileTimeParameterValidator
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.ui.process.periodic.utils.SchedulePropertyExtractorUtils
 
 // Valid expression is e.g.: 0 * * * * ? * which means run every minute at 0 second
-object CronParameterValidator extends CustomParameterValidatorDelegate("cron_validator") {
+object CronParameterValidator extends CompileTimeParameterValidator {
 
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
       implicit nodeId: api.NodeId

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/validation/ScenarioPropertiesValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/validation/ScenarioPropertiesValidator.scala
@@ -1,12 +1,12 @@
 package pl.touk.nussknacker.ui.validation
 
-import cats.data.Validated
+import cats.data.{NonEmptyList, Validated}
 import cats.data.Validated.{invalid, valid, Invalid, Valid}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ScenarioPropertyConfig
 import pl.touk.nussknacker.engine.api.context.PartSubGraphCompilationError
-import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.MissingRequiredProperty
-import pl.touk.nussknacker.engine.api.definition.{MandatoryParameterValidator, ParameterValidator}
+import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.{CannotCreateObjectError, MissingRequiredProperty}
+import pl.touk.nussknacker.engine.api.definition.{CompileTimeValidator, MandatoryParameterValidator, ParameterValidator}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.graph.expression.Expression
 import pl.touk.nussknacker.restmodel.validation.PrettyValidationErrors
@@ -53,11 +53,11 @@ class ScenarioPropertiesValidator(
 
     val propertiesWithConfiguredValidator = for {
       property  <- scenarioProperties
-      validator <- validatorsByPropertyName.getOrElse(property._1, List.empty)
+      validator <- ParameterValidator.resolveLoaders(validatorsByPropertyName.getOrElse(property._1, List.empty))
     } yield (property, config.get(property._1), validator)
 
     propertiesWithConfiguredValidator
-      .collect { case (property, Some(config), validator: ParameterValidator) =>
+      .collect { case (property, Some(config), validator: CompileTimeValidator) =>
         val expression = property._2
         val value = expression match {
           case ex if ex.isBlank => null

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/validation/ScenarioPropertiesValidator.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/validation/ScenarioPropertiesValidator.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.ui.validation
 
-import cats.data.{NonEmptyList, Validated}
+import cats.data.Validated
 import cats.data.Validated.{invalid, valid, Invalid, Valid}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ScenarioPropertyConfig

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -15,6 +15,11 @@ description: Stay informed with detailed changelogs covering new features, impro
 
 ### 1.19.0 (Not released yet)
 
+* Added possibility of runtime parameter validation.
+  * New `RuntimeParameterValidator` trait for validators that execute during scenario runtime.
+  * Custom validators can now implement `CustomRuntimeParameterValidator` to validate a parameter value at runtime.
+  * A failed runtime validation throws `ParameterValidationAtRuntimeException`.
+  * Existing built-in validators (`@NotBlank`, `@NotNull`, etc.) remain compile-time only — their behaviour is unchanged.
 * [#9317](https://github.com/TouK/nussknacker/pull/9317/) Add handling null in List during Flink serialization
 * [#8719](https://github.com/TouK/nussknacker/pull/8719) Feature: Add possibility to pass trace id to Context
 * [#8720](https://github.com/TouK/nussknacker/pull/8720) In those aggregates, that do not require preserving context, the context is now cleaned before grouping:

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -15,11 +15,12 @@ description: Stay informed with detailed changelogs covering new features, impro
 
 ### 1.19.0 (Not released yet)
 
-* Added possibility of runtime parameter validation.
-  * New `RuntimeParameterValidator` trait for validators that execute during scenario runtime.
-  * Custom validators can now implement `CustomRuntimeParameterValidator` to validate a parameter value at runtime.
-  * A failed runtime validation throws `ParameterValidationAtRuntimeException`.
-  * Existing built-in validators (`@NotBlank`, `@NotNull`, etc.) remain compile-time only — their behaviour is unchanged.
+* Runtime parameter validation support added.
+  * `Validator` is now a sealed trait. `CompileTimeValidator` carries the existing compile-time `isValid` signature; `RuntimeValidator` is new and runs after expression evaluation at runtime.
+  * Custom validators can implement `CustomCompileTimeParameterValidator`, `CustomRuntimeParameterValidator`, or both.
+  * A failed runtime validation throws `ParameterRuntimeValidationException` (a `NonTransientException`).
+  * New `@CustomValidator(classOf[MyValidator])` Java annotation (in `pl.touk.nussknacker.engine.api.validation`) attaches a `CustomParameterValidator` to a parameter by class.
+  * All existing built-in validators (`MandatoryParameterValidator`, `NotBlankParameterValidator`, etc.) remain compile-time only — their behavior is unchanged.
 * [#9317](https://github.com/TouK/nussknacker/pull/9317/) Add handling null in List during Flink serialization
 * [#8719](https://github.com/TouK/nussknacker/pull/8719) Feature: Add possibility to pass trace id to Context
 * [#8720](https://github.com/TouK/nussknacker/pull/8720) In those aggregates, that do not require preserving context, the context is now cleaned before grouping:

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -66,15 +66,21 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 
 ### Code API changes
 
-* Runtime parameter validation: `CustomParameterValidator` trait hierarchy refactored to support both compile-time and runtime validation.
-  * `CustomParameterValidator` no longer extends `ParameterValidator`. It is now a standalone sealed trait.
-  * `CustomCompileTimeParameterValidator` now extends `CompileTimeValidator` (previously `CompileTimeParameterValidator`).
-  * `CustomRuntimeParameterValidator` now extends `RuntimeValidator` (previously `RuntimeParameterValidator`).
-  * `CustomParameterValidatorLoader.resolved` now returns `ParameterValidator` (wrapping the custom validator in an anonymous class) instead of `CustomParameterValidator`.
-    Code that previously assigned `resolved` to a `CustomParameterValidator` variable must be updated.
-  * `CustomParameterValidatorByClassLoader` is a new loader used by the `@CustomValidator` annotation. It serializes as
-    `CustomParameterValidatorDelegate` with a `className` key. The existing name-based format (from `CustomParameterValidatorByNameLoader`)
-    remains unchanged and is still decoded correctly.
+* Runtime parameter validation: `Validator`, `ParameterValidator`, and `CustomParameterValidator` trait hierarchies refactored.
+  * `Validator` is now a sealed trait with no `isValid` method. Two new sub-traits carry the validation logic:
+    * `CompileTimeValidator` — the existing `isValid(paramName, expression, value, label)(nodeId)` returning `Validated[PartSubGraphCompilationError, Unit]`. All built-in validators implement this.
+    * `RuntimeValidator` — new; `isValid(paramName, expression, value: Any)(nodeId)` returning `Validated[ParameterRuntimeValidationError, Unit]`. Called after expression evaluation at runtime.
+  * `CompileTimeParameterValidator extends ParameterValidator with CompileTimeValidator` and `RuntimeParameterValidator extends ParameterValidator with RuntimeValidator` are the new intermediate traits.
+  * `CustomParameterValidator` is now a sealed trait with only `def name: String`. It no longer extends `Validator`.
+    Replace usages of the old `CustomParameterValidator` (which extended `Validator`) with:
+    * `CustomCompileTimeParameterValidator extends CustomParameterValidator with CompileTimeValidator` — compile-time custom validation.
+    * `CustomRuntimeParameterValidator extends CustomParameterValidator with RuntimeValidator` — runtime custom validation.
+    * A class may extend both if it needs to validate at both stages.
+  * `CustomParameterValidatorDelegate` is renamed to `CustomParameterValidatorByNameLoader`. JSON serialization format is unchanged — it still encodes/decodes as `"type": "CustomParameterValidatorDelegate"` with a `"name"` key.
+  * `CustomParameterValidatorLoader.resolved` now returns `ParameterValidator with WithUnderlyingCustomParameterValidator` instead of `CustomParameterValidator`. Code that previously assigned `resolved` to a `CustomParameterValidator` variable must be updated.
+  * New `CustomParameterValidatorByClassLoader` loads a `CustomParameterValidator` by fully-qualified class name (used by the `@CustomValidator` annotation). It serializes as `"type": "CustomParameterValidatorDelegate"` with a `"className"` key.
+  * New `@CustomValidator(classOf[MyValidator])` Java annotation in `pl.touk.nussknacker.engine.api.validation` attaches a `CustomParameterValidator` implementation to a parameter by class (alternative to the existing name-based `CustomParameterValidatorByNameLoader`).
+  * `ParameterValidator` JSON codec rewritten manually (was `@ConfiguredJsonCodec`). `ScenarioPropertyConfig` also receives an explicit `Decoder` in place of `@JsonCodec`.
 * [#8719](https://github.com/TouK/nussknacker/pull/8719) Feature: Add possibility to pass trace id to Context
   * added optional `traceId` field at `Context`, default None
   * Fro now `RequestResponseSource` transforms `Record[T]` instead T as a record
@@ -254,15 +260,6 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 * [#7137](https://github.com/TouK/nussknacker/pull/7137)[#8317](https://github.com/TouK/nussknacker/pull/8317) Updated Flink 1.19.2 -> 1.20.2.
 * [#8209](https://github.com/TouK/nussknacker/pull/8209) Nussknacker now requires flink to be run with replaced `lib/flink-scala_2.12-x.x.x.jar` by `pl.touk:flink-scala` lib for the same scala version as used Nussknacker distribution. We provide prebuild flink docker images on [Docker Hub](https://hub.docker.com/r/touk/flink)    
 * [#8478](https://github.com/TouK/nussknacker/pull/8478) The behavior of `enum` to json encoding has been changed - now it uses `.name()` instead of `.toString()` 
-* Runtime parameter validation — custom validators and `Validator` API changes:
-  * `Validator.isValid` return type changed from `Validated[PartSubGraphCompilationError, Unit]` to `Validated[ParameterValidationError, Unit]`.
-    Custom validators implementing `CustomParameterValidator` must update their `isValid` signature accordingly.
-  * Validators annotated on parameters are now always evaluated at runtime (not only at compile time).
-    The previously opt-in `globalParameters.enableRuntimeParameterValidation` configuration key has been removed.
-  * New `@CustomValidator(classOf[MyValidator])` annotation in `pl.touk.nussknacker.engine.api.validation` allows
-    attaching a `CustomParameterValidator` implementation (identified by class) directly to a parameter.
-    The corresponding sealed subtype `CustomParameterValidatorByClass` was added to `ParameterValidator`.
-
 ## In version 1.18.0
 
 ### Configuration changes

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -66,6 +66,15 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 
 ### Code API changes
 
+* Runtime parameter validation: `CustomParameterValidator` trait hierarchy refactored to support both compile-time and runtime validation.
+  * `CustomParameterValidator` no longer extends `ParameterValidator`. It is now a standalone sealed trait.
+  * `CustomCompileTimeParameterValidator` now extends `CompileTimeValidator` (previously `CompileTimeParameterValidator`).
+  * `CustomRuntimeParameterValidator` now extends `RuntimeValidator` (previously `RuntimeParameterValidator`).
+  * `CustomParameterValidatorLoader.resolved` now returns `ParameterValidator` (wrapping the custom validator in an anonymous class) instead of `CustomParameterValidator`.
+    Code that previously assigned `resolved` to a `CustomParameterValidator` variable must be updated.
+  * `CustomParameterValidatorByClassLoader` is a new loader used by the `@CustomValidator` annotation. It serializes as
+    `CustomParameterValidatorDelegate` with a `className` key. The existing name-based format (from `CustomParameterValidatorByNameLoader`)
+    remains unchanged and is still decoded correctly.
 * [#8719](https://github.com/TouK/nussknacker/pull/8719) Feature: Add possibility to pass trace id to Context
   * added optional `traceId` field at `Context`, default None
   * Fro now `RequestResponseSource` transforms `Record[T]` instead T as a record
@@ -245,6 +254,14 @@ To see the biggest differences please consult the [changelog](Changelog.md).
 * [#7137](https://github.com/TouK/nussknacker/pull/7137)[#8317](https://github.com/TouK/nussknacker/pull/8317) Updated Flink 1.19.2 -> 1.20.2.
 * [#8209](https://github.com/TouK/nussknacker/pull/8209) Nussknacker now requires flink to be run with replaced `lib/flink-scala_2.12-x.x.x.jar` by `pl.touk:flink-scala` lib for the same scala version as used Nussknacker distribution. We provide prebuild flink docker images on [Docker Hub](https://hub.docker.com/r/touk/flink)    
 * [#8478](https://github.com/TouK/nussknacker/pull/8478) The behavior of `enum` to json encoding has been changed - now it uses `.name()` instead of `.toString()` 
+* Runtime parameter validation — custom validators and `Validator` API changes:
+  * `Validator.isValid` return type changed from `Validated[PartSubGraphCompilationError, Unit]` to `Validated[ParameterValidationError, Unit]`.
+    Custom validators implementing `CustomParameterValidator` must update their `isValid` signature accordingly.
+  * Validators annotated on parameters are now always evaluated at runtime (not only at compile time).
+    The previously opt-in `globalParameters.enableRuntimeParameterValidation` configuration key has been removed.
+  * New `@CustomValidator(classOf[MyValidator])` annotation in `pl.touk.nussknacker.engine.api.validation` allows
+    attaching a `CustomParameterValidator` implementation (identified by class) directly to a parameter.
+    The corresponding sealed subtype `CustomParameterValidatorByClass` was added to `ParameterValidator`.
 
 ## In version 1.18.0
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
@@ -143,12 +143,20 @@ class ExpressionCompiler(
       nodeBranchParameters = List.empty,
       inputContext = inputContext,
       treatEagerParametersAsLazy = true
-    ).map(_.map {
-      case (TypedParameter(_, expr: SingleBranchTypedValue), paramDef) =>
-        CompiledParameter(expr.typedExpression, paramDef)
-      case (TypedParameter(_, _: MultipleBranchesTypedValue), _) =>
-        throw new IllegalArgumentException("Typed expression map should not be here...")
-    })
+    ).flatMap { compiledParamsWithDefs =>
+      compiledParamsWithDefs
+        .map {
+          case (TypedParameter(_, expr: SingleBranchTypedValue), paramDef) =>
+            paramDef.validators
+              .map(v => compileValidator(v, paramDef.name, paramDef.typ, inputContext.globalVariables))
+              .sequence
+              .map(validators => CompiledParameter(expr.typedExpression, paramDef, validators))
+          case (TypedParameter(_, _: MultipleBranchesTypedValue), _) =>
+            throw new IllegalArgumentException("Typed expression map should not be here...")
+        }
+        .sequence
+        .toIor
+    }
   }
 
   // used for most cases during node compilation - for all components that are factories of Executors
@@ -333,6 +341,19 @@ class ExpressionCompiler(
         )
       case v => Valid(v)
     }
+
+  def compileValidatorsOrThrow(
+      definition: Parameter,
+      globalVariables: Map[String, TypingResult]
+  )(implicit nodeId: NodeId, jobData: JobData): List[Validator] =
+    definition.validators
+      .map(v => compileValidator(v, definition.name, definition.typ, globalVariables))
+      .sequence
+      .valueOr(errors =>
+        throw new IllegalStateException(
+          s"Validator for '${definition.name.value}' failed compile during runtime preparation — should have been caught earlier: ${errors.toList.mkString(", ")}"
+        )
+      )
 
   private def compileValidationExpressionParameterValidator(
       toCompileValidator: ValidationExpressionParameterValidatorToCompile,

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ExpressionCompiler.scala
@@ -339,7 +339,8 @@ class ExpressionCompiler(
           paramType,
           globalVariables
         )
-      case v => Valid(v)
+      case l: CustomParameterValidatorLoader => Valid(l.resolved)
+      case v                                 => Valid(v)
     }
 
   def compileValidatorsOrThrow(

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilerData.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/ProcessCompilerData.scala
@@ -75,8 +75,9 @@ object ProcessCompilerData {
       nodeCompiler,
       customProcessValidator
     )
-    val expressionEvaluator = ExpressionEvaluator.optimizedEvaluator(globalVariablesPreparer, listeners)
-    val interpreter         = Interpreter(listeners, expressionEvaluator, runtimeMode, nodesData)
+    val expressionEvaluator =
+      ExpressionEvaluator.optimizedEvaluator(globalVariablesPreparer, listeners)
+    val interpreter = Interpreter(listeners, expressionEvaluator, runtimeMode, nodesData)
 
     new ProcessCompilerData(
       processCompiler,
@@ -86,7 +87,7 @@ object ProcessCompilerData {
       interpreter,
       listeners,
       jobData,
-      servicesDefs.map(service => service.name -> service.component.asInstanceOf[Lifecycle]).toMap
+      servicesDefs.map(service => service.name -> service.component.asInstanceOf[Lifecycle]).toMap,
     )
 
   }
@@ -101,7 +102,7 @@ final class ProcessCompilerData(
     val interpreter: Interpreter,
     val listeners: Seq[ProcessListener],
     val jobData: JobData,
-    services: Map[String, Lifecycle]
+    services: Map[String, Lifecycle],
 ) {
 
   def lifecycle(nodesToUse: List[_ <: NodeData]): Seq[Lifecycle] = {

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/Validations.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/Validations.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.compile
 import cats.data.{NonEmptyList, Validated}
 import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.context._
-import pl.touk.nussknacker.engine.api.definition.{Parameter, Validator}
+import pl.touk.nussknacker.engine.api.definition.{CompileTimeValidator, Parameter, ParameterValidator, Validator}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.compiledgraph.TypedParameter
 import pl.touk.nussknacker.engine.expression.parse.{MultipleBranchesTypedValue, SingleBranchTypedValue}
@@ -45,7 +45,9 @@ object Validations {
         }
     }
 
-    validators
+    ParameterValidator
+      .resolveLoaders(validators)
+      .collect { case v: CompileTimeValidator => v }
       .flatMap { validator =>
         paramWithValueAndExpressionList.map { case (name, value, expression) =>
           validator.isValid(name, Expression(expression.language, expression.original), value, None).toValidatedNel

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/DynamicNodeValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/DynamicNodeValidator.scala
@@ -291,12 +291,14 @@ object DynamicNodeValidator {
 
   def apply(modelData: ModelData): DynamicNodeValidator = {
     val globalVariablesPreparer = GlobalVariablesPreparer(modelData.modelDefinition.expressionConfig)
+    val expressionCompiler      = ExpressionCompiler.withoutOptimization(modelData)
     new DynamicNodeValidator(
-      ExpressionCompiler.withoutOptimization(modelData),
+      expressionCompiler,
       globalVariablesPreparer,
       new ParameterEvaluator(
         globalVariablesPreparer,
         Seq.empty,
+        expressionCompiler,
       ),
       modelData.modelConfig.globalParametersConfig
     )

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/EvaluableLazyParameterCreator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/EvaluableLazyParameterCreator.scala
@@ -1,14 +1,14 @@
 package pl.touk.nussknacker.engine.compile.nodecompilation
 
+import cats.implicits._
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.LazyParameter._
 import pl.touk.nussknacker.engine.api.context.ValidationContext
-import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.definition.Validator
 import pl.touk.nussknacker.engine.api.typed.typing._
 import pl.touk.nussknacker.engine.compile.ExpressionCompiler
-import pl.touk.nussknacker.engine.compiledgraph.BaseCompiledParameter
+import pl.touk.nussknacker.engine.compiledgraph.CompiledParameter
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
-import pl.touk.nussknacker.engine.expression.parse.CompiledExpression
 import pl.touk.nussknacker.engine.graph.expression.Expression
 
 // This class looks like a LazyParameter but actually it's not - it's a creator of the LazyParameter.
@@ -33,17 +33,16 @@ final class EvaluableLazyParameterCreator[T <: AnyRef](
   }
 
   private def createEvaluableLazyParameter(deps: EvaluableLazyParameterCreatorDeps) = {
+    implicit val implicitNodeId: NodeId   = nodeId
+    implicit val implicitJobData: JobData = deps.jobData
     val compiledExpression = deps.expressionCompiler
       .compile(expression, Some(parameterDef.name), inputValidationContext, parameterDef.typ)(nodeId)
       .valueOr(err =>
         throw new IllegalArgumentException(s"Compilation failed with errors: ${err.toList.mkString(", ")}")
       )
-    val compiledParameter: BaseCompiledParameter = new BaseCompiledParameter {
-      override val name: ParameterName                      = parameterDef.name
-      override val expression: CompiledExpression           = compiledExpression.expression
-      override val shouldBeWrappedWithScalaOption: Boolean  = parameterDef.scalaOptionParameter
-      override val shouldBeWrappedWithJavaOptional: Boolean = parameterDef.javaOptionalParameter
-    }
+    val compiledValidators: List[Validator] =
+      deps.expressionCompiler.compileValidatorsOrThrow(parameterDef, inputValidationContext.globalVariables)
+    val compiledParameter = CompiledParameter(compiledExpression, parameterDef, compiledValidators)
     new EvaluableLazyParameter[T](
       compiledParameter,
       deps.expressionEvaluator,
@@ -58,7 +57,7 @@ final class EvaluableLazyParameterCreator[T <: AnyRef](
 class EvaluableLazyParameterCreatorDeps(
     val expressionCompiler: ExpressionCompiler,
     val expressionEvaluator: ExpressionEvaluator,
-    val jobData: JobData
+    val jobData: JobData,
 )
 
 class DefaultToEvaluateFunctionConverter(deps: EvaluableLazyParameterCreatorDeps) extends ToEvaluateFunctionConverter {

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/NodeCompiler.scala
@@ -126,7 +126,12 @@ class NodeCompiler(
     new StaticComponentOutputValidationContextDeterminer(globalVariablesPreparer)
 
   private val parametersEvaluator =
-    new ParameterEvaluator(globalVariablesPreparer, listeners)
+    new ParameterEvaluator(
+      globalVariablesPreparer,
+      listeners,
+      expressionCompiler,
+    )
+
   private val factory = new ComponentExecutorFactory(parametersEvaluator)
 
   private val dynamicNodeValidator =

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/ParameterEvaluator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compile/nodecompilation/ParameterEvaluator.scala
@@ -3,6 +3,7 @@ package pl.touk.nussknacker.engine.compile.nodecompilation
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.context.ValidationContext
 import pl.touk.nussknacker.engine.api.definition.{AdditionalVariableWithFixedValue, Parameter => ParameterDef}
+import pl.touk.nussknacker.engine.compile.ExpressionCompiler
 import pl.touk.nussknacker.engine.compile.nodecompilation.LazyParameterCreationStrategy.{
   EvaluableLazyParameterStrategy,
   PostponedEvaluatorLazyParameterStrategy
@@ -16,11 +17,16 @@ import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 
 class ParameterEvaluator(
     globalVariablesPreparer: GlobalVariablesPreparer,
-    listeners: Seq[ProcessListener]
+    listeners: Seq[ProcessListener],
+    expressionCompiler: ExpressionCompiler,
 ) {
 
   private val compileTimeExpressionEvaluator = ExpressionEvaluator.unOptimizedEvaluator(globalVariablesPreparer)
-  private val runtimeExpressionEvaluator = ExpressionEvaluator.optimizedEvaluator(globalVariablesPreparer, listeners)
+
+  private val runtimeExpressionEvaluator = ExpressionEvaluator.optimizedEvaluator(
+    globalVariablesPreparer,
+    listeners,
+  )
 
   private val contextToUse: Context = Context.dummy
 
@@ -108,8 +114,10 @@ class ParameterEvaluator(
   ): LazyParameter[Nothing] = {
     lazyParameterCreationStrategy match {
       case EvaluableLazyParameterStrategy =>
+        val compiledValidators =
+          expressionCompiler.compileValidatorsOrThrow(definition, validationContext.globalVariables)
         new EvaluableLazyParameter(
-          CompiledParameter(exprValue, definition),
+          CompiledParameter(exprValue, definition, compiledValidators),
           runtimeExpressionEvaluator,
           nodeId,
           jobData

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/CompiledParameter.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/CompiledParameter.scala
@@ -11,14 +11,8 @@ object CompiledParameter {
   def apply(
       typedExpression: TypedExpression,
       parameterDefinition: Parameter,
+      validators: List[Validator] = Nil,
   ): CompiledParameter =
-    apply(typedExpression, parameterDefinition, Nil)
-
-  def apply(
-      typedExpression: TypedExpression,
-      parameterDefinition: Parameter,
-      validators: List[Validator],
-  ): CompiledParameter = {
     CompiledParameter(
       parameterDefinition.name,
       typedExpression.expression,
@@ -27,7 +21,6 @@ object CompiledParameter {
       typedExpression.typingInfo,
       validators,
     )
-  }
 
 }
 
@@ -37,17 +30,16 @@ final case class CompiledParameter(
     override val shouldBeWrappedWithScalaOption: Boolean,
     override val shouldBeWrappedWithJavaOptional: Boolean,
     typingInfo: ExpressionTypingInfo,
-    validators: List[Validator] = Nil,
+    validators: List[Validator],
 ) extends BaseCompiledParameter {
 
-  lazy val expressionForValidation: Expression =
+  val expressionForValidation: Expression =
     Expression(expression.language, expression.original)
 
-  private lazy val resolvedValidators: List[Validator] =
-    ParameterValidator.resolveLoaders(validators)
-
   lazy val runtimeValidators: List[RuntimeValidator] =
-    resolvedValidators.collect { case v: RuntimeValidator => v }
+    ParameterValidator
+      .resolveLoaders(validators)
+      .collect { case v: RuntimeValidator => v }
 
 }
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/CompiledParameter.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/CompiledParameter.scala
@@ -1,22 +1,31 @@
 package pl.touk.nussknacker.engine.compiledgraph
 
-import pl.touk.nussknacker.engine.api.definition.Parameter
+import pl.touk.nussknacker.engine.api.definition._
 import pl.touk.nussknacker.engine.api.expression.ExpressionTypingInfo
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.expression.parse.{CompiledExpression, TypedExpression}
+import pl.touk.nussknacker.engine.graph.expression.Expression
 
 object CompiledParameter {
 
   def apply(
       typedExpression: TypedExpression,
-      parameterDefinition: Parameter
+      parameterDefinition: Parameter,
+  ): CompiledParameter =
+    apply(typedExpression, parameterDefinition, Nil)
+
+  def apply(
+      typedExpression: TypedExpression,
+      parameterDefinition: Parameter,
+      validators: List[Validator],
   ): CompiledParameter = {
     CompiledParameter(
       parameterDefinition.name,
       typedExpression.expression,
       parameterDefinition.scalaOptionParameter,
       parameterDefinition.javaOptionalParameter,
-      typedExpression.typingInfo
+      typedExpression.typingInfo,
+      validators,
     )
   }
 
@@ -27,8 +36,20 @@ final case class CompiledParameter(
     override val expression: CompiledExpression,
     override val shouldBeWrappedWithScalaOption: Boolean,
     override val shouldBeWrappedWithJavaOptional: Boolean,
-    typingInfo: ExpressionTypingInfo
-) extends BaseCompiledParameter
+    typingInfo: ExpressionTypingInfo,
+    validators: List[Validator] = Nil,
+) extends BaseCompiledParameter {
+
+  lazy val expressionForValidation: Expression =
+    Expression(expression.language, expression.original)
+
+  private lazy val resolvedValidators: List[Validator] =
+    ParameterValidator.resolveLoaders(validators)
+
+  lazy val runtimeValidators: List[RuntimeValidator] =
+    resolvedValidators.collect { case v: RuntimeValidator => v }
+
+}
 
 trait BaseCompiledParameter {
   def name: ParameterName

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/CompiledParameter.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/compiledgraph/CompiledParameter.scala
@@ -37,9 +37,7 @@ final case class CompiledParameter(
     Expression(expression.language, expression.original)
 
   lazy val runtimeValidators: List[RuntimeValidator] =
-    ParameterValidator
-      .resolveLoaders(validators)
-      .collect { case v: RuntimeValidator => v }
+    validators.collect { case v: RuntimeValidator => v }
 
 }
 

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/validator/ValidationExpressionParameterValidator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/validator/ValidationExpressionParameterValidator.scala
@@ -5,7 +5,7 @@ import cats.data.Validated.{invalid, valid}
 import pl.touk.nussknacker.engine.api.{Context, ContextId, JobData, NodeId}
 import pl.touk.nussknacker.engine.api.context.PartSubGraphCompilationError
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError._
-import pl.touk.nussknacker.engine.api.definition.Validator
+import pl.touk.nussknacker.engine.api.definition.{CompileTimeValidator, Validator}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.definition.component.parameter.validator.ValidationExpressionParameterValidator.variableName
 import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
@@ -19,7 +19,7 @@ case class ValidationExpressionParameterValidator(
     validationFailedMessage: Option[String],
     expressionEvaluator: ExpressionEvaluator,
     jobData: JobData
-) extends Validator {
+) extends CompileTimeValidator {
 
   override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
       implicit nodeId: NodeId

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/validator/ValidatorsExtractor.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/definition/component/parameter/validator/ValidatorsExtractor.scala
@@ -2,12 +2,13 @@ package pl.touk.nussknacker.engine.definition.component.parameter.validator
 
 import pl.touk.nussknacker.engine.api.definition
 import pl.touk.nussknacker.engine.api.definition.{
+  CustomParameterValidatorByClassLoader,
   MaximalNumberValidator,
   MinimalNumberValidator,
   NotBlankParameterValidator,
   ParameterValidator
 }
-import pl.touk.nussknacker.engine.api.validation.JsonValidator
+import pl.touk.nussknacker.engine.api.validation.{CustomValidator, JsonValidator}
 
 import javax.validation.constraints.{Max, Min, NotBlank}
 
@@ -21,7 +22,10 @@ object ValidatorsExtractor {
       CompileTimeEvaluableValueValidatorExtractor,
       AnnotationValidatorExtractor[NotBlank](NotBlankParameterValidator),
       AnnotationValidatorExtractor[Min]((annotation: Min) => MinimalNumberValidator(annotation.value())),
-      AnnotationValidatorExtractor[Max]((annotation: Max) => MaximalNumberValidator(annotation.value()))
+      AnnotationValidatorExtractor[Max]((annotation: Max) => MaximalNumberValidator(annotation.value())),
+      AnnotationValidatorExtractor[CustomValidator]((annotation: CustomValidator) =>
+        CustomParameterValidatorByClassLoader(annotation.value())
+      )
     ).flatMap(_.extract(params))
     // TODO: should validators from config override or append those from annotations, types etc.?
     (fromValidatorExtractors ++ params.parameterConfig.validators.toList.flatten).distinct

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
@@ -3,7 +3,7 @@ package pl.touk.nussknacker.engine.expression
 import cats.data.Validated.{Invalid, Valid}
 import pl.touk.nussknacker.engine.api._
 import pl.touk.nussknacker.engine.api.definition.ParameterRuntimeValidationError
-import pl.touk.nussknacker.engine.api.exception.ParameterValidationAtRuntimeException
+import pl.touk.nussknacker.engine.api.exception.ParameterRuntimeValidationException
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.CustomNodeValidationException
 import pl.touk.nussknacker.engine.compiledgraph.{BaseCompiledParameter, CompiledParameter}
@@ -100,7 +100,7 @@ class ExpressionEvaluator(
     param.runtimeValidators.foreach { validator =>
       validator.isValid(param.name, param.expressionForValidation, rawValue) match {
         case Invalid(ParameterRuntimeValidationError(input, message)) =>
-          throw new ParameterValidationAtRuntimeException(input, message)
+          throw ParameterRuntimeValidationException(param.name, input, message)
         case Valid(_) => ()
       }
     }

--- a/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
+++ b/scenario-compiler/src/main/scala/pl/touk/nussknacker/engine/expression/ExpressionEvaluator.scala
@@ -1,6 +1,9 @@
 package pl.touk.nussknacker.engine.expression
 
+import cats.data.Validated.{Invalid, Valid}
 import pl.touk.nussknacker.engine.api._
+import pl.touk.nussknacker.engine.api.definition.ParameterRuntimeValidationError
+import pl.touk.nussknacker.engine.api.exception.ParameterValidationAtRuntimeException
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.typed.CustomNodeValidationException
 import pl.touk.nussknacker.engine.compiledgraph.{BaseCompiledParameter, CompiledParameter}
@@ -25,7 +28,11 @@ object ExpressionEvaluator {
       globalVariablesPreparer: GlobalVariablesPreparer,
       listeners: Seq[ProcessListener],
   ): ExpressionEvaluator = {
-    new ExpressionEvaluator(globalVariablesPreparer, listeners, cacheGlobalVariables = true)
+    new ExpressionEvaluator(
+      globalVariablesPreparer,
+      listeners,
+      cacheGlobalVariables = true,
+    )
   }
 
   // This is for evaluation expressions fixed expressions during object creation *and* during tests/service queries
@@ -38,7 +45,7 @@ object ExpressionEvaluator {
 class ExpressionEvaluator(
     globalVariablesPreparer: GlobalVariablesPreparer,
     listeners: Seq[ProcessListener],
-    cacheGlobalVariables: Boolean
+    cacheGlobalVariables: Boolean,
 ) {
   private def prepareGlobals(jobData: JobData): Map[String, Any] =
     globalVariablesPreparer.prepareGlobalVariables(jobData).mapValuesNow(_.obj)
@@ -64,18 +71,38 @@ class ExpressionEvaluator(
       param: BaseCompiledParameter,
       ctx: Context
   )(implicit nodeId: NodeId, jobData: JobData): ValueWithContext[AnyRef] = {
-    try {
-      val valueWithModifiedContext = evaluate[AnyRef](param.expression, param.name.value, nodeId.id, ctx)
-      valueWithModifiedContext.map { evaluatedValue =>
-        if (param.shouldBeWrappedWithScalaOption)
-          Option(evaluatedValue)
-        else if (param.shouldBeWrappedWithJavaOptional)
-          Optional.ofNullable(evaluatedValue)
-        else
-          evaluatedValue
+    val valueWithModifiedContext =
+      try {
+        evaluate[AnyRef](param.expression, param.name.value, nodeId.id, ctx)
+      } catch {
+        case NonFatal(ex) => throw CustomNodeValidationException(ex.getMessage, Some(param.name), ex)
       }
-    } catch {
-      case NonFatal(ex) => throw CustomNodeValidationException(ex.getMessage, Some(param.name), ex)
+    param match {
+      case cp: CompiledParameter if cp.runtimeValidators.nonEmpty =>
+        validateParameterAtRuntime(cp, valueWithModifiedContext.value)
+      case _ =>
+    }
+    valueWithModifiedContext.map { evaluatedValue =>
+      if (param.shouldBeWrappedWithScalaOption)
+        Option(evaluatedValue)
+      else if (param.shouldBeWrappedWithJavaOptional)
+        Optional.ofNullable(evaluatedValue)
+      else
+        evaluatedValue
+    }
+  }
+
+  // Validation runs on the raw value before Option/Optional wrapping, so validators receive null
+  // for parameters where the expression evaluated to null (e.g. before wrapping to None/Optional.empty).
+  private def validateParameterAtRuntime(param: CompiledParameter, rawValue: AnyRef)(
+      implicit nodeId: NodeId
+  ): Unit = {
+    param.runtimeValidators.foreach { validator =>
+      validator.isValid(param.name, param.expressionForValidation, rawValue) match {
+        case Invalid(ParameterRuntimeValidationError(input, message)) =>
+          throw new ParameterValidationAtRuntimeException(input, message)
+        case Valid(_) => ()
+      }
     }
   }
 

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
@@ -1,6 +1,6 @@
 package pl.touk.nussknacker.engine
 
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.data.Validated.{Invalid, Valid}
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
@@ -17,7 +17,12 @@ import pl.touk.nussknacker.engine.api.component.{
   NodesDeploymentData,
   UnboundedStreamComponent
 }
-import pl.touk.nussknacker.engine.api.context.{ContextTransformation, ProcessCompilationError, ValidationContext}
+import pl.touk.nussknacker.engine.api.context.{
+  ContextTransformation,
+  PartSubGraphCompilationError,
+  ProcessCompilationError,
+  ValidationContext
+}
 import pl.touk.nussknacker.engine.api.context.ProcessCompilationError.InvalidFragment
 import pl.touk.nussknacker.engine.api.context.transformation.{
   DefinedEagerParameter,
@@ -27,23 +32,27 @@ import pl.touk.nussknacker.engine.api.context.transformation.{
 }
 import pl.touk.nussknacker.engine.api.definition.{AdditionalVariable => _, _}
 import pl.touk.nussknacker.engine.api.dict.embedded.EmbeddedDictDefinition
-import pl.touk.nussknacker.engine.api.exception.NuExceptionInfo
+import pl.touk.nussknacker.engine.api.exception.{NuExceptionInfo, ParameterValidationAtRuntimeException}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors.ServiceInvocationCollector
 import pl.touk.nussknacker.engine.api.typed.typing
 import pl.touk.nussknacker.engine.api.typed.typing.Typed
+import pl.touk.nussknacker.engine.api.validation.CustomValidator
 import pl.touk.nussknacker.engine.build.{GraphBuilder, ScenarioBuilder}
 import pl.touk.nussknacker.engine.canonicalgraph.{canonicalnode, CanonicalProcess}
 import pl.touk.nussknacker.engine.canonicalgraph.canonicalnode.FlatNode
 import pl.touk.nussknacker.engine.compile._
 import pl.touk.nussknacker.engine.compile.nodecompilation.SingleInputNodeInputValidationContext
+import pl.touk.nussknacker.engine.compiledgraph.CompiledParameter
 import pl.touk.nussknacker.engine.compiledgraph.part.{CustomNodePart, ProcessPart, SinkPart}
 import pl.touk.nussknacker.engine.definition.component.Components
 import pl.touk.nussknacker.engine.definition.component.Components.ComponentDefinitionExtractionMode
 import pl.touk.nussknacker.engine.definition.model.{ModelDefinition, ModelDefinitionWithClasses}
 import pl.touk.nussknacker.engine.dict.SimpleDictRegistry
+import pl.touk.nussknacker.engine.expression.ExpressionEvaluator
+import pl.touk.nussknacker.engine.expression.parse.CompiledExpression
 import pl.touk.nussknacker.engine.graph.evaluatedparam.{Parameter => NodeParameter}
 import pl.touk.nussknacker.engine.graph.expression._
 import pl.touk.nussknacker.engine.graph.expression.Expression.Language
@@ -62,8 +71,9 @@ import pl.touk.nussknacker.engine.util.service.{
   EagerServiceWithStaticParametersAndReturnType,
   EnricherContextTransformation
 }
+import pl.touk.nussknacker.engine.variables.GlobalVariablesPreparer
 
-import java.util.{Collections, Optional}
+import java.util.{Collections, Objects, Optional}
 import javax.annotation.Nullable
 import javax.validation.constraints.NotBlank
 import scala.concurrent.{ExecutionContext, Future}
@@ -87,6 +97,11 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
     ComponentDefinition("nullableTypesService", NullableTypesService),
     ComponentDefinition("mandatoryTypesService", MandatoryTypesService),
     ComponentDefinition("notBlankTypesService", NotBlankTypesService),
+    ComponentDefinition("notNullTypesService", NotNullTypesService),
+    ComponentDefinition("nullSensitiveService", NullSensitiveService),
+    ComponentDefinition("customValidatorTypesService", CustomValidatorTypesService),
+    ComponentDefinition("notBlankRuntimeTypesService", NotBlankRuntimeTypesService),
+    ComponentDefinition("dualNotBlankTypesService", DualNotBlankTypesService),
     ComponentDefinition("eagerServiceWithMethod", EagerServiceWithMethod),
     ComponentDefinition("dynamicEagerService", DynamicEagerService),
     ComponentDefinition("eagerServiceWithFixedAdditional", EagerServiceWithFixedAdditional),
@@ -110,7 +125,7 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
       transaction: Transaction,
       additionalComponents: List[ComponentDefinition] = servicesDef,
       listeners: Seq[ProcessListener] = listenersDef(),
-      runtimeMode: RuntimeMode = RuntimeMode.Live
+      runtimeMode: RuntimeMode = RuntimeMode.Live,
   ): Any = {
     import Interpreter._
 
@@ -188,8 +203,9 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
       jobData: JobData,
       additionalComponents: List[ComponentDefinition],
       listeners: Seq[ProcessListener],
-      runtimeMode: RuntimeMode
+      runtimeMode: RuntimeMode,
   ): ProcessCompilerData = {
+    val globalParametersConfig = GlobalParametersConfig.default
     val components =
       ComponentDefinition("transaction-source", TransactionSource) ::
         ComponentDefinition("dummySink", SinkFactory.noParam(new pl.touk.nussknacker.engine.api.process.Sink {})) ::
@@ -202,13 +218,13 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
           ComponentsUiConfig.Empty,
           id => DesignerWideComponentId(id.toString),
           Map.empty,
-          GlobalParametersConfig.default,
+          globalParametersConfig,
           ComponentDefinitionExtractionMode.FinalDefinition
         ),
       ModelDefinitionBuilder.emptyExpressionConfig,
       ClassExtractionSettings.Default,
       allowEndingScenarioWithoutSink = false,
-      globalParametersConfig = GlobalParametersConfig.default,
+      globalParametersConfig = globalParametersConfig,
     )
     val definitionsWithTypes = ModelDefinitionWithClasses(definitions)
     ProcessCompilerData.prepare(
@@ -993,6 +1009,240 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
     }.getMessage shouldBe "Compilation errors: BlankParameter(This field value is required and can not be blank,Please fill field value for this parameter,expression,customNode)"
   }
 
+  test("CompileTimeValidator does not run at runtime for dynamic expression evaluating to blank") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "notBlankTypesService", "expression" -> "#input.msisdn".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    interpretProcess(process, Transaction(msisdn = "")) shouldBe ""
+  }
+
+  test("CompileTimeValidator does not run at runtime for dynamic expression evaluating to a valid value") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "notBlankTypesService", "expression" -> "#input.msisdn".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    interpretProcess(process, Transaction(msisdn = "valid-value")) shouldBe "valid-value"
+  }
+
+  test("CompileTimeValidator does not run at runtime for dynamic expression evaluating to null") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "notNullTypesService", "expression" -> "#input.msisdn".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    interpretProcess(process, Transaction(msisdn = null)).asInstanceOf[String] shouldBe null
+  }
+
+  test("null reaches service and causes NullPointerException when component is null-sensitive") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "nullSensitiveService", "expression" -> "#input.msisdn".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    intercept[NullPointerException] {
+      interpretProcess(process, Transaction(msisdn = null))
+    }
+  }
+
+  test("CompileTimeValidator annotated with @CustomValidator does not run at runtime for dynamic expression") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "customValidatorTypesService", "expression" -> "#input.msisdn".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    interpretProcess(process, Transaction(msisdn = "")) shouldBe ""
+  }
+
+  test("not throw when @CustomValidator passes for dynamic expression") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "customValidatorTypesService", "expression" -> "#input.msisdn".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    interpretProcess(process, Transaction(msisdn = "valid-value")) shouldBe "valid-value"
+  }
+
+  test("RuntimeValidator fires and throws ParameterValidationAtRuntimeException during scenario execution") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "notBlankRuntimeTypesService", "expression" -> "''".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    intercept[ParameterValidationAtRuntimeException] {
+      interpretProcess(process, Transaction())
+    }.getMessage should include("expression")
+  }
+
+  test("RuntimeValidator allows valid value through during scenario execution") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "notBlankRuntimeTypesService", "expression" -> "'valid'".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    interpretProcess(process, Transaction()) shouldBe "valid"
+  }
+
+  test("RuntimeValidator runs at runtime for dynamic expression evaluating to blank") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "notBlankRuntimeTypesService", "expression" -> "#input.msisdn".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    intercept[ParameterValidationAtRuntimeException] {
+      interpretProcess(process, Transaction(msisdn = ""))
+    }.getMessage should include("expression")
+  }
+
+  test("dual validator (compile-time+runtime): compile-time fires for blank literal") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "dualNotBlankTypesService", "expression" -> "''".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    intercept[IllegalArgumentException] {
+      interpretProcess(process, Transaction())
+    }.getMessage shouldBe "Compilation errors: CustomParameterValidationError(Value must not be blank,Please provide a non-blank value,expression,customNode)"
+  }
+
+  test("dual validator (compile-time+runtime): runtime fires for dynamic expression evaluating to blank") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "dualNotBlankTypesService", "expression" -> "#input.msisdn".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    intercept[ParameterValidationAtRuntimeException] {
+      interpretProcess(process, Transaction(msisdn = ""))
+    }.getMessage should include("expression")
+  }
+
+  test("dual validator (compile-time+runtime): valid value passes both") {
+    val process = ScenarioBuilder
+      .streaming("test")
+      .source("start", "transaction-source")
+      .enricher("customNode", "rawExpression", "dualNotBlankTypesService", "expression" -> "#input.msisdn".spel)
+      .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
+      .emptySink("end-end", "dummySink")
+
+    interpretProcess(process, Transaction(msisdn = "valid-value")) shouldBe "valid-value"
+  }
+
+  // Unit-level tests for ExpressionEvaluator runtime validation — exercise evaluateParameter directly, not via interpretProcess
+
+  test("ExpressionEvaluator: RuntimeValidator fires and throws when value is invalid") {
+    implicit val nodeId: NodeId   = NodeId("testNode")
+    val metaData                  = MetaData("TestProcess", StreamMetaData())
+    implicit val jobData: JobData = JobData(metaData, ProcessVersion.empty.copy(processName = metaData.name))
+    val evaluator = ExpressionEvaluator.optimizedEvaluator(
+      GlobalVariablesPreparer(ModelDefinitionBuilder.empty.build.expressionConfig),
+      Nil,
+    )
+    val param = CompiledParameter(
+      name = ParameterName("param"),
+      expression = new FixedValueExpression(""),
+      shouldBeWrappedWithScalaOption = false,
+      shouldBeWrappedWithJavaOptional = false,
+      typingInfo = null,
+      validators = List(NotBlankRuntimeValidator),
+    )
+
+    intercept[ParameterValidationAtRuntimeException] {
+      evaluator.evaluateParameter(param, Context.dummy)
+    }.getMessage should include("param")
+  }
+
+  test("ExpressionEvaluator: RuntimeValidator does not throw when value is valid") {
+    implicit val nodeId: NodeId   = NodeId("testNode")
+    val metaData                  = MetaData("TestProcess", StreamMetaData())
+    implicit val jobData: JobData = JobData(metaData, ProcessVersion.empty.copy(processName = metaData.name))
+    val evaluator = ExpressionEvaluator.optimizedEvaluator(
+      GlobalVariablesPreparer(ModelDefinitionBuilder.empty.build.expressionConfig),
+      Nil,
+    )
+    val param = CompiledParameter(
+      name = ParameterName("param"),
+      expression = new FixedValueExpression("valid"),
+      shouldBeWrappedWithScalaOption = false,
+      shouldBeWrappedWithJavaOptional = false,
+      typingInfo = null,
+      validators = List(NotBlankRuntimeValidator),
+    )
+
+    evaluator.evaluateParameter(param, Context.dummy).value shouldBe "valid"
+  }
+
+  test("ExpressionEvaluator: no exception when no RuntimeValidator is attached") {
+    implicit val nodeId: NodeId   = NodeId("testNode")
+    val metaData                  = MetaData("TestProcess", StreamMetaData())
+    implicit val jobData: JobData = JobData(metaData, ProcessVersion.empty.copy(processName = metaData.name))
+    val evaluator = ExpressionEvaluator.optimizedEvaluator(
+      GlobalVariablesPreparer(ModelDefinitionBuilder.empty.build.expressionConfig),
+      Nil,
+    )
+    val param = CompiledParameter(
+      name = ParameterName("param"),
+      expression = new FixedValueExpression(""),
+      shouldBeWrappedWithScalaOption = false,
+      shouldBeWrappedWithJavaOptional = false,
+      typingInfo = null,
+      validators = Nil,
+    )
+
+    evaluator.evaluateParameter(param, Context.dummy).value shouldBe ""
+  }
+
+  test("ExpressionEvaluator: RuntimeValidator can return a non-default exception type") {
+    implicit val nodeId: NodeId   = NodeId("testNode")
+    val metaData                  = MetaData("TestProcess", StreamMetaData())
+    implicit val jobData: JobData = JobData(metaData, ProcessVersion.empty.copy(processName = metaData.name))
+    val evaluator = ExpressionEvaluator.optimizedEvaluator(
+      GlobalVariablesPreparer(ModelDefinitionBuilder.empty.build.expressionConfig),
+      Nil,
+    )
+    val customValidator = new RuntimeValidator {
+      override def isValid(paramName: ParameterName, expression: Expression, value: Any)(
+          implicit nodeId: NodeId
+      ): Validated[ParameterRuntimeValidationError, Unit] =
+        throw new IllegalStateException("custom error")
+    }
+    val param = CompiledParameter(
+      name = ParameterName("param"),
+      expression = new FixedValueExpression("anything"),
+      shouldBeWrappedWithScalaOption = false,
+      shouldBeWrappedWithJavaOptional = false,
+      typingInfo = null,
+      validators = List(customValidator),
+    )
+
+    intercept[IllegalStateException] {
+      evaluator.evaluateParameter(param, Context.dummy)
+    }.getMessage shouldBe "custom error"
+  }
+
   test("use eager service") {
     val process = ScenarioBuilder
       .streaming("test")
@@ -1260,6 +1510,168 @@ object InterpreterSpec {
   object NotBlankTypesService extends Service {
     @MethodToInvoke(returnType = classOf[String])
     def invoke(@ParamName("expression") @NotBlank expr: String) = Future.successful(expr)
+  }
+
+  class FailingForBlankCustomValidator extends CustomCompileTimeParameterValidator {
+    override val name: String = "failingForBlankCustomValidator"
+
+    override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
+        implicit nodeId: NodeId
+    ): Validated[PartSubGraphCompilationError, Unit] =
+      value match {
+        case Some(s: String) if s.isBlank =>
+          Invalid(
+            ProcessCompilationError.CustomParameterValidationError(
+              "Value must not be blank",
+              "Please provide a non-blank value",
+              paramName,
+              nodeId.id
+            )
+          )
+        case _ => Valid(())
+      }
+
+  }
+
+  object CustomValidatorTypesService extends Service {
+
+    @MethodToInvoke(returnType = classOf[String])
+    def invoke(
+        @ParamName("expression") @CustomValidator(classOf[FailingForBlankCustomValidator]) expr: String
+    ): Future[String] = Future.successful(expr)
+
+  }
+
+  class DualNotBlankValidator extends CompileTimeParameterValidator with RuntimeParameterValidator {
+
+    override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
+        implicit nodeId: NodeId
+    ): Validated[PartSubGraphCompilationError, Unit] =
+      value match {
+        case Some(s: String) if s.isBlank =>
+          Invalid(
+            ProcessCompilationError.CustomParameterValidationError(
+              "Value must not be blank",
+              "Please provide a non-blank value",
+              paramName,
+              nodeId.id
+            )
+          )
+        case _ => Valid(())
+      }
+
+    override def isValid(paramName: ParameterName, expression: Expression, value: Any)(
+        implicit nodeId: NodeId
+    ): Validated[ParameterRuntimeValidationError, Unit] =
+      value match {
+        case s: String if !s.isBlank => Valid(())
+        case _ =>
+          Invalid(ParameterRuntimeValidationError(paramName.value, s"Parameter '${paramName.value}' must not be blank"))
+      }
+
+  }
+
+  object DualNotBlankTypesService extends EagerServiceWithStaticParametersAndReturnType {
+
+    private val dualValidator = new DualNotBlankValidator
+
+    override def parameters: List[Parameter] = List(
+      Parameter[String](ParameterName("expression"))
+        .copy(isLazyParameter = true, validators = List(dualValidator))
+    )
+
+    override def returnType: typing.TypingResult = Typed[String]
+
+    override def invoke(params: Map[ParameterName, Any])(
+        implicit ec: ExecutionContext,
+        collector: ServiceInvocationCollector,
+        context: Context,
+        metaData: MetaData,
+        componentUseContext: ComponentUseContext
+    ): Future[AnyRef] =
+      Future.successful(params(ParameterName("expression")).asInstanceOf[AnyRef])
+
+  }
+
+  object NotNullTypesService extends EagerServiceWithStaticParametersAndReturnType {
+
+    override def parameters: List[Parameter] = List(
+      Parameter[String](ParameterName("expression"))
+        .copy(isLazyParameter = true, validators = List(NotNullParameterValidator))
+    )
+
+    override def returnType: typing.TypingResult = Typed[String]
+
+    override def invoke(params: Map[ParameterName, Any])(
+        implicit ec: ExecutionContext,
+        collector: ServiceInvocationCollector,
+        context: Context,
+        metaData: MetaData,
+        componentUseContext: ComponentUseContext
+    ): Future[AnyRef] =
+      Future.successful(params(ParameterName("expression")).asInstanceOf[AnyRef])
+
+  }
+
+  object NullSensitiveService extends EagerServiceWithStaticParametersAndReturnType {
+
+    override def parameters: List[Parameter] = List(
+      Parameter[String](ParameterName("expression"))
+        .copy(isLazyParameter = true, validators = List(NotNullParameterValidator))
+    )
+
+    override def returnType: typing.TypingResult = Typed[String]
+
+    override def invoke(params: Map[ParameterName, Any])(
+        implicit ec: ExecutionContext,
+        collector: ServiceInvocationCollector,
+        context: Context,
+        metaData: MetaData,
+        componentUseContext: ComponentUseContext
+    ): Future[AnyRef] =
+      Future.successful(
+        Objects.requireNonNull(params(ParameterName("expression")), "expression must not be null").asInstanceOf[AnyRef]
+      )
+
+  }
+
+  object NotBlankRuntimeValidator extends RuntimeParameterValidator {
+
+    override def isValid(paramName: ParameterName, expression: Expression, value: Any)(
+        implicit nodeId: NodeId
+    ): Validated[ParameterRuntimeValidationError, Unit] =
+      value match {
+        case s: String if !s.isBlank => Valid(())
+        case _ =>
+          Invalid(ParameterRuntimeValidationError(paramName.value, s"Parameter '${paramName.value}' must not be blank"))
+      }
+
+  }
+
+  object NotBlankRuntimeTypesService extends EagerServiceWithStaticParametersAndReturnType {
+
+    override def parameters: List[Parameter] = List(
+      Parameter[String](ParameterName("expression"))
+        .copy(isLazyParameter = true, validators = List(NotBlankRuntimeValidator))
+    )
+
+    override def returnType: typing.TypingResult = Typed[String]
+
+    override def invoke(params: Map[ParameterName, Any])(
+        implicit ec: ExecutionContext,
+        collector: ServiceInvocationCollector,
+        context: Context,
+        metaData: MetaData,
+        componentUseContext: ComponentUseContext
+    ): Future[AnyRef] =
+      Future.successful(params(ParameterName("expression")).asInstanceOf[AnyRef])
+
+  }
+
+  private class FixedValueExpression(value: String) extends CompiledExpression {
+    override val language: Language                                      = Language.Spel
+    override val original: String                                        = s"'$value'"
+    override def evaluate[T](ctx: Context, globals: Map[String, Any]): T = value.asInstanceOf[T]
   }
 
   object TransactionSource extends SourceFactory with UnboundedStreamComponent {

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/InterpreterSpec.scala
@@ -32,7 +32,7 @@ import pl.touk.nussknacker.engine.api.context.transformation.{
 }
 import pl.touk.nussknacker.engine.api.definition.{AdditionalVariable => _, _}
 import pl.touk.nussknacker.engine.api.dict.embedded.EmbeddedDictDefinition
-import pl.touk.nussknacker.engine.api.exception.{NuExceptionInfo, ParameterValidationAtRuntimeException}
+import pl.touk.nussknacker.engine.api.exception.{NuExceptionInfo, ParameterRuntimeValidationException}
 import pl.touk.nussknacker.engine.api.parameter.ParameterName
 import pl.touk.nussknacker.engine.api.process._
 import pl.touk.nussknacker.engine.api.test.InvocationCollectors
@@ -1077,7 +1077,7 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
     interpretProcess(process, Transaction(msisdn = "valid-value")) shouldBe "valid-value"
   }
 
-  test("RuntimeValidator fires and throws ParameterValidationAtRuntimeException during scenario execution") {
+  test("RuntimeValidator fires and throws ParameterRuntimeValidationException during scenario execution") {
     val process = ScenarioBuilder
       .streaming("test")
       .source("start", "transaction-source")
@@ -1085,7 +1085,7 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
       .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
       .emptySink("end-end", "dummySink")
 
-    intercept[ParameterValidationAtRuntimeException] {
+    intercept[ParameterRuntimeValidationException] {
       interpretProcess(process, Transaction())
     }.getMessage should include("expression")
   }
@@ -1109,7 +1109,7 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
       .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
       .emptySink("end-end", "dummySink")
 
-    intercept[ParameterValidationAtRuntimeException] {
+    intercept[ParameterRuntimeValidationException] {
       interpretProcess(process, Transaction(msisdn = ""))
     }.getMessage should include("expression")
   }
@@ -1135,7 +1135,7 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
       .buildSimpleVariable("result-end", resultVariable, "#rawExpression".spel)
       .emptySink("end-end", "dummySink")
 
-    intercept[ParameterValidationAtRuntimeException] {
+    intercept[ParameterRuntimeValidationException] {
       interpretProcess(process, Transaction(msisdn = ""))
     }.getMessage should include("expression")
   }
@@ -1170,7 +1170,7 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
       validators = List(NotBlankRuntimeValidator),
     )
 
-    intercept[ParameterValidationAtRuntimeException] {
+    intercept[ParameterRuntimeValidationException] {
       evaluator.evaluateParameter(param, Context.dummy)
     }.getMessage should include("param")
   }
@@ -1215,7 +1215,7 @@ class InterpreterSpec extends AnyFunSuite with Matchers {
     evaluator.evaluateParameter(param, Context.dummy).value shouldBe ""
   }
 
-  test("ExpressionEvaluator: RuntimeValidator can return a non-default exception type") {
+  test("ExpressionEvaluator: exception thrown inside RuntimeValidator.isValid propagates as-is, not wrapped") {
     implicit val nodeId: NodeId   = NodeId("testNode")
     val metaData                  = MetaData("TestProcess", StreamMetaData())
     implicit val jobData: JobData = JobData(metaData, ProcessVersion.empty.copy(processName = metaData.name))

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/compile/ProcessValidatorSpec.scala
@@ -131,7 +131,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
       Some(Unknown),
       nonEndingOneInputComponent,
       Parameter[String](ParameterName("param"))
-        .copy(validators = List(CustomParameterValidatorDelegate("test_custom_validator")))
+        .copy(validators = List(CustomParameterValidatorByNameLoader("test_custom_validator").resolved))
     )
     .withCustom(
       "withAdditionalVariable",
@@ -1972,7 +1972,7 @@ class ProcessValidatorSpec extends AnyFunSuite with Matchers with Inside with Op
 
 }
 
-class StartingWithACustomValidator extends CustomParameterValidator {
+class StartingWithACustomValidator extends CustomCompileTimeParameterValidator {
   override def name: String = "test_custom_validator"
 
   import cats.data.Validated.{invalid, valid}

--- a/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/definition/component/parameter/validator/ValidatorsExtractorTest.scala
+++ b/scenario-compiler/src/test/scala/pl/touk/nussknacker/engine/definition/component/parameter/validator/ValidatorsExtractorTest.scala
@@ -1,19 +1,34 @@
 package pl.touk.nussknacker.engine.definition.component.parameter.validator
 
+import cats.data.Validated
+import cats.data.Validated.valid
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.engine.ModelConfig.GlobalParametersConfig
+import pl.touk.nussknacker.engine.api.NodeId
 import pl.touk.nussknacker.engine.api.component.ParameterConfig
+import pl.touk.nussknacker.engine.api.context.PartSubGraphCompilationError
 import pl.touk.nussknacker.engine.api.definition._
-import pl.touk.nussknacker.engine.api.validation.CompileTimeEvaluableValue
+import pl.touk.nussknacker.engine.api.parameter.ParameterName
+import pl.touk.nussknacker.engine.api.validation.{CompileTimeEvaluableValue, CustomValidator}
 import pl.touk.nussknacker.engine.definition.clazz.ClassDefinitionExtractor
 import pl.touk.nussknacker.engine.definition.component.parameter.{OptionalDeterminer, ParameterData}
 import pl.touk.nussknacker.engine.definition.component.parameter.editor.EditorExtractor
+import pl.touk.nussknacker.engine.graph.expression.Expression
 
 import java.time.LocalDate
 import java.util.Optional
 import javax.annotation.Nullable
 import javax.validation.constraints.{Max, Min, NotBlank}
+
+class SampleCustomValidator extends CustomCompileTimeParameterValidator {
+  override val name: String = "sampleCustomValidator"
+
+  override def isValid(paramName: ParameterName, expression: Expression, value: Option[Any], label: Option[String])(
+      implicit nodeId: NodeId
+  ): Validated[PartSubGraphCompilationError, Unit] = valid(())
+
+}
 
 class ValidatorsExtractorTest extends AnyFunSuite with Matchers {
 
@@ -44,6 +59,8 @@ class ValidatorsExtractorTest extends AnyFunSuite with Matchers {
     getFirstParam("minimalAndMaximalValueIntegerAnnotatedParam", classOf[Int])
   private val minimalAndMaximalValueBigDecimalParam =
     getFirstParam("minimalAndMaximalValueBigDecimalAnnotatedParam", classOf[BigDecimal])
+
+  private val customValidatorParam = getFirstParam("customValidatorAnnotatedParam", classOf[String])
 
   private def notAnnotated(param: String) = ()
 
@@ -78,6 +95,8 @@ class ValidatorsExtractorTest extends AnyFunSuite with Matchers {
   private def minimalAndMaximalValueIntegerAnnotatedParam(@Min(value = 0) @Max(value = 1) value: Int) = ()
 
   private def minimalAndMaximalValueBigDecimalAnnotatedParam(@Min(value = 0) @Max(value = 1) value: BigDecimal) = ()
+
+  private def customValidatorAnnotatedParam(@CustomValidator(classOf[SampleCustomValidator]) param: String) = ()
 
   private def getFirstParam(name: String, params: Class[_]*) = {
     this.getClass.getDeclaredMethod(name, params: _*).getParameters.apply(0)
@@ -197,6 +216,14 @@ class ValidatorsExtractorTest extends AnyFunSuite with Matchers {
   test("extract minimalAndMaximalValueBigDecimalParam value validator when @Min and @Max annotation detected") {
     ValidatorsExtractor.extract(validatorParams(minimalAndMaximalValueBigDecimalParam)) shouldBe
       List(MandatoryParameterValidator, MinimalNumberValidator(0), MaximalNumberValidator(1))
+  }
+
+  test("extract custom validator when @CustomValidator annotation detected") {
+    val extracted = ValidatorsExtractor.extract(validatorParams(customValidatorParam))
+    extracted should have size 2
+    extracted.head shouldBe MandatoryParameterValidator
+    val underlyingCustomValidator = extracted(1).asInstanceOf[CustomParameterValidatorByClassLoader].resolved.underlying
+    underlyingCustomValidator shouldBe a[SampleCustomValidator]
   }
 
   test("determine validators based on config") {


### PR DESCRIPTION
## Describe your changes
* Added possibility of runtime parameter validation.
  * New `RuntimeParameterValidator` trait for validators that execute during scenario runtime.
  * Custom validators can now implement `CustomRuntimeParameterValidator` to validate a parameter value at runtime.
  * A failed runtime validation throws `ParameterValidationAtRuntimeException`.
  * Existing built-in validators (`@NotBlank`, `@NotNull`, etc.) remain compile-time only — their behaviour is unchanged.

PR on ESP branch, will cherry pick to staging when accepted

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
