### PR TITLE
Allow periodic scheduler to use the main leader lock

### DIFF
--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/factory/DomainServices.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/factory/DomainServices.scala
@@ -138,7 +138,8 @@ object DomainServices extends LazyLogging {
       )
       scenarioActivityRepository = DbScenarioActivityRepository.create(dbRef, clock)
       distributedLock            = DistributedLock(alreadyLoadedConfig.haMode, dbRef, clock)
-      periodicLock <- PeriodicDeploymentLock.create(alreadyLoadedConfig.haMode, distributedLock)
+      leadership   <- Leadership.create(alreadyLoadedConfig.haMode, distributedLock, clock)
+      periodicLock <- PeriodicDeploymentLock.create(alreadyLoadedConfig.haMode, distributedLock, leadership)
       deploymentData <- DeploymentManagersLoader.load(
         alreadyLoadedConfig.processingTypeConfigs(),
         deploymentManagersClassLoader,
@@ -206,7 +207,6 @@ object DomainServices extends LazyLogging {
         ),
         dbioRunner
       )
-      leadership <- Leadership.create(alreadyLoadedConfig.haMode, distributedLock, clock)
       _ <- DeploymentsStatusesSynchronizationScheduler.resource(
         actorSystem,
         deploymentsStatusesSynchronizer,

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/ha/DistributedLock.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/ha/DistributedLock.scala
@@ -27,9 +27,8 @@ object DistributedLock {
 
   def apply(haMode: HaMode, dbRef: DbRef, clock: Clock)(implicit ec: ExecutionContext): DistributedLock =
     haMode match {
-      case HaMode.Disabled(_) => NoOpDistributedLock
-      case HaMode.Enabled(instanceId, _, _, lockQueryTimeout) =>
-        SlickDistributedLock(dbRef, instanceId, lockQueryTimeout, clock)
+      case HaMode.Disabled(_)      => NoOpDistributedLock
+      case enabled: HaMode.Enabled => SlickDistributedLock(dbRef, enabled.instanceId, enabled.lockQueryTimeout, clock)
     }
 
 }

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/ha/HaMode.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/ha/HaMode.scala
@@ -2,6 +2,7 @@ package pl.touk.nussknacker.ui.ha
 
 import com.typesafe.config.Config
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+import net.ceedubs.ficus.readers.EnumerationReader._
 import pl.touk.nussknacker.engine.util.config.CustomFicusInstances._
 
 import java.net.InetAddress
@@ -20,9 +21,17 @@ object HaMode {
       releaseOnStop: Boolean = true,
   )
 
+  object PeriodicLockMode extends Enumeration {
+    type PeriodicLockMode = Value
+
+    val Dedicated: Value = Value("dedicated")
+    val Leader: Value    = Value("leader")
+  }
+
   final case class Enabled(
       instanceId: String,
       leader: LeaderConfig,
+      periodicLockMode: PeriodicLockMode.Value = PeriodicLockMode.Dedicated,
       periodicLockDuration: FiniteDuration,
       lockQueryTimeout: FiniteDuration,
   ) extends HaMode
@@ -33,6 +42,7 @@ object HaMode {
       val enabled = Enabled(
         instanceId = cfg.instanceId.getOrElse(defaultInstanceId),
         leader = cfg.leader,
+        periodicLockMode = cfg.periodicLockMode,
         periodicLockDuration = cfg.periodicLockDuration,
         lockQueryTimeout = cfg.lockQueryTimeout,
       )
@@ -66,6 +76,7 @@ object HaMode {
   private final case class EnabledConfig(
       instanceId: Option[String] = None,
       leader: LeaderConfig = LeaderConfig(),
+      periodicLockMode: PeriodicLockMode.Value = PeriodicLockMode.Dedicated,
       periodicLockDuration: FiniteDuration = 5.minutes,
       lockQueryTimeout: FiniteDuration = 5.seconds,
   )

--- a/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicDeploymentLock.scala
+++ b/designer/server/src/main/scala/pl/touk/nussknacker/ui/process/periodic/PeriodicDeploymentLock.scala
@@ -2,36 +2,60 @@ package pl.touk.nussknacker.ui.process.periodic
 
 import cats.effect.{IO, Resource}
 import com.typesafe.scalalogging.LazyLogging
-import pl.touk.nussknacker.ui.ha.{DistributedLock, HaMode, NoOpDistributedLock}
+import pl.touk.nussknacker.ui.ha.{DistributedLock, HaMode, Leadership}
+import pl.touk.nussknacker.ui.ha.HaMode.PeriodicLockMode
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
-final class PeriodicDeploymentLock(underlying: DistributedLock, val lockDuration: Option[FiniteDuration])(
+sealed trait PeriodicDeploymentLock {
+  def acquireOrRenew(): Future[Boolean]
+  def release(): Future[Boolean]
+  def lockDuration: Option[FiniteDuration]
+}
+
+final class NoOpPeriodicDeploymentLock extends PeriodicDeploymentLock {
+  override def acquireOrRenew(): Future[Boolean]    = Future.successful(true)
+  override def release(): Future[Boolean]           = Future.successful(true)
+  override def lockDuration: Option[FiniteDuration] = None
+}
+
+final class DedicatedPeriodicDeploymentLock(underlying: DistributedLock, lockDuration: FiniteDuration)(
     implicit ec: ExecutionContext
-) {
-  private val name                      = "periodic-process-deployment"
-  private val duration                  = lockDuration.getOrElse(0.seconds)
-  def acquireOrRenew(): Future[Boolean] = underlying.acquireOrRenew(name, duration).map(_.isDefined)
-  def release(): Future[Boolean]        = underlying.release(name)
+) extends PeriodicDeploymentLock {
+  private val name                                  = "periodic-process-deployment"
+  override def acquireOrRenew(): Future[Boolean]    = underlying.acquireOrRenew(name, lockDuration).map(_.isDefined)
+  override def release(): Future[Boolean]           = underlying.release(name)
+  override def lockDuration: Option[FiniteDuration] = Some(lockDuration)
+}
+
+final class LeaderPeriodicDeploymentLock(leadership: Leadership) extends PeriodicDeploymentLock {
+  override def acquireOrRenew(): Future[Boolean]    = Future.successful(leadership.isLeader())
+  override def release(): Future[Boolean]           = Future.successful(true)
+  override val lockDuration: Option[FiniteDuration] = None
 }
 
 object PeriodicDeploymentLock extends LazyLogging {
 
-  def create(haMode: HaMode, distributedLock: DistributedLock)(
+  def create(haMode: HaMode, distributedLock: DistributedLock, leadership: Leadership)(
       implicit ec: ExecutionContext
   ): Resource[IO, PeriodicDeploymentLock] =
     haMode match {
       case HaMode.Disabled(_) =>
-        Resource.pure(new PeriodicDeploymentLock(NoOpDistributedLock, None))
+        Resource.pure(new NoOpPeriodicDeploymentLock)
       case e: HaMode.Enabled =>
-        Resource.make(IO.pure(new PeriodicDeploymentLock(distributedLock, Some(e.periodicLockDuration))))(lock =>
-          IO.fromFuture(IO(lock.release()))
-            .handleError(ex =>
-              logger.error("Failed to release periodic lock on stop — lease will expire naturally", ex)
+        e.periodicLockMode match {
+          case PeriodicLockMode.Leader =>
+            Resource.pure(new LeaderPeriodicDeploymentLock(leadership))
+          case PeriodicLockMode.Dedicated =>
+            Resource.make(IO.pure(new DedicatedPeriodicDeploymentLock(distributedLock, e.periodicLockDuration)))(lock =>
+              IO.fromFuture(IO(lock.release()))
+                .handleError(ex =>
+                  logger.error("Failed to release periodic lock on stop — lease will expire naturally", ex)
+                )
+                .void
             )
-            .void
-        )
+        }
     }
 
 }

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/ha/HaModeSpec.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/ha/HaModeSpec.scala
@@ -1,0 +1,36 @@
+package pl.touk.nussknacker.ui.ha
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class HaModeSpec extends AnyFunSuite with Matchers {
+
+  private def parse(config: String): HaMode = HaMode.fromConfig(ConfigFactory.parseString(config))
+
+  test("periodicLockMode defaults to dedicated when not configured") {
+    val mode = parse("""ha { enabled: true, instanceId: "node-1" }""")
+
+    mode shouldBe a[HaMode.Enabled]
+    mode.asInstanceOf[HaMode.Enabled].periodicLockMode shouldBe HaMode.PeriodicLockMode.Dedicated
+  }
+
+  test("periodicLockMode is read from config") {
+    val mode = parse("""ha { enabled: true, instanceId: "node-1", periodicLockMode: leader }""")
+
+    mode.asInstanceOf[HaMode.Enabled].periodicLockMode shouldBe HaMode.PeriodicLockMode.Leader
+  }
+
+  test("unknown periodicLockMode fails config parsing") {
+    a[Exception] should be thrownBy parse(
+      """ha { enabled: true, instanceId: "node-1", periodicLockMode: whatever }"""
+    )
+  }
+
+  test("periodicLockMode is not read when ha is disabled") {
+    parse("""ha { enabled: false, instanceId: "node-1", periodicLockMode: whatever }""") shouldBe HaMode.Disabled(
+      "node-1"
+    )
+  }
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/ha/TogglableLeadership.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/ha/TogglableLeadership.scala
@@ -1,0 +1,19 @@
+package pl.touk.nussknacker.ui.ha
+
+import cats.effect.{IO, Resource}
+import cats.effect.std.Supervisor
+
+class TogglableLeadership(initiallyLeader: Boolean) extends Leadership {
+
+  @volatile private var leader: Boolean = initiallyLeader
+
+  def becomeLeader(): Unit   = leader = true
+  def loseLeadership(): Unit = leader = false
+
+  override val haEnabled: Boolean  = true
+  override val instanceId: String  = "test-instance"
+  override def isLeader(): Boolean = leader
+
+  override protected def doStartHeartbeat(supervisor: Supervisor[IO]): Resource[IO, Unit] = Resource.unit[IO]
+
+}

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/DeploymentActorTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/DeploymentActorTest.scala
@@ -5,9 +5,10 @@ import org.apache.pekko.testkit.{TestKit, TestKitBase, TestProbe}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import pl.touk.nussknacker.ui.ha.DistributedLock
+import pl.touk.nussknacker.ui.ha.{DistributedLock, TogglableLeadership}
+import pl.touk.nussknacker.ui.process.periodic.DedicatedPeriodicDeploymentLock
 import pl.touk.nussknacker.ui.process.periodic.DeploymentActor
-import pl.touk.nussknacker.ui.process.periodic.PeriodicDeploymentLock
+import pl.touk.nussknacker.ui.process.periodic.LeaderPeriodicDeploymentLock
 import pl.touk.nussknacker.ui.process.periodic.model.PeriodicProcessDeployment
 
 import java.time.Instant
@@ -27,14 +28,15 @@ class DeploymentActorTest extends AnyFunSuite with TestKitBase with Matchers wit
     TestKit.shutdownActorSystem(system)
   }
 
-  private def lockReturning(value: Boolean) = new PeriodicDeploymentLock(
+  private def mockedLock(acquire: => Future[Option[Instant]]) = new DedicatedPeriodicDeploymentLock(
     new DistributedLock {
-      override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] =
-        Future.successful(if (value) Some(Instant.MAX) else None)
+      override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] = acquire
       override def release(name: String): Future[Boolean] = Future.successful(true)
     },
-    None
+    1.minute
   )
+
+  private def lockReturning(value: Boolean) = mockedLock { Future.successful(if (value) Some(Instant.MAX) else None) }
 
   test("should find to be deployed scenarios repeatedly") {
     shouldFindToBeDeployedScenarios(Future.successful(Seq.empty))
@@ -125,15 +127,10 @@ class DeploymentActorTest extends AnyFunSuite with TestKitBase with Matchers wit
     val deployProbe       = TestProbe()
     val waitingDeployment = PeriodicProcessDeploymentGen()
     var failLock          = true
-    val lock = new PeriodicDeploymentLock(
-      new DistributedLock {
-        override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] =
-          if (failLock) Future.failed(new RuntimeException("db error"))
-          else Future.successful(Some(Instant.MAX))
-        override def release(name: String): Future[Boolean] = Future.successful(true)
-      },
-      None
-    )
+    val lock = mockedLock {
+      if (failLock) Future.failed(new RuntimeException("db error"))
+      else Future.successful(Some(Instant.MAX))
+    }
     val actor = system.actorOf(
       DeploymentActor.props(
         findToBeDeployed = Future.successful(Seq(waitingDeployment)),
@@ -185,19 +182,12 @@ class DeploymentActorTest extends AnyFunSuite with TestKitBase with Matchers wit
     val waitingDeployment                            = PeriodicProcessDeploymentGen()
     var toBeDeployed: Seq[PeriodicProcessDeployment] = Seq(waitingDeployment)
     val lockPromise                                  = Promise[Option[Instant]]()
-    val lock = new PeriodicDeploymentLock(
-      new DistributedLock {
-        override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] =
-          lockPromise.future
-        override def release(name: String): Future[Boolean] = Future.successful(true)
-      },
-      None
-    )
+
     val actor = system.actorOf(
       DeploymentActor.props(
         findToBeDeployed = Future.successful(toBeDeployed),
         deploy = d => { deployProbe.ref ! d; toBeDeployed = Seq.empty; Future.unit },
-        lock = lock,
+        lock = mockedLock { lockPromise.future },
         interval
       )
     )
@@ -245,16 +235,10 @@ class DeploymentActorTest extends AnyFunSuite with TestKitBase with Matchers wit
     val deployPromise     = Promise[Unit]()
     val waitingDeployment = PeriodicProcessDeploymentGen()
 
-    val lock = new PeriodicDeploymentLock(
-      new DistributedLock {
-        override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] = {
-          acquireCount.incrementAndGet()
-          Future.successful(Some(Instant.MAX))
-        }
-        override def release(name: String): Future[Boolean] = Future.successful(true)
-      },
-      None
-    )
+    val lock = mockedLock {
+      acquireCount.incrementAndGet()
+      Future.successful(Some(Instant.MAX))
+    }
 
     val actor = system.actorOf(
       DeploymentActor.props(
@@ -279,15 +263,10 @@ class DeploymentActorTest extends AnyFunSuite with TestKitBase with Matchers wit
     val deployPromise     = Promise[Unit]()
     val waitingDeployment = PeriodicProcessDeploymentGen()
 
-    val lock = new PeriodicDeploymentLock(
-      new DistributedLock {
-        override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] =
-          // first two calls succeed (pre-finding + pre-deployment acquire), then lock is lost
-          Future.successful(if (acquireCount.getAndIncrement() < 2) Some(Instant.MAX) else None)
-        override def release(name: String): Future[Boolean] = Future.successful(true)
-      },
-      None
-    )
+    val lock = mockedLock {
+      // first two calls succeed (pre-finding + pre-deployment acquire), then lock is lost
+      Future.successful(if (acquireCount.getAndIncrement() < 2) Some(Instant.MAX) else None)
+    }
 
     val actor = system.actorOf(
       DeploymentActor.props(
@@ -306,20 +285,38 @@ class DeploymentActorTest extends AnyFunSuite with TestKitBase with Matchers wit
     system.stop(actor)
   }
 
+  test("should deploy only while being a leader when lock is backed by leadership") {
+    val deployProbe       = TestProbe()
+    val waitingDeployment = PeriodicProcessDeploymentGen()
+    val leadership        = new TogglableLeadership(initiallyLeader = false)
+    var toBeDeployed      = Seq(waitingDeployment)
+
+    val actor = system.actorOf(
+      DeploymentActor.props(
+        findToBeDeployed = Future.successful(toBeDeployed),
+        deploy = d => { deployProbe.ref ! d; toBeDeployed = Seq.empty; Future.unit },
+        new LeaderPeriodicDeploymentLock(leadership),
+        interval
+      )
+    )
+
+    deployProbe.expectNoMessage(interval * 3) // not a leader — nothing is deployed
+    leadership.becomeLeader()
+
+    within(maxWaitTime) { deployProbe.expectMsg(waitingDeployment) }
+
+    system.stop(actor)
+  }
+
   test("should skip deploy if lock is lost between finding and deploying, retry on next tick") {
     val deployProbe       = TestProbe()
     val waitingDeployment = PeriodicProcessDeploymentGen()
     val acquireCount      = new AtomicInteger(0)
 
-    val lock = new PeriodicDeploymentLock(
-      new DistributedLock {
-        override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] =
-          // call 0 (pre-find, tick 1): succeed; call 1 (pre-deploy, tick 1): fail; call 2+ (tick 2): succeed
-          Future.successful(if (acquireCount.getAndIncrement() == 1) None else Some(Instant.MAX))
-        override def release(name: String): Future[Boolean] = Future.successful(true)
-      },
-      None
-    )
+    val lock = mockedLock {
+      // call 0 (pre-find, tick 1): succeed; call 1 (pre-deploy, tick 1): fail; call 2+ (tick 2): succeed
+      Future.successful(if (acquireCount.getAndIncrement() == 1) None else Some(Instant.MAX))
+    }
 
     val actor = system.actorOf(
       DeploymentActor.props(

--- a/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/RescheduleFinishedActorTest.scala
+++ b/designer/server/src/test/scala/pl/touk/nussknacker/ui/process/periodic/flink/RescheduleFinishedActorTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pl.touk.nussknacker.ui.ha.DistributedLock
-import pl.touk.nussknacker.ui.process.periodic.PeriodicDeploymentLock
+import pl.touk.nussknacker.ui.process.periodic.DedicatedPeriodicDeploymentLock
 import pl.touk.nussknacker.ui.process.periodic.RescheduleFinishedActor
 
 import java.time.Instant
@@ -26,14 +26,15 @@ class RescheduleFinishedActorTest extends AnyFunSuite with TestKitBase with Matc
     TestKit.shutdownActorSystem(system)
   }
 
-  private def lockReturning(value: Boolean) = new PeriodicDeploymentLock(
+  private def mockedLock(acquire: => Future[Option[Instant]]) = new DedicatedPeriodicDeploymentLock(
     new DistributedLock {
-      override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] =
-        Future.successful(if (value) Some(Instant.MAX) else None)
+      override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] = acquire
       override def release(name: String): Future[Boolean] = Future.successful(true)
     },
-    None
+    1.minute
   )
+
+  private def lockReturning(value: Boolean) = mockedLock { Future.successful(if (value) Some(Instant.MAX) else None) }
 
   test("should invoke handle finished repeatedly") {
     shouldInvokeHandleFinishedRepeatedly(Future.successful(()))
@@ -79,16 +80,10 @@ class RescheduleFinishedActorTest extends AnyFunSuite with TestKitBase with Matc
     val finishPromise = Promise[Unit]()
     val probe         = TestProbe()
 
-    val lock = new PeriodicDeploymentLock(
-      new DistributedLock {
-        override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] = {
-          acquireCount.incrementAndGet()
-          Future.successful(Some(Instant.MAX))
-        }
-        override def release(name: String): Future[Boolean] = Future.successful(true)
-      },
-      None
-    )
+    val lock = mockedLock {
+      acquireCount.incrementAndGet()
+      Future.successful(Some(Instant.MAX))
+    }
 
     def handleFinished: Future[Unit] = { probe.ref ! "started"; finishPromise.future }
 
@@ -107,14 +102,9 @@ class RescheduleFinishedActorTest extends AnyFunSuite with TestKitBase with Matc
     val finishPromise = Promise[Unit]()
     val probe         = TestProbe()
 
-    val lock = new PeriodicDeploymentLock(
-      new DistributedLock {
-        override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] =
-          Future.successful(if (acquireCount.getAndIncrement() == 0) Some(Instant.MAX) else None)
-        override def release(name: String): Future[Boolean] = Future.successful(true)
-      },
-      None
-    )
+    val lock = mockedLock {
+      Future.successful(if (acquireCount.getAndIncrement() == 0) Some(Instant.MAX) else None)
+    }
 
     def handleFinished: Future[Unit] = { probe.ref ! "started"; finishPromise.future }
 
@@ -156,15 +146,10 @@ class RescheduleFinishedActorTest extends AnyFunSuite with TestKitBase with Matc
     val acquireCount = new AtomicInteger(0)
     val probe        = TestProbe()
 
-    val lock = new PeriodicDeploymentLock(
-      new DistributedLock {
-        override def acquireOrRenew(name: String, duration: FiniteDuration): Future[Option[Instant]] =
-          if (acquireCount.getAndIncrement() < 2) Future.failed(new RuntimeException("db error"))
-          else Future.successful(Some(Instant.MAX))
-        override def release(name: String): Future[Boolean] = Future.successful(true)
-      },
-      None
-    )
+    val lock = mockedLock {
+      if (acquireCount.getAndIncrement() < 2) Future.failed(new RuntimeException("db error"))
+      else Future.successful(Some(Instant.MAX))
+    }
 
     def handleFinished: Future[Unit] = { probe.ref ! "invoked"; Future.successful(()) }
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -22,7 +22,7 @@ description: Stay informed with detailed changelogs covering new features, impro
     * Comparing against a remote (secondary) environment now diffs the raw stored scenario graph on both sides. Previously the remote side was fetched validated and dictionary-resolved while the local side was not, which produced spurious differences for scenarios using dictionaries.
     * `GET /remoteEnvironment/{scenarioName}/versions` now requires the `Read` permission on the scenario. Previously it had no permission check at all, so any authenticated user could read the remote environment's version history for any scenario. Callers that relied on receiving an empty list for an inaccessible scenario now get `403 Forbidden`.
     * See the [Migration Guide](MigrationGuide.md) for the `RemoteEnvironment` API change.
-* [#9416](https://github.com/TouK/nussknacker/pull/9416) Feature: High Availability (HA) mode for the Designer.
+* [#9416](https://github.com/TouK/nussknacker/pull/9416)[#9447](https://github.com/TouK/nussknacker/pull/9447) Feature: High Availability (HA) mode for the Designer.
     * Multiple Designer instances can now run concurrently. All instances serve requests; coordinated operations (such as recovering failed deployments) are performed by the elected leader only. If the leader fails, another instance takes over automatically.
     * New endpoint `GET /api/app/leader` (no authentication required) returns `{ "isLeader": true/false, "instanceId": "<id>", "haEnabled": true/false }` — suitable for load-balancer routing.
     * **Requires PostgreSQL** as the designer database.
@@ -48,7 +48,13 @@ ha {
     releaseOnStop: true   # default
   }
 
+  # How scheduling (periodic scenarios) is fenced across instances:
+  #  - dedicated: acquires and renews its own lock
+  #  - leader:    reuses the leader lock so all deployments happen on the leader instance only
+  periodicLockMode: dedicated   # default
+
   # Maximum time a periodic scenario lock is held (covers the full deploy round-trip).
+  # Only used when periodicLockMode is "dedicated".
   periodicLockDuration: 5m   # default
 
   # Timeout for individual lock DB queries (must be < leader.heartbeatInterval).


### PR DESCRIPTION
## Describe your changes

Allow periodic scheduler to use the main leader lock. Allows for easier reasoning about the place where periodic deployments happen at the cost of larger delay during failover.

## Checklist before merge
- [ ] Related issue ID is placed at the beginning of PR title in \[brackets\] (can be GH issue or Nu Jira issue)
- [ ] Code is cleaned from temporary changes and commented out lines
- [ ] Parts of the code that are not easy to understand are documented in the code
- [ ] Changes are covered by automated tests
- [ ] Showcase in dev-application.conf added to demonstrate the feature
- [ ] Documentation added or updated
- [ ] Added entry in _Changelog.md_ describing the change from the perspective of a public distribution user
- [ ] Added _MigrationGuide.md_ entry in the appropriate subcategory if introducing a breaking change
- [ ] Verify that PR will be squashed during merge
